### PR TITLE
Fix hook show in routed rig workspaces

### DIFF
--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -503,7 +503,19 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 			if rigName != "" && rigName != "mayor" && rigName != "deacon" {
 				// Agent beads can be stale or missing during recovery. The source
 				// work assignment is authoritative, so query the target rig DB directly.
-				workDir = filepath.Join(townRoot, rigName, "mayor", "rig")
+				//
+				// Do not hardcode <rig>/mayor/rig here: routed Gas Town workspaces
+				// can store the rig beads database at the rig root while keeping
+				// source code in mayor/rig. ResolveHookDir follows routes.jsonl and
+				// supports both layouts.
+				role, _, _ := parseRoleString(target)
+				agentBeadID := buildAgentBeadID(target, role, townRoot)
+				fallbackPath := filepath.Join(townRoot, rigName)
+				if resolved := beads.ResolveHookDir(townRoot, agentBeadID, fallbackPath); resolved != "" {
+					workDir = resolved
+				} else {
+					workDir = fallbackPath
+				}
 			}
 		}
 	}

--- a/internal/cmd/hook_show_integration_test.go
+++ b/internal/cmd/hook_show_integration_test.go
@@ -107,3 +107,74 @@ func TestHookShowShorthandResolvesToCanonical(t *testing.T) {
 			active.BeadID, active.Status, issue.ID)
 	}
 }
+
+func TestHookShowRoutedRigRootBeads(t *testing.T) {
+	if _, err := exec.LookPath("bd"); err != nil {
+		t.Skip("bd not installed, skipping integration test")
+	}
+
+	townRoot, polecatDir, rigPrefix := setupHookTestTown(t)
+
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	if err := beads.WriteRoutes(townBeadsDir, []beads.Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: rigPrefix + "-", Path: "gastown"},
+	}); err != nil {
+		t.Fatalf("rewrite routes: %v", err)
+	}
+
+	rigRoot := filepath.Join(townRoot, "gastown")
+	initBeadsDBWithPrefix(t, rigRoot, rigPrefix)
+
+	b := beads.New(rigRoot)
+	issue, err := b.Create(beads.CreateOptions{
+		Title:    "Hook show routed rig root test",
+		Type:     "task",
+		Priority: 2,
+	})
+	if err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	hooked := beads.StatusHooked
+	assignee := "gastown/polecats/toast"
+	if err := b.Update(issue.ID, beads.UpdateOptions{
+		Status:   &hooked,
+		Assignee: &assignee,
+	}); err != nil {
+		t.Fatalf("hook issue: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir to town root: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+
+	prevJSON := moleculeJSON
+	moleculeJSON = true
+	t.Cleanup(func() {
+		moleculeJSON = prevJSON
+	})
+
+	out := captureStdout(t, func() {
+		if err := runHookShow(nil, []string{"gastown/polecats/toast"}); err != nil {
+			t.Fatalf("runHookShow: %v", err)
+		}
+	})
+	var parsed hookShowJSON
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("parse runHookShow output %q: %v", out, err)
+	}
+	if parsed.BeadID != issue.ID || parsed.Status != beads.StatusHooked {
+		t.Fatalf("routed rig-root target mismatch: got bead=%q status=%q, want bead=%q status=%q",
+			parsed.BeadID, parsed.Status, issue.ID, beads.StatusHooked)
+	}
+
+	_ = polecatDir
+}

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
-	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -37,7 +36,7 @@ func buildAgentBeadID(identity string, role Role, townRoot string) string {
 
 	// Helper to get prefix for a rig
 	getPrefix := func(rig string) string {
-		return config.GetRigPrefix(townRoot, rig)
+		return beads.GetPrefixForRig(townRoot, rig)
 	}
 
 	// If role is unknown or empty, try to infer from identity


### PR DESCRIPTION
## Summary
- resolve `gt hook show <rig>/<agent>` through route-aware rig Beads locations instead of hardcoding `<rig>/mayor/rig`
- build agent bead IDs using route-aware rig prefixes from `routes.jsonl`
- add an integration regression test for rig-root Beads databases

## Tests
- `CGO_ENABLED=0 go test ./internal/cmd -run 'TestNormalizeHookShowTarget|TestTownLevelRole|TestHookShow'`
- `CGO_ENABLED=0 go test -tags=integration ./internal/cmd -run 'TestHookShow'`
- `CGO_ENABLED=0 go test ./internal/cmd -run 'TestInstantiateFormulaOnBead|TestSlingFormulaOnBead|TestFormulaOnBead|TestCookFormula|TestSlingHookRawBeadFlag|TestResolveFormula'`