### PR TITLE
fix: enforce dependency-aware merge queue readiness

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -318,6 +318,9 @@ func unresolvedBlockingDependencyIDs(issue *Issue) ([]string, int) {
 		if issue.BlockedByCount > count {
 			count = issue.BlockedByCount
 		}
+		if issue.DependencyCount > count {
+			count = issue.DependencyCount
+		}
 		return ids, count
 	}
 
@@ -360,7 +363,7 @@ func isBlockingDependencyType(depType string) bool {
 func isResolvedDependency(dep IssueDep) bool {
 	status := strings.ToLower(strings.TrimSpace(dep.Status))
 	switch status {
-	case "tombstone":
+	case "tombstone", "pinned":
 		return true
 	case "closed":
 		if strings.EqualFold(strings.TrimSpace(dep.DependencyType), "merge-blocks") {
@@ -383,6 +386,7 @@ type ListOptions struct {
 	NoAssignee bool   // filter for issues with no assignee
 	Limit      int    // Max results (0 = unlimited, overrides bd default of 50)
 	Ephemeral  bool   // Search wisps table (ephemeral issues) instead of issues table
+	Rig        string // filter merge-request descriptions by rig before hydration
 }
 
 // CreateOptions specifies options for creating an issue.
@@ -1232,7 +1236,23 @@ func (b *Beads) ListMergeRequests(opts ListOptions) ([]*Issue, error) {
 		}
 	}
 
+	issueResults = filterMergeRequestsByRig(issueResults, opts.Rig)
 	return b.hydrateMergeRequestDetails(issueResults)
+}
+
+func filterMergeRequestsByRig(issues []*Issue, rigName string) []*Issue {
+	if rigName == "" || len(issues) == 0 {
+		return issues
+	}
+	filtered := make([]*Issue, 0, len(issues))
+	for _, issue := range issues {
+		fields := ParseMRFields(issue)
+		if fields != nil && fields.Rig != "" && !strings.EqualFold(fields.Rig, rigName) {
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+	return filtered
 }
 
 func (b *Beads) hydrateMergeRequestDetails(issues []*Issue) ([]*Issue, error) {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -281,6 +281,95 @@ type IssueDep struct {
 	Priority       int    `json:"priority"`
 	Type           string `json:"issue_type"`
 	DependencyType string `json:"dependency_type,omitempty"`
+	CloseReason    string `json:"close_reason,omitempty"`
+}
+
+var blockingDependencyTypes = map[string]bool{
+	"blocks":             true,
+	"conditional-blocks": true,
+	"waits-for":          true,
+	"merge-blocks":       true,
+}
+
+// HasUnresolvedBlockers reports whether an issue has any unresolved blocking
+// dependencies. Detailed dependency data takes precedence over list counters.
+func HasUnresolvedBlockers(issue *Issue) bool {
+	_, count := unresolvedBlockingDependencyIDs(issue)
+	return count > 0
+}
+
+// FirstUnresolvedBlockerID returns the first unresolved blocker ID, or empty if
+// the issue is unblocked or only a blocker count is available.
+func FirstUnresolvedBlockerID(issue *Issue) string {
+	ids, _ := unresolvedBlockingDependencyIDs(issue)
+	if len(ids) == 0 {
+		return ""
+	}
+	return ids[0]
+}
+
+func unresolvedBlockingDependencyIDs(issue *Issue) ([]string, int) {
+	if issue == nil {
+		return nil, 0
+	}
+	if len(issue.Dependencies) == 0 {
+		ids := normalizedIssueIDs(issue.BlockedBy)
+		count := len(ids)
+		if issue.BlockedByCount > count {
+			count = issue.BlockedByCount
+		}
+		return ids, count
+	}
+
+	seen := make(map[string]bool)
+	ids := make([]string, 0, len(issue.Dependencies))
+	count := 0
+	for _, dep := range issue.Dependencies {
+		if !isBlockingDependencyType(dep.DependencyType) || isResolvedDependency(dep) {
+			continue
+		}
+		count++
+		id := ExtractIssueID(dep.ID)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	return ids, count
+}
+
+func normalizedIssueIDs(ids []string) []string {
+	seen := make(map[string]bool, len(ids))
+	result := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = ExtractIssueID(id)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		result = append(result, id)
+	}
+	return result
+}
+
+func isBlockingDependencyType(depType string) bool {
+	return blockingDependencyTypes[strings.ToLower(strings.TrimSpace(depType))]
+}
+
+func isResolvedDependency(dep IssueDep) bool {
+	status := strings.ToLower(strings.TrimSpace(dep.Status))
+	switch status {
+	case "tombstone":
+		return true
+	case "closed":
+		if strings.EqualFold(strings.TrimSpace(dep.DependencyType), "merge-blocks") {
+			return strings.HasPrefix(dep.CloseReason, "Merged in ")
+		}
+		return true
+	default:
+		return false
+	}
 }
 
 // ListOptions specifies filters for listing issues.
@@ -1063,7 +1152,8 @@ func isJSONBytes(b []byte) bool {
 // ListMergeRequests returns merge-request beads from both the issues table
 // and the wisps table. MRs are created as ephemeral (wisps) by gt mq submit,
 // but bd list only queries the issues table. This method queries the wisps
-// table via bd sql --json to get full data including labels and assignee.
+// table via bd sql --json, then hydrates each MR with bd show detail so
+// dependency readiness fields are consistent for display and selection.
 func (b *Beads) ListMergeRequests(opts ListOptions) ([]*Issue, error) {
 	// 1. Query issues table (bd list) — don't use Ephemeral since bd query
 	// can't parse colons in label values like "gt:merge-request".
@@ -1142,7 +1232,81 @@ func (b *Beads) ListMergeRequests(opts ListOptions) ([]*Issue, error) {
 		}
 	}
 
-	return issueResults, nil
+	return b.hydrateMergeRequestDetails(issueResults)
+}
+
+func (b *Beads) hydrateMergeRequestDetails(issues []*Issue) ([]*Issue, error) {
+	if len(issues) == 0 {
+		return issues, nil
+	}
+
+	ids := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		if issue != nil && issue.ID != "" {
+			ids = append(ids, issue.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return issues, nil
+	}
+
+	details, err := b.ShowMultiple(ids)
+	if err != nil {
+		return nil, fmt.Errorf("hydrating merge-request dependencies: %w", err)
+	}
+
+	hydrated := make([]*Issue, 0, len(issues))
+	for _, issue := range issues {
+		if issue == nil || issue.ID == "" {
+			hydrated = append(hydrated, issue)
+			continue
+		}
+
+		detail, ok := details[issue.ID]
+		if !ok || detail == nil {
+			return nil, fmt.Errorf("hydrating merge-request dependencies: %s: %w", issue.ID, ErrNotFound)
+		}
+
+		mergeListIssueFields(detail, issue)
+		normalizeUnresolvedBlockers(detail)
+		hydrated = append(hydrated, detail)
+	}
+
+	return hydrated, nil
+}
+
+func mergeListIssueFields(detail, listed *Issue) {
+	detail.Ephemeral = detail.Ephemeral || listed.Ephemeral
+	if detail.Title == "" {
+		detail.Title = listed.Title
+	}
+	if detail.Description == "" {
+		detail.Description = listed.Description
+	}
+	if detail.Status == "" {
+		detail.Status = listed.Status
+	}
+	if detail.Assignee == "" {
+		detail.Assignee = listed.Assignee
+	}
+	if detail.CreatedAt == "" {
+		detail.CreatedAt = listed.CreatedAt
+	}
+	if detail.UpdatedAt == "" {
+		detail.UpdatedAt = listed.UpdatedAt
+	}
+	if detail.CreatedBy == "" {
+		detail.CreatedBy = listed.CreatedBy
+	}
+	if len(detail.Labels) == 0 {
+		detail.Labels = listed.Labels
+	}
+}
+
+func normalizeUnresolvedBlockers(issue *Issue) {
+	ids, count := unresolvedBlockingDependencyIDs(issue)
+	issue.BlockedBy = ids
+	issue.BlockedByCount = count
 }
 
 // ListByAssignee returns all issues assigned to a specific assignee.

--- a/internal/beads/beads_mr_test.go
+++ b/internal/beads/beads_mr_test.go
@@ -1,6 +1,12 @@
 package beads
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
 
 func TestMatchesMRSourceIssue(t *testing.T) {
 	tests := []struct {
@@ -74,4 +80,180 @@ func TestMatchesMRSourceIssue(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnresolvedBlockingDependencyIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		deps []IssueDep
+		want []string
+	}{
+		{
+			name: "open blocks dependency blocks",
+			deps: []IssueDep{{ID: "gt-blocker", Status: "open", DependencyType: "blocks"}},
+			want: []string{"gt-blocker"},
+		},
+		{
+			name: "blocking types match ready-work semantics",
+			deps: []IssueDep{
+				{ID: "gt-conditional", Status: "open", DependencyType: "conditional-blocks"},
+				{ID: "gt-waits", Status: "open", DependencyType: "waits-for"},
+				{ID: "gt-merge", Status: "open", DependencyType: "merge-blocks"},
+			},
+			want: []string{"gt-conditional", "gt-waits", "gt-merge"},
+		},
+		{
+			name: "closed and tombstone dependencies are resolved",
+			deps: []IssueDep{
+				{ID: "gt-closed", Status: "closed", DependencyType: "blocks"},
+				{ID: "gt-tombstone", Status: "tombstone", DependencyType: "blocks"},
+			},
+		},
+		{
+			name: "merge-blocks requires merged close reason",
+			deps: []IssueDep{
+				{ID: "gt-closed-only", Status: "closed", DependencyType: "merge-blocks"},
+				{ID: "gt-merged", Status: "closed", DependencyType: "merge-blocks", CloseReason: "Merged in abc123"},
+			},
+			want: []string{"gt-closed-only"},
+		},
+		{
+			name: "nonblocking dependency types do not block",
+			deps: []IssueDep{
+				{ID: "gt-empty", Status: "open"},
+				{ID: "gt-parent", Status: "open", DependencyType: "parent-child"},
+				{ID: "gt-track", Status: "open", DependencyType: "tracks"},
+				{ID: "gt-related", Status: "open", DependencyType: "related"},
+				{ID: "gt-custom", Status: "open", DependencyType: "custom-link"},
+			},
+		},
+		{
+			name: "external dependency IDs are normalized",
+			deps: []IssueDep{{ID: "external:gt:gt-blocker", Status: "open", DependencyType: "blocks"}},
+			want: []string{"gt-blocker"},
+		},
+		{
+			name: "missing status fails closed",
+			deps: []IssueDep{{ID: "gt-unknown-status", DependencyType: "blocks"}},
+			want: []string{"gt-unknown-status"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := unresolvedBlockingDependencyIDs(&Issue{Dependencies: tt.deps})
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Fatalf("unresolvedBlockingDependencyIDs() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasUnresolvedBlockersFallsBackToListFields(t *testing.T) {
+	if !HasUnresolvedBlockers(&Issue{BlockedByCount: 1}) {
+		t.Fatal("BlockedByCount fallback should block when detailed dependencies are absent")
+	}
+	if got := FirstUnresolvedBlockerID(&Issue{BlockedBy: []string{"external:gt:gt-blocker"}}); got != "gt-blocker" {
+		t.Fatalf("FirstUnresolvedBlockerID() = %q, want gt-blocker", got)
+	}
+	if HasUnresolvedBlockers(&Issue{Dependencies: []IssueDep{{ID: "gt-closed", Status: "closed", DependencyType: "blocks"}}, BlockedByCount: 1}) {
+		t.Fatal("detailed closed dependency should override stale list blocker count")
+	}
+}
+
+func TestListMergeRequestsHydratesWispMRBlockers(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+	installListMergeRequestsBDStub(t, false)
+
+	b := New(t.TempDir())
+	issues, err := b.ListMergeRequests(ListOptions{Label: "gt:merge-request", Status: "open", Priority: -1})
+	if err != nil {
+		t.Fatalf("ListMergeRequests() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("ListMergeRequests() returned %d issues, want 1", len(issues))
+	}
+
+	issue := issues[0]
+	if !issue.Ephemeral {
+		t.Fatal("hydrated wisp MR should preserve Ephemeral=true")
+	}
+	if !HasUnresolvedBlockers(issue) {
+		t.Fatalf("hydrated MR should be blocked: %#v", issue)
+	}
+	if got := FirstUnresolvedBlockerID(issue); got != "gt-blocker" {
+		t.Fatalf("FirstUnresolvedBlockerID() = %q, want gt-blocker", got)
+	}
+	if issue.BlockedByCount != 1 {
+		t.Fatalf("BlockedByCount = %d, want 1", issue.BlockedByCount)
+	}
+	if len(issue.Dependencies) != 1 {
+		t.Fatalf("Dependencies len = %d, want 1", len(issue.Dependencies))
+	}
+}
+
+func TestListMergeRequestsReturnsHydrationError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+	installListMergeRequestsBDStub(t, true)
+
+	b := New(t.TempDir())
+	_, err := b.ListMergeRequests(ListOptions{Label: "gt:merge-request", Status: "open", Priority: -1})
+	if err == nil {
+		t.Fatal("ListMergeRequests() error = nil, want hydration error")
+	}
+	if !strings.Contains(err.Error(), "hydrating merge-request dependencies") {
+		t.Fatalf("ListMergeRequests() error = %v, want hydration context", err)
+	}
+}
+
+func installListMergeRequestsBDStub(t *testing.T, failShow bool) {
+	t.Helper()
+	ResetBdAllowStaleCacheForTest()
+	t.Cleanup(ResetBdAllowStaleCacheForTest)
+
+	binDir := t.TempDir()
+	showCase := `
+    printf '%s\n' '[{"id":"gt-wisp-mr","title":"Merge: gt-source","description":"branch: polecat/test/gt-source@abc\ntarget: main\nsource_issue: gt-source\nrig: gastown\n","status":"open","priority":1,"created_at":"2026-06-29T00:00:00Z","updated_at":"2026-06-29T00:00:00Z","ephemeral":true,"labels":["gt:merge-request"],"dependencies":[{"id":"gt-blocker","title":"Blocker","status":"open","priority":1,"issue_type":"task","dependency_type":"blocks"}],"dependency_count":1}]'
+    exit 0
+`
+	if failShow {
+		showCase = `
+    echo 'show failed' >&2
+    exit 2
+`
+	}
+
+	script := `#!/bin/sh
+if [ "${1:-}" = "--allow-stale" ]; then
+  if [ "${2:-}" = "version" ]; then
+    echo "Error: unknown flag: --allow-stale" >&2
+    exit 0
+  fi
+  shift
+fi
+case "${1:-}" in
+  list)
+    printf '%s\n' '[]'
+    exit 0
+    ;;
+  sql)
+    printf '%s\n' '[{"id":"gt-wisp-mr","title":"Merge: gt-source","description":"branch: polecat/test/gt-source@abc\ntarget: main\nsource_issue: gt-source\nrig: gastown\n","status":"open","priority":1,"assignee":"","created_at":"2026-06-29T00:00:00Z","updated_at":"2026-06-29T00:00:00Z","created_by":"tester","labels_csv":"gt:merge-request"}]'
+    exit 0
+    ;;
+  show)` + showCase + `
+    ;;
+  *)
+    printf '%s\n' '[]'
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/beads/beads_mr_test.go
+++ b/internal/beads/beads_mr_test.go
@@ -107,6 +107,7 @@ func TestUnresolvedBlockingDependencyIDs(t *testing.T) {
 			deps: []IssueDep{
 				{ID: "gt-closed", Status: "closed", DependencyType: "blocks"},
 				{ID: "gt-tombstone", Status: "tombstone", DependencyType: "blocks"},
+				{ID: "gt-pinned", Status: "pinned", DependencyType: "blocks"},
 			},
 		},
 		{
@@ -152,6 +153,12 @@ func TestUnresolvedBlockingDependencyIDs(t *testing.T) {
 func TestHasUnresolvedBlockersFallsBackToListFields(t *testing.T) {
 	if !HasUnresolvedBlockers(&Issue{BlockedByCount: 1}) {
 		t.Fatal("BlockedByCount fallback should block when detailed dependencies are absent")
+	}
+	if !HasUnresolvedBlockers(&Issue{DependencyCount: 1}) {
+		t.Fatal("DependencyCount fallback should fail closed when detailed dependencies are absent")
+	}
+	if got := FirstUnresolvedBlockerID(&Issue{DependencyCount: 1}); got != "" {
+		t.Fatalf("FirstUnresolvedBlockerID() = %q, want empty when only count is available", got)
 	}
 	if got := FirstUnresolvedBlockerID(&Issue{BlockedBy: []string{"external:gt:gt-blocker"}}); got != "gt-blocker" {
 		t.Fatalf("FirstUnresolvedBlockerID() = %q, want gt-blocker", got)
@@ -210,6 +217,22 @@ func TestListMergeRequestsReturnsHydrationError(t *testing.T) {
 	}
 }
 
+func TestListMergeRequestsFiltersRigBeforeHydration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+	installListMergeRequestsRigFilterBDStub(t)
+
+	b := New(t.TempDir())
+	issues, err := b.ListMergeRequests(ListOptions{Label: "gt:merge-request", Status: "open", Priority: -1, Rig: "gastown"})
+	if err != nil {
+		t.Fatalf("ListMergeRequests() error = %v", err)
+	}
+	if len(issues) != 1 || issues[0].ID != "gt-current" {
+		t.Fatalf("ListMergeRequests() = %#v, want only gt-current", issues)
+	}
+}
+
 func installListMergeRequestsBDStub(t *testing.T, failShow bool) {
 	t.Helper()
 	ResetBdAllowStaleCacheForTest()
@@ -245,6 +268,48 @@ case "${1:-}" in
     exit 0
     ;;
   show)` + showCase + `
+    ;;
+  *)
+    printf '%s\n' '[]'
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func installListMergeRequestsRigFilterBDStub(t *testing.T) {
+	t.Helper()
+	ResetBdAllowStaleCacheForTest()
+	t.Cleanup(ResetBdAllowStaleCacheForTest)
+
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+if [ "${1:-}" = "--allow-stale" ]; then
+  if [ "${2:-}" = "version" ]; then
+    echo "Error: unknown flag: --allow-stale" >&2
+    exit 0
+  fi
+  shift
+fi
+case "${1:-}" in
+  list)
+    printf '%s\n' '[]'
+    exit 0
+    ;;
+  sql)
+    printf '%s\n' '[{"id":"gt-current","title":"Merge: gt-source","description":"branch: polecat/test/gt-source@abc\ntarget: main\nsource_issue: gt-source\nrig: gastown\n","status":"open","priority":1,"assignee":"","created_at":"2026-06-29T00:00:00Z","updated_at":"2026-06-29T00:00:00Z","created_by":"tester","labels_csv":"gt:merge-request"},{"id":"gt-other","title":"Merge: gt-other","description":"branch: polecat/test/gt-other@abc\ntarget: main\nsource_issue: gt-other-source\nrig: other-rig\n","status":"open","priority":1,"assignee":"","created_at":"2026-06-29T00:00:00Z","updated_at":"2026-06-29T00:00:00Z","created_by":"tester","labels_csv":"gt:merge-request"}]'
+    exit 0
+    ;;
+  show)
+    case "$*" in
+      *gt-other*) echo 'other rig should not be hydrated' >&2; exit 7 ;;
+    esac
+    printf '%s\n' '[{"id":"gt-current","title":"Merge: gt-source","description":"branch: polecat/test/gt-source@abc\ntarget: main\nsource_issue: gt-source\nrig: gastown\n","status":"open","priority":1,"created_at":"2026-06-29T00:00:00Z","updated_at":"2026-06-29T00:00:00Z","ephemeral":true,"labels":["gt:merge-request"]}]'
+    exit 0
     ;;
   *)
     printf '%s\n' '[]'

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -117,16 +117,21 @@ func sdkIssueToIssue(si *beadsdk.Issue) *Issue {
 	if len(si.Dependencies) > 0 {
 		var deps []string
 		for _, dep := range si.Dependencies {
-			switch dep.Type {
-			case beadsdk.DepParentChild:
+			if dep.IssueID != si.ID {
+				continue
+			}
+
+			issue.Dependencies = append(issue.Dependencies, IssueDep{
+				ID:             dep.DependsOnID,
+				DependencyType: string(dep.Type),
+			})
+
+			switch {
+			case dep.Type == beadsdk.DepParentChild:
 				// If this issue depends on the parent, the parent is the DependsOnID
-				if dep.IssueID == si.ID {
-					issue.Parent = dep.DependsOnID
-				}
-			case beadsdk.DepBlocks:
-				if dep.IssueID == si.ID {
-					deps = append(deps, dep.DependsOnID)
-				}
+				issue.Parent = dep.DependsOnID
+			case isBlockingDependencyType(string(dep.Type)):
+				deps = append(deps, dep.DependsOnID)
 			}
 		}
 		if len(deps) > 0 {

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -121,11 +121,6 @@ func sdkIssueToIssue(si *beadsdk.Issue) *Issue {
 				continue
 			}
 
-			issue.Dependencies = append(issue.Dependencies, IssueDep{
-				ID:             dep.DependsOnID,
-				DependencyType: string(dep.Type),
-			})
-
 			switch {
 			case dep.Type == beadsdk.DepParentChild:
 				// If this issue depends on the parent, the parent is the DependsOnID
@@ -140,6 +135,36 @@ func sdkIssueToIssue(si *beadsdk.Issue) *Issue {
 	}
 
 	return issue
+}
+
+func sdkDependencyMetadataToIssueDep(dep *beadsdk.IssueWithDependencyMetadata) IssueDep {
+	if dep == nil {
+		return IssueDep{}
+	}
+	return IssueDep{
+		ID:             dep.ID,
+		Title:          dep.Title,
+		Status:         string(dep.Status),
+		Priority:       dep.Priority,
+		Type:           string(dep.IssueType),
+		DependencyType: string(dep.DependencyType),
+		CloseReason:    dep.CloseReason,
+	}
+}
+
+func sdkDependencyMetadataToIssueDeps(deps []*beadsdk.IssueWithDependencyMetadata) []IssueDep {
+	if len(deps) == 0 {
+		return nil
+	}
+	issueDeps := make([]IssueDep, 0, len(deps))
+	for _, dep := range deps {
+		issueDep := sdkDependencyMetadataToIssueDep(dep)
+		if issueDep.ID == "" {
+			continue
+		}
+		issueDeps = append(issueDeps, issueDep)
+	}
+	return issueDeps
 }
 
 // sdkIssuesToIssues converts a slice of SDK issues to gastown issues.
@@ -250,7 +275,10 @@ func (b *Beads) storeShow(id string) (*Issue, error) {
 		return nil, fmt.Errorf("store show: %w", err)
 	}
 
-	issue := sdkIssueToIssue(si)
+	issue, err := b.storeHydrateIssueDetails(ctx, sdkIssueToIssue(si))
+	if err != nil {
+		return nil, err
+	}
 
 	// Enrich with labels (SDK GetIssue may not include them)
 	if issue.Labels == nil {
@@ -279,9 +307,26 @@ func (b *Beads) storeShowMultiple(ids []string) (map[string]*Issue, error) {
 
 	result := make(map[string]*Issue, len(sdkIssues))
 	for _, si := range sdkIssues {
-		result[si.ID] = sdkIssueToIssue(si)
+		issue, hydrateErr := b.storeHydrateIssueDetails(ctx, sdkIssueToIssue(si))
+		if hydrateErr != nil {
+			return nil, hydrateErr
+		}
+		result[si.ID] = issue
 	}
 	return result, nil
+}
+
+func (b *Beads) storeHydrateIssueDetails(ctx context.Context, issue *Issue) (*Issue, error) {
+	if issue == nil {
+		return nil, nil
+	}
+	deps, err := b.store.GetDependenciesWithMetadata(ctx, issue.ID)
+	if err != nil {
+		return nil, fmt.Errorf("store dependencies for %s: %w", issue.ID, err)
+	}
+	issue.Dependencies = sdkDependencyMetadataToIssueDeps(deps)
+	issue.DependencyCount = len(issue.Dependencies)
+	return issue, nil
 }
 
 // storeCreate implements Create using the in-process store.

--- a/internal/beads/store_test.go
+++ b/internal/beads/store_test.go
@@ -767,8 +767,17 @@ func TestStoreShowMultipleHydratesDependencyMetadata(t *testing.T) {
 	store.issues["gt-blocker"] = &beadsdk.Issue{ID: "gt-blocker", Title: "blocker", Status: beadsdk.StatusOpen}
 	store.issues["gt-wait"] = &beadsdk.Issue{ID: "gt-wait", Title: "closed wait", Status: beadsdk.StatusClosed}
 	store.issues["gt-parent"] = &beadsdk.Issue{ID: "gt-parent", Title: "parent", Status: beadsdk.StatusOpen}
+	store.issues["gt-merge-mr"] = &beadsdk.Issue{
+		ID:     "gt-merge-mr",
+		Title:  "merge-blocked request",
+		Status: beadsdk.StatusOpen,
+		Dependencies: []*beadsdk.Dependency{
+			{IssueID: "gt-merge-mr", DependsOnID: "gt-merged", Type: beadsdk.DependencyType("merge-blocks")},
+		},
+	}
+	store.issues["gt-merged"] = &beadsdk.Issue{ID: "gt-merged", Title: "merged dependency", Status: beadsdk.StatusClosed, CloseReason: "Merged in gt-wisp"}
 
-	issues, err := b.storeShowMultiple([]string{"gt-mr"})
+	issues, err := b.storeShowMultiple([]string{"gt-mr", "gt-merge-mr"})
 	if err != nil {
 		t.Fatalf("storeShowMultiple: %v", err)
 	}
@@ -790,6 +799,9 @@ func TestStoreShowMultipleHydratesDependencyMetadata(t *testing.T) {
 	}
 	if !HasUnresolvedBlockers(issue) {
 		t.Fatal("SDK dependencies should feed shared blocker semantics")
+	}
+	if HasUnresolvedBlockers(issues["gt-merge-mr"]) {
+		t.Fatal("store-backed merged merge-block should be resolved")
 	}
 }
 

--- a/internal/beads/store_test.go
+++ b/internal/beads/store_test.go
@@ -14,22 +14,22 @@ import (
 // Embeds beadsdk.Storage to satisfy unimplemented methods (they panic if called).
 type mockStorage struct {
 	beadsdk.Storage // embedded for unimplemented methods
-	issues     map[string]*beadsdk.Issue
-	labels     map[string][]string // issueID -> labels
-	deps       map[string][]string // issueID -> depends-on IDs
-	nextID     int
-	prefix     string
-	closed     map[string]bool
-	closeErr   error
-	createErr  error
-	updateErr  error
-	searchErr  error
-	getErr     error
-	addLabelErr    error
-	removeLabelErr error
-	addDepErr      error
-	removeDepErr   error
-	getLabelsErr   error
+	issues          map[string]*beadsdk.Issue
+	labels          map[string][]string // issueID -> labels
+	deps            map[string][]string // issueID -> depends-on IDs
+	nextID          int
+	prefix          string
+	closed          map[string]bool
+	closeErr        error
+	createErr       error
+	updateErr       error
+	searchErr       error
+	getErr          error
+	addLabelErr     error
+	removeLabelErr  error
+	addDepErr       error
+	removeDepErr    error
+	getLabelsErr    error
 }
 
 func newMockStorage() *mockStorage {
@@ -213,7 +213,6 @@ func (m *mockStorage) RemoveDependency(_ context.Context, issueID, dependsOnID, 
 	}
 	return nil
 }
-
 
 func (m *mockStorage) AddLabel(_ context.Context, issueID, label, _ string) error {
 	if m.addLabelErr != nil {
@@ -724,6 +723,37 @@ func TestSdkIssueToIssueDependsOnInit(t *testing.T) {
 	}
 	if len(issue.DependsOn) != 2 {
 		t.Fatalf("expected 2 deps, got %d", len(issue.DependsOn))
+	}
+}
+
+func TestSdkIssueToIssuePopulatesDetailedBlockers(t *testing.T) {
+	si := &beadsdk.Issue{
+		ID:     "gt-mr",
+		Title:  "merge request",
+		Status: beadsdk.StatusOpen,
+		Dependencies: []*beadsdk.Dependency{
+			{IssueID: "gt-mr", DependsOnID: "gt-blocker", Type: beadsdk.DepBlocks},
+			{IssueID: "gt-mr", DependsOnID: "gt-wait", Type: beadsdk.DependencyType("waits-for")},
+			{IssueID: "gt-mr", DependsOnID: "gt-parent", Type: beadsdk.DepParentChild},
+			{IssueID: "gt-dependent", DependsOnID: "gt-mr", Type: beadsdk.DepBlocks},
+		},
+	}
+
+	issue := sdkIssueToIssue(si)
+	if issue.Parent != "gt-parent" {
+		t.Fatalf("Parent = %q, want gt-parent", issue.Parent)
+	}
+	if len(issue.DependsOn) != 2 {
+		t.Fatalf("DependsOn len = %d, want 2: %#v", len(issue.DependsOn), issue.DependsOn)
+	}
+	if len(issue.Dependencies) != 3 {
+		t.Fatalf("Dependencies len = %d, want 3: %#v", len(issue.Dependencies), issue.Dependencies)
+	}
+	if got := FirstUnresolvedBlockerID(issue); got != "gt-blocker" {
+		t.Fatalf("FirstUnresolvedBlockerID() = %q, want gt-blocker", got)
+	}
+	if !HasUnresolvedBlockers(issue) {
+		t.Fatal("SDK dependencies should feed shared blocker semantics")
 	}
 }
 

--- a/internal/beads/store_test.go
+++ b/internal/beads/store_test.go
@@ -79,6 +79,30 @@ func (m *mockStorage) GetIssuesByIDs(_ context.Context, ids []string) ([]*beadsd
 	return result, nil
 }
 
+func (m *mockStorage) GetDependenciesWithMetadata(_ context.Context, issueID string) ([]*beadsdk.IssueWithDependencyMetadata, error) {
+	issue, ok := m.issues[issueID]
+	if !ok {
+		return nil, fmt.Errorf("issue %s not found", issueID)
+	}
+
+	var result []*beadsdk.IssueWithDependencyMetadata
+	for _, dep := range issue.Dependencies {
+		if dep.IssueID != issueID {
+			continue
+		}
+
+		target, ok := m.issues[dep.DependsOnID]
+		if !ok {
+			target = &beadsdk.Issue{ID: dep.DependsOnID}
+		}
+		result = append(result, &beadsdk.IssueWithDependencyMetadata{
+			Issue:          *target,
+			DependencyType: dep.Type,
+		})
+	}
+	return result, nil
+}
+
 func (m *mockStorage) UpdateIssue(_ context.Context, id string, updates map[string]interface{}, _ string) error {
 	if m.updateErr != nil {
 		return m.updateErr
@@ -726,8 +750,10 @@ func TestSdkIssueToIssueDependsOnInit(t *testing.T) {
 	}
 }
 
-func TestSdkIssueToIssuePopulatesDetailedBlockers(t *testing.T) {
-	si := &beadsdk.Issue{
+func TestStoreShowMultipleHydratesDependencyMetadata(t *testing.T) {
+	store := newMockStorage()
+	b := newTestBeads(store)
+	store.issues["gt-mr"] = &beadsdk.Issue{
 		ID:     "gt-mr",
 		Title:  "merge request",
 		Status: beadsdk.StatusOpen,
@@ -738,8 +764,18 @@ func TestSdkIssueToIssuePopulatesDetailedBlockers(t *testing.T) {
 			{IssueID: "gt-dependent", DependsOnID: "gt-mr", Type: beadsdk.DepBlocks},
 		},
 	}
+	store.issues["gt-blocker"] = &beadsdk.Issue{ID: "gt-blocker", Title: "blocker", Status: beadsdk.StatusOpen}
+	store.issues["gt-wait"] = &beadsdk.Issue{ID: "gt-wait", Title: "closed wait", Status: beadsdk.StatusClosed}
+	store.issues["gt-parent"] = &beadsdk.Issue{ID: "gt-parent", Title: "parent", Status: beadsdk.StatusOpen}
 
-	issue := sdkIssueToIssue(si)
+	issues, err := b.storeShowMultiple([]string{"gt-mr"})
+	if err != nil {
+		t.Fatalf("storeShowMultiple: %v", err)
+	}
+	issue := issues["gt-mr"]
+	if issue == nil {
+		t.Fatal("missing hydrated issue")
+	}
 	if issue.Parent != "gt-parent" {
 		t.Fatalf("Parent = %q, want gt-parent", issue.Parent)
 	}

--- a/internal/cmd/mq_list.go
+++ b/internal/cmd/mq_list.go
@@ -64,8 +64,8 @@ func runMQList(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("querying ready MRs: %w", err)
 		}
 		for _, issue := range allOpen {
-			if len(issue.BlockedBy) > 0 || issue.BlockedByCount > 0 {
-				continue // Skip blocked issues
+			if !isMergeRequestReadyForSelection(issue) {
+				continue
 			}
 			issues = append(issues, issue)
 		}
@@ -201,7 +201,7 @@ func runMQList(cmd *cobra.Command, args []string) error {
 		// Determine display status
 		displayStatus := issue.Status
 		if issue.Status == "open" {
-			if len(issue.BlockedBy) > 0 || issue.BlockedByCount > 0 {
+			if beads.HasUnresolvedBlockers(issue) {
 				displayStatus = "blocked"
 			} else {
 				displayStatus = "ready"
@@ -305,16 +305,16 @@ func runMQList(cmd *cobra.Command, args []string) error {
 	for _, item := range scored {
 		issue := item.issue
 		displayStatus := issue.Status
-		if issue.Status == "open" && (len(issue.BlockedBy) > 0 || issue.BlockedByCount > 0) {
+		if issue.Status == "open" && beads.HasUnresolvedBlockers(issue) {
 			displayStatus = "blocked"
 		}
-		if displayStatus == "blocked" && len(issue.BlockedBy) > 0 {
+		if blockerID := beads.FirstUnresolvedBlockerID(issue); displayStatus == "blocked" && blockerID != "" {
 			displayID := issue.ID
 			if len(displayID) > 12 {
 				displayID = displayID[:12]
 			}
 			fmt.Printf("  %s %s\n", style.Dim.Render(displayID+":"),
-				style.Dim.Render(fmt.Sprintf("waiting on %s", issue.BlockedBy[0])))
+				style.Dim.Render(fmt.Sprintf("waiting on %s", blockerID)))
 		}
 	}
 

--- a/internal/cmd/mq_list.go
+++ b/internal/cmd/mq_list.go
@@ -42,6 +42,7 @@ func runMQList(cmd *cobra.Command, args []string) error {
 	opts := beads.ListOptions{
 		Label:    "gt:merge-request",
 		Priority: -1,
+		Rig:      rigName,
 	}
 
 	// Apply status filter if specified

--- a/internal/cmd/mq_next.go
+++ b/internal/cmd/mq_next.go
@@ -65,6 +65,7 @@ func runMQNext(cmd *cobra.Command, args []string) error {
 		Label:    "gt:merge-request",
 		Status:   "open",
 		Priority: -1, // No priority filter
+		Rig:      rigName,
 	}
 
 	issues, err := b.ListMergeRequests(opts)

--- a/internal/cmd/mq_next.go
+++ b/internal/cmd/mq_next.go
@@ -75,11 +75,7 @@ func runMQNext(cmd *cobra.Command, args []string) error {
 	// Filter to only ready MRs (no blockers)
 	var ready []*beads.Issue
 	for _, issue := range issues {
-		// Skip closed MRs (workaround for bd list not respecting --status filter)
-		if issue.Status != "open" {
-			continue
-		}
-		if len(issue.BlockedBy) == 0 && issue.BlockedByCount == 0 {
+		if isMergeRequestReadyForSelection(issue) {
 			ready = append(ready, issue)
 		}
 	}

--- a/internal/cmd/mq_ready.go
+++ b/internal/cmd/mq_ready.go
@@ -1,0 +1,7 @@
+package cmd
+
+import "github.com/steveyegge/gastown/internal/beads"
+
+func isMergeRequestReadyForSelection(issue *beads.Issue) bool {
+	return issue != nil && issue.Status == "open" && !beads.HasUnresolvedBlockers(issue)
+}

--- a/internal/cmd/mq_ready_test.go
+++ b/internal/cmd/mq_ready_test.go
@@ -32,6 +32,10 @@ func TestIsMergeRequestReadyForSelection(t *testing.T) {
 			},
 		},
 		{
+			name:  "open issue with unhydrated dependency count is not ready",
+			issue: &beads.Issue{Status: "open", DependencyCount: 1},
+		},
+		{
 			name: "closed dependency overrides stale blocked count",
 			issue: &beads.Issue{
 				Status:         "open",

--- a/internal/cmd/mq_ready_test.go
+++ b/internal/cmd/mq_ready_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestIsMergeRequestReadyForSelection(t *testing.T) {
+	tests := []struct {
+		name  string
+		issue *beads.Issue
+		want  bool
+	}{
+		{
+			name:  "open without blockers is ready",
+			issue: &beads.Issue{Status: "open"},
+			want:  true,
+		},
+		{
+			name: "nil issue is not ready",
+		},
+		{
+			name:  "closed issue is not ready",
+			issue: &beads.Issue{Status: "closed"},
+		},
+		{
+			name: "open issue with blocking dependency is not ready",
+			issue: &beads.Issue{
+				Status:       "open",
+				Dependencies: []beads.IssueDep{{ID: "gt-blocker", Status: "open", DependencyType: "blocks"}},
+			},
+		},
+		{
+			name: "closed dependency overrides stale blocked count",
+			issue: &beads.Issue{
+				Status:         "open",
+				BlockedByCount: 1,
+				Dependencies:   []beads.IssueDep{{ID: "gt-closed", Status: "closed", DependencyType: "blocks"}},
+			},
+			want: true,
+		},
+		{
+			name: "unmerged merge-block remains not ready",
+			issue: &beads.Issue{
+				Status:       "open",
+				Dependencies: []beads.IssueDep{{ID: "gt-closed-only", Status: "closed", DependencyType: "merge-blocks"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMergeRequestReadyForSelection(tt.issue); got != tt.want {
+				t.Fatalf("isMergeRequestReadyForSelection() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/refinery.go
+++ b/internal/cmd/refinery.go
@@ -635,6 +635,7 @@ func runRefineryUnclaimed(cmd *cobra.Command, args []string) error {
 		Status:   "open",
 		Label:    "gt:merge-request",
 		Priority: -1,
+		Rig:      rigName,
 	})
 	if err != nil {
 		return fmt.Errorf("listing merge requests: %w", err)

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1965,6 +1965,7 @@ func (e *Engineer) ListReadyMRs() ([]*MRInfo, error) {
 		Status:   "open",
 		Label:    "gt:merge-request",
 		Priority: -1, // No priority filter
+		Rig:      e.rig.Name,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("querying beads for merge-requests: %w", err)
@@ -2033,6 +2034,7 @@ func (e *Engineer) ListBlockedMRs() ([]*MRInfo, error) {
 		Status:   "open",
 		Label:    "gt:merge-request",
 		Priority: -1, // No priority filter
+		Rig:      e.rig.Name,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("querying beads for merge-requests: %w", err)
@@ -2079,6 +2081,7 @@ func (e *Engineer) ListAllOpenMRs() ([]*MRInfo, error) {
 		Status:   "open",
 		Label:    "gt:merge-request",
 		Priority: -1,
+		Rig:      e.rig.Name,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("querying beads for merge-requests: %w", err)
@@ -2120,6 +2123,7 @@ func (e *Engineer) ListQueueAnomalies(now time.Time) ([]*MRAnomaly, error) {
 		Status:   "open",
 		Label:    "gt:merge-request",
 		Priority: -1,
+		Rig:      e.rig.Name,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("querying beads for merge-requests: %w", err)

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1889,18 +1889,6 @@ func conflictTaskMetadata(description string) map[string]string {
 	return metadata
 }
 
-// IsBeadOpen checks if a bead is still open (not closed).
-// This is used as a status checker to filter blocked MRs.
-func (e *Engineer) IsBeadOpen(beadID string) (bool, error) {
-	issue, err := e.beads.Show(beadID)
-	if err != nil {
-		// If we can't find the bead, treat as not open (fail open - allow MR to proceed)
-		return false, nil
-	}
-	// "closed" status means the bead is done
-	return issue.Status != "closed", nil
-}
-
 // issueToMRInfo converts a beads issue (with parsed MR fields) into an MRInfo.
 // Shared by ListReadyMRs, ListBlockedMRs, and ListAllOpenMRs.
 func issueToMRInfo(issue *beads.Issue, fields *beads.MRFields) *MRInfo {
@@ -1956,21 +1944,14 @@ func issueToMRInfo(issue *beads.Issue, fields *beads.MRFields) *MRInfo {
 	}
 }
 
-// firstOpenBlocker returns the ID of the first open blocker for an issue,
-// or empty string if none are open.
+// firstOpenBlocker returns the first unresolved blocker ID for an issue.
 func (e *Engineer) firstOpenBlocker(issue *beads.Issue) string {
-	for _, blockerID := range issue.BlockedBy {
-		isOpen, err := e.IsBeadOpen(blockerID)
-		if err == nil && isOpen {
-			return blockerID
-		}
-	}
-	return ""
+	return beads.FirstUnresolvedBlockerID(issue)
 }
 
 // ListReadyMRs returns MRs that are ready for processing:
 // - Not claimed by another worker (checked via assignee field)
-// - Not blocked by an open task (checked via firstOpenBlocker)
+// - Not blocked by unresolved dependencies
 // Sorted by priority (highest first).
 //
 // Uses bd list instead of bd ready because MRs are ephemeral beads and
@@ -1998,7 +1979,7 @@ func (e *Engineer) ListReadyMRs() ([]*MRInfo, error) {
 		}
 
 		// Skip blocked MRs (replaces bd ready's blocker filtering)
-		if blockedBy := e.firstOpenBlocker(issue); blockedBy != "" {
+		if beads.HasUnresolvedBlockers(issue) {
 			continue
 		}
 
@@ -2060,16 +2041,15 @@ func (e *Engineer) ListBlockedMRs() ([]*MRInfo, error) {
 	// Filter for blocked issues (those with open blockers)
 	var mrs []*MRInfo
 	for _, issue := range issues {
-		// Skip if not blocked
-		if len(issue.BlockedBy) == 0 {
+		if issue.Status != "open" {
 			continue
 		}
 
-		// Check if any blocker is still open
-		blockedBy := e.firstOpenBlocker(issue)
-		if blockedBy == "" {
-			continue // All blockers are closed, not blocked
+		if !beads.HasUnresolvedBlockers(issue) {
+			continue
 		}
+
+		blockedBy := e.firstOpenBlocker(issue)
 
 		fields := beads.ParseMRFields(issue)
 		if fields == nil {

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -67,6 +67,56 @@ func TestIsConflictTaskForMR(t *testing.T) {
 	}
 }
 
+func TestEngineerFirstOpenBlockerUsesDependencySemantics(t *testing.T) {
+	e := &Engineer{}
+	tests := []struct {
+		name  string
+		issue *beads.Issue
+		want  string
+	}{
+		{
+			name:  "open blocking dependency blocks",
+			issue: &beads.Issue{Dependencies: []beads.IssueDep{{ID: "gt-blocker", Status: "open", DependencyType: "blocks"}}},
+			want:  "gt-blocker",
+		},
+		{
+			name:  "external blocker ID is normalized",
+			issue: &beads.Issue{Dependencies: []beads.IssueDep{{ID: "external:gt:gt-blocker", Status: "open", DependencyType: "waits-for"}}},
+			want:  "gt-blocker",
+		},
+		{
+			name:  "closed blocking dependency is resolved",
+			issue: &beads.Issue{Dependencies: []beads.IssueDep{{ID: "gt-closed", Status: "closed", DependencyType: "blocks"}}},
+		},
+		{
+			name:  "tombstone blocking dependency is resolved",
+			issue: &beads.Issue{Dependencies: []beads.IssueDep{{ID: "gt-tombstone", Status: "tombstone", DependencyType: "blocks"}}},
+		},
+		{
+			name:  "closed merge-block without merge reason still blocks",
+			issue: &beads.Issue{Dependencies: []beads.IssueDep{{ID: "gt-closed-only", Status: "closed", DependencyType: "merge-blocks"}}},
+			want:  "gt-closed-only",
+		},
+		{
+			name:  "merged merge-block is resolved",
+			issue: &beads.Issue{Dependencies: []beads.IssueDep{{ID: "gt-merged", Status: "closed", DependencyType: "merge-blocks", CloseReason: "Merged in gt-wisp"}}},
+		},
+		{
+			name:  "raw blocked_by fallback uses shared normalization",
+			issue: &beads.Issue{BlockedBy: []string{"external:gt:gt-raw-blocker"}},
+			want:  "gt-raw-blocker",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := e.firstOpenBlocker(tt.issue); got != tt.want {
+				t.Fatalf("firstOpenBlocker() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEngineerClearAgentActiveMRUsesTownBeadsDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses Unix shell script mock for bd")

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -341,6 +341,7 @@ func (m *Manager) Queue() ([]QueueItem, error) {
 		Label:    "gt:merge-request",
 		Status:   "open",
 		Priority: -1, // No priority filter
+		Rig:      m.rig.Name,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("querying merge queue from beads: %w", err)

--- a/internal/refinery/prepush_recheck_test.go
+++ b/internal/refinery/prepush_recheck_test.go
@@ -71,6 +71,13 @@ func (s *prepushStore) GetLabels(_ context.Context, id string) ([]string, error)
 	return append([]string(nil), issue.Labels...), nil
 }
 
+func (s *prepushStore) GetDependenciesWithMetadata(_ context.Context, id string) ([]*beadsdk.IssueWithDependencyMetadata, error) {
+	if _, ok := s.issues[id]; !ok {
+		return nil, fmt.Errorf("issue %s not found", id)
+	}
+	return nil, nil
+}
+
 func (s *prepushStore) UpdateIssue(_ context.Context, id string, updates map[string]interface{}, _ string) error {
 	issue, ok := s.issues[id]
 	if !ok {


### PR DESCRIPTION
Clean-port for hq-vmrwr safety stop.\n\nThis PR ports the merge queue dependency-readiness fix onto a clean upstream/main-based branch, excluding contaminated fork main d403e69d.\n\nEvidence recorded on gt-clean-port-mq-ready-dependencies-upstream-20260629. hq-vmrwr remains active; do not process via refinery.\n\nVerification from worker:\n- 15 research legs, 5 pre-implementation reviews, 5 post-implementation reviews\n- CGO_ENABLED=0 go test ./internal/beads ./internal/cmd ./internal/refinery\n- Final commits include dependency-aware readiness enforcement and store blocker metadata hydration\n