### PR TITLE
fix(daemon): checkpoint_dog fails to unstage nested runtime dirs (ac-d39p9)

### DIFF
--- a/internal/daemon/checkpoint_dog.go
+++ b/internal/daemon/checkpoint_dog.go
@@ -158,6 +158,19 @@ func (d *Daemon) checkpointWorktree(workDir, rigName, polecatName string) bool {
 		_, _ = runGitCmd(workDir, "reset", "HEAD", "--", dir)
 	}
 
+	// Unstage nested runtime/ephemeral dirs (e.g. web/.beads/, service/foo/.claude/).
+	// The root-level loop above only resets top-level dirs like .beads/ — it does NOT
+	// cover paths like web/.beads/redirect. When a file was previously tracked on the
+	// branch (committed before a gitignore rule landed), git add -A re-stages it on
+	// every checkpoint even though it is now gitignored, because git tracks changes to
+	// known paths regardless of .gitignore. Scanning staged paths and unstaging any
+	// that contain a runtime-dir component at any depth fixes this.
+	if stagedOut, err := runGitCmd(workDir, "diff", "--cached", "--name-only"); err == nil {
+		for _, dir := range nestedRuntimeArtifactDirs(stagedOut) {
+			_, _ = runGitCmd(workDir, "reset", "HEAD", "--", dir)
+		}
+	}
+
 	// Unstage deletions of tracked files. A checkpoint should preserve work
 	// (additions + modifications), never commit deletions of tracked files.
 	// This prevents the bug where a polecat's working tree has a missing
@@ -217,6 +230,42 @@ func resolveCheckpointWorkDir(polecatsDir, polecatName, rigName string) string {
 		return flat
 	}
 	return ""
+}
+
+// nestedRuntimeArtifactDirs scans staged file paths and returns the deduplicated
+// set of path prefixes that end at a runtime artifact directory component. It
+// skips root-level dirs (depth 0) because those are already handled by the
+// runtimeExcludeDirs reset loop. Only truly nested occurrences (depth ≥ 1) are
+// returned so callers can issue targeted git reset HEAD -- <prefix>/ commands.
+//
+// Example: given "web/.beads/redirect\nservice/foo/.claude/settings.json",
+// returns ["web/.beads/", "service/foo/.claude/"].
+func nestedRuntimeArtifactDirs(stagedOutput string) []string {
+	seen := make(map[string]bool)
+	var dirs []string
+	for _, f := range strings.Split(strings.TrimSpace(stagedOutput), "\n") {
+		if f == "" {
+			continue
+		}
+		parts := strings.Split(filepath.ToSlash(f), "/")
+		for i, part := range parts {
+			if i == 0 {
+				// Root-level already handled by runtimeExcludeDirs loop.
+				continue
+			}
+			for _, dir := range runtimeExcludeDirs {
+				if part == strings.TrimSuffix(dir, "/") {
+					prefix := strings.Join(parts[:i+1], "/") + "/"
+					if !seen[prefix] {
+						seen[prefix] = true
+						dirs = append(dirs, prefix)
+					}
+					break
+				}
+			}
+		}
+	}
+	return dirs
 }
 
 // runGitCmd executes a git command in the given directory and returns stdout.

--- a/internal/daemon/checkpoint_dog_test.go
+++ b/internal/daemon/checkpoint_dog_test.go
@@ -204,3 +204,61 @@ func TestIsGitWorktree(t *testing.T) {
 		t.Error(".git file (linked worktree) should count as worktree")
 	}
 }
+
+func TestNestedRuntimeArtifactDirs_Empty(t *testing.T) {
+	if got := nestedRuntimeArtifactDirs(""); len(got) != 0 {
+		t.Errorf("expected empty for empty input, got %v", got)
+	}
+}
+
+func TestNestedRuntimeArtifactDirs_RootLevelSkipped(t *testing.T) {
+	// Root-level runtime dirs are already handled by runtimeExcludeDirs loop.
+	got := nestedRuntimeArtifactDirs(".beads/redirect\n.claude/settings.json")
+	if len(got) != 0 {
+		t.Errorf("expected root-level dirs to be skipped, got %v", got)
+	}
+}
+
+func TestNestedRuntimeArtifactDirs_NestedBeads(t *testing.T) {
+	// web/.beads/redirect — the exact bug that triggered this fix.
+	got := nestedRuntimeArtifactDirs("web/.beads/redirect")
+	if len(got) != 1 || got[0] != "web/.beads/" {
+		t.Errorf("expected [web/.beads/], got %v", got)
+	}
+}
+
+func TestNestedRuntimeArtifactDirs_DeepNested(t *testing.T) {
+	// service/accent-ci/.beads/redirect — two-level prefix.
+	got := nestedRuntimeArtifactDirs("service/accent-ci/.beads/redirect")
+	if len(got) != 1 || got[0] != "service/accent-ci/.beads/" {
+		t.Errorf("expected [service/accent-ci/.beads/], got %v", got)
+	}
+}
+
+func TestNestedRuntimeArtifactDirs_MultipleDeduped(t *testing.T) {
+	// Two staged files under the same nested dir should produce only one entry.
+	input := "web/.beads/redirect\nweb/.beads/other-file"
+	got := nestedRuntimeArtifactDirs(input)
+	if len(got) != 1 || got[0] != "web/.beads/" {
+		t.Errorf("expected deduped [web/.beads/], got %v", got)
+	}
+}
+
+func TestNestedRuntimeArtifactDirs_MixedRootAndNested(t *testing.T) {
+	// Root-level skipped; nested collected.
+	input := ".beads/redirect\nweb/.beads/redirect\nservice/foo/.claude/settings.json"
+	got := nestedRuntimeArtifactDirs(input)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 nested dirs, got %v", got)
+	}
+	gotSet := make(map[string]bool)
+	for _, d := range got {
+		gotSet[d] = true
+	}
+	if !gotSet["web/.beads/"] {
+		t.Errorf("missing web/.beads/ in %v", got)
+	}
+	if !gotSet["service/foo/.claude/"] {
+		t.Errorf("missing service/foo/.claude/ in %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- **Bug**: The `runtimeExcludeDirs` reset loop in `checkpointWorktree()` only ran `git reset HEAD -- .beads/`, which covers the repo-root `.beads/` directory but not nested occurrences like `web/.beads/` or `service/accent-ci/.beads/`.
- **Mechanism**: Once a file is tracked in git (committed before a gitignore rule), `git add -A` re-stages it on every checkpoint regardless of `.gitignore`. The existing root-level reset did not reach nested paths, so files like `web/.beads/redirect` kept appearing in WIP checkpoints.
- **Fix**: After the root-level reset loop, scan staged paths with `git diff --cached --name-only`, collect unique path prefixes that end at a runtime-dir component at depth ≥ 1 (`nestedRuntimeArtifactDirs()`), and issue a targeted `git reset HEAD -- <prefix>/` for each. Root-level dirs continue to be handled by the existing loop.

## Repro

Commit a `.beads/redirect` file anywhere other than the repo root on a polecat branch, add `**/.beads/redirect` to `.gitignore`, then let checkpoint_dog run. Before this fix, the file is staged again on every WIP checkpoint. After this fix, it is correctly excluded.

## Test Plan

- [ ] `TestNestedRuntimeArtifactDirs_Empty` — empty input returns no dirs
- [ ] `TestNestedRuntimeArtifactDirs_RootLevelSkipped` — root-level dirs are skipped (handled by existing loop)
- [ ] `TestNestedRuntimeArtifactDirs_NestedBeads` — `web/.beads/redirect` → `web/.beads/`
- [ ] `TestNestedRuntimeArtifactDirs_DeepNested` — `service/accent-ci/.beads/redirect` → `service/accent-ci/.beads/`
- [ ] `TestNestedRuntimeArtifactDirs_MultipleDeduped` — two staged files under same nested dir produce one entry
- [ ] `TestNestedRuntimeArtifactDirs_MixedRootAndNested` — root-level skipped, nested collected

All 6 new tests pass alongside existing `TestCheckpointDog*`, `TestIsGitWorktree`, and `TestResolveCheckpointWorkDir*` tests.

Closes ac-d39p9 (accent rig bead: gt-pvx auto-save FORCE-ADDS .beads/redirect, bypassing **/.beads/redirect gitignore)