### PR TITLE
fix: collapse mol-orphan-scan scope default

### DIFF
--- a/internal/formula/formulas/mol-orphan-scan.formula.toml
+++ b/internal/formula/formulas/mol-orphan-scan.formula.toml
@@ -323,7 +323,6 @@ Dog returns to available state in the pool.
 [vars.scope]
 description = "Scan scope: 'town' or specific rig name"
 required = true
-default = "town"
 
 [vars.action]
 description = "Recovery action taken for an orphan (computed during execution)"


### PR DESCRIPTION
Clean upstream/main recovery PR for gt-mol-orphan-scan-formula-validation.\n\nWhat changed:\n- Removes the redundant default from vars.scope in mol-orphan-scan.\n- Leaves scope as the required caller-provided input, collapsing the invalid required+default formula shape.\n\nWhy:\n- bd formula validation rejects variables that are both required and defaulted.\n- Deacon orphan-scan dispatch was blocked by vars.scope having required=true and default=town.\n\nVerification:\n- bd --readonly cook internal/formula/formulas/mol-orphan-scan.formula.toml --dry-run\n- bd --readonly cook internal/formula/formulas/mol-orphan-scan.formula.toml --mode=runtime --var scope=town --dry-run\n- go test ./internal/formula -run 'TestParseRealFormulas|TestAllEmbeddedFormulas_VariableValidation|TestAllDogFormulas_CanBeWisped' -count=1\n- bd mol wisp mol-orphan-scan --var scope=town --dry-run\n\nRecovery note:\n- Original polecat completion pushed commit f07be70a1 to fork main and created a closed hq-prefixed MR. This PR is the clean upstream/main branch for review/merge.\n\nMerge note:\n- Bug fix, cleanup-first. Merge only after CI and PR Sheriff gates pass.