### PR TITLE
fix: guard safety-stopped refinery starts

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -357,7 +357,7 @@ func (b *Beads) CreateOrReopenAgentBead(id, title string, fields *AgentFields) (
 	updateOpts := UpdateOptions{
 		Title:       &title,
 		Description: &description,
-		SetLabels:   []string{"gt:agent"},
+		SetLabels:   labelsForAgentBeadReuse(existing.Labels),
 	}
 	if err := target.Update(id, updateOpts); err != nil {
 		return nil, fmt.Errorf("updating agent bead: %w", err)
@@ -368,6 +368,19 @@ func (b *Beads) CreateOrReopenAgentBead(id, title string, fields *AgentFields) (
 
 	// Return the updated bead
 	return target.Show(id)
+}
+
+func labelsForAgentBeadReuse(existing []string) []string {
+	labels := []string{"gt:agent"}
+	seen := map[string]bool{"gt:agent": true}
+	for _, label := range existing {
+		if !strings.HasPrefix(label, "safety_stop:") || seen[label] {
+			continue
+		}
+		labels = append(labels, label)
+		seen[label] = true
+	}
+	return labels
 }
 
 // ResetAgentBeadForReuse clears all mutable fields on an agent bead without closing it.

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -348,6 +348,27 @@ func TestMergeAgentBeadSources(t *testing.T) {
 	})
 }
 
+func TestLabelsForAgentBeadReusePreservesOnlySafetyStop(t *testing.T) {
+	got := labelsForAgentBeadReuse([]string{
+		"gt:agent",
+		"heartbeat:123",
+		"idle:2",
+		"done-intent:COMPLETED:123",
+		"safety_stop:hq-vmrwr",
+		"safety_stop:hq-vmrwr",
+		"safety_stop:hq-other",
+	})
+	want := []string{"gt:agent", "safety_stop:hq-vmrwr", "safety_stop:hq-other"}
+	if len(got) != len(want) {
+		t.Fatalf("labels = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("labels = %v, want %v", got, want)
+		}
+	}
+}
+
 func installMockBDCreateRecorder(t *testing.T, logPath string) {
 	t.Helper()
 

--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/cli"
+	"github.com/steveyegge/gastown/internal/refinery"
 	"github.com/steveyegge/gastown/internal/style"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -201,6 +203,12 @@ func burnPreviousPatrolWisps(cfg PatrolConfig) {
 // self-cleaning regardless of the caller.
 // Returns the patrol ID or an error.
 func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
+	if stop, err := refineryPatrolSafetyStop(cfg); err != nil {
+		return "", err
+	} else if stop != nil {
+		return "", refinery.NewSafetyStoppedError(stop)
+	}
+
 	// Resolve the beads directory following redirects.
 	// This ensures bd targets the correct database (e.g., rig database
 	// instead of HQ) regardless of inherited BEADS_DIR. See gt-ctir.
@@ -331,6 +339,10 @@ func outputPatrolContext(cfg PatrolConfig) {
 		var err error
 		patrolID, err = autoSpawnPatrol(cfg)
 		if err != nil {
+			if errors.Is(err, refinery.ErrSafetyStopped) {
+				fmt.Println(style.Dim.Render(err.Error()))
+				return
+			}
 			if patrolID != "" {
 				fmt.Printf("⚠ %s\n", err.Error())
 			} else {
@@ -357,4 +369,15 @@ func outputPatrolContext(cfg PatrolConfig) {
 		fmt.Println()
 		fmt.Printf("Current patrol ID: %s\n", patrolID)
 	}
+}
+
+func refineryPatrolSafetyStop(cfg PatrolConfig) (*refinery.SafetyStop, error) {
+	if cfg.RoleName != "refinery" {
+		return nil, nil
+	}
+	rigName := strings.TrimSuffix(cfg.Assignee, "/refinery")
+	if rigName == cfg.Assignee || rigName == "" {
+		return nil, nil
+	}
+	return refinery.ActiveSafetyStop(cfg.BeadsDir, rigName)
 }

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -5,16 +5,21 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/refinery"
 	"github.com/steveyegge/gastown/internal/testutil"
 )
 
@@ -90,6 +95,78 @@ func TestBuildRefineryPatrolVars_MissingSettings(t *testing.T) {
 	if got := varMap["target_branch"]; got != "main" {
 		t.Errorf("target_branch = %q, want %q", got, "main")
 	}
+}
+
+func TestAutoSpawnPatrol_RefinerySafetyStoppedSkipsWispCreate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock bd script uses POSIX shell")
+	}
+	townRoot := setupRefinerySafetyStopTown(t)
+	logPath := installRefinerySafetyStopMockBD(t)
+
+	_, err := autoSpawnPatrol(PatrolConfig{
+		RoleName:      "refinery",
+		PatrolMolName: constants.MolRefineryPatrol,
+		BeadsDir:      townRoot,
+		Assignee:      "testrig/refinery",
+	})
+	if !errors.Is(err, refinery.ErrSafetyStopped) {
+		t.Fatalf("autoSpawnPatrol error = %v, want ErrSafetyStopped", err)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	if strings.Contains(string(logData), "mol wisp create") || strings.Contains(string(logData), "update ") {
+		t.Fatalf("autoSpawnPatrol mutated patrol state despite safety stop; log:\n%s", logData)
+	}
+}
+
+func setupRefinerySafetyStopTown(t *testing.T) string {
+	t.Helper()
+	townRoot := t.TempDir()
+	for _, dir := range []string{filepath.Join(townRoot, "mayor"), filepath.Join(townRoot, ".beads"), filepath.Join(townRoot, "testrig")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+	return townRoot
+}
+
+func installRefinerySafetyStopMockBD(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "bd.log")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+case "$cmd" in
+  version)
+    echo "bd test"
+    ;;
+  show)
+    printf '%s\n' '[{"id":"gt-testrig-refinery","title":"Refinery","issue_type":"task","labels":["gt:agent","safety_stop:hq-vmrwr"],"status":"open","description":"role_type: refinery\nrig: testrig\nagent_state: idle"}]'
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
 }
 
 func TestBuildRefineryPatrolVars_NilMergeQueue(t *testing.T) {
@@ -343,8 +420,8 @@ func TestBuildRefineryPatrolVars_BoolFormat(t *testing.T) {
 	trueVal := true
 	falseVal2 := false
 	mq := &config.MergeQueueConfig{
-		Enabled:                         true,
-		IntegrationBranchAutoLand:       &trueVal,
+		Enabled:                          true,
+		IntegrationBranchAutoLand:        &trueVal,
 		IntegrationBranchRefineryEnabled: &trueVal,
 		RunTests:                         &trueVal,
 		SetupCommand:                     "npm ci",

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -18,6 +18,7 @@ import (
 	"github.com/steveyegge/gastown/internal/cli"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/lock"
+	"github.com/steveyegge/gastown/internal/refinery"
 	"github.com/steveyegge/gastown/internal/state"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/telemetry"
@@ -687,6 +688,14 @@ func checkSlungWork(ctx RoleContext, hookedBead *beads.Issue) (bool, error) {
 	if hookedBead == nil {
 		return false, nil
 	}
+	if ctx.Role == RoleRefinery {
+		if stop, err := refinery.ActiveSafetyStop(ctx.TownRoot, ctx.Rig); err != nil {
+			return true, fmt.Errorf("checking refinery safety stop: %w", err)
+		} else if stop != nil {
+			outputRefinerySafetyStopDirective(ctx, stop)
+			return true, nil
+		}
+	}
 
 	attachment := beads.ParseAttachmentFields(hookedBead)
 	hasWorkflow := hasWorkflowAttachment(attachment)
@@ -703,6 +712,14 @@ func checkSlungWork(ctx RoleContext, hookedBead *beads.Issue) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func outputRefinerySafetyStopDirective(ctx RoleContext, stop *refinery.SafetyStop) {
+	fmt.Println()
+	fmt.Printf("%s\n", style.Bold.Render("## REFINERY SAFETY STOP ACTIVE"))
+	fmt.Printf("Refinery %s is %s.\n", ctx.Rig, stop.Reason())
+	fmt.Println("Hooked refinery work remains parked; do not run patrol, MR, or merge workflow until Mayor clears the safety_stop label.")
+	fmt.Println()
 }
 
 func hasWorkflowAttachment(attachment *beads.AttachmentFields) bool {

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/deacon"
 	"github.com/steveyegge/gastown/internal/formula"
+	"github.com/steveyegge/gastown/internal/refinery"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
 )
@@ -370,6 +371,13 @@ func outputWitnessPatrolContext(ctx RoleContext) {
 func outputRefineryPatrolContext(ctx RoleContext) {
 	if stopped, reason := IsRigParkedOrDocked(ctx.TownRoot, ctx.Rig); stopped {
 		fmt.Printf("\n⏸️  Rig %s is %s — skipping patrol wisp generation.\n", ctx.Rig, reason)
+		return
+	}
+	if stop, err := refinery.ActiveSafetyStop(ctx.TownRoot, ctx.Rig); err != nil {
+		style.PrintWarning("could not check refinery safety stop: %v", err)
+		return
+	} else if stop != nil {
+		fmt.Printf("\nRefinery %s is %s; skipping patrol wisp generation.\n", ctx.Rig, stop.Reason())
 		return
 	}
 	cfg := PatrolConfig{

--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -15,6 +15,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/deacon"
+	"github.com/steveyegge/gastown/internal/refinery"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
@@ -518,6 +519,20 @@ func outputStartupDirective(ctx RoleContext) {
 			fmt.Println("---")
 			fmt.Println()
 			fmt.Printf("Rig %s is %s. No patrol needed. Exit cleanly.\n", ctx.Rig, reason)
+			return
+		}
+		if stop, err := refinery.ActiveSafetyStop(ctx.TownRoot, ctx.Rig); err != nil {
+			fmt.Println()
+			fmt.Println("---")
+			fmt.Println()
+			style.PrintWarning("could not check refinery safety stop: %v", err)
+			fmt.Println("No patrol needed. Exit cleanly until safety-stop state can be verified.")
+			return
+		} else if stop != nil {
+			fmt.Println()
+			fmt.Println("---")
+			fmt.Println()
+			fmt.Printf("Refinery %s is %s. No patrol needed. Exit cleanly.\n", ctx.Rig, stop.Reason())
 			return
 		}
 		fmt.Println()

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -954,6 +955,62 @@ func TestCheckSlungWork_StandaloneFormulaUsesWorkflowOutput(t *testing.T) {
 	}
 	if !strings.Contains(output, "--var version=1.2.3") {
 		t.Fatalf("expected standalone formula context to be shown, got:\n%s", output)
+	}
+}
+
+func TestCheckSlungWork_RefinerySafetyStoppedSkipsWorkflowOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock bd script uses POSIX shell")
+	}
+	townRoot := setupRefinerySafetyStopTown(t)
+	installRefinerySafetyStopMockBD(t)
+
+	ctx := RoleContext{Role: RoleRefinery, Rig: "testrig", TownRoot: townRoot}
+	hookedBead := &beads.Issue{
+		ID:    "gt-wisp-refinery",
+		Title: constants.MolRefineryPatrol,
+		Description: strings.Join([]string{
+			"attached_formula: " + constants.MolRefineryPatrol,
+			`attached_vars: ["target_branch=main"]`,
+		}, "\n"),
+	}
+
+	var found bool
+	var gotErr error
+	output := captureStdout(t, func() {
+		found, gotErr = checkSlungWork(ctx, hookedBead)
+	})
+	if gotErr != nil {
+		t.Fatalf("checkSlungWork() error = %v", gotErr)
+	}
+	if !found {
+		t.Fatalf("checkSlungWork() = false, want true")
+	}
+	if !strings.Contains(output, "REFINERY SAFETY STOP ACTIVE") {
+		t.Fatalf("expected safety-stop directive, got:\n%s", output)
+	}
+	for _, forbidden := range []string{"ATTACHED FORMULA", "AUTONOMOUS WORK MODE", "Work through each patrol step"} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("did not expect %q while safety-stopped, got:\n%s", forbidden, output)
+		}
+	}
+}
+
+func TestOutputStartupDirective_RefinerySafetyStoppedSkipsPatrolNew(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock bd script uses POSIX shell")
+	}
+	townRoot := setupRefinerySafetyStopTown(t)
+	installRefinerySafetyStopMockBD(t)
+
+	output := captureStdout(t, func() {
+		outputStartupDirective(RoleContext{Role: RoleRefinery, Rig: "testrig", TownRoot: townRoot})
+	})
+	if !strings.Contains(output, "No patrol needed. Exit cleanly.") {
+		t.Fatalf("expected safety-stop startup directive, got:\n%s", output)
+	}
+	if strings.Contains(output, "gt patrol new") || strings.Contains(output, "create patrol") {
+		t.Fatalf("startup directive should not tell safety-stopped refinery to create patrol, got:\n%s", output)
 	}
 }
 

--- a/internal/cmd/refinery.go
+++ b/internal/cmd/refinery.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -496,7 +497,7 @@ func runRefineryAttach(cmd *cobra.Command, args []string) error {
 	}
 
 	// Use getRefineryManager to validate rig (and infer from cwd if needed)
-	mgr, _, rigName, err := getRefineryManager(rigName)
+	mgr, r, rigName, err := getRefineryManager(rigName)
 	if err != nil {
 		return err
 	}
@@ -509,6 +510,17 @@ func runRefineryAttach(cmd *cobra.Command, args []string) error {
 	running, err := t.HasSession(sessionID)
 	if err != nil {
 		return fmt.Errorf("checking session: %w", err)
+	}
+	if stop, err := refinery.ActiveSafetyStop(filepath.Dir(r.Path), rigName); err != nil {
+		return fmt.Errorf("checking refinery safety stop: %w", err)
+	} else if stop != nil {
+		if running {
+			fmt.Printf("Refinery %s is safety-stopped; stopping leftover session %s.\n", rigName, sessionID)
+			if err := mgr.Stop(); err != nil && err != refinery.ErrNotRunning {
+				return fmt.Errorf("%w: stopping leftover refinery session: %v", refinery.NewSafetyStoppedError(stop), err)
+			}
+		}
+		return refinery.NewSafetyStoppedError(stop)
 	}
 	if !running {
 		// Auto-start if not running
@@ -529,7 +541,7 @@ func runRefineryRestart(cmd *cobra.Command, args []string) error {
 		rigName = args[0]
 	}
 
-	mgr, _, rigName, err := getRefineryManager(rigName)
+	mgr, r, rigName, err := getRefineryManager(rigName)
 	if err != nil {
 		return err
 	}
@@ -539,6 +551,14 @@ func runRefineryRestart(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Restarting refinery for %s...\n", rigName)
+	if stop, err := refinery.ActiveSafetyStop(filepath.Dir(r.Path), rigName); err != nil {
+		return fmt.Errorf("checking refinery safety stop: %w", err)
+	} else if stop != nil {
+		if err := mgr.Stop(); err != nil && err != refinery.ErrNotRunning {
+			return fmt.Errorf("%w: stopping leftover refinery session: %v", refinery.NewSafetyStoppedError(stop), err)
+		}
+		return refinery.NewSafetyStoppedError(stop)
+	}
 
 	// Stop if running (ignore ErrNotRunning)
 	if err := mgr.Stop(); err != nil && err != refinery.ErrNotRunning {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1797,6 +1797,20 @@ func (d *Daemon) ensureRefineryRunning(rigName string) {
 		}
 		return
 	}
+	if stop, err := refinery.ActiveSafetyStop(d.config.TownRoot, rigName); err != nil {
+		d.logger.Printf("Skipping refinery auto-start for %s: cannot verify safety stop: %v", rigName, err)
+		return
+	} else if stop != nil {
+		d.logger.Printf("Skipping refinery auto-start for %s: %s", rigName, stop.Reason())
+		name := session.RefinerySessionName(session.PrefixFor(rigName))
+		if exists, _ := d.tmux.HasSession(name); exists {
+			d.logger.Printf("Killing leftover refinery %s (%s)", name, stop.Reason())
+			if err := d.tmux.KillSessionWithProcesses(name); err != nil {
+				d.logger.Printf("Error killing leftover refinery %s: %v", name, err)
+			}
+		}
+		return
+	}
 
 	// Event gate: don't spawn a new Claude session when there's nothing to process.
 	// If a refinery session is already running, Start() returns ErrAlreadyRunning (cheap).
@@ -1831,9 +1845,13 @@ func (d *Daemon) ensureRefineryRunning(rigName string) {
 	// See: daemon.log "is hung (no activity for 30m0s), killing for restart"
 
 	if err := mgr.Start(false, ""); err != nil {
-		if err == refinery.ErrAlreadyRunning {
+		if errors.Is(err, refinery.ErrAlreadyRunning) {
 			// Already running - this is the expected case when fix is working
 			d.logger.Printf("Refinery for %s already running, skipping spawn", rigName)
+			return
+		}
+		if errors.Is(err, refinery.ErrSafetyStopped) {
+			d.logger.Printf("Skipping refinery auto-start for %s: %v", rigName, err)
 			return
 		}
 		d.logger.Printf("Error starting refinery for %s: %v", rigName, err)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+	"github.com/steveyegge/gastown/internal/tmux"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -150,6 +151,86 @@ func TestSyncWorkspaceRefusesTownRootWorkDir(t *testing.T) {
 		t.Fatalf("HEAD changed after nested sync: got %s, want %s", got, headBefore)
 	}
 	assertDaemonTownFilesPreserved(t, townRoot, filesBefore)
+}
+
+func TestEnsureRefineryRunningSafetyStoppedDoesNotSpawn(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock bd/tmux scripts use POSIX shell")
+	}
+	townRoot := t.TempDir()
+	writeDaemonTownFile(t, townRoot, "mayor/town.json", `{"name":"test"}`)
+	writeDaemonTownFile(t, townRoot, ".beads/metadata.json", `{"prefix":"hq"}`)
+	writeDaemonTownFile(t, townRoot, "events/refinery/pending.event", "{}")
+	if err := os.MkdirAll(filepath.Join(townRoot, "testrig"), 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "commands.log")
+	writeDaemonSafetyStopMockBD(t, binDir, logPath)
+	writeDaemonSafetyStopMockTmux(t, binDir, logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	d := &Daemon{
+		config: DefaultConfig(townRoot),
+		logger: log.New(io.Discard, "", 0),
+		tmux:   tmux.NewTmux(),
+	}
+	d.ensureRefineryRunning("testrig")
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read command log: %v", err)
+	}
+	if strings.Contains(string(logData), "new-session") {
+		t.Fatalf("daemon spawned refinery despite safety stop; log:\n%s", logData)
+	}
+}
+
+func writeDaemonSafetyStopMockBD(t *testing.T, binDir, logPath string) {
+	t.Helper()
+	script := `#!/bin/sh
+printf 'bd %s\n' "$*" >> "` + logPath + `"
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+case "$cmd" in
+  version)
+    echo "bd test"
+    ;;
+  show)
+    printf '%s\n' '[{"id":"gt-testrig-refinery","title":"Refinery","issue_type":"task","labels":["gt:agent","safety_stop:hq-vmrwr"],"status":"open","description":"role_type: refinery\nrig: testrig\nagent_state: idle"}]'
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+}
+
+func writeDaemonSafetyStopMockTmux(t *testing.T, binDir, logPath string) {
+	t.Helper()
+	script := `#!/bin/sh
+printf 'tmux %s\n' "$*" >> "` + logPath + `"
+case "$1" in
+  has-session)
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
 }
 
 func writeDaemonTownFile(t *testing.T, root, rel, contents string) {

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -15,6 +15,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	gtgit "github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/refinery"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
@@ -352,6 +353,14 @@ func (d *Daemon) restartSession(sessionName, identity string) error {
 		if operational, reason := d.isRigOperational(parsed.RigName); !operational {
 			d.logger.Printf("Skipping session restart for %s: %s", identity, reason)
 			return fmt.Errorf("cannot restart session: %s", reason)
+		}
+	}
+	if parsed.RoleType == constants.RoleRefinery {
+		if stop, err := refinery.ActiveSafetyStop(d.config.TownRoot, parsed.RigName); err != nil {
+			return fmt.Errorf("checking refinery safety stop: %w", err)
+		} else if stop != nil {
+			d.logger.Printf("Skipping session restart for %s: %s", identity, stop.Reason())
+			return refinery.NewSafetyStoppedError(stop)
 		}
 	}
 

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -119,6 +119,21 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		return fmt.Errorf("foreground mode is deprecated; use background mode (remove --foreground flag)")
 	}
 
+	townRoot := filepath.Dir(m.rig.Path)
+	stop, err := ActiveSafetyStop(townRoot, m.rig.Name)
+	if err != nil {
+		return fmt.Errorf("checking refinery safety stop: %w", err)
+	}
+	if stop != nil {
+		if running, _ := t.HasSession(sessionID); running {
+			_, _ = fmt.Fprintf(m.output, "Refinery %s is safety-stopped; killing leftover session %s.\n", m.rig.Name, sessionID)
+			if err := t.KillSessionWithProcesses(sessionID); err != nil {
+				return fmt.Errorf("%w: killing leftover refinery session: %v", NewSafetyStoppedError(stop), err)
+			}
+		}
+		return NewSafetyStoppedError(stop)
+	}
+
 	// Check if session already exists
 	running, _ := t.HasSession(sessionID)
 	if running {
@@ -166,7 +181,6 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 
 	// Ensure runtime settings exist in the shared refinery parent directory.
 	// Settings are passed to Claude Code via --settings flag.
-	townRoot := filepath.Dir(m.rig.Path)
 
 	// Resolve CLAUDE_CONFIG_DIR from accounts.json so refinery sessions
 	// use the correct account. Mirrors the daemon restart path (lifecycle.go).

--- a/internal/refinery/manager_test.go
+++ b/internal/refinery/manager_test.go
@@ -1,8 +1,10 @@
 package refinery
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -64,6 +66,234 @@ func TestManager_SessionName(t *testing.T) {
 	got := mgr.SessionName()
 	if got != want {
 		t.Errorf("SessionName() = %s, want %s", got, want)
+	}
+}
+
+func TestSafetyStopFromIssue(t *testing.T) {
+	stop := safetyStopFromIssue("", &beads.Issue{
+		ID:     "gt-testrig-refinery",
+		Labels: []string{"gt:agent", "safety_stop:hq-vmrwr"},
+	})
+	if stop == nil {
+		t.Fatal("expected safety stop")
+	}
+	if stop.AgentID != "gt-testrig-refinery" || stop.Label != "safety_stop:hq-vmrwr" || stop.StopID != "hq-vmrwr" {
+		t.Fatalf("stop = %+v", stop)
+	}
+
+	if got := safetyStopFromIssue("gt-testrig-refinery", &beads.Issue{Labels: []string{"gt:agent"}}); got != nil {
+		t.Fatalf("unexpected safety stop: %+v", got)
+	}
+}
+
+func TestActiveSafetyStopUsesRoutesPrefix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock bd script uses POSIX shell")
+	}
+	townRoot := t.TempDir()
+	for _, dir := range []string{filepath.Join(townRoot, "mayor"), filepath.Join(townRoot, ".beads"), filepath.Join(townRoot, "beads")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+	if err := beads.WriteRoutes(filepath.Join(townRoot, ".beads"), []beads.Route{{Prefix: "bd-", Path: "beads/mayor/rig"}}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	binDir := t.TempDir()
+	writeRoutePrefixSafetyStopMockBD(t, binDir)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	stop, err := ActiveSafetyStop(townRoot, "beads")
+	if err != nil {
+		t.Fatalf("ActiveSafetyStop: %v", err)
+	}
+	if stop == nil {
+		t.Fatal("expected safety stop from route-prefixed refinery bead")
+	}
+	if stop.AgentID != "bd-beads-refinery" {
+		t.Fatalf("AgentID = %q, want bd-beads-refinery", stop.AgentID)
+	}
+}
+
+func TestManager_StartSafetyStoppedDoesNotCreateSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock bd/tmux scripts use POSIX shell")
+	}
+	setupTestRegistry(t)
+
+	townRoot := t.TempDir()
+	for _, dir := range []string{filepath.Join(townRoot, "mayor"), filepath.Join(townRoot, ".beads"), filepath.Join(townRoot, "testrig")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "commands.log")
+	writeSafetyStopMockBD(t, binDir)
+	writeSafetyStopMockTmux(t, binDir, logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	mgr := NewManager(&rig.Rig{Name: "testrig", Path: filepath.Join(townRoot, "testrig")})
+	err := mgr.Start(false, "")
+	if !errors.Is(err, ErrSafetyStopped) {
+		t.Fatalf("Start error = %v, want ErrSafetyStopped", err)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read command log: %v", err)
+	}
+	if strings.Contains(string(logData), "new-session") {
+		t.Fatalf("Start created a tmux session despite safety stop; log:\n%s", logData)
+	}
+}
+
+func TestManager_StartSafetyStoppedKillsLeftoverSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock bd/tmux scripts use POSIX shell")
+	}
+	setupTestRegistry(t)
+
+	townRoot := t.TempDir()
+	for _, dir := range []string{filepath.Join(townRoot, "mayor"), filepath.Join(townRoot, ".beads"), filepath.Join(townRoot, "testrig")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "commands.log")
+	writeSafetyStopMockBD(t, binDir)
+	writeSafetyStopRunningMockTmux(t, binDir, logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	mgr := NewManager(&rig.Rig{Name: "testrig", Path: filepath.Join(townRoot, "testrig")})
+	err := mgr.Start(false, "")
+	if !errors.Is(err, ErrSafetyStopped) {
+		t.Fatalf("Start error = %v, want ErrSafetyStopped", err)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read command log: %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "kill-session") {
+		t.Fatalf("Start did not kill leftover safety-stopped session; log:\n%s", logData)
+	}
+	if strings.Contains(log, "new-session") {
+		t.Fatalf("Start created a tmux session despite safety stop; log:\n%s", logData)
+	}
+}
+
+func writeSafetyStopMockBD(t *testing.T, binDir string) {
+	t.Helper()
+	script := `#!/bin/sh
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+case "$cmd" in
+  version)
+    echo "bd test"
+    ;;
+  show)
+    printf '%s\n' '[{"id":"gt-testrig-refinery","title":"Refinery","issue_type":"task","labels":["gt:agent","safety_stop:hq-vmrwr"],"status":"open","description":"role_type: refinery\nrig: testrig\nagent_state: idle"}]'
+    ;;
+  *)
+    echo "unexpected bd command: $*" >&2
+    exit 9
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+}
+
+func writeRoutePrefixSafetyStopMockBD(t *testing.T, binDir string) {
+	t.Helper()
+	script := `#!/bin/sh
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+case "$cmd" in
+  version)
+    echo "bd test"
+    ;;
+  show)
+    case "$*" in
+      *bd-beads-refinery*)
+        printf '%s\n' '[{"id":"bd-beads-refinery","title":"Refinery","issue_type":"task","labels":["gt:agent","safety_stop:hq-vmrwr"],"status":"open","description":"role_type: refinery\nrig: beads\nagent_state: idle"}]'
+        ;;
+      *)
+        printf '%s\n' '[]'
+        ;;
+    esac
+    ;;
+  *)
+    echo "unexpected bd command: $*" >&2
+    exit 9
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+}
+
+func writeSafetyStopMockTmux(t *testing.T, binDir, logPath string) {
+	t.Helper()
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$1" in
+  has-session)
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+}
+
+func writeSafetyStopRunningMockTmux(t *testing.T, binDir, logPath string) {
+	t.Helper()
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+case "$1" in
+  has-session)
+    exit 0
+    ;;
+  display-message)
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
 	}
 }
 

--- a/internal/refinery/safety_stop.go
+++ b/internal/refinery/safety_stop.go
@@ -1,0 +1,99 @@
+package refinery
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+const safetyStopLabelPrefix = "safety_stop:"
+
+// ErrSafetyStopped is returned when the refinery agent bead carries an active
+// safety-stop label. The label is the durable operator-cleared guard.
+var ErrSafetyStopped = errors.New("refinery safety-stopped")
+
+// SafetyStop describes the active refinery safety-stop label.
+type SafetyStop struct {
+	AgentID string
+	Label   string
+	StopID  string
+}
+
+func (s *SafetyStop) Reason() string {
+	if s == nil {
+		return "refinery safety-stopped"
+	}
+	if s.StopID != "" {
+		return fmt.Sprintf("refinery safety-stopped by %s", s.StopID)
+	}
+	return fmt.Sprintf("refinery safety-stopped by %s", s.Label)
+}
+
+// SafetyStopError wraps ErrSafetyStopped with the label that blocked startup.
+type SafetyStopError struct {
+	Stop *SafetyStop
+}
+
+func (e *SafetyStopError) Error() string {
+	if e == nil || e.Stop == nil {
+		return ErrSafetyStopped.Error()
+	}
+	return fmt.Sprintf("%s (label %s on %s)", e.Stop.Reason(), e.Stop.Label, e.Stop.AgentID)
+}
+
+func (e *SafetyStopError) Unwrap() error {
+	return ErrSafetyStopped
+}
+
+// NewSafetyStoppedError returns a typed startup-blocking safety-stop error.
+func NewSafetyStoppedError(stop *SafetyStop) error {
+	return &SafetyStopError{Stop: stop}
+}
+
+// ActiveSafetyStop returns the active safety stop for a rig's refinery, if any.
+// The refinery agent bead's safety_stop:* label is the single durable source of
+// truth; the referenced ID is provenance, not an implicit clear condition.
+func ActiveSafetyStop(townRoot, rigName string) (*SafetyStop, error) {
+	townRoot = strings.TrimSpace(townRoot)
+	rigName = strings.TrimSpace(rigName)
+	if townRoot == "" || rigName == "" {
+		return nil, nil
+	}
+
+	prefix := beads.GetPrefixForRig(townRoot, rigName)
+	agentID := beads.RefineryBeadIDWithPrefix(prefix, rigName)
+	rigPath := filepath.Join(townRoot, rigName)
+	b := beads.NewWithBeadsDir(rigPath, filepath.Join(townRoot, ".beads")).ForAgentBead()
+
+	issue, _, err := b.GetAgentBead(agentID)
+	if err != nil {
+		return nil, err
+	}
+	if issue == nil {
+		return nil, nil
+	}
+	return safetyStopFromIssue(agentID, issue), nil
+}
+
+func safetyStopFromIssue(agentID string, issue *beads.Issue) *SafetyStop {
+	if issue == nil {
+		return nil
+	}
+	if agentID == "" {
+		agentID = issue.ID
+	}
+	for _, label := range issue.Labels {
+		if !strings.HasPrefix(label, safetyStopLabelPrefix) {
+			continue
+		}
+		return &SafetyStop{
+			AgentID: agentID,
+			Label:   label,
+			StopID:  strings.TrimPrefix(label, safetyStopLabelPrefix),
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Clean upstream/main-based port for gt-clean-port-refinery-safety-stop-guard-upstream-20260629.

Summary:
- Use refinery agent bead safety_stop:* labels as the single durable safety-stop authority.
- Block Manager.Start, daemon refinery auto-start/restart, patrol auto-spawn, refinery prime/no-hook startup guidance, hooked-work prime, and refinery attach/restart bypasses while stopped.
- Preserve safety_stop:* labels when reusing agent beads.

Verification:
- CGO_ENABLED=0 go test ./internal/refinery ./internal/beads ./internal/cmd ./internal/daemon
- git diff --check upstream/main...HEAD
- git merge-base --is-ancestor upstream/main HEAD

Note: this branch is based on gastownhall/gastown upstream/main and intentionally avoids origin/main/refinery merge automation.