### PR TITLE
fix: exclude nested runtime artifacts from checkpoints

### DIFF
--- a/internal/daemon/checkpoint_dog.go
+++ b/internal/daemon/checkpoint_dog.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/constants"
+	gtgit "github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/util"
 )
@@ -37,15 +38,6 @@ func checkpointDogInterval(config *DaemonPatrolConfig) time.Duration {
 		}
 	}
 	return defaultCheckpointDogInterval
-}
-
-// runtimeExcludeDirs are directories to unstage after git add -A.
-// These contain runtime/ephemeral data that should not be checkpointed.
-var runtimeExcludeDirs = []string{
-	".claude/",
-	".beads/",
-	".runtime/",
-	"__pycache__/",
 }
 
 // runCheckpointDog auto-commits WIP changes in active polecat worktrees.
@@ -152,10 +144,19 @@ func (d *Daemon) checkpointWorktree(workDir, rigName, polecatName string) bool {
 		return false
 	}
 
-	// Unstage runtime/ephemeral directories
-	for _, dir := range runtimeExcludeDirs {
-		// git reset HEAD -- <dir> is safe even if dir doesn't exist (exits 0)
-		_, _ = runGitCmd(workDir, "reset", "HEAD", "--", dir)
+	// Unstage runtime/ephemeral artifacts using the same centralized policy as
+	// gt done. Scanning staged paths catches tracked nested runtime dirs that
+	// git add -A can restage despite ignore rules.
+	stagedOut, err := runGitCmdRaw(workDir, "diff", "--cached", "--name-only", "-z")
+	if err != nil {
+		d.logger.Printf("checkpoint_dog: git diff --cached failed in %s/%s: %v", rigName, polecatName, err)
+		return false
+	}
+	for _, pathspec := range gtgit.RuntimeArtifactPathspecs(splitNullSeparatedPaths(stagedOut)) {
+		if _, err := runGitCmd(workDir, "reset", "HEAD", "--", pathspec); err != nil {
+			d.logger.Printf("checkpoint_dog: git reset runtime artifact %q failed in %s/%s: %v", pathspec, rigName, polecatName, err)
+			return false
+		}
 	}
 
 	// Unstage deletions of tracked files. A checkpoint should preserve work
@@ -221,6 +222,14 @@ func resolveCheckpointWorkDir(polecatsDir, polecatName, rigName string) string {
 
 // runGitCmd executes a git command in the given directory and returns stdout.
 func runGitCmd(workDir string, args ...string) (string, error) {
+	out, err := runGitCmdRaw(workDir, args...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func runGitCmdRaw(workDir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = workDir
 	util.SetDetachedProcessGroup(cmd)
@@ -238,5 +247,19 @@ func runGitCmd(workDir string, args ...string) (string, error) {
 		return "", err
 	}
 
-	return strings.TrimSpace(stdout.String()), nil
+	return stdout.String(), nil
+}
+
+func splitNullSeparatedPaths(out string) []string {
+	if out == "" {
+		return nil
+	}
+	parts := strings.Split(out, "\x00")
+	paths := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			paths = append(paths, part)
+		}
+	}
+	return paths
 }

--- a/internal/daemon/checkpoint_dog_test.go
+++ b/internal/daemon/checkpoint_dog_test.go
@@ -1,8 +1,11 @@
 package daemon
 
 import (
+	"io"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -203,4 +206,92 @@ func TestIsGitWorktree(t *testing.T) {
 	if !isGitWorktree(fileGit) {
 		t.Error(".git file (linked worktree) should count as worktree")
 	}
+}
+
+func TestCheckpointWorktreeExcludesNestedRuntimeArtifacts(t *testing.T) {
+	workDir := t.TempDir()
+	mustRunGit(t, workDir, "init")
+	mustRunGit(t, workDir, "config", "user.name", "Checkpoint Dog")
+	mustRunGit(t, workDir, "config", "user.email", "checkpoint@example.com")
+
+	if err := os.MkdirAll(filepath.Join(workDir, "src"), 0o755); err != nil {
+		t.Fatalf("setup src: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workDir, "web", ".beads"), 0o755); err != nil {
+		t.Fatalf("setup nested runtime dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "src", "app.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "web", ".beads", "redirect"), []byte("before\n"), 0o644); err != nil {
+		t.Fatalf("write runtime file: %v", err)
+	}
+	mustRunGit(t, workDir, "add", "src/app.go", "web/.beads/redirect")
+	mustRunGit(t, workDir, "commit", "-m", "initial")
+
+	if err := os.WriteFile(filepath.Join(workDir, "src", "app.go"), []byte("package main\n// checkpoint me\n"), 0o644); err != nil {
+		t.Fatalf("modify source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "web", ".beads", "redirect"), []byte("after\n"), 0o644); err != nil {
+		t.Fatalf("modify runtime file: %v", err)
+	}
+
+	d := &Daemon{logger: log.New(io.Discard, "", 0)}
+	if !d.checkpointWorktree(workDir, "rig", "polecat") {
+		t.Fatal("checkpointWorktree did not create a checkpoint commit")
+	}
+
+	if got := strings.TrimSpace(mustRunGit(t, workDir, "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD")); got != "src/app.go" {
+		t.Fatalf("checkpoint commit changed %q, want only src/app.go", got)
+	}
+	if got := strings.TrimSpace(mustRunGit(t, workDir, "diff", "--cached", "--name-only")); got != "" {
+		t.Fatalf("runtime artifact remained staged: %q", got)
+	}
+	if got := strings.TrimSpace(mustRunGit(t, workDir, "diff", "--", "web/.beads/redirect")); got == "" {
+		t.Fatal("nested runtime artifact change was committed or lost; want it left unstaged in worktree")
+	}
+}
+
+func TestCheckpointWorktreeSkipsRuntimeOnlyNestedArtifacts(t *testing.T) {
+	workDir := t.TempDir()
+	mustRunGit(t, workDir, "init")
+	mustRunGit(t, workDir, "config", "user.name", "Checkpoint Dog")
+	mustRunGit(t, workDir, "config", "user.email", "checkpoint@example.com")
+
+	if err := os.MkdirAll(filepath.Join(workDir, "web", ".beads"), 0o755); err != nil {
+		t.Fatalf("setup nested runtime dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "web", ".beads", "redirect"), []byte("before\n"), 0o644); err != nil {
+		t.Fatalf("write runtime file: %v", err)
+	}
+	mustRunGit(t, workDir, "add", "web/.beads/redirect")
+	mustRunGit(t, workDir, "commit", "-m", "initial")
+	before := mustRunGit(t, workDir, "rev-parse", "HEAD")
+
+	if err := os.WriteFile(filepath.Join(workDir, "web", ".beads", "redirect"), []byte("after\n"), 0o644); err != nil {
+		t.Fatalf("modify runtime file: %v", err)
+	}
+
+	d := &Daemon{logger: log.New(io.Discard, "", 0)}
+	if d.checkpointWorktree(workDir, "rig", "polecat") {
+		t.Fatal("checkpointWorktree created a checkpoint for runtime-only changes")
+	}
+	if after := mustRunGit(t, workDir, "rev-parse", "HEAD"); after != before {
+		t.Fatalf("checkpointWorktree advanced HEAD to %s, want %s", after, before)
+	}
+	if got := strings.TrimSpace(mustRunGit(t, workDir, "diff", "--cached", "--name-only")); got != "" {
+		t.Fatalf("runtime artifact remained staged: %q", got)
+	}
+	if got := strings.TrimSpace(mustRunGit(t, workDir, "diff", "--", "web/.beads/redirect")); got == "" {
+		t.Fatal("nested runtime artifact change was lost; want it left unstaged in worktree")
+	}
+}
+
+func mustRunGit(t *testing.T, workDir string, args ...string) string {
+	t.Helper()
+	out, err := runGitCmd(workDir, args...)
+	if err != nil {
+		t.Fatalf("git %s: %v", strings.Join(args, " "), err)
+	}
+	return out
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2927,21 +2927,29 @@ func isGasTownRuntimePath(path string) bool {
 	return ok
 }
 
-// RuntimeArtifactPaths returns deduplicated pathspecs for runtime artifacts in the
-// current uncommitted work. Callers can pass the result to git reset after git add
+// RuntimeArtifactPathspecs returns deduplicated git pathspecs for runtime
+// artifacts in paths. Callers can pass the result to git reset after git add
 // to keep generated state out of safety-net commits.
-func (s *UncommittedWorkStatus) RuntimeArtifactPaths() []string {
+func RuntimeArtifactPathspecs(paths []string) []string {
 	seen := make(map[string]bool)
-	var paths []string
-	for _, f := range append(append([]string{}, s.ModifiedFiles...), s.UntrackedFiles...) {
+	var pathspecs []string
+	for _, f := range paths {
 		root, ok := runtimeArtifactRoot(f)
 		if !ok || seen[root] {
 			continue
 		}
 		seen[root] = true
-		paths = append(paths, root)
+		pathspecs = append(pathspecs, root)
 	}
-	return paths
+	return pathspecs
+}
+
+// RuntimeArtifactPaths returns deduplicated pathspecs for runtime artifacts in the
+// current uncommitted work. Callers can pass the result to git reset after git add
+// to keep generated state out of safety-net commits.
+func (s *UncommittedWorkStatus) RuntimeArtifactPaths() []string {
+	paths := append(append([]string{}, s.ModifiedFiles...), s.UntrackedFiles...)
+	return RuntimeArtifactPathspecs(paths)
 }
 
 // NonRuntimePaths returns uncommitted paths that are not covered by the runtime

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2408,6 +2408,39 @@ func TestRuntimeArtifactPaths(t *testing.T) {
 	}
 }
 
+func TestRuntimeArtifactPathspecs(t *testing.T) {
+	got := RuntimeArtifactPathspecs([]string{
+		".beads/redirect",
+		"web/.beads/redirect",
+		"web/.beads/db.sqlite",
+		".opencode/settings.json",
+		"api/.opencode/settings.json",
+		"./.runtime/state.json",
+		"svc/.runtime/state.json",
+		"tools/.claude/settings.json",
+		"src/main.go",
+		"pkg/cache.pyc",
+	})
+	want := []string{
+		".beads/",
+		"web/.beads/",
+		".opencode/",
+		"api/.opencode/",
+		".runtime/",
+		"svc/.runtime/",
+		"tools/.claude/",
+		"pkg/cache.pyc",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("RuntimeArtifactPathspecs() = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("RuntimeArtifactPathspecs()[%d] = %q, want %q (all: %#v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 func TestParsePorcelainStatusEntryPreservesRenameCopySourceAndConflict(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
Clean upstream-main port of the accepted PR #4354 fix, converged through the centralized runtime artifact pathspec policy instead of adding another checkpoint-only exclusion layer.

Original contribution: #4354 by @ryanwclark1.
Replacement branch is based on gastownhall/gastown main and excludes contaminated fork-main history.
Commit includes Co-authored-by attribution for ace <36689148+ryanwclark1@users.noreply.github.com>.

Verification:
- CGO_ENABLED=0 go test ./internal/git ./internal/daemon -count=1

Beads:
- Source: gt-clean-port-pr4354-runtime-exclusions-upstream-20260629

Do not close original #4354 as superseded until this replacement is merged.