### PR TITLE
fix: converge formula bond dependency linking

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1983,14 +1983,8 @@ func nukeCleanupMolecules(workBeadID string, r *rig.Rig) {
 		return
 	}
 
-	// Remove dependency bond so collectExistingMolecules won't find the
-	// closed molecule and block re-dispatch. Without this, the bond persists
-	// and every sling attempt fails with "bead has existing molecule(s)".
-	if err := bd.RemoveDependency(workBeadID, moleculeID); err != nil {
-		fmt.Printf("  %s molecule bond removal failed for %s → %s: %v\n",
-			style.Warning.Render("⚠"), workBeadID, moleculeID, err)
-		// Non-fatal: detach already cleared the description pointer.
-	}
+	// Remove dependency bonds so stale molecule discovery does not block re-dispatch.
+	removeMoleculeBonds(bd, workBeadID, moleculeID)
 
 	// Force-close the orphaned wisp root so it doesn't linger
 	if closeErr := bd.ForceCloseWithReason("burned: polecat nuked", moleculeID); closeErr != nil {

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -786,49 +786,54 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// Handle --force when bead is already hooked/in_progress: send shutdown to old polecat and unhook (GH#1380)
 	if (info.Status == "hooked" || info.Status == "in_progress") && force && info.Assignee != "" {
 		fmt.Printf("%s Bead already hooked to %s, forcing reassignment...\n", style.Warning.Render("⚠"), info.Assignee)
+		if slingDryRun {
+			fmt.Printf("Would send LIFECYCLE:Shutdown to previous assignee %s\n", info.Assignee)
+			fmt.Printf("Would unhook %s from previous assignee\n", beadID)
+		} else {
 
-		// Determine requester identity from env vars, fall back to "gt-sling"
-		requester := "gt-sling"
-		if polecat := os.Getenv("GT_POLECAT"); polecat != "" {
-			requester = polecat
-		} else if user := os.Getenv("USER"); user != "" {
-			requester = user
-		}
+			// Determine requester identity from env vars, fall back to "gt-sling"
+			requester := "gt-sling"
+			if polecat := os.Getenv("GT_POLECAT"); polecat != "" {
+				requester = polecat
+			} else if user := os.Getenv("USER"); user != "" {
+				requester = user
+			}
 
-		// Extract rig name from assignee (e.g., "gastown/polecats/Toast" -> "gastown")
-		assigneeParts := strings.Split(info.Assignee, "/")
-		if len(assigneeParts) >= 3 && assigneeParts[1] == "polecats" {
-			oldRigName := assigneeParts[0]
-			oldPolecatName := assigneeParts[2]
+			// Extract rig name from assignee (e.g., "gastown/polecats/Toast" -> "gastown")
+			assigneeParts := strings.Split(info.Assignee, "/")
+			if len(assigneeParts) >= 3 && assigneeParts[1] == "polecats" {
+				oldRigName := assigneeParts[0]
+				oldPolecatName := assigneeParts[2]
 
-			// Send LIFECYCLE:Shutdown to witness - will auto-nuke if clean,
-			// otherwise create cleanup wisp for manual intervention
-			if townRoot != "" {
-				router := mail.NewRouter(townRoot)
-				defer router.WaitPendingNotifications()
-				shutdownMsg := &mail.Message{
-					From:     "gt-sling",
-					To:       fmt.Sprintf("%s/witness", oldRigName),
-					Subject:  fmt.Sprintf("LIFECYCLE:Shutdown %s", oldPolecatName),
-					Body:     fmt.Sprintf("Reason: work_reassigned\nRequestedBy: %s\nBead: %s\nNewAssignee: %s", requester, beadID, targetAgent),
-					Type:     mail.TypeTask,
-					Priority: mail.PriorityHigh,
-				}
-				if err := router.Send(shutdownMsg); err != nil {
-					fmt.Printf("%s Could not send shutdown to witness: %v\n", style.Dim.Render("Warning:"), err)
-				} else {
-					fmt.Printf("%s Sent LIFECYCLE:Shutdown to %s/witness for %s\n", style.Bold.Render("→"), oldRigName, oldPolecatName)
+				// Send LIFECYCLE:Shutdown to witness - will auto-nuke if clean,
+				// otherwise create cleanup wisp for manual intervention
+				if townRoot != "" {
+					router := mail.NewRouter(townRoot)
+					defer router.WaitPendingNotifications()
+					shutdownMsg := &mail.Message{
+						From:     "gt-sling",
+						To:       fmt.Sprintf("%s/witness", oldRigName),
+						Subject:  fmt.Sprintf("LIFECYCLE:Shutdown %s", oldPolecatName),
+						Body:     fmt.Sprintf("Reason: work_reassigned\nRequestedBy: %s\nBead: %s\nNewAssignee: %s", requester, beadID, targetAgent),
+						Type:     mail.TypeTask,
+						Priority: mail.PriorityHigh,
+					}
+					if err := router.Send(shutdownMsg); err != nil {
+						fmt.Printf("%s Could not send shutdown to witness: %v\n", style.Dim.Render("Warning:"), err)
+					} else {
+						fmt.Printf("%s Sent LIFECYCLE:Shutdown to %s/witness for %s\n", style.Bold.Render("→"), oldRigName, oldPolecatName)
+					}
 				}
 			}
-		}
 
-		// Unhook the bead from old owner (set status back to open)
-		unhookDir := beads.ResolveHookDir(townRoot, beadID, "")
-		if err := BdCmd("update", beadID, "--status=open", "--assignee=").
-			Dir(unhookDir).
-			WithAutoCommit().
-			Run(); err != nil {
-			fmt.Printf("%s Could not unhook bead from old owner: %v\n", style.Dim.Render("Warning:"), err)
+			// Unhook the bead from old owner (set status back to open)
+			unhookDir := beads.ResolveHookDir(townRoot, beadID, "")
+			if err := BdCmd("update", beadID, "--status=open", "--assignee=").
+				Dir(unhookDir).
+				WithAutoCommit().
+				Run(); err != nil {
+				fmt.Printf("%s Could not unhook bead from old owner: %v\n", style.Dim.Render("Warning:"), err)
+			}
 		}
 	}
 
@@ -888,10 +893,13 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// Without this, each sling creates a new wisp bonded to the bead, leaving orphaned molecules.
 	// NOTE: Uses local `force` (not `slingForce`) to respect auto-force paths (dead agent detection).
 	if formulaName != "" {
-		existingMolecules := collectExistingMolecules(info)
+		existingMolecules, err := collectExistingMoleculesForBead(info, beadID, townRoot)
+		if err != nil {
+			return fmt.Errorf("checking existing molecule bonds: %w", err)
+		}
 		if len(existingMolecules) > 0 {
 			stale := force || isOrphanMolecule(info)
-			if slingDryRun {
+			if slingDryRun && stale {
 				fmt.Printf("  Would burn %d stale molecule(s): %s\n",
 					len(existingMolecules), strings.Join(existingMolecules, ", "))
 			} else if stale {
@@ -911,9 +919,8 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		if formulaName != "" {
 			fmt.Printf("Would instantiate formula %s:\n", formulaName)
 			fmt.Printf("  1. bd cook %s\n", formulaName)
-			fmt.Printf("  2. bd mol wisp %s --var feature=\"%s\" --var issue=\"%s\"\n", formulaName, info.Title, beadID)
-			fmt.Printf("  3. bd mol bond <wisp-root> %s\n", beadID)
-			fmt.Printf("  4. bd update <compound-root> --status=hooked --assignee=%s\n", targetAgent)
+			fmt.Printf("  2. bd mol bond %s %s --json --ephemeral --var feature=\"%s\" --var issue=\"%s\"\n", formulaName, beadID, info.Title, beadID)
+			fmt.Printf("  3. bd update %s --status=hooked --assignee=%s\n", beadID, targetAgent)
 		} else {
 			fmt.Printf("Would run: bd update %s --status=hooked --assignee=%s\n", beadID, targetAgent)
 		}
@@ -1300,6 +1307,11 @@ func rollbackSlingArtifacts(spawnInfo *SpawnedPolecatInfo, beadID, hookWorkDir, 
 				fmt.Printf("  %s Could not inspect bead %s for stale molecules: %v\n", style.Dim.Render("Warning:"), beadID, infoErr)
 			} else {
 				existingMolecules := collectExistingMoleculesForRollback(info)
+				if depMolecules, depErr := collectExistingMoleculeDeps(beadID, townRoot); depErr != nil {
+					fmt.Printf("  %s Could not inspect canonical molecule bonds for %s: %v\n", style.Dim.Render("Warning:"), beadID, depErr)
+				} else {
+					existingMolecules = appendUniqueMolecules(existingMolecules, depMolecules...)
+				}
 				if len(existingMolecules) > 0 {
 					if burnErr := burnExistingMoleculesForRollback(existingMolecules, beadID, townRoot); burnErr != nil {
 						fmt.Printf("  %s Could not burn stale molecule(s) from %s: %v\n", style.Dim.Render("Warning:"), beadID, burnErr)

--- a/internal/cmd/sling_288_test.go
+++ b/internal/cmd/sling_288_test.go
@@ -60,10 +60,11 @@ case "$cmd" in
     shift || true
     case "$sub" in
       wisp)
-        echo '{"new_epic_id":"gt-wisp-288"}'
+        echo 'legacy mol wisp should not be called' >&2
+        exit 1
         ;;
       bond)
-        echo '{"root_id":"gt-wisp-288"}'
+        echo '{"result_id":"gt-abc123","id_mapping":{"mol-polecat-work":"gt-wisp-288"}}'
         ;;
     esac
     ;;
@@ -88,11 +89,11 @@ if "%cmd%"=="formula" (
 if "%cmd%"=="cook" exit /b 0
 if "%cmd%"=="mol" (
   if "%sub%"=="wisp" (
-    echo {^"new_epic_id^":^"gt-wisp-288^"}
-    exit /b 0
+    echo legacy mol wisp should not be called 1>&2
+    exit /b 1
   )
   if "%sub%"=="bond" (
-    echo {^"root_id^":^"gt-wisp-288^"}
+    echo {^"result_id^":^"gt-abc123^",^"id_mapping^":{^"mol-polecat-work^":^"gt-wisp-288^"}}
     exit /b 0
   )
 )
@@ -137,14 +138,14 @@ exit /b 0
 	if !strings.Contains(logContent, "cook mol-polecat-work") {
 		t.Errorf("cook command not found in log:\n%s", logContent)
 	}
-	if !strings.Contains(logContent, "mol wisp mol-polecat-work") {
-		t.Errorf("mol wisp command not found in log:\n%s", logContent)
+	if strings.Contains(logContent, "mol wisp") {
+		t.Errorf("legacy mol wisp command should not be called:\n%s", logContent)
 	}
 	if !strings.Contains(logContent, "--var branch=polecat/furiosa/gt-abc123") {
-		t.Errorf("extra vars not passed to wisp command:\n%s", logContent)
+		t.Errorf("extra vars not passed to bond command:\n%s", logContent)
 	}
-	if !strings.Contains(logContent, "mol bond") {
-		t.Errorf("mol bond command not found in log:\n%s", logContent)
+	if !strings.Contains(logContent, "mol bond mol-polecat-work gt-abc123 --json --ephemeral") {
+		t.Errorf("direct mol bond command not found in log:\n%s", logContent)
 	}
 }
 
@@ -179,8 +180,8 @@ case "$cmd" in
   mol)
     sub="$1"; shift || true
     case "$sub" in
-      wisp) echo '{"new_epic_id":"gt-wisp-skip"}';;
-      bond) echo '{"root_id":"gt-wisp-skip"}';;
+      wisp) echo 'legacy mol wisp should not be called' >&2; exit 1;;
+      bond) echo '{"result_id":"gt-test","id_mapping":{"mol-polecat-work":"gt-wisp-skip"}}';;
     esac;;
 esac
 exit 0
@@ -192,11 +193,11 @@ set "cmd=%1"
 set "sub=%2"
 if "%cmd%"=="mol" (
   if "%sub%"=="wisp" (
-    echo {^"new_epic_id^":^"gt-wisp-skip^"}
-    exit /b 0
+    echo legacy mol wisp should not be called 1>&2
+    exit /b 1
   )
   if "%sub%"=="bond" (
-    echo {^"root_id^":^"gt-wisp-skip^"}
+    echo {^"result_id^":^"gt-test^",^"id_mapping^":{^"mol-polecat-work^":^"gt-wisp-skip^"}}
     exit /b 0
   )
 )
@@ -225,11 +226,11 @@ exit /b 0
 		t.Errorf("cook should be skipped when skipCook=true, but was called:\n%s", logContent)
 	}
 
-	// Verify wisp and bond were still called
-	if !strings.Contains(logContent, "mol wisp") {
-		t.Errorf("mol wisp should still be called")
+	// Verify direct bond was still called without the legacy wisp path.
+	if strings.Contains(logContent, "mol wisp") {
+		t.Errorf("mol wisp should not be called")
 	}
-	if !strings.Contains(logContent, "mol bond") {
+	if !strings.Contains(logContent, "mol bond mol-polecat-work gt-test --json --ephemeral") {
 		t.Errorf("mol bond should still be called")
 	}
 }
@@ -371,8 +372,8 @@ case "$cmd" in
   mol)
     sub="$1"; shift || true
     case "$sub" in
-      wisp) echo '{"new_epic_id":"gt-wisp-var"}';;
-      bond) echo '{"root_id":"gt-wisp-var"}';;
+      wisp) echo 'legacy mol wisp should not be called' >&2; exit 1;;
+      bond) echo '{"result_id":"gt-abc123","id_mapping":{"mol-polecat-work":"gt-wisp-var"}}';;
     esac;;
 esac
 exit 0
@@ -385,11 +386,11 @@ set "sub=%2"
 if "%cmd%"=="cook" exit /b 0
 if "%cmd%"=="mol" (
   if "%sub%"=="wisp" (
-    echo {^"new_epic_id^":^"gt-wisp-var^"}
-    exit /b 0
+    echo legacy mol wisp should not be called 1>&2
+    exit /b 1
   )
   if "%sub%"=="bond" (
-    echo {^"root_id^":^"gt-wisp-var^"}
+    echo {^"result_id^":^"gt-abc123^",^"id_mapping^":{^"mol-polecat-work^":^"gt-wisp-var^"}}
     exit /b 0
   )
 )
@@ -412,29 +413,29 @@ exit /b 0
 	logBytes, _ := os.ReadFile(logPath)
 	logContent := string(logBytes)
 
-	// Find mol wisp line
-	var wispLine string
+	// Find direct mol bond line
+	var bondLine string
 	for _, line := range strings.Split(logContent, "\n") {
-		if strings.Contains(line, "mol wisp") {
-			wispLine = line
+		if strings.Contains(line, "mol bond") {
+			bondLine = line
 			break
 		}
 	}
 
-	if wispLine == "" {
-		t.Fatalf("mol wisp command not found:\n%s", logContent)
+	if bondLine == "" {
+		t.Fatalf("mol bond command not found:\n%s", logContent)
 	}
 
-	if !strings.Contains(wispLine, "feature=My Cool Feature") {
-		t.Errorf("mol wisp missing feature variable:\n%s", wispLine)
+	if !strings.Contains(bondLine, "feature=My Cool Feature") {
+		t.Errorf("mol bond missing feature variable:\n%s", bondLine)
 	}
 
-	if !strings.Contains(wispLine, "issue=gt-abc123") {
-		t.Errorf("mol wisp missing issue variable:\n%s", wispLine)
+	if !strings.Contains(bondLine, "issue=gt-abc123") {
+		t.Errorf("mol bond missing issue variable:\n%s", bondLine)
 	}
 }
 
-func TestInstantiateFormulaOnBead_FallbackToDirectBond(t *testing.T) {
+func TestInstantiateFormulaOnBead_DirectBondParsesIDMapping(t *testing.T) {
 	townRoot := t.TempDir()
 
 	// Minimal workspace
@@ -454,11 +455,8 @@ func TestInstantiateFormulaOnBead_FallbackToDirectBond(t *testing.T) {
 	}
 	logPath := filepath.Join(townRoot, "bd.log")
 
-	// Legacy path behavior:
-	// - mol wisp succeeds and returns a root ID
-	// - mol bond <wisp-id> fails with "not found"
-	// Fallback behavior:
-	// - mol bond <formula> <bead> --ephemeral succeeds and returns id_mapping
+	// Direct bond returns the base bead as result_id and the spawned molecule root
+	// under id_mapping keyed by the original formula name.
 	bdScript := `#!/bin/sh
 set -e
 echo "CMD:$*" >> "${BD_LOG}"
@@ -544,24 +542,24 @@ exit /b 0
 		t.Fatalf("read log: %v", err)
 	}
 	logContent := string(logBytes)
-	if !strings.Contains(logContent, "mol bond gt-wisp-missing gt-abc123 --json") {
-		t.Fatalf("missing legacy bond attempt in log:\n%s", logContent)
+	if strings.Contains(logContent, "mol wisp") {
+		t.Fatalf("legacy mol wisp should not be called:\n%s", logContent)
 	}
-	var fallbackBondLine string
+	var directBondLine string
 	for _, line := range strings.Split(logContent, "\n") {
 		if strings.Contains(line, "mol bond mol-polecat-work gt-abc123 --json --ephemeral") {
-			fallbackBondLine = line
+			directBondLine = line
 			break
 		}
 	}
-	if fallbackBondLine == "" {
-		t.Fatalf("missing direct bond fallback in log:\n%s", logContent)
+	if directBondLine == "" {
+		t.Fatalf("missing direct bond in log:\n%s", logContent)
 	}
-	if !containsVarArg(fallbackBondLine, "feature", "My Cool Feature") {
-		t.Fatalf("fallback bond missing feature variable:\n%s", logContent)
+	if !containsVarArg(directBondLine, "feature", "My Cool Feature") {
+		t.Fatalf("direct bond missing feature variable:\n%s", logContent)
 	}
-	if !containsVarArg(fallbackBondLine, "issue", "gt-abc123") {
-		t.Fatalf("fallback bond missing issue variable:\n%s", logContent)
+	if !containsVarArg(directBondLine, "issue", "gt-abc123") {
+		t.Fatalf("direct bond missing issue variable:\n%s", logContent)
 	}
 	for _, required := range []struct {
 		key   string
@@ -574,40 +572,13 @@ exit /b 0
 		{"test_command", ""},
 		{"build_command", ""},
 	} {
-		if !containsVarArg(fallbackBondLine, required.key, required.value) {
-			t.Fatalf("fallback bond missing required variable %q:\n%s", required.key, logContent)
+		if !containsVarArg(directBondLine, required.key, required.value) {
+			t.Fatalf("direct bond missing required variable %q:\n%s", required.key, logContent)
 		}
 	}
 }
 
-// TestIsMalformedWispID verifies detection of doubled "-wisp-" in wisp IDs (gt-4gjd).
-func TestIsMalformedWispID(t *testing.T) {
-	tests := []struct {
-		name          string
-		wispID        string
-		wantMalformed bool
-	}{
-		{"normal wisp ID", "gt-wisp-abc", false},
-		{"normal with long random", "oag-wisp-gm7c", false},
-		{"doubled wisp marker", "oag-wisp-wisp-rsia", true},
-		{"triple wisp marker", "gt-wisp-wisp-wisp-x", true},
-		{"empty", "", false},
-		{"no wisp marker", "gt-abc", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isMalformedWispID(tt.wispID)
-			if got != tt.wantMalformed {
-				t.Errorf("isMalformedWispID(%q) = %v, want %v", tt.wispID, got, tt.wantMalformed)
-			}
-		})
-	}
-}
-
-// TestInstantiateFormulaOnBead_MalformedWispIDProceedsWithBond verifies that
-// when bd mol wisp returns a malformed ID (doubled "-wisp-"), a warning is logged
-// but the legacy bond is still attempted and succeeds (gt-4gjd).
-func TestInstantiateFormulaOnBead_MalformedWispIDProceedsWithBond(t *testing.T) {
+func TestInstantiateFormulaOnBead_DirectBondHandlesNonGTIDs(t *testing.T) {
 	townRoot := t.TempDir()
 
 	// Minimal workspace
@@ -627,8 +598,8 @@ func TestInstantiateFormulaOnBead_MalformedWispIDProceedsWithBond(t *testing.T) 
 	}
 	logPath := filepath.Join(townRoot, "bd.log")
 
-	// bd mol wisp returns a malformed ID with doubled "-wisp-".
-	// Legacy bond SHOULD be called with the malformed ID and succeed.
+	// Direct bond should accept the spawned root returned by bd, even when its
+	// prefix is not gt-.
 	bdScript := `#!/bin/sh
 set -e
 echo "CMD:$*" >> "${BD_LOG}"
@@ -637,19 +608,19 @@ case "$cmd" in
   cook)
     exit 0
     ;;
-  mol)
-    sub="$1"; shift || true
-    case "$sub" in
-      wisp)
-        echo '{"new_epic_id":"oag-wisp-wisp-rsia"}'
-        exit 0
-        ;;
-      bond)
-        left="$1"; shift || true
-        if [ "$left" = "oag-wisp-wisp-rsia" ]; then
-          echo '{"root_id":"oag-wisp-wisp-rsia"}'
-          exit 0
-        fi
+	  mol)
+		sub="$1"; shift || true
+		case "$sub" in
+		  wisp)
+			echo 'legacy mol wisp should not be called' >&2
+			exit 1
+			;;
+		  bond)
+			left="$1"; shift || true
+			if [ "$left" = "mol-polecat-work" ]; then
+			  echo '{"result_id":"oag-npeat","id_mapping":{"mol-polecat-work":"oag-wisp-wisp-rsia"}}'
+			  exit 0
+			fi
         echo "Error: unexpected bond target: $left" >&2
         exit 1
         ;;
@@ -667,12 +638,12 @@ set "left=%3"
 if "%cmd%"=="cook" exit /b 0
 if "%cmd%"=="mol" (
   if "%sub%"=="wisp" (
-    echo {^"new_epic_id^":^"oag-wisp-wisp-rsia^"}
-    exit /b 0
+    echo legacy mol wisp should not be called 1>&2
+    exit /b 1
   )
   if "%sub%"=="bond" (
-    if "%left%"=="oag-wisp-wisp-rsia" (
-      echo {^"root_id^":^"oag-wisp-wisp-rsia^"}
+    if "%left%"=="mol-polecat-work" (
+      echo {^"result_id^":^"oag-npeat^",^"id_mapping^":{^"mol-polecat-work^":^"oag-wisp-wisp-rsia^"}}
       exit /b 0
     )
     echo Error: unexpected bond target: %left% 1>&2
@@ -701,21 +672,20 @@ exit /b 0
 		t.Fatalf("BeadToHook = %q, want %q", result.BeadToHook, "oag-npeat")
 	}
 
-	// Verify the legacy bond WAS called with the malformed ID.
 	logBytes, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("read log: %v", err)
 	}
 	logContent := string(logBytes)
-	if !strings.Contains(logContent, "mol bond oag-wisp-wisp-rsia") {
-		t.Fatalf("legacy bond should have been called with malformed wisp ID:\n%s", logContent)
+	if strings.Contains(logContent, "mol wisp") {
+		t.Fatalf("legacy mol wisp should not have been called:\n%s", logContent)
+	}
+	if !strings.Contains(logContent, "mol bond mol-polecat-work oag-npeat --json --ephemeral") {
+		t.Fatalf("direct bond should have been called with formula and bead:\n%s", logContent)
 	}
 }
 
-// TestInstantiateFormulaOnBead_FallbackCleansUpOrphanedWisp verifies that when
-// the legacy bond fails and fallback is used, the orphaned wisp from bd mol wisp
-// is cleaned up (gt-4gjd).
-func TestInstantiateFormulaOnBead_FallbackCleansUpOrphanedWisp(t *testing.T) {
+func TestInstantiateFormulaOnBead_DirectBondCreatesNoOrphanCleanup(t *testing.T) {
 	townRoot := t.TempDir()
 
 	// Minimal workspace
@@ -735,8 +705,7 @@ func TestInstantiateFormulaOnBead_FallbackCleansUpOrphanedWisp(t *testing.T) {
 	}
 	logPath := filepath.Join(townRoot, "bd.log")
 
-	// Legacy path: mol wisp succeeds, mol bond <wisp-id> fails.
-	// After fallback succeeds, a close command should be issued for the orphaned wisp.
+	// The direct path should not create an intermediate wisp that needs orphan cleanup.
 	bdScript := `#!/bin/sh
 set -e
 echo "CMD:$*" >> "${BD_LOG}"
@@ -747,19 +716,15 @@ case "$cmd" in
     ;;
   mol)
     sub="$1"; shift || true
-    case "$sub" in
-      wisp)
-        echo '{"new_epic_id":"gt-wisp-orphan"}'
-        exit 0
-        ;;
-      bond)
-        left="$1"; shift || true
-        if [ "$left" = "gt-wisp-orphan" ]; then
-          echo "Error: 'gt-wisp-orphan' not found (not an issue ID or formula name)" >&2
-          exit 1
-        fi
-        if [ "$left" = "mol-polecat-work" ]; then
-          echo '{"result_id":"gt-test","id_mapping":{"mol-polecat-work":"gt-wisp-clean"}}'
+		case "$sub" in
+		  wisp)
+			echo 'legacy mol wisp should not be called' >&2
+			exit 1
+			;;
+		  bond)
+			left="$1"; shift || true
+			if [ "$left" = "mol-polecat-work" ]; then
+			  echo '{"result_id":"gt-test","id_mapping":{"mol-polecat-work":"gt-wisp-clean"}}'
           exit 0
         fi
         echo "Error: unexpected bond target: $left" >&2
@@ -782,14 +747,10 @@ set "left=%3"
 if "%cmd%"=="cook" exit /b 0
 if "%cmd%"=="mol" (
   if "%sub%"=="wisp" (
-    echo {^"new_epic_id^":^"gt-wisp-orphan^"}
-    exit /b 0
+    echo legacy mol wisp should not be called 1>&2
+    exit /b 1
   )
   if "%sub%"=="bond" (
-    if "%left%"=="gt-wisp-orphan" (
-      echo Error: 'gt-wisp-orphan' not found 1>&2
-      exit /b 1
-    )
     if "%left%"=="mol-polecat-work" (
       echo {^"result_id^":^"gt-test^",^"id_mapping^":{^"mol-polecat-work^":^"gt-wisp-clean^"}}
       exit /b 0
@@ -818,21 +779,17 @@ exit /b 0
 		t.Fatalf("WispRootID = %q, want %q", result.WispRootID, "gt-wisp-clean")
 	}
 
-	// Verify a close command was issued for the orphaned wisp
 	logBytes, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("read log: %v", err)
 	}
 	logContent := string(logBytes)
-	if !strings.Contains(logContent, "close") || !strings.Contains(logContent, "gt-wisp-orphan") {
-		t.Fatalf("expected close command for orphaned wisp gt-wisp-orphan in log:\n%s", logContent)
+	if strings.Contains(logContent, "mol wisp") || strings.Contains(logContent, "close") {
+		t.Fatalf("direct bond should not create or clean an orphaned wisp:\n%s", logContent)
 	}
 }
 
-// TestInstantiateFormulaOnBead_ParseFailureFallbackFailure verifies that when
-// legacy bond exits 0 with non-JSON output AND the direct-bond fallback also
-// fails, InstantiateFormulaOnBead returns an error instead of silent success.
-func TestInstantiateFormulaOnBead_ParseFailureFallbackFailure(t *testing.T) {
+func TestInstantiateFormulaOnBead_DirectBondParseFailure(t *testing.T) {
 	townRoot := t.TempDir()
 
 	// Minimal workspace
@@ -852,8 +809,7 @@ func TestInstantiateFormulaOnBead_ParseFailureFallbackFailure(t *testing.T) {
 	}
 	logPath := filepath.Join(townRoot, "bd.log")
 
-	// Legacy bond exits 0 but returns non-JSON garbage.
-	// Direct-bond fallback also fails (all bond calls fail).
+	// Direct bond exits 0 but returns non-JSON garbage.
 	bdScript := `#!/bin/sh
 set -e
 echo "CMD:$*" >> "${BD_LOG}"
@@ -864,16 +820,16 @@ case "$cmd" in
     ;;
   mol)
     sub="$1"; shift || true
-    case "$sub" in
-      wisp)
-        echo '{"new_epic_id":"gt-wisp-abc"}'
-        exit 0
-        ;;
-      bond)
-        left="$1"; shift || true
-        if [ "$left" = "gt-wisp-abc" ]; then
-          echo 'NOT-JSON-GARBAGE'
-          exit 0
+		case "$sub" in
+		  wisp)
+			echo 'legacy mol wisp should not be called' >&2
+			exit 1
+			;;
+		  bond)
+			left="$1"; shift || true
+			if [ "$left" = "mol-polecat-work" ]; then
+			  echo 'NOT-JSON-GARBAGE'
+			  exit 0
         fi
         echo "Error: bond failed" >&2
         exit 1
@@ -892,11 +848,11 @@ set "left=%3"
 if "%cmd%"=="cook" exit /b 0
 if "%cmd%"=="mol" (
   if "%sub%"=="wisp" (
-    echo {^"new_epic_id^":^"gt-wisp-abc^"}
-    exit /b 0
+    echo legacy mol wisp should not be called 1>&2
+    exit /b 1
   )
   if "%sub%"=="bond" (
-    if "%left%"=="gt-wisp-abc" (
+    if "%left%"=="mol-polecat-work" (
       echo NOT-JSON-GARBAGE
       exit /b 0
     )
@@ -919,7 +875,7 @@ exit /b 0
 	if err == nil {
 		t.Fatal("expected error when bond returns non-JSON and fallback fails, got nil")
 	}
-	if !strings.Contains(err.Error(), "not parseable") && !strings.Contains(err.Error(), "fallback failed") {
-		t.Fatalf("error message should mention parse failure and fallback: %v", err)
+	if !strings.Contains(err.Error(), "missing spawned root id") {
+		t.Fatalf("error message should mention missing spawned root id: %v", err)
 	}
 }

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -206,7 +206,11 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 
 	// 2. Burn stale molecules (if formula applies)
 	if params.FormulaName != "" {
-		existingMolecules := collectExistingMolecules(info)
+		existingMolecules, err := collectExistingMoleculesForBead(info, params.BeadID, townRoot)
+		if err != nil {
+			result.ErrMsg = fmt.Sprintf("molecule check failed: %v", err)
+			return result, fmt.Errorf("checking existing molecule bonds: %w", err)
+		}
 		if len(existingMolecules) > 0 {
 			// Auto-burn when bead is unassigned (molecules are definitionally stale),
 			// or when the assigned agent's session is dead. This unblocks the daemon's
@@ -369,11 +373,19 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 		Args:             params.Args,
 		Vars:             varsForAttachment,
 		AttachedMolecule: attachedMoleculeID,
-		AttachedFormula:  params.FormulaName,
 		NoMerge:          params.NoMerge,
 		ReviewOnly:       params.ReviewOnly,
 		Mode:             &params.Mode,
 		FormulaVars:      formulaVarsForAttachment,
+	}
+	if params.FormulaName != "" {
+		if attachedMoleculeID != "" {
+			fieldUpdates.AttachedFormula = params.FormulaName
+		} else {
+			fieldUpdates.ClearAttachment = true
+			fieldUpdates.Vars = nil
+			fieldUpdates.FormulaVars = ""
+		}
 	}
 	// Use beadToHook for the update target (may differ from beadID when formula-on-bead)
 	if err := storeFieldsInBead(beadToHook, fieldUpdates); err != nil {

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -221,6 +221,66 @@ func collectExistingMolecules(info *beadInfo) []string {
 	return molecules
 }
 
+func appendUniqueMolecules(molecules []string, extras ...string) []string {
+	seen := make(map[string]bool, len(molecules)+len(extras))
+	for _, molecule := range molecules {
+		seen[molecule] = true
+	}
+	for _, molecule := range extras {
+		if molecule == "" || seen[molecule] {
+			continue
+		}
+		seen[molecule] = true
+		molecules = append(molecules, molecule)
+	}
+	return molecules
+}
+
+func collectExistingMoleculesForBead(info *beadInfo, beadID, townRoot string) ([]string, error) {
+	molecules := collectExistingMolecules(info)
+	deps, err := collectExistingMoleculeDeps(beadID, townRoot)
+	if err != nil {
+		return molecules, err
+	}
+	return appendUniqueMolecules(molecules, deps...), nil
+}
+
+func collectExistingMoleculeDeps(beadID, townRoot string) ([]string, error) {
+	if beadID == "" {
+		return nil, nil
+	}
+	if !isValidBeadID(beadID) {
+		return nil, fmt.Errorf("invalid bead ID: %q", beadID)
+	}
+
+	dir := resolveBeadDirFromTownRoot(townRoot, beadID)
+	query := fmt.Sprintf(`SELECT DISTINCT wisp_dependencies.issue_id FROM wisp_dependencies JOIN wisps ON wisps.id = wisp_dependencies.issue_id WHERE wisps.issue_type = 'molecule' AND wisps.status NOT IN ('closed', 'tombstone') AND wisp_dependencies.type IN ('blocks', 'conditional-blocks', 'parent-child') AND (wisp_dependencies.depends_on_issue_id = '%[1]s' OR wisp_dependencies.depends_on_wisp_id = '%[1]s' OR wisp_dependencies.depends_on_external = '%[1]s' OR %[2]s)`, beadID, sqlExternalDepTargetClause(beadID))
+	out, err := runBdJSON(dir, "sql", query, "--json")
+	if err != nil {
+		return nil, err
+	}
+	if len(strings.TrimSpace(string(out))) == 0 {
+		return nil, nil
+	}
+
+	var rows []map[string]string
+	if err := json.Unmarshal(out, &rows); err != nil {
+		return nil, fmt.Errorf("parsing canonical molecule deps for %s: %w", beadID, err)
+	}
+
+	seen := make(map[string]bool, len(rows))
+	var molecules []string
+	for _, row := range rows {
+		moleculeID := row["issue_id"]
+		if moleculeID == "" || seen[moleculeID] {
+			continue
+		}
+		seen[moleculeID] = true
+		molecules = append(molecules, moleculeID)
+	}
+	return molecules, nil
+}
+
 // burnExistingMolecules burns all molecule wisps attached to a bead.
 // Order: force-close descendants → detach from bead → remove dep bonds → force-close roots.
 // Matches nukeCleanupMolecules pattern. Returns an error if detach fails, since
@@ -267,13 +327,7 @@ func burnExistingMolecules(molecules []string, beadID, townRoot string) error {
 	// Without this, the next sling attempt finds the closed molecule via the
 	// bond and refuses with "bead has existing molecule(s)".
 	for _, molID := range molecules {
-		if err := bd.RemoveDependency(beadID, molID); err != nil {
-			fmt.Printf("  %s Could not remove dep bond %s → %s: %v\n",
-				style.Dim.Render("Warning:"), beadID, molID, err)
-			// Non-fatal: the detach already cleared the description pointer.
-			// The bond is stale metadata that won't cause functional issues
-			// beyond the "existing molecule(s)" check, which uses --force.
-		}
+		removeMoleculeBonds(bd, beadID, molID)
 	}
 
 	// Step 4: Close descendants, then force-close the orphaned wisp roots.
@@ -291,6 +345,32 @@ func burnExistingMolecules(molecules []string, beadID, townRoot string) error {
 	}
 
 	return nil
+}
+
+func removeMoleculeBonds(bd *beads.Beads, beadID, molID string) {
+	for _, bond := range []struct {
+		from string
+		to   string
+	}{
+		{from: molID, to: beadID}, // canonical bd mol bond direction
+		{from: beadID, to: molID}, // legacy reverse direction
+	} {
+		if err := bd.RemoveDependency(bond.from, bond.to); err != nil && !dependencyRemovalMissing(err) {
+			fmt.Printf("  %s Could not remove dep bond %s → %s: %v\n",
+				style.Dim.Render("Warning:"), bond.from, bond.to, err)
+		}
+	}
+}
+
+func dependencyRemovalMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "does not exist") ||
+		strings.Contains(msg, "no dependency") ||
+		strings.Contains(msg, "not present")
 }
 
 // verifyBeadExists checks that the bead exists using bd show.
@@ -467,6 +547,7 @@ type beadFieldUpdates struct {
 	Vars             []string // Formula variables (key=value pairs)
 	AttachedMolecule string   // Wisp root ID
 	AttachedFormula  string   // Formula name (e.g., "mol-polecat-work") for inline step display
+	ClearAttachment  bool     // Clear stale workflow attachment fields before applying updates
 	NoMerge          bool     // Skip merge queue on completion
 	ReviewOnly       bool     // Review-only mode: assignee must not merge/commit/push
 	Mode             *string  // Execution mode: nil means unchanged, "" clears, "ralph" enables Ralph mode
@@ -541,6 +622,13 @@ func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
 	}
 
 	// Apply all updates in one pass
+	if updates.ClearAttachment {
+		fields.AttachedMolecule = ""
+		fields.AttachedFormula = ""
+		fields.AttachedAt = ""
+		fields.AttachedVars = nil
+		fields.FormulaVars = ""
+	}
 	if updates.Dispatcher != "" {
 		fields.DispatchedBy = updates.Dispatcher
 	}
@@ -911,7 +999,7 @@ type FormulaOnBeadResult struct {
 	FormulaVars []string // Vars used to instantiate/render the formula
 }
 
-// InstantiateFormulaOnBead creates a wisp from a formula, bonds it to a bead.
+// InstantiateFormulaOnBead bonds a formula directly to a bead.
 // This is the formula-on-bead pattern used by issue #288 for auto-applying mol-polecat-work.
 //
 // Parameters:
@@ -923,10 +1011,10 @@ type FormulaOnBeadResult struct {
 //   - skipCook: if true, skip cooking (for batch mode optimization where cook happens once)
 //   - extraVars: additional --var values supplied by the user
 //
-// Returns the wisp root ID which should be hooked.
+// Returns the spawned molecule root ID while leaving the base bead as the hook target.
 func InstantiateFormulaOnBead(ctx context.Context, formulaName, beadID, title, hookWorkDir, townRoot string, skipCook bool, extraVars []string) (_ *FormulaOnBeadResult, retErr error) {
 	defer func() { telemetry.RecordFormulaInstantiate(ctx, formulaName, beadID, retErr) }()
-	// Route bd mutations (wisp/bond) to the correct beads context for the target bead.
+	// Route bd mutations to the correct beads context for the target bead.
 	formulaWorkDir := beads.ResolveHookDir(townRoot, beadID, hookWorkDir)
 
 	// Step 1: Cook the formula (ensures proto exists)
@@ -963,95 +1051,12 @@ func InstantiateFormulaOnBead(ctx context.Context, formulaName, beadID, title, h
 		telemetry.RecordMolCook(ctx, formulaName, nil)
 	}
 
-	// Build variable list once so both legacy and fallback paths use
-	// identical formula inputs.
-	featureVar := fmt.Sprintf("feature=%s", title)
-	issueVar := fmt.Sprintf("issue=%s", beadID)
-	formulaVars := []string{featureVar, issueVar}
-	formulaVars = append(formulaVars, extraVars...)
-	formulaVars = ensureFormulaRequiredVars(formulaName, formulaVars)
-
-	// Step 2: Create wisp with feature and issue variables from bead.
-	// Use resolvedFormula which may be a temp file path if the embedded fallback was used.
-	// Root-only: don't materialize child step wisps — agents read inline steps from embedded formula.
-	wispArgs := []string{"mol", "wisp", resolvedFormula, "--var", featureVar, "--var", issueVar}
-	for _, variable := range extraVars {
-		wispArgs = append(wispArgs, "--var", variable)
-	}
-	wispArgs = append(wispArgs, "--json")
-	wispOut, err := BdCmd(wispArgs...).
-		Dir(formulaWorkDir).
-		WithAutoCommit().
-		WithGTRoot(townRoot).
-		Output()
+	formulaVars := formulaVarsForBead(formulaName, beadID, title, extraVars)
+	wispRootID, err := bondFormulaDirect(resolvedFormula, formulaName, beadID, formulaWorkDir, townRoot, formulaVars)
 	if err != nil {
-		return nil, fmt.Errorf("creating wisp for formula %s: %w", formulaName, err)
-	}
-
-	// Parse wisp output to get the root ID
-	wispRootID, err := parseWispIDFromJSON(wispOut)
-	if err != nil {
-		telemetry.RecordMolWisp(ctx, formulaName, "", beadID, err)
-		return nil, fmt.Errorf("parsing wisp output: %w", err)
+		return nil, fmt.Errorf("bonding formula %s to bead %s: %w", formulaName, beadID, err)
 	}
 	telemetry.RecordMolWisp(ctx, formulaName, wispRootID, beadID, nil)
-
-	// Step 3: Bond wisp to original bead (creates compound).
-	//
-	// Compatibility fallback:
-	// Some bd versions return a wisp ID from `mol wisp` that is not bond-resolvable
-	// ("<id> not found"), while direct formula->bead bond still works. If legacy
-	// wisp->bead bond fails, retry with direct formula bond in ephemeral mode.
-	//
-	// gt-4gjd: Warn about malformed wisp IDs (e.g., doubled "-wisp-" like "oag-wisp-wisp-rsia")
-	// but proceed — they are valid in the DB and bond correctly. The bd-side fix is ef57293e
-	// (not yet released).
-	if isMalformedWispID(wispRootID) {
-		fmt.Fprintf(os.Stderr, "Warning: bd mol wisp returned malformed ID %q (known bd bug, proceeding with bond)\n", wispRootID)
-	}
-
-	bondArgs := []string{"mol", "bond", wispRootID, beadID, "--json"}
-	bondOut, err := BdCmd(bondArgs...).
-		Dir(formulaWorkDir).
-		WithAutoCommit().
-		WithGTRoot(townRoot).
-		Output()
-	if err != nil {
-		// Clean up orphaned wisp from the failed legacy path.
-		cleanupOrphanedWisp(wispRootID, formulaWorkDir)
-
-		fallbackRootID, fallbackErr := bondFormulaDirect(resolvedFormula, beadID, formulaWorkDir, townRoot, formulaVars)
-		if fallbackErr != nil {
-			return nil, fmt.Errorf("bonding formula to bead: %w (direct formula bond fallback failed: %v)", err, fallbackErr)
-		}
-		return &FormulaOnBeadResult{
-			WispRootID:  fallbackRootID,
-			BeadToHook:  beadID, // Hook the BASE bead (lifecycle fix: wisp is attached_molecule)
-			FormulaVars: append([]string(nil), formulaVars...),
-		}, nil
-	}
-
-	// Parse bond output - the wisp root becomes the compound root.
-	// Some environments may return success with non-JSON/empty stdout while
-	// still writing an error to stderr. If parsing fails, retry direct bond.
-	parsedRootID, parsed := parseBondSpawnRootIDWithStatus(bondOut, formulaName, beadID, wispRootID)
-	if !parsed {
-		// gt-4gjd: Clean up orphaned wisp before fallback.
-		cleanupOrphanedWisp(wispRootID, formulaWorkDir)
-
-		fallbackRootID, fallbackErr := bondFormulaDirect(resolvedFormula, beadID, formulaWorkDir, townRoot, formulaVars)
-		if fallbackErr != nil {
-			return nil, fmt.Errorf("bond output not parseable and direct formula bond fallback failed: %v", fallbackErr)
-		}
-		return &FormulaOnBeadResult{
-			WispRootID:  fallbackRootID,
-			BeadToHook:  beadID, // Hook the BASE bead (lifecycle fix: wisp is attached_molecule)
-			FormulaVars: append([]string(nil), formulaVars...),
-		}, nil
-	}
-	if parsedRootID != "" {
-		wispRootID = parsedRootID
-	}
 
 	return &FormulaOnBeadResult{
 		WispRootID:  wispRootID,
@@ -1060,11 +1065,18 @@ func InstantiateFormulaOnBead(ctx context.Context, formulaName, beadID, title, h
 	}, nil
 }
 
-// bondFormulaDirect retries formula attachment using direct formula->bead bond.
-// Newer bd versions support this polymorphic path even when legacy wisp->bead
-// bonding fails with "not found" for the generated wisp ID.
-func bondFormulaDirect(formulaName, beadID, formulaWorkDir, townRoot string, vars []string) (string, error) {
-	bondArgs := []string{"mol", "bond", formulaName, beadID, "--json", "--ephemeral"}
+func formulaVarsForBead(formulaName, beadID, title string, extraVars []string) []string {
+	formulaVars := []string{
+		fmt.Sprintf("feature=%s", title),
+		fmt.Sprintf("issue=%s", beadID),
+	}
+	formulaVars = append(formulaVars, extraVars...)
+	return ensureFormulaRequiredVars(formulaName, formulaVars)
+}
+
+// bondFormulaDirect attaches a formula to a bead through bd's canonical bond path.
+func bondFormulaDirect(bondTarget, formulaName, beadID, formulaWorkDir, townRoot string, vars []string) (string, error) {
+	bondArgs := []string{"mol", "bond", bondTarget, beadID, "--json", "--ephemeral"}
 	for _, variable := range vars {
 		bondArgs = append(bondArgs, "--var", variable)
 	}
@@ -1110,6 +1122,20 @@ func parseBondSpawnRootIDWithStatus(bondOut []byte, formulaName, beadID, fallbac
 			if mappedID := bondResult.IDMapping["mol-"+formulaName]; mappedID != "" {
 				return mappedID, true
 			}
+		}
+		var onlySpawned string
+		for _, mappedID := range bondResult.IDMapping {
+			if mappedID == "" || mappedID == beadID {
+				continue
+			}
+			if onlySpawned != "" && onlySpawned != mappedID {
+				onlySpawned = ""
+				break
+			}
+			onlySpawned = mappedID
+		}
+		if onlySpawned != "" {
+			return onlySpawned, true
 		}
 	}
 
@@ -1421,32 +1447,6 @@ func shouldAcceptPermissionWarning(agentName string) bool {
 		return false
 	}
 	return preset.EmitsPermissionWarning
-}
-
-// isMalformedWispID detects obviously malformed wisp IDs from bd mol wisp output.
-// Known bd bug (gt-4gjd): some versions generate wisp IDs with doubled "-wisp-"
-// infix (e.g., "oag-wisp-wisp-rsia" instead of "oag-wisp-rsia"). Detecting these
-// early avoids a doomed bond attempt and the associated noisy error.
-func isMalformedWispID(wispID string) bool {
-	// Look for "wisp-wisp-" anywhere in the ID — the hallmark of the doubled-infix bug.
-	return strings.Contains(wispID, "wisp-wisp-")
-}
-
-// cleanupOrphanedWisp attempts to force-close a wisp that was created by
-// bd mol wisp but could not be bonded. This prevents orphaned wisp accumulation
-// when the legacy bond path fails and the direct-bond fallback is used (gt-4gjd).
-// Best-effort: errors are logged but not propagated.
-func cleanupOrphanedWisp(wispID, formulaWorkDir string) {
-	if wispID == "" {
-		return
-	}
-	bd := beads.New(formulaWorkDir)
-	if err := bd.ForceCloseWithReason("burned: orphaned wisp from failed bond (gt-4gjd)", wispID); err != nil {
-		// Non-fatal: the wisp may not exist (phantom ID from bd bug),
-		// or it may be in a different database. Orphaned wisps will be
-		// caught by the doctor's DetectOrphanedMolecules.
-		fmt.Fprintf(os.Stderr, "Warning: could not clean up orphaned wisp %s: %v\n", wispID, err)
-	}
 }
 
 // updateAgentMode updates the mode field on the agent bead.

--- a/internal/cmd/sling_helpers_test.go
+++ b/internal/cmd/sling_helpers_test.go
@@ -211,6 +211,57 @@ func TestCollectExistingMoleculesFiltersClosedMolecules(t *testing.T) {
 	}
 }
 
+func TestCollectExistingMoleculeDepsReadsCanonicalWispEdges(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses Unix shell script bd stub")
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "bd.log")
+	script := `#!/bin/sh
+echo "$*" >> "${BD_LOG}"
+if [ "$1" = "sql" ]; then
+  case "$2" in
+    *wisp_dependencies*depends_on_issue_id*depends_on_wisp_id*)
+      echo '[{"issue_id":"gt-wisp-live"},{"issue_id":"gt-wisp-live"},{"issue_id":"gt-wisp-other"}]'
+      exit 0
+      ;;
+  esac
+  echo 'unexpected query' >&2
+  exit 1
+fi
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_LOG", logPath)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(binDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	got, err := collectExistingMoleculeDeps("gt-work", "")
+	if err != nil {
+		t.Fatalf("collectExistingMoleculeDeps: %v", err)
+	}
+	want := []string{"gt-wisp-live", "gt-wisp-other"}
+	if len(got) != len(want) {
+		t.Fatalf("collectExistingMoleculeDeps() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("collectExistingMoleculeDeps()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestIsSlingConfigError(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -198,17 +198,18 @@ case "$cmd" in
   cook)
     exit 0
     ;;
-  mol)
-    sub="$1"
-    shift || true
-    case "$sub" in
-      wisp)
-        echo '{"new_epic_id":"gt-wisp-xyz"}'
-        ;;
-      bond)
-        echo '{"root_id":"gt-wisp-xyz"}'
-        ;;
-    esac
+	  mol)
+		sub="$1"
+		shift || true
+		case "$sub" in
+		  wisp)
+			echo 'legacy mol wisp should not be called' >&2
+			exit 1
+			;;
+		  bond)
+			echo '{"result_id":"gt-abc123","id_mapping":{"mol-polecat-work":"gt-wisp-xyz"}}'
+			;;
+		esac
     ;;
   update)
     exit 0
@@ -340,9 +341,7 @@ exit /b 0
 		wantBeadsDir = resolved
 	}
 	gotPolecatCook := false
-	gotPolecatWisp := false
 	gotReviewCook := false
-	gotReviewWisp := false
 	gotBondCount := 0
 	gotCreate := false
 	gotTargetDBCheck := false
@@ -390,6 +389,8 @@ exit /b 0
 		case strings.Contains(args, "show "+newBeadID) && strings.Contains(args, "--json"):
 			gotTargetDBCheck = true
 			assertTargetRig("target DB check", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
+		case strings.Contains(args, "sql SELECT DISTINCT wisp_dependencies.issue_id"):
+			assertTargetRig("molecule dep check", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
 		case strings.Contains(args, "cook "):
 			switch {
 			case strings.Contains(args, "mol-polecat-work"):
@@ -400,18 +401,11 @@ exit /b 0
 				t.Fatalf("bd cook args = %q, want expected formula", args)
 			}
 			assertTargetRig("cook", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
-		case strings.Contains(args, "mol wisp "):
-			switch {
-			case strings.Contains(args, "mol-polecat-work"):
-				gotPolecatWisp = true
-			case strings.Contains(args, "mol-review"):
-				gotReviewWisp = true
-			default:
-				t.Fatalf("bd mol wisp args = %q, want expected formula", args)
-			}
-			assertTargetRig("mol wisp", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
 		case strings.Contains(args, "mol bond "):
 			gotBondCount++
+			if !strings.Contains(args, "--ephemeral") {
+				t.Fatalf("bd mol bond args = %q, want --ephemeral", args)
+			}
 			assertTargetRig("mol bond", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
 		case strings.Contains(args, "update "+newBeadID) && strings.Contains(args, "--status=hooked"):
 			gotHook = true
@@ -429,9 +423,9 @@ exit /b 0
 		}
 	}
 
-	if !gotCreate || !gotTargetDBCheck || !gotPolecatCook || !gotPolecatWisp || !gotReviewCook || !gotReviewWisp || gotBondCount < 2 || !gotHook || !gotMetadata {
-		t.Fatalf("missing expected bd commands: create=%v targetDBCheck=%v polecat(cook=%v wisp=%v) review(cook=%v wisp=%v) bondCount=%d hook=%v metadata=%v (log: %q)",
-			gotCreate, gotTargetDBCheck, gotPolecatCook, gotPolecatWisp, gotReviewCook, gotReviewWisp, gotBondCount, gotHook, gotMetadata, string(logBytes))
+	if !gotCreate || !gotTargetDBCheck || !gotPolecatCook || !gotReviewCook || gotBondCount < 2 || !gotHook || !gotMetadata {
+		t.Fatalf("missing expected bd commands: create=%v targetDBCheck=%v polecatCook=%v reviewCook=%v bondCount=%d hook=%v metadata=%v (log: %q)",
+			gotCreate, gotTargetDBCheck, gotPolecatCook, gotReviewCook, gotBondCount, gotHook, gotMetadata, string(logBytes))
 	}
 }
 
@@ -1785,7 +1779,7 @@ exit /b 0
 
 // TestSlingFormulaOnBeadPassesFeatureAndIssueVars verifies that when using
 // gt sling <formula> --on <bead>, both --var feature=<title> and --var issue=<beadID>
-// are passed to the bd mol wisp command.
+// are passed to the canonical bd mol bond command.
 func TestSlingFormulaOnBeadPassesFeatureAndIssueVars(t *testing.T) {
 	townRoot := t.TempDir()
 
@@ -1811,7 +1805,7 @@ func TestSlingFormulaOnBeadPassesFeatureAndIssueVars(t *testing.T) {
 		t.Fatalf("write routes.jsonl: %v", err)
 	}
 
-	// Stub bd so we can observe the arguments passed to mol wisp.
+	// Stub bd so we can observe the arguments passed to mol bond.
 	binDir := filepath.Join(townRoot, "bin")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		t.Fatalf("mkdir binDir: %v", err)
@@ -1835,17 +1829,18 @@ case "$cmd" in
   cook)
     exit 0
     ;;
-  mol)
-    sub="$1"
-    shift || true
-    case "$sub" in
-      wisp)
-        echo '{"new_epic_id":"gt-wisp-xyz"}'
-        ;;
-      bond)
-        echo '{"root_id":"gt-wisp-xyz"}'
-        ;;
-    esac
+	  mol)
+		sub="$1"
+		shift || true
+		case "$sub" in
+		  wisp)
+			echo 'legacy mol wisp should not be called' >&2
+			exit 1
+			;;
+		  bond)
+			echo '{"result_id":"gt-abc123","id_mapping":{"mol-review":"gt-wisp-xyz"}}'
+			;;
+		esac
     ;;
 esac
 exit 0
@@ -1866,11 +1861,11 @@ if "%cmd%"=="formula" (
 if "%cmd%"=="cook" exit /b 0
 if "%cmd%"=="mol" (
   if "%sub%"=="wisp" (
-    echo {^"new_epic_id^":^"gt-wisp-xyz^"}
-    exit /b 0
+    echo legacy mol wisp should not be called 1>&2
+    exit /b 1
   )
   if "%sub%"=="bond" (
-    echo {^"root_id^":^"gt-wisp-xyz^"}
+    echo {^"result_id^":^"gt-abc123^",^"id_mapping^":{^"mol-review^":^"gt-wisp-xyz^"}}
     exit /b 0
   )
 )
@@ -1926,28 +1921,28 @@ exit /b 0
 		t.Fatalf("read bd log: %v", err)
 	}
 
-	// Find the mol wisp command and verify both --var arguments
+	// Find the mol bond command and verify both --var arguments
 	logLines := strings.Split(string(logBytes), "\n")
-	var wispLine string
+	var bondLine string
 	for _, line := range logLines {
-		if strings.Contains(line, "mol wisp") {
-			wispLine = line
+		if strings.Contains(line, "mol bond") {
+			bondLine = line
 			break
 		}
 	}
 
-	if wispLine == "" {
-		t.Fatalf("mol wisp command not found in log: %s", string(logBytes))
+	if bondLine == "" {
+		t.Fatalf("mol bond command not found in log: %s", string(logBytes))
 	}
 
 	// Verify --var feature=<title> is present
-	if !containsVarArg(wispLine, "feature", "My Test Feature") {
-		t.Errorf("mol wisp missing --var feature=<title>\ngot: %s", wispLine)
+	if !containsVarArg(bondLine, "feature", "My Test Feature") {
+		t.Errorf("mol bond missing --var feature=<title>\ngot: %s", bondLine)
 	}
 
 	// Verify --var issue=<beadID> is present
-	if !containsVarArg(wispLine, "issue", "gt-abc123") {
-		t.Errorf("mol wisp missing --var issue=<beadID>\ngot: %s", wispLine)
+	if !containsVarArg(bondLine, "issue", "gt-abc123") {
+		t.Errorf("mol bond missing --var issue=<beadID>\ngot: %s", bondLine)
 	}
 }
 
@@ -2332,10 +2327,11 @@ case "$cmd" in
     shift || true
     case "$sub" in
       wisp)
-        echo '{"new_epic_id":"gt-wisp-xyz"}'
+        echo 'legacy mol wisp should not be called' >&2
+        exit 1
         ;;
       bond)
-        echo '{"root_id":"gt-wisp-xyz"}'
+        echo '{"result_id":"gt-abc123","id_mapping":{"mol-polecat-work":"gt-wisp-xyz"}}'
         ;;
     esac
     ;;
@@ -2362,11 +2358,11 @@ if "%cmd%"=="formula" (
 if "%cmd%"=="cook" exit /b 0
 if "%cmd%"=="mol" (
   if "%sub%"=="wisp" (
-    echo {^"new_epic_id^":^"gt-wisp-xyz^"}
-    exit /b 0
+    echo legacy mol wisp should not be called 1>&2
+    exit /b 1
   )
   if "%sub%"=="bond" (
-    echo {^"root_id^":^"gt-wisp-xyz^"}
+    echo {^"result_id^":^"gt-abc123^",^"id_mapping^":{^"mol-polecat-work^":^"gt-wisp-xyz^"}}
     exit /b 0
   )
 )
@@ -2473,6 +2469,9 @@ exit /b 0
 	attachment := beads.ParseAttachmentFields(&beads.Issue{Description: string(descBytes)})
 	if attachment == nil {
 		t.Fatalf("parse attached fields returned nil:\n%s", string(descBytes))
+	}
+	if attachment.AttachedMolecule != "gt-wisp-xyz" {
+		t.Fatalf("attached_molecule = %q, want gt-wisp-xyz\nDescription:\n%s", attachment.AttachedMolecule, string(descBytes))
 	}
 	vars := map[string]string{}
 	for _, kv := range attachmentFormulaVars(attachment) {


### PR DESCRIPTION
Clean upstream/main port of gt-sling-formula-dependency-schema-mismatch.

What changed:
- Converges formula-on-bead onto the canonical direct bd mol bond path used by preflight.
- Removes the legacy bd mol wisp + wisp-to-bead bond/orphan cleanup path from sling formula flow.
- Clears stale attachment fields after nonfatal batch formula failure.
- Updates sling/formula tests around attachment parsing, failure cleanup, and formula bond behavior.

Evidence:
- Bead: gt-sling-formula-dependency-schema-clean-upstream-port.
- Original completed branch carried fork-main drift; this PR branch is cleanly based on upstream/main.
- git log origin/main..HEAD shows one intended commit and no WIP/checkpoint commits.
- git diff --check passed.
- Local verification passed:
  - CGO_ENABLED=0 go test -tags gms_pure_go ./internal/cmd -run "Test(Sling|Formula|Molecule|Attachment|Preflight|Batch|Polecat)" -count=1
  - CGO_ENABLED=0 go test -tags gms_pure_go ./internal/beads -count=1

Merge note:
- Bug fix, cleanup-first. Merge only after CI and PR Sheriff gates pass.