### PR TITLE
fix: persist convoy close state to JSONL

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -1854,9 +1854,6 @@ func notifyConvoyCompletion(townBeads, convoyID, title string) {
 		fields = &beads.ConvoyFields{}
 	}
 	if fields.CompletionNotifiedAt != "" {
-		if err := persistTownBeadsJSONL(townBeads); err != nil {
-			style.PrintWarning("could not retry convoy completion notification JSONL export for %s: %v", convoyID, err)
-		}
 		return
 	}
 

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1062,11 +1061,7 @@ func closeConvoyIfComplete(townBeads, convoyID, title string, tracked []trackedI
 	reason := "All tracked issues completed"
 	closeArgs := []string{"close", convoyID, "-r", reason}
 	if err := runTownMutationAndExport(townBeads, closeArgs...); err != nil {
-		if errors.As(err, new(townJSONLExportError)) {
-			style.PrintWarning("convoy close recorded for %s, but JSONL export failed; continuing notification: %v", convoyID, err)
-		} else {
-			return false, fmt.Errorf("closing convoy: %w", err)
-		}
+		return false, fmt.Errorf("closing convoy: %w", err)
 	}
 
 	fmt.Printf("%s Auto-closed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, title)
@@ -1110,7 +1105,7 @@ func checkSingleConvoy(townBeads, convoyID string, dryRun bool) error {
 	// Check if convoy is already closed
 	if normalizeConvoyStatus(convoy.Status) == convoyStatusClosed {
 		fmt.Printf("%s Convoy %s is already closed\n", style.Dim.Render("○"), convoyID)
-		return nil
+		return persistAndNotifyConvoyCompletion(townBeads, convoyID, convoy.Title)
 	}
 
 	// Get tracked issues
@@ -1165,7 +1160,7 @@ func runConvoyClose(cmd *cobra.Command, args []string) error {
 	// Idempotent: if already closed, just report it
 	if normalizeConvoyStatus(convoy.Status) == convoyStatusClosed {
 		fmt.Printf("%s Convoy %s is already closed\n", style.Dim.Render("○"), convoyID)
-		return nil
+		return persistAndNotifyConvoyCompletion(townBeads, convoyID, convoy.Title)
 	}
 	if err := validateConvoyStatusTransition(convoy.Status, convoyStatusClosed); err != nil {
 		return fmt.Errorf("can't close convoy '%s': %w", convoyID, err)
@@ -1216,11 +1211,7 @@ func runConvoyClose(cmd *cobra.Command, args []string) error {
 	// Close the convoy
 	closeArgs := []string{"close", convoyID, "-r", reason}
 	if err := runTownMutationAndExport(townBeads, closeArgs...); err != nil {
-		if errors.As(err, new(townJSONLExportError)) {
-			style.PrintWarning("convoy close recorded for %s, but JSONL export failed; continuing notification: %v", convoyID, err)
-		} else {
-			return fmt.Errorf("closing convoy: %w", err)
-		}
+		return fmt.Errorf("closing convoy: %w", err)
 	}
 
 	fmt.Printf("%s Closed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, convoy.Title)
@@ -1325,7 +1316,7 @@ func runConvoyLand(cmd *cobra.Command, args []string) error {
 	}
 	if normalizeConvoyStatus(convoy.Status) == convoyStatusClosed {
 		fmt.Printf("%s Convoy %s is already closed\n", style.Dim.Render("○"), convoyID)
-		return nil
+		return persistAndNotifyConvoyCompletion(townBeads, convoyID, convoy.Title)
 	}
 
 	// Get tracked issues
@@ -1393,11 +1384,7 @@ func runConvoyLand(cmd *cobra.Command, args []string) error {
 	reason := "Landed by owner"
 	closeArgs := []string{"close", convoyID, "-r", reason}
 	if err := runTownMutationAndExport(townBeads, closeArgs...); err != nil {
-		if errors.As(err, new(townJSONLExportError)) {
-			style.PrintWarning("convoy close recorded for %s, but JSONL export failed; continuing notification: %v", convoyID, err)
-		} else {
-			return fmt.Errorf("closing convoy: %w", err)
-		}
+		return fmt.Errorf("closing convoy: %w", err)
 	}
 
 	fmt.Printf("\n%s Landed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, convoy.Title)
@@ -1811,25 +1798,18 @@ func persistTownBeadsJSONL(townBeads string) error {
 	return BdCmd("export", "-o", issuesPath).Dir(townBeads).Run()
 }
 
-type townJSONLExportError struct {
-	err error
-}
-
-func (e townJSONLExportError) Error() string {
-	return e.err.Error()
-}
-
-func (e townJSONLExportError) Unwrap() error {
-	return e.err
-}
-
 func runTownMutationAndExport(townBeads string, args ...string) error {
 	if err := BdCmd(args...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
 		return err
 	}
+	return persistTownBeadsJSONL(townBeads)
+}
+
+func persistAndNotifyConvoyCompletion(townBeads, convoyID, title string) error {
 	if err := persistTownBeadsJSONL(townBeads); err != nil {
-		return townJSONLExportError{err: err}
+		return fmt.Errorf("persisting convoy close to JSONL: %w", err)
 	}
+	notifyConvoyCompletion(townBeads, convoyID, title)
 	return nil
 }
 

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -947,6 +947,9 @@ func runConvoyAdd(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("couldn't clear convoy completion notification state: %w", err)
 			}
 		}
+		if err := persistTownBeadsJSONL(townBeads); err != nil {
+			return fmt.Errorf("couldn't persist reopened convoy to JSONL: %w", err)
+		}
 		reopened = true
 		fmt.Printf("%s Reopened convoy %s\n", style.Bold.Render("↺"), convoyID)
 	}
@@ -1059,6 +1062,9 @@ func closeConvoyIfComplete(townBeads, convoyID, title string, tracked []trackedI
 	closeArgs := []string{"close", convoyID, "-r", reason}
 	if err := BdCmd(closeArgs...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
 		return false, fmt.Errorf("closing convoy: %w", err)
+	}
+	if err := persistTownBeadsJSONL(townBeads); err != nil {
+		return false, fmt.Errorf("persisting convoy close to JSONL: %w", err)
 	}
 
 	fmt.Printf("%s Auto-closed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, title)
@@ -1209,6 +1215,9 @@ func runConvoyClose(cmd *cobra.Command, args []string) error {
 	closeArgs := []string{"close", convoyID, "-r", reason}
 	if err := BdCmd(closeArgs...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
 		return fmt.Errorf("closing convoy: %w", err)
+	}
+	if err := persistTownBeadsJSONL(townBeads); err != nil {
+		return fmt.Errorf("persisting convoy close to JSONL: %w", err)
 	}
 
 	fmt.Printf("%s Closed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, convoy.Title)
@@ -1382,6 +1391,9 @@ func runConvoyLand(cmd *cobra.Command, args []string) error {
 	closeArgs := []string{"close", convoyID, "-r", reason}
 	if err := BdCmd(closeArgs...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
 		return fmt.Errorf("closing convoy: %w", err)
+	}
+	if err := persistTownBeadsJSONL(townBeads); err != nil {
+		return fmt.Errorf("persisting convoy close to JSONL: %w", err)
 	}
 
 	fmt.Printf("\n%s Landed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, convoy.Title)
@@ -1782,6 +1794,19 @@ func checkAndCloseCompletedConvoys(townBeads string, dryRun bool) ([]struct{ ID,
 	return closed, nil
 }
 
+// persistTownBeadsJSONL writes the current town Beads state to the JSONL file
+// used by bd's fallback import path. Convoy close/check suppresses bd's implicit
+// auto-export for normal command hygiene, but close state must survive a later
+// Dolt rebuild from .beads/issues.jsonl.
+func persistTownBeadsJSONL(townBeads string) error {
+	beadsDir := beads.ResolveBeadsDir(townBeads)
+	if beadsDir == "" {
+		return fmt.Errorf("could not resolve town .beads directory")
+	}
+	issuesPath := filepath.Join(beadsDir, "issues.jsonl")
+	return BdCmd("export", "-o", issuesPath).Dir(townBeads).Run()
+}
+
 // notifyConvoyCompletion sends notifications to owner, any notify addresses, and mayor/.
 func notifyConvoyCompletion(townBeads, convoyID, title string) {
 	stdout, err := runBdJSON(townBeads, "show", convoyID, "--json")
@@ -1809,6 +1834,10 @@ func notifyConvoyCompletion(townBeads, convoyID, title string) {
 	newDesc := beads.SetConvoyFields(&beads.Issue{Description: convoys[0].Description}, fields)
 	if err := BdCmd("update", convoyID, "--description="+newDesc).Dir(townBeads).WithAutoCommit().Run(); err != nil {
 		style.PrintWarning("could not record convoy completion notification state for %s: %v", convoyID, err)
+		return
+	}
+	if err := persistTownBeadsJSONL(townBeads); err != nil {
+		style.PrintWarning("could not persist convoy completion notification state for %s: %v", convoyID, err)
 		return
 	}
 

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1060,11 +1061,12 @@ func closeConvoyIfComplete(townBeads, convoyID, title string, tracked []trackedI
 
 	reason := "All tracked issues completed"
 	closeArgs := []string{"close", convoyID, "-r", reason}
-	if err := BdCmd(closeArgs...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
-		return false, fmt.Errorf("closing convoy: %w", err)
-	}
-	if err := persistTownBeadsJSONL(townBeads); err != nil {
-		return false, fmt.Errorf("persisting convoy close to JSONL: %w", err)
+	if err := runTownMutationAndExport(townBeads, closeArgs...); err != nil {
+		if errors.As(err, new(townJSONLExportError)) {
+			style.PrintWarning("convoy close recorded for %s, but JSONL export failed; continuing notification: %v", convoyID, err)
+		} else {
+			return false, fmt.Errorf("closing convoy: %w", err)
+		}
 	}
 
 	fmt.Printf("%s Auto-closed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, title)
@@ -1213,11 +1215,12 @@ func runConvoyClose(cmd *cobra.Command, args []string) error {
 
 	// Close the convoy
 	closeArgs := []string{"close", convoyID, "-r", reason}
-	if err := BdCmd(closeArgs...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
-		return fmt.Errorf("closing convoy: %w", err)
-	}
-	if err := persistTownBeadsJSONL(townBeads); err != nil {
-		return fmt.Errorf("persisting convoy close to JSONL: %w", err)
+	if err := runTownMutationAndExport(townBeads, closeArgs...); err != nil {
+		if errors.As(err, new(townJSONLExportError)) {
+			style.PrintWarning("convoy close recorded for %s, but JSONL export failed; continuing notification: %v", convoyID, err)
+		} else {
+			return fmt.Errorf("closing convoy: %w", err)
+		}
 	}
 
 	fmt.Printf("%s Closed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, convoy.Title)
@@ -1389,11 +1392,12 @@ func runConvoyLand(cmd *cobra.Command, args []string) error {
 	// Phase 2: Close the convoy
 	reason := "Landed by owner"
 	closeArgs := []string{"close", convoyID, "-r", reason}
-	if err := BdCmd(closeArgs...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
-		return fmt.Errorf("closing convoy: %w", err)
-	}
-	if err := persistTownBeadsJSONL(townBeads); err != nil {
-		return fmt.Errorf("persisting convoy close to JSONL: %w", err)
+	if err := runTownMutationAndExport(townBeads, closeArgs...); err != nil {
+		if errors.As(err, new(townJSONLExportError)) {
+			style.PrintWarning("convoy close recorded for %s, but JSONL export failed; continuing notification: %v", convoyID, err)
+		} else {
+			return fmt.Errorf("closing convoy: %w", err)
+		}
 	}
 
 	fmt.Printf("\n%s Landed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, convoy.Title)
@@ -1807,6 +1811,28 @@ func persistTownBeadsJSONL(townBeads string) error {
 	return BdCmd("export", "-o", issuesPath).Dir(townBeads).Run()
 }
 
+type townJSONLExportError struct {
+	err error
+}
+
+func (e townJSONLExportError) Error() string {
+	return e.err.Error()
+}
+
+func (e townJSONLExportError) Unwrap() error {
+	return e.err
+}
+
+func runTownMutationAndExport(townBeads string, args ...string) error {
+	if err := BdCmd(args...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
+		return err
+	}
+	if err := persistTownBeadsJSONL(townBeads); err != nil {
+		return townJSONLExportError{err: err}
+	}
+	return nil
+}
+
 // notifyConvoyCompletion sends notifications to owner, any notify addresses, and mayor/.
 func notifyConvoyCompletion(townBeads, convoyID, title string) {
 	stdout, err := runBdJSON(townBeads, "show", convoyID, "--json")
@@ -1828,6 +1854,9 @@ func notifyConvoyCompletion(townBeads, convoyID, title string) {
 		fields = &beads.ConvoyFields{}
 	}
 	if fields.CompletionNotifiedAt != "" {
+		if err := persistTownBeadsJSONL(townBeads); err != nil {
+			style.PrintWarning("could not retry convoy completion notification JSONL export for %s: %v", convoyID, err)
+		}
 		return
 	}
 
@@ -1893,12 +1922,8 @@ func notifyConvoyCompletion(townBeads, convoyID, title string) {
 
 	fields.CompletionNotifiedAt = time.Now().UTC().Format(time.RFC3339)
 	newDesc := beads.SetConvoyFields(&beads.Issue{Description: convoys[0].Description}, fields)
-	if err := BdCmd("update", convoyID, "--description="+newDesc).Dir(townBeads).WithAutoCommit().Run(); err != nil {
+	if err := runTownMutationAndExport(townBeads, "update", convoyID, "--description="+newDesc); err != nil {
 		style.PrintWarning("could not record convoy completion notification state for %s: %v", convoyID, err)
-		return
-	}
-	if err := persistTownBeadsJSONL(townBeads); err != nil {
-		style.PrintWarning("could not persist convoy completion notification state for %s: %v", convoyID, err)
 		return
 	}
 }

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -1830,16 +1830,6 @@ func notifyConvoyCompletion(townBeads, convoyID, title string) {
 	if fields.CompletionNotifiedAt != "" {
 		return
 	}
-	fields.CompletionNotifiedAt = time.Now().UTC().Format(time.RFC3339)
-	newDesc := beads.SetConvoyFields(&beads.Issue{Description: convoys[0].Description}, fields)
-	if err := BdCmd("update", convoyID, "--description="+newDesc).Dir(townBeads).WithAutoCommit().Run(); err != nil {
-		style.PrintWarning("could not record convoy completion notification state for %s: %v", convoyID, err)
-		return
-	}
-	if err := persistTownBeadsJSONL(townBeads); err != nil {
-		style.PrintWarning("could not persist convoy completion notification state for %s: %v", convoyID, err)
-		return
-	}
 
 	// Compute duration since convoy was created.
 	var durationStr string
@@ -1900,6 +1890,17 @@ func notifyConvoyCompletion(townBeads, convoyID, title string) {
 
 	// Push notification to active Mayor session if configured.
 	notifyMayorSession(townBeads, convoyID, title)
+
+	fields.CompletionNotifiedAt = time.Now().UTC().Format(time.RFC3339)
+	newDesc := beads.SetConvoyFields(&beads.Issue{Description: convoys[0].Description}, fields)
+	if err := BdCmd("update", convoyID, "--description="+newDesc).Dir(townBeads).WithAutoCommit().Run(); err != nil {
+		style.PrintWarning("could not record convoy completion notification state for %s: %v", convoyID, err)
+		return
+	}
+	if err := persistTownBeadsJSONL(townBeads); err != nil {
+		style.PrintWarning("could not persist convoy completion notification state for %s: %v", convoyID, err)
+		return
+	}
 }
 
 // notifyMayorSession pushes a convoy completion notification into the active

--- a/internal/cmd/convoy_notification_test.go
+++ b/internal/cmd/convoy_notification_test.go
@@ -262,7 +262,7 @@ exit 0
 	}
 }
 
-func TestCloseConvoyIfComplete_CloseExportFailureDoesNotSuppressNotification(t *testing.T) {
+func TestCloseConvoyIfComplete_CloseExportFailureRequiresDurableRetryBeforeNotification(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows - shell stubs")
 	}
@@ -333,11 +333,14 @@ exit 0
 	closed, err := closeConvoyIfComplete(townRoot, "hq-cv-close-export-fail", "Close Export Failure", []trackedIssueInfo{
 		{ID: "gt-done", Status: "closed"},
 	}, false)
-	if err != nil {
-		t.Fatalf("closeConvoyIfComplete returned error: %v", err)
+	if err == nil {
+		t.Fatal("closeConvoyIfComplete returned nil error after close JSONL export failure")
 	}
-	if !closed {
-		t.Fatal("closeConvoyIfComplete returned closed=false, want true")
+	if closed {
+		t.Fatal("closeConvoyIfComplete returned closed=true after close JSONL export failure")
+	}
+	if err := persistAndNotifyConvoyCompletion(townRoot, "hq-cv-close-export-fail", "Close Export Failure"); err != nil {
+		t.Fatalf("persistAndNotifyConvoyCompletion returned error: %v", err)
 	}
 
 	data, err := os.ReadFile(orderPath)
@@ -347,6 +350,7 @@ exit 0
 	got := strings.TrimSpace(string(data))
 	want := strings.Join([]string{
 		"close",
+		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
 		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
 		"mail",
 		"update",

--- a/internal/cmd/convoy_notification_test.go
+++ b/internal/cmd/convoy_notification_test.go
@@ -90,8 +90,8 @@ exit 0
 	if err != nil {
 		t.Fatalf("read export log: %v", err)
 	}
-	if got := strings.Count(string(exportData), "export -o"); got != 2 {
-		t.Fatalf("bd export calls = %d, want 2; log:\n%s", got, string(exportData))
+	if got := strings.Count(string(exportData), "export -o"); got != 1 {
+		t.Fatalf("bd export calls = %d, want 1; log:\n%s", got, string(exportData))
 	}
 	if !strings.Contains(string(exportData), filepath.Join(townRoot, ".beads", "issues.jsonl")) {
 		t.Fatalf("bd export did not target town issues.jsonl; log:\n%s", string(exportData))
@@ -259,99 +259,6 @@ exit 0
 	}, "\n")
 	if got != want {
 		t.Fatalf("operation order mismatch:\n got:\n%s\nwant:\n%s", got, want)
-	}
-}
-
-func TestNotifyConvoyCompletion_RetriesJSONLExportWithoutDuplicateMail(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows - shell stubs")
-	}
-
-	binDir := t.TempDir()
-	townRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
-		t.Fatalf("mkdir .beads: %v", err)
-	}
-
-	statePath := filepath.Join(binDir, "notified.state")
-	exportFailedPath := filepath.Join(binDir, "export.failed")
-	orderPath := filepath.Join(binDir, "order.log")
-	bdPath := filepath.Join(binDir, "bd")
-	gtPath := filepath.Join(binDir, "gt")
-
-	bdScript := `#!/bin/sh
-STATE="` + statePath + `"
-EXPORT_FAILED="` + exportFailedPath + `"
-ORDER="` + orderPath + `"
-if [ "$1" = "--allow-stale" ]; then
-  shift
-fi
-case "$1" in
-  version)
-    exit 0
-    ;;
-  show)
-    if [ -f "$STATE" ]; then
-      printf '%s\n' '[{"id":"hq-cv-retry","description":"Owner: mayor/\ncompletion_notified_at: 2026-05-25T02:30:00Z","created_at":"2026-05-25T02:00:00Z"}]'
-    else
-      printf '%s\n' '[{"id":"hq-cv-retry","description":"Owner: mayor/","created_at":"2026-05-25T02:00:00Z"}]'
-    fi
-    exit 0
-    ;;
-  sql)
-    printf '%s\n' '[]'
-    exit 0
-    ;;
-  update)
-    echo update >> "$ORDER"
-    touch "$STATE"
-    exit 0
-    ;;
-  export)
-    echo export:"$@" >> "$ORDER"
-    if [ ! -f "$EXPORT_FAILED" ]; then
-      touch "$EXPORT_FAILED"
-      exit 1
-    fi
-    exit 0
-    ;;
-esac
-exit 1
-`
-	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
-		t.Fatalf("write bd stub: %v", err)
-	}
-
-	gtScript := `#!/bin/sh
-if [ "$1" = "mail" ] && [ "$2" = "send" ]; then
-  echo mail >> "` + orderPath + `"
-fi
-exit 0
-`
-	if err := os.WriteFile(gtPath, []byte(gtScript), 0755); err != nil {
-		t.Fatalf("write gt stub: %v", err)
-	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-
-	notifyConvoyCompletion(townRoot, "hq-cv-retry", "Retry Export")
-	notifyConvoyCompletion(townRoot, "hq-cv-retry", "Retry Export")
-
-	data, err := os.ReadFile(orderPath)
-	if err != nil {
-		t.Fatalf("read order log: %v", err)
-	}
-	got := strings.TrimSpace(string(data))
-	want := strings.Join([]string{
-		"mail",
-		"update",
-		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
-		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
-	}, "\n")
-	if got != want {
-		t.Fatalf("operation order mismatch:\n got:\n%s\nwant:\n%s", got, want)
-	}
-	if got := strings.Count(string(data), "mail"); got != 1 {
-		t.Fatalf("mail sends = %d, want 1; log:\n%s", got, string(data))
 	}
 }
 

--- a/internal/cmd/convoy_notification_test.go
+++ b/internal/cmd/convoy_notification_test.go
@@ -90,8 +90,8 @@ exit 0
 	if err != nil {
 		t.Fatalf("read export log: %v", err)
 	}
-	if got := strings.Count(string(exportData), "export -o"); got != 1 {
-		t.Fatalf("bd export calls = %d, want 1; log:\n%s", got, string(exportData))
+	if got := strings.Count(string(exportData), "export -o"); got != 2 {
+		t.Fatalf("bd export calls = %d, want 2; log:\n%s", got, string(exportData))
 	}
 	if !strings.Contains(string(exportData), filepath.Join(townRoot, ".beads", "issues.jsonl")) {
 		t.Fatalf("bd export did not target town issues.jsonl; log:\n%s", string(exportData))
@@ -253,6 +253,194 @@ exit 0
 	}
 	got := strings.TrimSpace(string(data))
 	want := strings.Join([]string{
+		"mail",
+		"update",
+		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
+	}, "\n")
+	if got != want {
+		t.Fatalf("operation order mismatch:\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestNotifyConvoyCompletion_RetriesJSONLExportWithoutDuplicateMail(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	binDir := t.TempDir()
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	statePath := filepath.Join(binDir, "notified.state")
+	exportFailedPath := filepath.Join(binDir, "export.failed")
+	orderPath := filepath.Join(binDir, "order.log")
+	bdPath := filepath.Join(binDir, "bd")
+	gtPath := filepath.Join(binDir, "gt")
+
+	bdScript := `#!/bin/sh
+STATE="` + statePath + `"
+EXPORT_FAILED="` + exportFailedPath + `"
+ORDER="` + orderPath + `"
+if [ "$1" = "--allow-stale" ]; then
+  shift
+fi
+case "$1" in
+  version)
+    exit 0
+    ;;
+  show)
+    if [ -f "$STATE" ]; then
+      printf '%s\n' '[{"id":"hq-cv-retry","description":"Owner: mayor/\ncompletion_notified_at: 2026-05-25T02:30:00Z","created_at":"2026-05-25T02:00:00Z"}]'
+    else
+      printf '%s\n' '[{"id":"hq-cv-retry","description":"Owner: mayor/","created_at":"2026-05-25T02:00:00Z"}]'
+    fi
+    exit 0
+    ;;
+  sql)
+    printf '%s\n' '[]'
+    exit 0
+    ;;
+  update)
+    echo update >> "$ORDER"
+    touch "$STATE"
+    exit 0
+    ;;
+  export)
+    echo export:"$@" >> "$ORDER"
+    if [ ! -f "$EXPORT_FAILED" ]; then
+      touch "$EXPORT_FAILED"
+      exit 1
+    fi
+    exit 0
+    ;;
+esac
+exit 1
+`
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	gtScript := `#!/bin/sh
+if [ "$1" = "mail" ] && [ "$2" = "send" ]; then
+  echo mail >> "` + orderPath + `"
+fi
+exit 0
+`
+	if err := os.WriteFile(gtPath, []byte(gtScript), 0755); err != nil {
+		t.Fatalf("write gt stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	notifyConvoyCompletion(townRoot, "hq-cv-retry", "Retry Export")
+	notifyConvoyCompletion(townRoot, "hq-cv-retry", "Retry Export")
+
+	data, err := os.ReadFile(orderPath)
+	if err != nil {
+		t.Fatalf("read order log: %v", err)
+	}
+	got := strings.TrimSpace(string(data))
+	want := strings.Join([]string{
+		"mail",
+		"update",
+		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
+		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
+	}, "\n")
+	if got != want {
+		t.Fatalf("operation order mismatch:\n got:\n%s\nwant:\n%s", got, want)
+	}
+	if got := strings.Count(string(data), "mail"); got != 1 {
+		t.Fatalf("mail sends = %d, want 1; log:\n%s", got, string(data))
+	}
+}
+
+func TestCloseConvoyIfComplete_CloseExportFailureDoesNotSuppressNotification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	binDir := t.TempDir()
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	exportFailedPath := filepath.Join(binDir, "export.failed")
+	orderPath := filepath.Join(binDir, "order.log")
+	bdPath := filepath.Join(binDir, "bd")
+	gtPath := filepath.Join(binDir, "gt")
+
+	bdScript := `#!/bin/sh
+EXPORT_FAILED="` + exportFailedPath + `"
+ORDER="` + orderPath + `"
+if [ "$1" = "--allow-stale" ]; then
+  shift
+fi
+case "$1" in
+  version)
+    exit 0
+    ;;
+  close)
+    echo close >> "$ORDER"
+    exit 0
+    ;;
+  export)
+    echo export:"$@" >> "$ORDER"
+    if [ ! -f "$EXPORT_FAILED" ]; then
+      touch "$EXPORT_FAILED"
+      exit 1
+    fi
+    exit 0
+    ;;
+  show)
+    printf '%s\n' '[{"id":"hq-cv-close-export-fail","description":"Owner: mayor/","created_at":"2026-05-25T02:00:00Z"}]'
+    exit 0
+    ;;
+  update)
+    echo update >> "$ORDER"
+    exit 0
+    ;;
+  sql)
+    printf '%s\n' '[]'
+    exit 0
+    ;;
+esac
+exit 1
+`
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	gtScript := `#!/bin/sh
+if [ "$1" = "mail" ] && [ "$2" = "send" ]; then
+  echo mail >> "` + orderPath + `"
+fi
+exit 0
+`
+	if err := os.WriteFile(gtPath, []byte(gtScript), 0755); err != nil {
+		t.Fatalf("write gt stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	closed, err := closeConvoyIfComplete(townRoot, "hq-cv-close-export-fail", "Close Export Failure", []trackedIssueInfo{
+		{ID: "gt-done", Status: "closed"},
+	}, false)
+	if err != nil {
+		t.Fatalf("closeConvoyIfComplete returned error: %v", err)
+	}
+	if !closed {
+		t.Fatal("closeConvoyIfComplete returned closed=false, want true")
+	}
+
+	data, err := os.ReadFile(orderPath)
+	if err != nil {
+		t.Fatalf("read order log: %v", err)
+	}
+	got := strings.TrimSpace(string(data))
+	want := strings.Join([]string{
+		"close",
+		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
 		"mail",
 		"update",
 		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),

--- a/internal/cmd/convoy_notification_test.go
+++ b/internal/cmd/convoy_notification_test.go
@@ -178,9 +178,84 @@ exit 0
 	want := strings.Join([]string{
 		"close",
 		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
+		"mail",
 		"update",
 		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
+	}, "\n")
+	if got != want {
+		t.Fatalf("operation order mismatch:\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestNotifyConvoyCompletion_ExportFailureDoesNotPreventMail(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	binDir := t.TempDir()
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	orderPath := filepath.Join(binDir, "order.log")
+	bdPath := filepath.Join(binDir, "bd")
+	gtPath := filepath.Join(binDir, "gt")
+
+	bdScript := `#!/bin/sh
+ORDER="` + orderPath + `"
+if [ "$1" = "--allow-stale" ]; then
+  shift
+fi
+case "$1" in
+  version)
+    exit 0
+    ;;
+  show)
+    printf '%s\n' '[{"id":"hq-cv-export-fail","description":"Owner: mayor/","created_at":"2026-05-25T02:00:00Z"}]'
+    exit 0
+    ;;
+  sql)
+    printf '%s\n' '[]'
+    exit 0
+    ;;
+  update)
+    echo update >> "$ORDER"
+    exit 0
+    ;;
+  export)
+    echo export:"$@" >> "$ORDER"
+    exit 1
+    ;;
+esac
+exit 1
+`
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	gtScript := `#!/bin/sh
+if [ "$1" = "mail" ] && [ "$2" = "send" ]; then
+  echo mail >> "` + orderPath + `"
+fi
+exit 0
+`
+	if err := os.WriteFile(gtPath, []byte(gtScript), 0755); err != nil {
+		t.Fatalf("write gt stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	notifyConvoyCompletion(townRoot, "hq-cv-export-fail", "Export Failure")
+
+	data, err := os.ReadFile(orderPath)
+	if err != nil {
+		t.Fatalf("read order log: %v", err)
+	}
+	got := strings.TrimSpace(string(data))
+	want := strings.Join([]string{
 		"mail",
+		"update",
+		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
 	}, "\n")
 	if got != want {
 		t.Fatalf("operation order mismatch:\n got:\n%s\nwant:\n%s", got, want)

--- a/internal/cmd/convoy_notification_test.go
+++ b/internal/cmd/convoy_notification_test.go
@@ -21,11 +21,13 @@ func TestNotifyConvoyCompletion_StampsAndSkipsDuplicate(t *testing.T) {
 
 	statePath := filepath.Join(binDir, "notified.state")
 	mailLogPath := filepath.Join(binDir, "mail.log")
+	exportLogPath := filepath.Join(binDir, "export.log")
 	bdPath := filepath.Join(binDir, "bd")
 	gtPath := filepath.Join(binDir, "gt")
 
 	bdScript := `#!/bin/sh
 STATE="` + statePath + `"
+EXPORT_LOG="` + exportLogPath + `"
 if [ "$1" = "--allow-stale" ]; then
   shift
 fi
@@ -43,6 +45,10 @@ case "$1" in
     ;;
   update)
     touch "$STATE"
+    exit 0
+    ;;
+  export)
+    echo "$@" >> "$EXPORT_LOG"
     exit 0
     ;;
   sql)
@@ -79,5 +85,104 @@ exit 0
 	}
 	if _, err := os.Stat(statePath); err != nil {
 		t.Fatalf("completion notification state was not recorded: %v", err)
+	}
+	exportData, err := os.ReadFile(exportLogPath)
+	if err != nil {
+		t.Fatalf("read export log: %v", err)
+	}
+	if got := strings.Count(string(exportData), "export -o"); got != 1 {
+		t.Fatalf("bd export calls = %d, want 1; log:\n%s", got, string(exportData))
+	}
+	if !strings.Contains(string(exportData), filepath.Join(townRoot, ".beads", "issues.jsonl")) {
+		t.Fatalf("bd export did not target town issues.jsonl; log:\n%s", string(exportData))
+	}
+}
+
+func TestCloseConvoyIfComplete_ExportsJSONLBeforeNotification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	binDir := t.TempDir()
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	orderPath := filepath.Join(binDir, "order.log")
+	bdPath := filepath.Join(binDir, "bd")
+	gtPath := filepath.Join(binDir, "gt")
+
+	bdScript := `#!/bin/sh
+ORDER="` + orderPath + `"
+if [ "$1" = "--allow-stale" ]; then
+  shift
+fi
+case "$1" in
+  version)
+    exit 0
+    ;;
+  close)
+    echo close >> "$ORDER"
+    exit 0
+    ;;
+  export)
+    echo export:"$@" >> "$ORDER"
+    exit 0
+    ;;
+  show)
+    printf '%s\n' '[{"id":"hq-cv-done","description":"Owner: mayor/","created_at":"2026-05-25T02:00:00Z"}]'
+    exit 0
+    ;;
+  update)
+    echo update >> "$ORDER"
+    exit 0
+    ;;
+  sql)
+    printf '%s\n' '[]'
+    exit 0
+    ;;
+esac
+exit 1
+`
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	gtScript := `#!/bin/sh
+if [ "$1" = "mail" ] && [ "$2" = "send" ]; then
+  echo mail >> "` + orderPath + `"
+fi
+exit 0
+`
+	if err := os.WriteFile(gtPath, []byte(gtScript), 0755); err != nil {
+		t.Fatalf("write gt stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	closed, err := closeConvoyIfComplete(townRoot, "hq-cv-done", "Done Convoy", []trackedIssueInfo{
+		{ID: "gt-done", Status: "closed"},
+	}, false)
+	if err != nil {
+		t.Fatalf("closeConvoyIfComplete returned error: %v", err)
+	}
+	if !closed {
+		t.Fatal("closeConvoyIfComplete returned closed=false, want true")
+	}
+
+	data, err := os.ReadFile(orderPath)
+	if err != nil {
+		t.Fatalf("read order log: %v", err)
+	}
+	got := strings.TrimSpace(string(data))
+	want := strings.Join([]string{
+		"close",
+		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
+		"update",
+		"export:export -o " + filepath.Join(townRoot, ".beads", "issues.jsonl"),
+		"mail",
+	}, "\n")
+	if got != want {
+		t.Fatalf("operation order mismatch:\n got:\n%s\nwant:\n%s", got, want)
 	}
 }


### PR DESCRIPTION
Clean upstream-main port of the accepted PR #4357 fix.

Original contribution: #4357 by @mderdzinski.
Replacement branch is based on gastownhall/gastown main and excludes the contaminated fork-main history.
Commit author is preserved as deacon <mark.derdzinski@gmail.com>; cherry-pick provenance is preserved in the commit message.

Verification:
- CGO_ENABLED=0 go test ./internal/cmd -run 'Test(NotifyConvoyCompletion_StampsAndSkipsDuplicate|CloseConvoyIfComplete_ExportsJSONLBeforeNotification|CloseConvoyIfComplete_UnknownBlocksAutoClose)$' -count=1 -v\n\nBeads:\n- Source: gt-clean-port-pr4357-convoy-jsonl-upstream-20260629\n- Internal MR: gt-wisp-aae1\n\nDo not close original #4357 as superseded until this replacement is merged.