### PR TITLE
fix: enforce clean fork PR workflow

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -80,7 +80,10 @@ const (
 func doneContaminationBaseRef(defaultBranch, explicitTarget string) string {
 	targetBranch := defaultBranch
 	if explicitTarget != "" {
-		targetBranch = strings.TrimPrefix(explicitTarget, "origin/")
+		targetBranch = strings.TrimSpace(explicitTarget)
+		if strings.HasPrefix(targetBranch, "origin/") || strings.HasPrefix(targetBranch, "upstream/") {
+			return targetBranch
+		}
 	}
 
 	return "origin/" + targetBranch
@@ -528,6 +531,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	if rigCfg, err := rig.LoadRigConfig(filepath.Join(townRoot, rigName)); err == nil && rigCfg.DefaultBranch != "" {
 		defaultBranch = rigCfg.DefaultBranch
 	}
+	baseRef := g.CleanBaseRef("origin", defaultBranch, doneTarget)
 
 	// For COMPLETED, we need an issue ID and branch must not be the default branch
 	var mrID string
@@ -565,10 +569,9 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			return fmt.Errorf("cannot complete: uncommitted changes would be lost\nCommit your changes first, or use --status DEFERRED to exit without completing\nUncommitted: %s", workStatus.String())
 		}
 
-		// Check if branch has commits ahead of origin/default
+		// Check if branch has commits ahead of the clean target base.
 		// If not, work may have been pushed directly to main - that's fine, just skip MR
-		originDefault := "origin/" + defaultBranch
-		aheadCount, err := g.CommitsAhead(originDefault, "HEAD")
+		aheadCount, err := g.CommitsAhead(baseRef, "HEAD")
 		if err != nil {
 			// Fallback to local branch comparison if origin not available
 			aheadCount, err = g.CommitsAhead(defaultBranch, branch)
@@ -618,7 +621,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 						"Polecats must have at least 1 commit to submit.\n"+
 						"If the bug was already fixed upstream: gt done --status DEFERRED\n"+
 						"If you're blocked: gt done --status ESCALATED",
-						originDefault)
+						baseRef)
 				}
 			}
 
@@ -626,7 +629,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			// (report-only tasks like audits/reviews), or no_merge polecat
 			// (non-code tasks like email/research per GH#2496):
 			// zero commits is valid.
-			fmt.Printf("%s Branch has no commits ahead of %s\n", style.Bold.Render("→"), originDefault)
+			fmt.Printf("%s Branch has no commits ahead of %s\n", style.Bold.Render("→"), baseRef)
 			fmt.Printf("  Work was likely pushed directly to main or already merged.\n")
 			fmt.Printf("  Skipping MR creation - completing without merge request.\n\n")
 
@@ -702,9 +705,16 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// the auto-rebase below) sees the current state of origin. Without this,
 		// the local view of origin/<base> may be stale and we'd skip a rebase that
 		// is actually needed.
-		contaminationBase := doneContaminationBaseRef(defaultBranch, doneTarget)
-		if fetchErr := g.Fetch("origin"); fetchErr != nil {
-			style.PrintWarning("could not fetch origin before contamination check: %v (proceeding with local refs)", fetchErr)
+		contaminationBase := baseRef
+		if doneTarget != "" && doneTarget != defaultBranch {
+			contaminationBase = doneContaminationBaseRef(defaultBranch, doneTarget)
+		}
+		fetchRemote := git.RemoteForRef(contaminationBase)
+		if fetchRemote == "" {
+			fetchRemote = "origin"
+		}
+		if fetchErr := g.Fetch(fetchRemote); fetchErr != nil {
+			style.PrintWarning("could not fetch %s before contamination check: %v (proceeding with local refs)", fetchRemote, fetchErr)
 		}
 		contam, err := g.CheckBranchContamination(contaminationBase)
 		if err == nil && contam.Behind > 0 {
@@ -729,7 +739,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			if rebased {
 				fmt.Printf("%s Branch rebased onto %s\n", style.Bold.Render("✓"), contaminationBase)
 				// Recompute commits ahead since rebase rewrote history.
-				aheadCount, _ = g.CommitsAhead("origin/"+defaultBranch, "HEAD")
+				aheadCount, _ = g.CommitsAhead(baseRef, "HEAD")
 			} else if skipReason != "" {
 				style.PrintWarning("branch is %d commits behind %s but %s; skipping auto-rebase", contam.Behind, contaminationBase, skipReason)
 			}
@@ -738,9 +748,9 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// Strip Gas Town overlay from CLAUDE.md / CLAUDE.local.md (gt-p35).
 		// Polecats commit the overlay (polecat lifecycle boilerplate) into repos,
 		// overwriting project-specific CLAUDE.md content. Detect and revert before push.
-		if stripped := stripOverlayCLAUDEmd(g, defaultBranch); stripped {
+		if stripped := stripOverlayCLAUDEmd(g, defaultBranch, baseRef); stripped {
 			// Recalculate commits ahead since we added a cleanup commit
-			aheadCount, _ = g.CommitsAhead("origin/"+defaultBranch, "HEAD")
+			aheadCount, _ = g.CommitsAhead(baseRef, "HEAD")
 		}
 
 		// Determine merge strategy from convoy (gt-myofa.3)
@@ -775,7 +785,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		if convoyInfo != nil && convoyInfo.MergeStrategy == "direct" {
 			fmt.Printf("%s Direct merge strategy: pushing to %s\n", style.Bold.Render("→"), defaultBranch)
 			// Push submodule changes before direct push (gt-dzs)
-			pushSubmoduleChanges(g, defaultBranch)
+			pushSubmoduleChanges(g, baseRef)
 			directRefspec := branch + ":" + defaultBranch
 			directPushErr := g.Push("origin", directRefspec, false)
 			if directPushErr != nil {
@@ -852,7 +862,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// If the parent repo's submodule pointer references commits that don't
 		// exist on the submodule's remote, the Refinery MR will be broken.
 		// Detect modified submodules and push each one first.
-		pushSubmoduleChanges(g, defaultBranch)
+		pushSubmoduleChanges(g, baseRef)
 
 		// Use explicit refspec (branch:branch) to create the remote branch.
 		// Without refspec, git push follows the tracking config — polecat branches
@@ -988,7 +998,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 						}
 					}
 					// Add diff stat for quick review context
-					if diffStat, diffErr := g.DiffStat(defaultBranch + "..." + branch); diffErr == nil && diffStat != "" {
+					if diffStat, diffErr := g.DiffStat(baseRef + "..." + branch); diffErr == nil && diffStat != "" {
 						prBodyBuilder.WriteString("## Changes\n\n```\n")
 						prBodyBuilder.WriteString(diffStat)
 						prBodyBuilder.WriteString("```\n\n")
@@ -1267,12 +1277,13 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			if donePreVerified {
 				description += "\npre_verified: true"
 				description += fmt.Sprintf("\npre_verified_at: %s", time.Now().UTC().Format(time.RFC3339))
-				// Capture current origin/target HEAD as the verified base.
+				// Capture current clean target HEAD as the verified base.
 				// The polecat rebased onto this SHA before running gates.
-				if verifiedBase, baseErr := g.Rev("origin/" + target); baseErr == nil {
+				verifiedBaseRef := g.CleanBaseRef("origin", defaultBranch, target)
+				if verifiedBase, baseErr := g.Rev(verifiedBaseRef); baseErr == nil {
 					description += fmt.Sprintf("\npre_verified_base: %s", verifiedBase)
 				} else {
-					style.PrintWarning("could not resolve origin/%s for pre-verified base: %v (pre-verification data incomplete)", target, baseErr)
+					style.PrintWarning("could not resolve %s for pre-verified base: %v (pre-verification data incomplete)", verifiedBaseRef, baseErr)
 				}
 			}
 
@@ -1500,9 +1511,13 @@ notifyWitness:
 			oldBranch := branch
 
 			fmt.Printf("%s Syncing worktree to %s...\n", style.Bold.Render("→"), defaultBranch)
-			syncRef := "origin/" + defaultBranch
-			if err := g.Fetch("origin"); err != nil {
-				style.PrintWarning("could not fetch origin before idle sync: %v (using local refs)", err)
+			syncRef := g.CleanDefaultBranchBaseRef("origin", defaultBranch)
+			fetchRemote := git.RemoteForRef(syncRef)
+			if fetchRemote == "" {
+				fetchRemote = "origin"
+			}
+			if err := g.Fetch(fetchRemote); err != nil {
+				style.PrintWarning("could not fetch %s before idle sync: %v (using local refs)", fetchRemote, err)
 			}
 			if err := g.CheckoutDetach(syncRef); err != nil {
 				if fallbackErr := g.CheckoutDetach(defaultBranch); fallbackErr != nil {
@@ -1555,12 +1570,12 @@ notifyWitness:
 	return nil
 }
 
-// pushSubmoduleChanges detects submodules modified between origin/defaultBranch
+// pushSubmoduleChanges detects submodules modified between baseRef
 // and HEAD, and pushes each submodule's new commit to its remote before the
 // parent repo push. This prevents the parent's submodule pointer from
 // referencing commits that don't exist on the submodule's remote (gt-dzs).
-func pushSubmoduleChanges(g *git.Git, defaultBranch string) {
-	subChanges, err := g.SubmoduleChanges("origin/"+defaultBranch, "HEAD")
+func pushSubmoduleChanges(g *git.Git, baseRef string) {
+	subChanges, err := g.SubmoduleChanges(baseRef, "HEAD")
 	if err != nil {
 		// Non-fatal: repos without submodules return nil, nil.
 		// Only warn if the error is real (not just "no submodules").
@@ -2206,11 +2221,9 @@ func isPolecatActor(actor string) bool {
 // and a cleanup commit is created.
 //
 // Returns true if a cleanup commit was created.
-func stripOverlayCLAUDEmd(g *git.Git, defaultBranch string) bool {
-	originRef := "origin/" + defaultBranch
-
-	// Check which files changed on this branch vs origin/main
-	changedFiles, err := g.DiffNameOnly(originRef, "HEAD")
+func stripOverlayCLAUDEmd(g *git.Git, defaultBranch, baseRef string) bool {
+	// Check which files changed on this branch vs the clean target base.
+	changedFiles, err := g.DiffNameOnly(baseRef, "HEAD")
 	if err != nil {
 		// Can't determine diff — skip silently (push will still work)
 		return false
@@ -2238,10 +2251,10 @@ func stripOverlayCLAUDEmd(g *git.Git, defaultBranch string) bool {
 		// Read current CLAUDE.md from HEAD
 		currentContent, showErr := g.ShowFile("HEAD", "CLAUDE.md")
 		if showErr == nil && strings.Contains(currentContent, templates.PolecatLifecycleMarker) {
-			// Current CLAUDE.md has overlay content — restore from origin
-			origContent, origErr := g.ShowFile(originRef, "CLAUDE.md")
+			// Current CLAUDE.md has overlay content — restore from the clean base.
+			origContent, origErr := g.ShowFile(baseRef, "CLAUDE.md")
 			if origErr != nil {
-				// CLAUDE.md didn't exist on origin/main — the overlay created it.
+				// CLAUDE.md didn't exist on the clean base — the overlay created it.
 				// Remove it from tracking.
 				if rmErr := g.RmCached("CLAUDE.md"); rmErr == nil {
 					needsCommit = true
@@ -2249,9 +2262,9 @@ func stripOverlayCLAUDEmd(g *git.Git, defaultBranch string) bool {
 						style.Bold.Render("→"), defaultBranch)
 				}
 			} else {
-				// CLAUDE.md existed on origin — restore original content
+				// CLAUDE.md existed on the clean base — restore original content
 				_ = origContent // Restore via checkout
-				if coErr := g.CheckoutFileFromRef(originRef, "CLAUDE.md"); coErr == nil {
+				if coErr := g.CheckoutFileFromRef(baseRef, "CLAUDE.md"); coErr == nil {
 					if addErr := g.Add("CLAUDE.md"); addErr == nil {
 						needsCommit = true
 						fmt.Printf("%s Restored original CLAUDE.md (stripped Gas Town overlay)\n",

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -569,8 +569,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			return fmt.Errorf("cannot complete: uncommitted changes would be lost\nCommit your changes first, or use --status DEFERRED to exit without completing\nUncommitted: %s", workStatus.String())
 		}
 
-		// Check if branch has commits ahead of the clean target base.
-		// If not, work may have been pushed directly to main - that's fine, just skip MR
+		// Check if branch has commits ahead of the clean target base. In fork-backed
+		// rigs this is upstream/main, not the fork's origin/main.
 		aheadCount, err := g.CommitsAhead(baseRef, "HEAD")
 		if err != nil {
 			// Fallback to local branch comparison if origin not available
@@ -596,7 +596,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			}
 		}
 
-		// If no commits ahead, work was likely pushed directly to main (or already merged)
+		// If no commits ahead, work was likely already merged or is a legitimate
+		// report-only completion. Fork-backed rigs must not infer success from fork main.
 		// For polecats, zero commits usually means the polecat sleepwalked through
 		// implementation without writing code (gastown#1484, beads#emma).
 		// The --cleanup-status=clean escape is preserved for legitimate report-only
@@ -630,7 +631,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			// (non-code tasks like email/research per GH#2496):
 			// zero commits is valid.
 			fmt.Printf("%s Branch has no commits ahead of %s\n", style.Bold.Render("→"), baseRef)
-			fmt.Printf("  Work was likely pushed directly to main or already merged.\n")
+			fmt.Printf("  Work was likely already merged or report-only.\n")
 			fmt.Printf("  Skipping MR creation - completing without merge request.\n\n")
 
 			// G15 fix: Close the base issue when completing with no MR.
@@ -656,7 +657,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				}
 
 				if !skipClose {
-					closeReason := "Completed with no code changes (already fixed or pushed directly to main)"
+					closeReason := "Completed with no code changes (already fixed or already merged)"
 					noMRCommitSHA, _ := g.Rev("HEAD")
 					if doneSkipVerify {
 						noteVerifiedPushSkipped(cwd, issueID, defaultBranch, noMRCommitSHA, "--skip-verify on no-MR close")
@@ -664,6 +665,9 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 							closeReason = fmt.Sprintf("%s\nskip_verify: true\ntarget_branch: %s\ncommit_sha: %s", closeReason, defaultBranch, noMRCommitSHA)
 						}
 					} else if !isNoMergeTask {
+						if g.ForkBackedRemote("origin") {
+							return fmt.Errorf("cannot close no-MR code bead in fork/upstream mode: %s has no commits ahead of %s; use the fork PR flow instead", branch, baseRef)
+						}
 						if verifyErr := g.VerifyPushedCommit("origin", defaultBranch, noMRCommitSHA); verifyErr != nil {
 							noteVerifiedPushFailure(cwd, issueID, defaultBranch, noMRCommitSHA, verifyErr)
 							return fmt.Errorf("cannot close no-MR code bead: %w", verifyErr)
@@ -702,9 +706,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// artifacts that will pollute the PR diff. (GH#2220)
 		//
 		// gh#3400: Refresh remote tracking refs first so contamination check (and
-		// the auto-rebase below) sees the current state of origin. Without this,
-		// the local view of origin/<base> may be stale and we'd skip a rebase that
-		// is actually needed.
+		// the auto-rebase below) sees the current clean base. In fork-backed rigs,
+		// that base is upstream/main, not the fork's origin/main.
 		contaminationBase := baseRef
 		if doneTarget != "" && doneTarget != defaultBranch {
 			contaminationBase = doneContaminationBaseRef(defaultBranch, doneTarget)
@@ -723,8 +726,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			if contam.Behind >= blockThreshold {
 				return fmt.Errorf("branch contamination: %d commits behind %s (threshold: %d)\n"+
 					"The branch is severely stale and will include unrelated changes in the PR.\n"+
-					"Fix: git fetch origin && git rebase %s",
-					contam.Behind, contaminationBase, blockThreshold, contaminationBase)
+					"Fix: git fetch %s && git rebase %s",
+					contam.Behind, contaminationBase, blockThreshold, fetchRemote, contaminationBase)
 			} else if contam.Behind >= warnThreshold {
 				style.PrintWarning("branch is %d commits behind %s — consider rebasing to avoid PR contamination", contam.Behind, contaminationBase)
 			}

--- a/internal/cmd/done_contamination_test.go
+++ b/internal/cmd/done_contamination_test.go
@@ -27,6 +27,12 @@ func TestDoneContaminationBaseRef(t *testing.T) {
 			explicitTarget: "origin/upstream-rebuild-main",
 			want:           "origin/upstream-rebuild-main",
 		},
+		{
+			name:           "preserves upstream-qualified base",
+			defaultBranch:  "main",
+			explicitTarget: "upstream/main",
+			want:           "upstream/main",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -1497,7 +1497,7 @@ func TestPushSubmoduleChanges_Integration(t *testing.T) {
 
 	// Call pushSubmoduleChanges — this should push the submodule commit
 	g := gitpkg.NewGit(parent)
-	pushSubmoduleChanges(g, "main")
+	pushSubmoduleChanges(g, "origin/main")
 
 	// Verify the submodule commit IS now on the remote
 	lsCmd = exec.Command("git", "ls-remote", subRemote, "refs/heads/main")
@@ -1537,7 +1537,7 @@ func TestPushSubmoduleChanges_NoSubmodules(t *testing.T) {
 
 	// Should not panic or error — just a no-op
 	g := gitpkg.NewGit(parent)
-	pushSubmoduleChanges(g, "main")
+	pushSubmoduleChanges(g, "origin/main")
 }
 
 // TestAutoCommitSafetyNet verifies that the gt done auto-commit safety net

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -975,9 +975,114 @@ func (g *Git) GetPushURL(remote string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
+// ForkBackedRemote reports whether pushes to remote land somewhere other than
+// the canonical fetch base. This covers both split push URLs and fork remotes
+// with a distinct upstream remote.
+func (g *Git) ForkBackedRemote(remote string) bool {
+	fetchURL, fetchErr := g.RemoteURL(remote)
+	if fetchErr != nil {
+		return false
+	}
+	pushURL, pushErr := g.GetPushURL(remote)
+	if pushErr == nil && pushURL != "" && !sameGitRemoteURL(fetchURL, pushURL) {
+		return true
+	}
+	upstreamURL, upstreamErr := g.GetUpstreamURL()
+	return upstreamErr == nil && upstreamURL != "" && !sameGitRemoteURL(fetchURL, upstreamURL)
+}
+
+// CleanDefaultBranchBaseRef returns the ref that should be used as a clean base
+// for default-branch work. In split push-url setups origin still fetches from
+// upstream, so origin/<default> is clean. When origin itself is a fork and a
+// distinct upstream remote is present, upstream/<default> is the clean base.
+func (g *Git) CleanDefaultBranchBaseRef(remote, defaultBranch string) string {
+	if defaultBranch == "" {
+		defaultBranch = "main"
+	}
+	fetchURL, fetchErr := g.RemoteURL(remote)
+	upstreamURL, upstreamErr := g.GetUpstreamURL()
+	if fetchErr == nil && upstreamErr == nil && upstreamURL != "" && !sameGitRemoteURL(fetchURL, upstreamURL) {
+		return "upstream/" + defaultBranch
+	}
+	return remote + "/" + defaultBranch
+}
+
+// CleanBaseRef returns a fully qualified base ref for a target branch. Explicit
+// origin/ or upstream/ refs are preserved; default-branch targets use the clean
+// fork-aware base.
+func (g *Git) CleanBaseRef(remote, defaultBranch, target string) string {
+	target = strings.TrimSpace(target)
+	if target == "" || target == defaultBranch {
+		return g.CleanDefaultBranchBaseRef(remote, defaultBranch)
+	}
+	if strings.HasPrefix(target, "origin/") || strings.HasPrefix(target, "upstream/") {
+		return target
+	}
+	return remote + "/" + target
+}
+
+// RemoteForRef returns the remote prefix from refs like origin/main or
+// upstream/main. It returns an empty string for local branch names.
+func RemoteForRef(ref string) string {
+	remote, _, ok := strings.Cut(strings.TrimSpace(ref), "/")
+	if !ok || remote == "" || strings.HasPrefix(remote, "refs") {
+		return ""
+	}
+	return remote
+}
+
+// RefuseForkBackedDefaultPush fails closed before default-branch pushes in a
+// fork/upstream topology. Feature branch pushes to the fork remain allowed.
+func (g *Git) RefuseForkBackedDefaultPush(remote, refspec, defaultBranch string) error {
+	if defaultBranch == "" {
+		defaultBranch = "main"
+	}
+	destination := pushDestinationBranch(refspec)
+	if destination != defaultBranch || !g.ForkBackedRemote(remote) {
+		return nil
+	}
+	return fmt.Errorf("refusing direct push to %s/%s: fork/upstream rig detected; push a feature branch and use the Mayor-managed fork PR flow to upstream %s (no refs were pushed)", remote, destination, defaultBranch)
+}
+
+func pushDestinationBranch(refspec string) string {
+	refspec = strings.TrimSpace(refspec)
+	for strings.HasPrefix(refspec, "+") {
+		refspec = strings.TrimPrefix(refspec, "+")
+	}
+	if _, dst, ok := strings.Cut(refspec, ":"); ok {
+		refspec = dst
+	}
+	refspec = strings.TrimPrefix(refspec, "refs/heads/")
+	return strings.TrimSpace(refspec)
+}
+
+func sameGitRemoteURL(a, b string) bool {
+	return normalizeGitRemoteURL(a) == normalizeGitRemoteURL(b)
+}
+
+func normalizeGitRemoteURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	s = strings.TrimSuffix(s, "/")
+	s = strings.TrimSuffix(s, ".git")
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.TrimPrefix(s, "ssh://")
+	s = strings.TrimPrefix(s, "git://")
+	if strings.HasPrefix(s, "git@") {
+		s = strings.TrimPrefix(s, "git@")
+		s = strings.Replace(s, ":", "/", 1)
+	} else if at := strings.LastIndex(s, "@"); at >= 0 {
+		s = s[at+1:]
+	}
+	return strings.ToLower(strings.TrimSuffix(s, "/"))
+}
+
 // Push pushes to the remote branch with a timeout to prevent indefinite hangs
 // when the remote is unreachable.
 func (g *Git) Push(remote, branch string, force bool) error {
+	if err := g.RefuseForkBackedDefaultPush(remote, branch, g.RemoteDefaultBranch()); err != nil {
+		return err
+	}
 	args := []string{"push", remote, branch}
 	if force {
 		args = append(args, "--force")
@@ -990,6 +1095,9 @@ func (g *Git) Push(remote, branch string, force bool) error {
 // Used by gt mq integration land to set GT_INTEGRATION_LAND=1, which the
 // pre-push hook checks to allow integration branch content landing on main.
 func (g *Git) PushWithEnv(remote, branch string, force bool, env []string) error {
+	if err := g.RefuseForkBackedDefaultPush(remote, branch, g.RemoteDefaultBranch()); err != nil {
+		return err
+	}
 	args := []string{"push", remote, branch}
 	if force {
 		args = append(args, "--force")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1025,7 +1025,7 @@ func (g *Git) CleanBaseRef(remote, defaultBranch, target string) string {
 // upstream/main. It returns an empty string for local branch names.
 func RemoteForRef(ref string) string {
 	remote, _, ok := strings.Cut(strings.TrimSpace(ref), "/")
-	if !ok || remote == "" || strings.HasPrefix(remote, "refs") {
+	if !ok || (remote != "origin" && remote != "upstream") {
 		return ""
 	}
 	return remote

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2759,6 +2759,96 @@ func initTestRepoWithSplitRemote(t *testing.T) (string, string, string, string) 
 	return localDir, upstream, fork, mainBranch
 }
 
+func TestForkBackedDefaultPushGuard_SplitPushURL(t *testing.T) {
+	localDir, _, _, mainBranch := initTestRepoWithSplitRemote(t)
+	g := NewGit(localDir)
+
+	if !g.ForkBackedRemote("origin") {
+		t.Fatal("split push URL should be detected as fork-backed")
+	}
+	if got := g.CleanDefaultBranchBaseRef("origin", mainBranch); got != "origin/"+mainBranch {
+		t.Fatalf("CleanDefaultBranchBaseRef split = %q, want origin/%s", got, mainBranch)
+	}
+
+	refspecs := []string{
+		mainBranch,
+		"refs/heads/" + mainBranch,
+		"feature:" + mainBranch,
+		"feature:refs/heads/" + mainBranch,
+		"HEAD:" + mainBranch,
+		"+feature:" + mainBranch,
+		":" + mainBranch,
+	}
+	for _, refspec := range refspecs {
+		if err := g.RefuseForkBackedDefaultPush("origin", refspec, mainBranch); err == nil {
+			t.Fatalf("RefuseForkBackedDefaultPush(%q) returned nil, want refusal", refspec)
+		}
+	}
+	if err := g.PushWithEnv("origin", "HEAD:"+mainBranch, false, []string{"GT_INTEGRATION_LAND=1"}); err == nil {
+		t.Fatal("PushWithEnv should not let GT_INTEGRATION_LAND bypass fork default-branch guard")
+	}
+}
+
+func TestForkBackedDefaultPushGuard_OriginForkWithUpstream(t *testing.T) {
+	localDir, upstream, fork, mainBranch := initTestRepoWithSplitRemote(t)
+	g := NewGit(localDir)
+	if err := g.ClearPushURL("origin"); err != nil {
+		t.Fatalf("ClearPushURL: %v", err)
+	}
+	if _, err := g.SetRemoteURL("origin", fork); err != nil {
+		t.Fatalf("SetRemoteURL origin fork: %v", err)
+	}
+	if err := g.AddUpstreamRemote(upstream); err != nil {
+		t.Fatalf("AddUpstreamRemote: %v", err)
+	}
+
+	if !g.ForkBackedRemote("origin") {
+		t.Fatal("origin fork plus distinct upstream should be detected as fork-backed")
+	}
+	if got := g.CleanDefaultBranchBaseRef("origin", mainBranch); got != "upstream/"+mainBranch {
+		t.Fatalf("CleanDefaultBranchBaseRef fork = %q, want upstream/%s", got, mainBranch)
+	}
+	if err := g.Push("origin", "feature:"+mainBranch, false); err == nil {
+		t.Fatal("Push should block feature-to-default refspec in fork/upstream topology")
+	}
+}
+
+func TestForkBackedDefaultPushGuard_AllowsNormalDefaultPush(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+
+	if g.ForkBackedRemote("origin") {
+		t.Fatal("plain origin remote should not be fork-backed")
+	}
+	if err := g.RefuseForkBackedDefaultPush("origin", mainBranch, mainBranch); err != nil {
+		t.Fatalf("normal default push should be allowed: %v", err)
+	}
+}
+
+func TestForkBackedDefaultPushGuard_AllowsFeatureBranchPush(t *testing.T) {
+	localDir, _, _, _ := initTestRepoWithSplitRemote(t)
+	g := NewGit(localDir)
+
+	if err := g.CreateBranch("polecat/fork-policy"); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if err := g.Checkout("polecat/fork-policy"); err != nil {
+		t.Fatalf("Checkout: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "policy.txt"), []byte("policy\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := g.Add("policy.txt"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := g.Commit("fork policy feature"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := g.Push("origin", "polecat/fork-policy:polecat/fork-policy", false); err != nil {
+		t.Fatalf("feature branch push should remain allowed: %v", err)
+	}
+}
+
 // TestPushRemoteBranchExists_SplitURL is the core regression test for GH#3224:
 // with a split fetch/push URL, RemoteBranchExists checks the fetch URL (upstream)
 // while PushRemoteBranchExists checks the push URL (fork/bare repo).

--- a/internal/refinery/batch_test.go
+++ b/internal/refinery/batch_test.go
@@ -134,6 +134,24 @@ func TestDefaultBatchConfig(t *testing.T) {
 	}
 }
 
+func TestFastForwardBatch_BlocksForkBackedDefaultPush(t *testing.T) {
+	workDir, g, cleanup := testGitRepo(t)
+	defer cleanup()
+	addDistinctUpstreamRemote(t, workDir, g)
+	e := newTestEngineer(t, workDir, g)
+	before := run(t, workDir, "git", "rev-parse", "origin/main")
+
+	writeFile(t, workDir, "batched.txt", "batched\n")
+	run(t, workDir, "git", "add", ".")
+	run(t, workDir, "git", "commit", "-m", "batch result")
+
+	result := e.fastForwardBatch(context.Background(), nil, "main", &BatchResult{})
+	if result.Error == nil || !strings.Contains(result.Error.Error(), "refusing direct push") {
+		t.Fatalf("expected fork-backed default push refusal, got: %+v", result)
+	}
+	assertOriginMainUnchangedAndReset(t, workDir, before)
+}
+
 // --- AssembleBatch tests ---
 
 func TestAssembleBatch_EmptyQueue(t *testing.T) {

--- a/internal/refinery/engineer_pr_merge_test.go
+++ b/internal/refinery/engineer_pr_merge_test.go
@@ -120,6 +120,34 @@ func TestDoMerge_DirectStrategy_SkipsPRPath(t *testing.T) {
 	}
 }
 
+func TestDoMerge_DirectStrategy_BlocksForkBackedDefaultPush(t *testing.T) {
+	workDir, g, _ := testGitRepo(t)
+	addDistinctUpstreamRemote(t, workDir, g)
+	e := newTestEngineer(t, workDir, g)
+	e.config.MergeStrategy = ""
+
+	createFeatureBranch(t, workDir, "feat/fork-guard", "fork.txt", "hello")
+	before := run(t, workDir, "git", "rev-parse", "origin/main")
+
+	result := e.doMerge(context.Background(), &MRInfo{ID: "mr-fork-guard", Branch: "feat/fork-guard", Target: "main"})
+	if result.Success {
+		t.Fatal("expected fork-backed default push to be refused")
+	}
+	if !strings.Contains(result.Error, "refusing direct push") {
+		t.Fatalf("expected direct-push refusal, got: %s", result.Error)
+	}
+	assertOriginMainUnchangedAndReset(t, workDir, before)
+}
+
+func addDistinctUpstreamRemote(t *testing.T, workDir string, g *gitpkg.Git) {
+	t.Helper()
+	upstream := filepath.Join(t.TempDir(), "upstream.git")
+	run(t, filepath.Dir(upstream), "git", "init", "--bare", "--initial-branch=main", upstream)
+	if _, err := g.AddRemote("upstream", upstream); err != nil {
+		t.Fatalf("AddRemote upstream: %v", err)
+	}
+}
+
 func TestDoMergePR_NoPR_ReturnsError(t *testing.T) {
 	// doMergePR should return an error when no PR exists for the branch.
 	workDir, g, _ := testGitRepo(t)


### PR DESCRIPTION
Clean-port for hq-vmrwr safety stop.\n\nThis PR ports the fork PR workflow/direct-push guard onto a clean upstream/main-based branch, excluding contaminated fork main d403e69d.\n\nEvidence recorded on gt-clean-port-fork-pr-flow-upstream-20260629. hq-vmrwr remains active; do not process via refinery.\n\nVerification from worker:\n- 15 research legs, 5 pre-implementation reviews, 5 post-implementation reviews\n- Branch merge-base is upstream/main@628b5f0f2\n- Tests cover git policy, gt done base refs, refinery direct path, batch path, and PushWithEnv non-bypass\n