### PR TITLE
Persist convoy close state to JSONL

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -848,6 +848,9 @@ func runConvoyAdd(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("couldn't clear convoy completion notification state: %w", err)
 			}
 		}
+		if err := persistTownBeadsJSONL(townBeads); err != nil {
+			return fmt.Errorf("couldn't persist reopened convoy to JSONL: %w", err)
+		}
 		reopened = true
 		fmt.Printf("%s Reopened convoy %s\n", style.Bold.Render("↺"), convoyID)
 	}
@@ -960,6 +963,9 @@ func closeConvoyIfComplete(townBeads, convoyID, title string, tracked []trackedI
 	closeArgs := []string{"close", convoyID, "-r", reason}
 	if err := BdCmd(closeArgs...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
 		return false, fmt.Errorf("closing convoy: %w", err)
+	}
+	if err := persistTownBeadsJSONL(townBeads); err != nil {
+		return false, fmt.Errorf("persisting convoy close to JSONL: %w", err)
 	}
 
 	fmt.Printf("%s Auto-closed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, title)
@@ -1110,6 +1116,9 @@ func runConvoyClose(cmd *cobra.Command, args []string) error {
 	closeArgs := []string{"close", convoyID, "-r", reason}
 	if err := BdCmd(closeArgs...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
 		return fmt.Errorf("closing convoy: %w", err)
+	}
+	if err := persistTownBeadsJSONL(townBeads); err != nil {
+		return fmt.Errorf("persisting convoy close to JSONL: %w", err)
 	}
 
 	fmt.Printf("%s Closed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, convoy.Title)
@@ -1283,6 +1292,9 @@ func runConvoyLand(cmd *cobra.Command, args []string) error {
 	closeArgs := []string{"close", convoyID, "-r", reason}
 	if err := BdCmd(closeArgs...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
 		return fmt.Errorf("closing convoy: %w", err)
+	}
+	if err := persistTownBeadsJSONL(townBeads); err != nil {
+		return fmt.Errorf("persisting convoy close to JSONL: %w", err)
 	}
 
 	fmt.Printf("\n%s Landed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, convoy.Title)
@@ -1683,6 +1695,19 @@ func checkAndCloseCompletedConvoys(townBeads string, dryRun bool) ([]struct{ ID,
 	return closed, nil
 }
 
+// persistTownBeadsJSONL writes the current town Beads state to the JSONL file
+// used by bd's fallback import path. Convoy close/check suppresses bd's implicit
+// auto-export for normal command hygiene, but close state must survive a later
+// Dolt rebuild from .beads/issues.jsonl.
+func persistTownBeadsJSONL(townBeads string) error {
+	beadsDir := beads.ResolveBeadsDir(townBeads)
+	if beadsDir == "" {
+		return fmt.Errorf("could not resolve town .beads directory")
+	}
+	issuesPath := filepath.Join(beadsDir, "issues.jsonl")
+	return BdCmd("export", "-o", issuesPath).Dir(townBeads).Run()
+}
+
 // notifyConvoyCompletion sends notifications to owner, any notify addresses, and mayor/.
 func notifyConvoyCompletion(townBeads, convoyID, title string) {
 	stdout, err := runBdJSON(townBeads, "show", convoyID, "--json")
@@ -1710,6 +1735,10 @@ func notifyConvoyCompletion(townBeads, convoyID, title string) {
 	newDesc := beads.SetConvoyFields(&beads.Issue{Description: convoys[0].Description}, fields)
 	if err := BdCmd("update", convoyID, "--description="+newDesc).Dir(townBeads).WithAutoCommit().Run(); err != nil {
 		style.PrintWarning("could not record convoy completion notification state for %s: %v", convoyID, err)
+		return
+	}
+	if err := persistTownBeadsJSONL(townBeads); err != nil {
+		style.PrintWarning("could not persist convoy completion notification state for %s: %v", convoyID, err)
 		return
 	}
 

--- a/internal/cmd/convoy_notification_test.go
+++ b/internal/cmd/convoy_notification_test.go
@@ -21,11 +21,13 @@ func TestNotifyConvoyCompletion_StampsAndSkipsDuplicate(t *testing.T) {
 
 	statePath := filepath.Join(binDir, "notified.state")
 	mailLogPath := filepath.Join(binDir, "mail.log")
+	exportLogPath := filepath.Join(binDir, "export.log")
 	bdPath := filepath.Join(binDir, "bd")
 	gtPath := filepath.Join(binDir, "gt")
 
 	bdScript := `#!/bin/sh
 STATE="` + statePath + `"
+EXPORT_LOG="` + exportLogPath + `"
 if [ "$1" = "--allow-stale" ]; then
   shift
 fi
@@ -43,6 +45,10 @@ case "$1" in
     ;;
   update)
     touch "$STATE"
+    exit 0
+    ;;
+  export)
+    echo "$@" >> "$EXPORT_LOG"
     exit 0
     ;;
   sql)
@@ -79,5 +85,104 @@ exit 0
 	}
 	if _, err := os.Stat(statePath); err != nil {
 		t.Fatalf("completion notification state was not recorded: %v", err)
+	}
+	exportData, err := os.ReadFile(exportLogPath)
+	if err != nil {
+		t.Fatalf("read export log: %v", err)
+	}
+	if got := strings.Count(string(exportData), "export -o"); got != 1 {
+		t.Fatalf("bd export calls = %d, want 1; log:\n%s", got, string(exportData))
+	}
+	if !strings.Contains(string(exportData), filepath.Join(townRoot, ".beads", "issues.jsonl")) {
+		t.Fatalf("bd export did not target town issues.jsonl; log:\n%s", string(exportData))
+	}
+}
+
+func TestCloseConvoyIfComplete_ExportsJSONLBeforeNotification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	binDir := t.TempDir()
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	orderPath := filepath.Join(binDir, "order.log")
+	bdPath := filepath.Join(binDir, "bd")
+	gtPath := filepath.Join(binDir, "gt")
+
+	bdScript := `#!/bin/sh
+ORDER="` + orderPath + `"
+if [ "$1" = "--allow-stale" ]; then
+  shift
+fi
+case "$1" in
+  version)
+    exit 0
+    ;;
+  close)
+    echo close >> "$ORDER"
+    exit 0
+    ;;
+  export)
+    echo export:"$@" >> "$ORDER"
+    exit 0
+    ;;
+  show)
+    printf '%s\n' '[{"id":"hq-cv-done","description":"Owner: mayor/","created_at":"2026-05-25T02:00:00Z"}]'
+    exit 0
+    ;;
+  update)
+    echo update >> "$ORDER"
+    exit 0
+    ;;
+  sql)
+    printf '%s\n' '[]'
+    exit 0
+    ;;
+esac
+exit 1
+`
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	gtScript := `#!/bin/sh
+if [ "$1" = "mail" ] && [ "$2" = "send" ]; then
+  echo mail >> "` + orderPath + `"
+fi
+exit 0
+`
+	if err := os.WriteFile(gtPath, []byte(gtScript), 0755); err != nil {
+		t.Fatalf("write gt stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	closed, err := closeConvoyIfComplete(townRoot, "hq-cv-done", "Done Convoy", []trackedIssueInfo{
+		{ID: "gt-done", Status: "closed"},
+	}, false)
+	if err != nil {
+		t.Fatalf("closeConvoyIfComplete returned error: %v", err)
+	}
+	if !closed {
+		t.Fatal("closeConvoyIfComplete returned closed=false, want true")
+	}
+
+	data, err := os.ReadFile(orderPath)
+	if err != nil {
+		t.Fatalf("read order log: %v", err)
+	}
+	got := strings.TrimSpace(string(data))
+	want := strings.Join([]string{
+		"close",
+		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
+		"update",
+		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
+		"mail",
+	}, "\n")
+	if got != want {
+		t.Fatalf("operation order mismatch:\n got:\n%s\nwant:\n%s", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- export town Beads JSONL after convoy close/reopen lifecycle mutations
- export again after recording convoy completion notification state before sending mail
- add regression coverage for close export ordering and duplicate notification guard

## Tests
- CGO_CPPFLAGS="-I/opt/homebrew/opt/icu4c@78/include" CGO_LDFLAGS="-L/opt/homebrew/opt/icu4c@78/lib" PKG_CONFIG_PATH="/opt/homebrew/opt/icu4c@78/lib/pkgconfig" go test ./internal/cmd -run 'TestNotifyConvoyCompletion_StampsAndSkipsDuplicate|TestCloseConvoyIfComplete_ExportsJSONLBeforeNotification' -count=1
- ./gastown-src/bin/gt convoy check hq-cv-472mo && ./gastown-src/bin/gt convoy check hq-cv-472mo

Note: broader convoy test sweep currently hits unrelated macOS /private/var vs /var temp path assertions in sling_batch_test.