### PR TITLE
fix: close review-only sling gaps

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -177,6 +177,8 @@ type Issue struct {
 	ID          string   `json:"id"`
 	Title       string   `json:"title"`
 	Description string   `json:"description"`
+	Design      string   `json:"design,omitempty"`
+	Notes       string   `json:"notes,omitempty"`
 	Status      string   `json:"status"`
 	Priority    int      `json:"priority"`
 	Type        string   `json:"issue_type"`
@@ -214,6 +216,16 @@ type Issue struct {
 	// delegation state (delegated_from key) and merge-slot state (holder/waiters).
 	// Populated by both bd show --json and the in-process store path.
 	Metadata json.RawMessage `json:"metadata,omitempty"`
+	Comments []Comment       `json:"comments,omitempty"`
+}
+
+// Comment represents a beads issue comment needed by review evidence checks.
+type Comment struct {
+	ID        string `json:"id"`
+	IssueID   string `json:"issue_id"`
+	Author    string `json:"author"`
+	Text      string `json:"text"`
+	CreatedAt string `json:"created_at"`
 }
 
 // HasLabel checks if an issue has a specific label.

--- a/internal/beads/beads_sling_context_test.go
+++ b/internal/beads/beads_sling_context_test.go
@@ -19,6 +19,7 @@ func TestFormatParseSlingContextRoundTrip(t *testing.T) {
 		Convoy:           "hq-cv-test",
 		BaseBranch:       "develop",
 		NoMerge:          true,
+		ReviewOnly:       true,
 		Account:          "acme",
 		Agent:            "gemini",
 		HookRawBead:      true,
@@ -67,6 +68,9 @@ func TestFormatParseSlingContextRoundTrip(t *testing.T) {
 	}
 	if parsed.NoMerge != original.NoMerge {
 		t.Errorf("NoMerge: got %v, want %v", parsed.NoMerge, original.NoMerge)
+	}
+	if parsed.ReviewOnly != original.ReviewOnly {
+		t.Errorf("ReviewOnly: got %v, want %v", parsed.ReviewOnly, original.ReviewOnly)
 	}
 	if parsed.Account != original.Account {
 		t.Errorf("Account: got %q, want %q", parsed.Account, original.Account)
@@ -135,9 +139,9 @@ func TestParseSlingContextFields_EmptyString(t *testing.T) {
 
 func TestFormatSlingContextDescription_SpecialChars(t *testing.T) {
 	fields := &capacity.SlingContextFields{
-		WorkBeadID: "gt-abc",
-		TargetRig:  "myrig",
-		Args:       "implement \"feature\" with\nnewlines\tand tabs",
+		WorkBeadID:  "gt-abc",
+		TargetRig:   "myrig",
+		Args:        "implement \"feature\" with\nnewlines\tand tabs",
 		LastFailure: "error: ---gt:scheduler:v1--- target_rig: evil",
 	}
 

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -95,6 +95,8 @@ func sdkIssueToIssue(si *beadsdk.Issue) *Issue {
 		ID:                 si.ID,
 		Title:              si.Title,
 		Description:        si.Description,
+		Design:             si.Design,
+		Notes:              si.Notes,
 		Status:             string(si.Status),
 		Priority:           si.Priority,
 		Type:               string(si.IssueType),
@@ -106,6 +108,13 @@ func sdkIssueToIssue(si *beadsdk.Issue) *Issue {
 		Ephemeral:          si.Ephemeral,
 		AcceptanceCriteria: si.AcceptanceCriteria,
 		Metadata:           si.Metadata,
+	}
+	for _, c := range si.Comments {
+		comment, ok := sdkCommentToComment(c)
+		if !ok {
+			continue
+		}
+		issue.Comments = append(issue.Comments, comment)
 	}
 
 	if si.ClosedAt != nil {
@@ -135,6 +144,19 @@ func sdkIssueToIssue(si *beadsdk.Issue) *Issue {
 	}
 
 	return issue
+}
+
+func sdkCommentToComment(c *beadsdk.Comment) (Comment, bool) {
+	if c == nil {
+		return Comment{}, false
+	}
+	return Comment{
+		ID:        c.ID,
+		IssueID:   c.IssueID,
+		Author:    c.Author,
+		Text:      c.Text,
+		CreatedAt: c.CreatedAt.Format(time.RFC3339),
+	}, true
 }
 
 func sdkDependencyMetadataToIssueDep(dep *beadsdk.IssueWithDependencyMetadata) IssueDep {

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -155,7 +155,7 @@ func sdkCommentToComment(c *beadsdk.Comment) (Comment, bool) {
 		IssueID:   c.IssueID,
 		Author:    c.Author,
 		Text:      c.Text,
-		CreatedAt: c.CreatedAt.Format(time.RFC3339),
+		CreatedAt: c.CreatedAt.Format(time.RFC3339Nano),
 	}, true
 }
 

--- a/internal/beads/store_test.go
+++ b/internal/beads/store_test.go
@@ -372,6 +372,35 @@ func TestStoreShow(t *testing.T) {
 	}
 }
 
+func TestStoreShowMapsReviewEvidenceFields(t *testing.T) {
+	store := newMockStorage()
+	b := newTestBeads(store)
+	now := time.Now()
+
+	store.CreateIssue(context.Background(), &beadsdk.Issue{
+		Title:  "review evidence",
+		Design: "REVIEW: design evidence",
+		Notes:  "FINDINGS: note evidence",
+		Comments: []*beadsdk.Comment{
+			{ID: "comment-1", IssueID: "test-1", Author: "tester", Text: "EVIDENCE: comment evidence", CreatedAt: now},
+		},
+	}, "actor")
+
+	issue, err := b.Show("test-1")
+	if err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	if issue.Design != "REVIEW: design evidence" {
+		t.Fatalf("Design = %q", issue.Design)
+	}
+	if issue.Notes != "FINDINGS: note evidence" {
+		t.Fatalf("Notes = %q", issue.Notes)
+	}
+	if len(issue.Comments) != 1 || issue.Comments[0].Text != "EVIDENCE: comment evidence" {
+		t.Fatalf("Comments = %#v", issue.Comments)
+	}
+}
+
 func TestStoreShowNotFound(t *testing.T) {
 	store := newMockStorage()
 	b := newTestBeads(store)

--- a/internal/beads/store_test.go
+++ b/internal/beads/store_test.go
@@ -399,6 +399,9 @@ func TestStoreShowMapsReviewEvidenceFields(t *testing.T) {
 	if len(issue.Comments) != 1 || issue.Comments[0].Text != "EVIDENCE: comment evidence" {
 		t.Fatalf("Comments = %#v", issue.Comments)
 	}
+	if issue.Comments[0].CreatedAt != now.Format(time.RFC3339Nano) {
+		t.Fatalf("Comment CreatedAt = %q, want %q", issue.Comments[0].CreatedAt, now.Format(time.RFC3339Nano))
+	}
 }
 
 func TestStoreShowNotFound(t *testing.T) {

--- a/internal/cmd/capacity_dispatch_test.go
+++ b/internal/cmd/capacity_dispatch_test.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"errors"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 )
 
 func TestShouldFireCrossRigEscalation_Debounces(t *testing.T) {
@@ -44,4 +48,43 @@ func TestShouldFireCrossRigEscalation_KeyedByRigAndPrefix(t *testing.T) {
 	if shouldFireCrossRigEscalation("walletui", "hq", now.Add(time.Minute)) {
 		t.Fatalf("walletui/hq repeat must not fire")
 	}
+}
+
+func TestDispatchSingleBeadRawReviewOnlyHookFailureClearsMetadata(t *testing.T) {
+	townRoot, _, descPath := setupMutableBDRawSlingTest(t, "Keep this body.")
+
+	prevSpawn := spawnPolecatForSling
+	prevHook := hookBeadWithRetryWithTownRootFn
+	t.Cleanup(func() {
+		spawnPolecatForSling = prevSpawn
+		hookBeadWithRetryWithTownRootFn = prevHook
+	})
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		return &SpawnedPolecatInfo{
+			RigName:     rigName,
+			PolecatName: "toast",
+			ClonePath:   filepath.Join(townRoot, "gastown", "polecats", "toast"),
+		}, nil
+	}
+	hookBeadWithRetryWithTownRootFn = func(beadID, targetAgent, hookDir, townRoot string) error {
+		assertHasRawReviewMetadata(t, readMutableBDDescription(t, descPath))
+		return errors.New("forced hook failure")
+	}
+
+	_, err := dispatchSingleBead(capacity.PendingBead{
+		ID:         "gt-context",
+		WorkBeadID: "gt-rawrollback",
+		TargetRig:  "gastown",
+		Context: &capacity.SlingContextFields{
+			WorkBeadID:  "gt-rawrollback",
+			TargetRig:   "gastown",
+			HookRawBead: true,
+			NoMerge:     true,
+			ReviewOnly:  true,
+		},
+	}, townRoot, "test")
+	if err == nil {
+		t.Fatal("expected scheduler dispatch hook failure")
+	}
+	assertNoRawReviewMetadata(t, readMutableBDDescription(t, descPath))
 }

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -262,7 +262,7 @@ func hasFreshReviewEvidenceComment(comments []beads.Comment, assignmentAt time.T
 	}
 	for _, comment := range comments {
 		createdAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(comment.CreatedAt))
-		if err != nil || createdAt.Before(assignmentAt) {
+		if err != nil || !createdAt.After(assignmentAt) {
 			continue
 		}
 		if strings.TrimSpace(comment.Author) != assignee {

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -101,6 +102,140 @@ func cleanupStatusAfterSuccessfulPush(status string) string {
 		return "clean"
 	}
 	return status
+}
+
+var reviewEvidencePrefixes = []string{
+	"report:",
+	"findings:",
+	"review:",
+	"evidence:",
+	"verdict:",
+	"decision:",
+	"pr-sheriff-evidence",
+	"pr sheriff evidence",
+}
+
+var generatedCommentPrefixes = []string{
+	"verified_push_",
+	"mr created:",
+}
+
+func doneSourceCloseSkipReason(bd *beads.Beads, issueID string, issue *beads.Issue) (string, bool) {
+	issue, skipReason, fatal := loadDoneSourceIssue(bd, issueID, issue)
+	if skipReason != "" {
+		return skipReason, fatal
+	}
+	if skipReason, fatal := doneReviewOnlyCloseSkipReason(bd, issueID, issue); skipReason != "" {
+		return skipReason, fatal
+	}
+	if unchecked := beads.HasUncheckedCriteria(issue); unchecked > 0 {
+		return fmt.Sprintf("issue %s has %d unchecked acceptance criteria — skipping close", issueID, unchecked), false
+	}
+	return "", false
+}
+
+func doneReviewOnlyCloseSkipReason(bd *beads.Beads, issueID string, issue *beads.Issue) (string, bool) {
+	issue, skipReason, fatal := loadDoneSourceIssue(bd, issueID, issue)
+	if skipReason != "" {
+		return skipReason, fatal
+	}
+	attachment := beads.ParseAttachmentFields(issue)
+	if attachment == nil || !attachment.ReviewOnly {
+		return "", false
+	}
+	hasEvidence, err := hasReviewReportEvidence(bd, issueID, issue)
+	if err != nil {
+		return fmt.Sprintf("could not verify review evidence for %s: %v", issueID, err), true
+	}
+	if !hasEvidence {
+		return fmt.Sprintf("review-only issue %s has no report/evidence — add a REPORT/FINDINGS/REVIEW/EVIDENCE entry before gt done", issueID), true
+	}
+	return "", false
+}
+
+func loadDoneSourceIssue(bd *beads.Beads, issueID string, issue *beads.Issue) (*beads.Issue, string, bool) {
+	if issueID == "" {
+		return nil, "", false
+	}
+	if issue != nil {
+		return issue, "", false
+	}
+	if bd == nil {
+		return nil, fmt.Sprintf("could not inspect issue %s close eligibility", issueID), true
+	}
+	loaded, err := bd.Show(issueID)
+	if err != nil {
+		return nil, fmt.Sprintf("could not inspect issue %s close eligibility: %v", issueID, err), true
+	}
+	return loaded, "", false
+}
+
+func hasReviewReportEvidence(bd *beads.Beads, issueID string, issue *beads.Issue) (bool, error) {
+	if issue != nil {
+		if isReviewEvidenceText(issue.Notes) || isReviewEvidenceText(issue.Design) {
+			return true, nil
+		}
+		for _, comment := range issue.Comments {
+			if isReviewEvidenceText(comment.Text) {
+				return true, nil
+			}
+		}
+	}
+	if bd == nil || issueID == "" {
+		return false, nil
+	}
+	if store := bd.Store(); store != nil {
+		comments, err := store.GetIssueComments(context.Background(), issueID)
+		if err != nil {
+			return false, err
+		}
+		for _, comment := range comments {
+			if comment != nil && isReviewEvidenceText(comment.Text) {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	out, err := bd.Run("comments", issueID, "--json")
+	if err != nil {
+		return false, err
+	}
+	var comments []beads.Comment
+	if err := json.Unmarshal(out, &comments); err != nil {
+		return false, fmt.Errorf("parsing comments: %w", err)
+	}
+	for _, comment := range comments {
+		if isReviewEvidenceText(comment.Text) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isReviewEvidenceText(text string) bool {
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		generated := false
+		for _, prefix := range generatedCommentPrefixes {
+			if strings.HasPrefix(lower, prefix) {
+				generated = true
+				break
+			}
+		}
+		if generated {
+			continue
+		}
+		for _, prefix := range reviewEvidencePrefixes {
+			if strings.HasPrefix(lower, prefix) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func init() {
@@ -587,12 +722,18 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// where zero commits is expected.
 		// Must be checked before the zero-commit guard below (GH#2496, gt-kvf).
 		isNoMergeTask := false
+		reviewOnlySource := false
 		if issueID != "" {
 			noMergeBd := beads.New(cwd)
-			if noMergeIssue, showErr := noMergeBd.Show(issueID); showErr == nil {
-				if af := beads.ParseAttachmentFields(noMergeIssue); af != nil && (af.NoMerge || af.ReviewOnly) {
+			noMergeIssue, showErr := noMergeBd.Show(issueID)
+			if showErr != nil {
+				return fmt.Errorf("cannot inspect source issue %s before completion: %w", issueID, showErr)
+			}
+			if af := beads.ParseAttachmentFields(noMergeIssue); af != nil {
+				if af.NoMerge || af.ReviewOnly {
 					isNoMergeTask = true
 				}
+				reviewOnlySource = af.ReviewOnly
 			}
 		}
 
@@ -642,18 +783,15 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			if issueID != "" {
 				bd := beads.New(cwd)
 
-				// Acceptance criteria gate: check for unchecked criteria before closing.
-				// If criteria exist and are unchecked, warn and skip close — the bead stays
-				// open for witness/mayor to handle.
 				skipClose := false
-				if issue, err := bd.Show(issueID); err == nil {
-					if unchecked := beads.HasUncheckedCriteria(issue); unchecked > 0 {
-						skipReason := fmt.Sprintf("issue %s has %d unchecked acceptance criteria — skipping close", issueID, unchecked)
-						style.PrintWarning("%s", skipReason)
-						fmt.Printf("  The bead will remain open for witness/mayor review.\n")
-						notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
-						skipClose = true
+				if skipReason, fatal := doneSourceCloseSkipReason(bd, issueID, nil); skipReason != "" {
+					style.PrintWarning("%s", skipReason)
+					fmt.Printf("  The bead will remain open for witness/mayor review.\n")
+					notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
+					if fatal {
+						return fmt.Errorf("cannot complete review-only/no-MR work: %s", skipReason)
 					}
+					skipClose = true
 				}
 
 				if !skipClose {
@@ -699,6 +837,10 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 			// Skip straight to witness notification (no MR needed)
 			goto notifyWitness
+		}
+
+		if reviewOnlySource {
+			return fmt.Errorf("cannot complete review-only issue %s with commits ahead of %s; persist review evidence in notes/design/comments and complete without code changes", issueID, baseRef)
 		}
 
 		// Branch contamination preflight: check if branch is significantly behind
@@ -815,21 +957,26 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			// Close the base issue — no MR/refinery will close it
 			if issueID != "" {
 				directBd := beads.New(cwd)
-				closeReason := fmt.Sprintf("Direct merge to %s (convoy strategy)", defaultBranch)
-				var closeErr error
-				for attempt := 1; attempt <= 3; attempt++ {
-					closeErr = directBd.ForceCloseWithReason(closeReason, issueID)
-					if closeErr == nil {
-						fmt.Printf("%s Issue %s closed (direct merge)\n", style.Bold.Render("✓"), issueID)
-						break
+				if skipReason, _ := doneReviewOnlyCloseSkipReason(directBd, issueID, nil); skipReason != "" {
+					style.PrintWarning("%s", skipReason)
+					notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
+				} else {
+					closeReason := fmt.Sprintf("Direct merge to %s (convoy strategy)", defaultBranch)
+					var closeErr error
+					for attempt := 1; attempt <= 3; attempt++ {
+						closeErr = directBd.ForceCloseWithReason(closeReason, issueID)
+						if closeErr == nil {
+							fmt.Printf("%s Issue %s closed (direct merge)\n", style.Bold.Render("✓"), issueID)
+							break
+						}
+						if attempt < 3 {
+							style.PrintWarning("close attempt %d/3 failed: %v (retrying in %ds)", attempt, closeErr, attempt*2)
+							time.Sleep(time.Duration(attempt*2) * time.Second)
+						}
 					}
-					if attempt < 3 {
-						style.PrintWarning("close attempt %d/3 failed: %v (retrying in %ds)", attempt, closeErr, attempt*2)
-						time.Sleep(time.Duration(attempt*2) * time.Second)
+					if closeErr != nil {
+						style.PrintWarning("could not close issue %s after 3 attempts: %v", issueID, closeErr)
 					}
-				}
-				if closeErr != nil {
-					style.PrintWarning("could not close issue %s after 3 attempts: %v", issueID, closeErr)
 				}
 			}
 
@@ -1052,7 +1199,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				// here after notifying the dispatcher. Otherwise hooked work remains open.
 				if issueID != "" {
 					canCloseIssue := true
-					if attachmentFields.AttachedMolecule != "" {
+					if skipReason, _ := doneReviewOnlyCloseSkipReason(bd, issueID, sourceIssueForNoMerge); skipReason != "" {
+						style.PrintWarning("%s", skipReason)
+						notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
+						canCloseIssue = false
+					}
+					if canCloseIssue && attachmentFields.AttachedMolecule != "" {
 						if n := closeDescendants(bd, attachmentFields.AttachedMolecule); n > 0 {
 							fmt.Fprintf(os.Stderr, "Closed %d molecule step(s) for %s\n", n, attachmentFields.AttachedMolecule)
 						}
@@ -1124,21 +1276,26 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 				// Close the issue directly — refinery won't process it.
 				if issueID != "" {
-					var closeErr error
-					for attempt := 1; attempt <= 3; attempt++ {
-						closeErr = bd.ForceCloseWithReason(
-							fmt.Sprintf("Direct merge to %s (convoy strategy, late detection)", defaultBranch), issueID)
-						if closeErr == nil {
-							fmt.Printf("%s Issue %s closed (direct merge)\n", style.Bold.Render("✓"), issueID)
-							break
+					if skipReason, _ := doneReviewOnlyCloseSkipReason(bd, issueID, nil); skipReason != "" {
+						style.PrintWarning("%s", skipReason)
+						notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
+					} else {
+						var closeErr error
+						for attempt := 1; attempt <= 3; attempt++ {
+							closeErr = bd.ForceCloseWithReason(
+								fmt.Sprintf("Direct merge to %s (convoy strategy, late detection)", defaultBranch), issueID)
+							if closeErr == nil {
+								fmt.Printf("%s Issue %s closed (direct merge)\n", style.Bold.Render("✓"), issueID)
+								break
+							}
+							if attempt < 3 {
+								style.PrintWarning("close attempt %d/3 failed: %v (retrying in %ds)", attempt, closeErr, attempt*2)
+								time.Sleep(time.Duration(attempt*2) * time.Second)
+							}
 						}
-						if attempt < 3 {
-							style.PrintWarning("close attempt %d/3 failed: %v (retrying in %ds)", attempt, closeErr, attempt*2)
-							time.Sleep(time.Duration(attempt*2) * time.Second)
+						if closeErr != nil {
+							style.PrintWarning("could not close issue %s after 3 attempts: %v", issueID, closeErr)
 						}
-					}
-					if closeErr != nil {
-						style.PrintWarning("could not close issue %s after 3 attempts: %v", issueID, closeErr)
 					}
 				}
 
@@ -1924,6 +2081,13 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
 			// infrastructure. Skip close and fall through to idle state update.
 			if beads.HasLabel(hookedBead, "gt:rig") {
 				fmt.Fprintf(os.Stderr, "Note: hooked bead %s is a rig identity bead (gt:rig) — skipping close\n", hookedBeadID)
+				goto doneStateUpdate
+			}
+
+			if skipReason, _ := doneReviewOnlyCloseSkipReason(bd, hookedBeadID, hookedBead); skipReason != "" {
+				style.PrintWarning("%s", skipReason)
+				fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
+				notifyDoneCloseSkipped(townRoot, ctx.Rig, detectSender(), hookedBeadID, skipReason)
 				goto doneStateUpdate
 			}
 

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -938,7 +938,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		}
 
 		if reviewOnlySource {
-			return fmt.Errorf("cannot complete review-only issue %s with commits ahead of %s; persist review evidence in notes/design/comments and complete without code changes", issueID, baseRef)
+			return fmt.Errorf("cannot complete review-only issue %s with commits ahead of %s; add a fresh review evidence comment and complete without code changes", issueID, baseRef)
 		}
 
 		// Branch contamination preflight: check if branch is significantly behind

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -121,11 +121,16 @@ var generatedCommentPrefixes = []string{
 }
 
 func doneSourceCloseSkipReason(bd *beads.Beads, issueID string, issue *beads.Issue) (string, bool) {
+	currentHead, _ := currentReviewEvidenceHead()
+	return doneSourceCloseSkipReasonForHead(bd, issueID, issue, currentHead)
+}
+
+func doneSourceCloseSkipReasonForHead(bd *beads.Beads, issueID string, issue *beads.Issue, currentHead string) (string, bool) {
 	issue, skipReason, fatal := loadDoneSourceIssue(bd, issueID, issue)
 	if skipReason != "" {
 		return skipReason, fatal
 	}
-	if skipReason, fatal := doneReviewOnlyCloseSkipReason(bd, issueID, issue); skipReason != "" {
+	if skipReason, fatal := doneReviewOnlyCloseSkipReasonForHead(bd, issueID, issue, currentHead); skipReason != "" {
 		return skipReason, fatal
 	}
 	if unchecked := beads.HasUncheckedCriteria(issue); unchecked > 0 {
@@ -143,12 +148,39 @@ func doneReviewOnlyCloseSkipReason(bd *beads.Beads, issueID string, issue *beads
 	if attachment == nil || !attachment.ReviewOnly {
 		return "", false
 	}
-	hasEvidence, err := hasReviewReportEvidence(bd, issueID, issue)
+	currentHead, err := currentReviewEvidenceHead()
+	if err != nil {
+		return fmt.Sprintf("could not verify review evidence for %s: %v", issueID, err), true
+	}
+	return doneReviewOnlyCloseSkipReasonForHead(bd, issueID, issue, currentHead)
+}
+
+func doneReviewOnlyCloseSkipReasonForHead(bd *beads.Beads, issueID string, issue *beads.Issue, currentHead string) (string, bool) {
+	issue, skipReason, fatal := loadDoneSourceIssue(bd, issueID, issue)
+	if skipReason != "" {
+		return skipReason, fatal
+	}
+	attachment := beads.ParseAttachmentFields(issue)
+	if attachment == nil || !attachment.ReviewOnly {
+		return "", false
+	}
+	assignmentAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(attachment.AttachedAt))
+	if err != nil {
+		return fmt.Sprintf("review-only issue %s has no fresh assignment timestamp — re-sling it or add evidence after a fresh assignment", issueID), true
+	}
+	if strings.TrimSpace(issue.Assignee) == "" {
+		return fmt.Sprintf("review-only issue %s has no assignee for evidence author validation", issueID), true
+	}
+	currentHead = strings.TrimSpace(currentHead)
+	if currentHead == "" {
+		return fmt.Sprintf("review-only issue %s has no current HEAD for evidence validation", issueID), true
+	}
+	hasEvidence, err := hasFreshReviewReportEvidence(bd, issueID, issue, assignmentAt, issue.Assignee, currentHead)
 	if err != nil {
 		return fmt.Sprintf("could not verify review evidence for %s: %v", issueID, err), true
 	}
 	if !hasEvidence {
-		return fmt.Sprintf("review-only issue %s has no report/evidence — add a REPORT/FINDINGS/REVIEW/EVIDENCE entry before gt done", issueID), true
+		return fmt.Sprintf("review-only issue %s has no fresh review evidence comment for assignee %s and head %s", issueID, strings.TrimSpace(issue.Assignee), currentHead), true
 	}
 	return "", false
 }
@@ -170,15 +202,19 @@ func loadDoneSourceIssue(bd *beads.Beads, issueID string, issue *beads.Issue) (*
 	return loaded, "", false
 }
 
-func hasReviewReportEvidence(bd *beads.Beads, issueID string, issue *beads.Issue) (bool, error) {
+func currentReviewEvidenceHead() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("resolving current HEAD: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func hasFreshReviewReportEvidence(bd *beads.Beads, issueID string, issue *beads.Issue, assignmentAt time.Time, assignee, currentHead string) (bool, error) {
 	if issue != nil {
-		if isReviewEvidenceText(issue.Notes) || isReviewEvidenceText(issue.Design) {
+		if hasFreshReviewEvidenceComment(issue.Comments, assignmentAt, assignee, currentHead) {
 			return true, nil
-		}
-		for _, comment := range issue.Comments {
-			if isReviewEvidenceText(comment.Text) {
-				return true, nil
-			}
 		}
 	}
 	if bd == nil || issueID == "" {
@@ -190,7 +226,15 @@ func hasReviewReportEvidence(bd *beads.Beads, issueID string, issue *beads.Issue
 			return false, err
 		}
 		for _, comment := range comments {
-			if comment != nil && isReviewEvidenceText(comment.Text) {
+			if comment == nil {
+				continue
+			}
+			candidate := beads.Comment{
+				Author:    comment.Author,
+				Text:      comment.Text,
+				CreatedAt: comment.CreatedAt.Format(time.RFC3339Nano),
+			}
+			if hasFreshReviewEvidenceComment([]beads.Comment{candidate}, assignmentAt, assignee, currentHead) {
 				return true, nil
 			}
 		}
@@ -204,12 +248,66 @@ func hasReviewReportEvidence(bd *beads.Beads, issueID string, issue *beads.Issue
 	if err := json.Unmarshal(out, &comments); err != nil {
 		return false, fmt.Errorf("parsing comments: %w", err)
 	}
-	for _, comment := range comments {
-		if isReviewEvidenceText(comment.Text) {
-			return true, nil
-		}
+	if hasFreshReviewEvidenceComment(comments, assignmentAt, assignee, currentHead) {
+		return true, nil
 	}
 	return false, nil
+}
+
+func hasFreshReviewEvidenceComment(comments []beads.Comment, assignmentAt time.Time, assignee, currentHead string) bool {
+	assignee = strings.TrimSpace(assignee)
+	currentHead = strings.TrimSpace(currentHead)
+	if assignee == "" || currentHead == "" {
+		return false
+	}
+	for _, comment := range comments {
+		createdAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(comment.CreatedAt))
+		if err != nil || createdAt.Before(assignmentAt) {
+			continue
+		}
+		if strings.TrimSpace(comment.Author) != assignee {
+			continue
+		}
+		if isGeneratedReviewComment(comment.Text) || !isReviewEvidenceText(comment.Text) {
+			continue
+		}
+		if reviewEvidenceHeadSHA(comment.Text) != currentHead {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func isGeneratedReviewComment(text string) bool {
+	for _, line := range strings.Split(text, "\n") {
+		lower := strings.ToLower(strings.TrimSpace(line))
+		if lower == "" {
+			continue
+		}
+		for _, prefix := range generatedCommentPrefixes {
+			if strings.HasPrefix(lower, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func reviewEvidenceHeadSHA(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		lower := strings.ToLower(trimmed)
+		for _, key := range []string{"head_sha", "target_head_sha", "head"} {
+			for _, sep := range []string{":", "="} {
+				prefix := key + sep
+				if strings.HasPrefix(lower, prefix) {
+					return strings.TrimSpace(trimmed[len(prefix):])
+				}
+			}
+		}
+	}
+	return ""
 }
 
 func isReviewEvidenceText(text string) bool {
@@ -957,9 +1055,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			// Close the base issue — no MR/refinery will close it
 			if issueID != "" {
 				directBd := beads.New(cwd)
-				if skipReason, _ := doneReviewOnlyCloseSkipReason(directBd, issueID, nil); skipReason != "" {
+				if skipReason, fatal := doneReviewOnlyCloseSkipReason(directBd, issueID, nil); skipReason != "" {
 					style.PrintWarning("%s", skipReason)
 					notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
+					if fatal {
+						return fmt.Errorf("cannot complete review-only work: %s", skipReason)
+					}
 				} else {
 					closeReason := fmt.Sprintf("Direct merge to %s (convoy strategy)", defaultBranch)
 					var closeErr error
@@ -1199,9 +1300,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				// here after notifying the dispatcher. Otherwise hooked work remains open.
 				if issueID != "" {
 					canCloseIssue := true
-					if skipReason, _ := doneReviewOnlyCloseSkipReason(bd, issueID, sourceIssueForNoMerge); skipReason != "" {
+					if skipReason, fatal := doneReviewOnlyCloseSkipReason(bd, issueID, sourceIssueForNoMerge); skipReason != "" {
 						style.PrintWarning("%s", skipReason)
 						notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
+						if fatal {
+							return fmt.Errorf("cannot complete review-only/no-merge work: %s", skipReason)
+						}
 						canCloseIssue = false
 					}
 					if canCloseIssue && attachmentFields.AttachedMolecule != "" {
@@ -1276,9 +1380,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 				// Close the issue directly — refinery won't process it.
 				if issueID != "" {
-					if skipReason, _ := doneReviewOnlyCloseSkipReason(bd, issueID, nil); skipReason != "" {
+					if skipReason, fatal := doneReviewOnlyCloseSkipReason(bd, issueID, nil); skipReason != "" {
 						style.PrintWarning("%s", skipReason)
 						notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
+						if fatal {
+							return fmt.Errorf("cannot complete review-only work: %s", skipReason)
+						}
 					} else {
 						var closeErr error
 						for attempt := 1; attempt <= 3; attempt++ {
@@ -1615,7 +1722,9 @@ notifyWitness:
 	}
 
 	// Update agent bead state (ZFC: self-report completion)
-	updateAgentStateOnDone(cwd, townRoot, exitType, issueID)
+	if err := updateAgentStateOnDone(cwd, townRoot, exitType, issueID); err != nil {
+		return err
+	}
 
 	// Nudge witness only after hook/cleanup state is updated. Otherwise witness can
 	// evaluate slot availability against stale hook_bead or cleanup_status and emit
@@ -1989,7 +2098,7 @@ func clearDoneCheckpoints(bd *beads.Beads, agentBeadID string) {
 // BUG FIX (hq-3xaxy): This function must be resilient to working directory deletion.
 // If the polecat's worktree is deleted before gt done finishes, we use env vars as fallback.
 // All errors are warnings, not failures - gt done must complete even if bead ops fail.
-func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
+func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 	// Get role context - try multiple sources for resilience
 	roleInfo, err := GetRoleWithContext(cwd, townRoot)
 	if err != nil {
@@ -2002,7 +2111,7 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
 		if envRole == "" || envRig == "" {
 			// Can't determine role, skip agent state update
 			style.PrintWarning("could not determine role for agent state update (env: GT_ROLE=%q, GT_RIG=%q)", envRole, envRig)
-			return
+			return nil
 		}
 
 		// Parse role string to get Role type
@@ -2029,7 +2138,7 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
 	agentBeadID := getAgentBeadID(ctx)
 	if agentBeadID == "" {
 		style.PrintWarning("no agent bead ID found for %s/%s, skipping agent state update", ctx.Rig, ctx.Polecat)
-		return
+		return nil
 	}
 
 	// Use rig path for bd commands.
@@ -2084,10 +2193,13 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
 				goto doneStateUpdate
 			}
 
-			if skipReason, _ := doneReviewOnlyCloseSkipReason(bd, hookedBeadID, hookedBead); skipReason != "" {
+			if skipReason, fatal := doneReviewOnlyCloseSkipReason(bd, hookedBeadID, hookedBead); skipReason != "" {
 				style.PrintWarning("%s", skipReason)
 				fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
 				notifyDoneCloseSkipped(townRoot, ctx.Rig, detectSender(), hookedBeadID, skipReason)
+				if fatal {
+					return fmt.Errorf("cannot complete review-only work: %s", skipReason)
+				}
 				goto doneStateUpdate
 			}
 
@@ -2182,6 +2294,7 @@ doneStateUpdate:
 	// lingering labels to detect the zombie and resume from checkpoints.
 	clearDoneIntentLabel(agentBd, agentBeadID)
 	clearDoneCheckpoints(agentBd, agentBeadID)
+	return nil
 }
 
 // ensureAgentBeadExists recreates a missing agent bead so done-intent labels,

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -193,20 +193,31 @@ func TestReviewOnlyGeneratedCommentsDoNotCountAsEvidence(t *testing.T) {
 }
 
 func TestReviewOnlyCloseRejectsStaleComment(t *testing.T) {
-	issue := &beads.Issue{
-		ID:          "gt-review",
-		Description: "review_only: true\nattached_at: 2026-07-01T12:00:00Z\n",
-		Assignee:    "gastown/polecats/toast",
-		Comments: []beads.Comment{{
-			Author:    "gastown/polecats/toast",
-			CreatedAt: "2026-07-01T11:59:59Z",
-			Text:      "PR-SHERIFF-EVIDENCE: pass\nhead_sha: abc123",
-		}},
+	tests := []struct {
+		name      string
+		createdAt string
+	}{
+		{name: "before attached_at", createdAt: "2026-07-01T11:59:59Z"},
+		{name: "equal to attached_at", createdAt: "2026-07-01T12:00:00Z"},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &beads.Issue{
+				ID:          "gt-review",
+				Description: "review_only: true\nattached_at: 2026-07-01T12:00:00Z\n",
+				Assignee:    "gastown/polecats/toast",
+				Comments: []beads.Comment{{
+					Author:    "gastown/polecats/toast",
+					CreatedAt: tt.createdAt,
+					Text:      "PR-SHERIFF-EVIDENCE: pass\nhead_sha: abc123",
+				}},
+			}
 
-	reason, fatal := doneReviewOnlyCloseSkipReasonForHead(nil, issue.ID, issue, "abc123")
-	if reason == "" || !fatal {
-		t.Fatalf("stale comment should not satisfy review evidence: reason=%q fatal=%v", reason, fatal)
+			reason, fatal := doneReviewOnlyCloseSkipReasonForHead(nil, issue.ID, issue, "abc123")
+			if reason == "" || !fatal {
+				t.Fatalf("stale comment should not satisfy review evidence: reason=%q fatal=%v", reason, fatal)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -122,6 +122,81 @@ func TestForceCloseIssueWithRetryReturnsFinalError(t *testing.T) {
 	}
 }
 
+func TestReviewOnlyCloseRequiresEvidence(t *testing.T) {
+	issue := &beads.Issue{
+		ID:          "gt-review",
+		Description: "review_only: true\n",
+	}
+
+	reason, fatal := doneReviewOnlyCloseSkipReason(nil, issue.ID, issue)
+	if reason == "" {
+		t.Fatal("expected review-only close skip reason")
+	}
+	if !fatal {
+		t.Fatal("review-only close without evidence should fail closed")
+	}
+	if !strings.Contains(reason, "no report/evidence") {
+		t.Fatalf("reason = %q, want missing evidence", reason)
+	}
+}
+
+func TestReviewOnlyCloseAllowsEvidence(t *testing.T) {
+	issue := &beads.Issue{
+		ID:          "gt-review",
+		Description: "review_only: true\n",
+		Notes:       "FINDINGS: reviewed and no code changes needed",
+	}
+
+	reason, fatal := doneReviewOnlyCloseSkipReason(nil, issue.ID, issue)
+	if reason != "" || fatal {
+		t.Fatalf("doneReviewOnlyCloseSkipReason = %q, %v; want allowed", reason, fatal)
+	}
+}
+
+func TestReviewOnlyGeneratedCommentsDoNotCountAsEvidence(t *testing.T) {
+	issue := &beads.Issue{
+		ID:          "gt-review",
+		Description: "review_only: true\n",
+		Comments: []beads.Comment{
+			{Text: "verified_push_skipped: --skip-verify on no-MR close"},
+			{Text: "MR created: gt-wisp-abc"},
+		},
+	}
+
+	reason, fatal := doneReviewOnlyCloseSkipReason(nil, issue.ID, issue)
+	if reason == "" || !fatal {
+		t.Fatalf("generated comments should not satisfy review evidence: reason=%q fatal=%v", reason, fatal)
+	}
+}
+
+func TestNonReviewOnlyCloseDoesNotRequireEvidence(t *testing.T) {
+	issue := &beads.Issue{
+		ID:          "gt-review",
+		Description: "no_merge: true\n",
+	}
+
+	reason, fatal := doneReviewOnlyCloseSkipReason(nil, issue.ID, issue)
+	if reason != "" || fatal {
+		t.Fatalf("non-review-only close gate = %q, %v; want no restriction", reason, fatal)
+	}
+}
+
+func TestNonReviewOnlyReviewGateDoesNotChangeCriteriaHandling(t *testing.T) {
+	issue := &beads.Issue{
+		ID:                 "gt-review",
+		Description:        "no_merge: true\n",
+		AcceptanceCriteria: "- [ ] still open\n",
+	}
+
+	reason, fatal := doneSourceCloseSkipReason(nil, issue.ID, issue)
+	if reason == "" || fatal {
+		t.Fatalf("criteria gate = %q, %v; want non-fatal skip", reason, fatal)
+	}
+	if !strings.Contains(reason, "unchecked acceptance criteria") {
+		t.Fatalf("reason = %q, want criteria reason", reason)
+	}
+}
+
 // TestDoneBeadsInitWithoutRedirect verifies that beads initialization works
 // normally when no redirect file exists.
 func TestDoneBeadsInitWithoutRedirect(t *testing.T) {

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -128,26 +128,48 @@ func TestReviewOnlyCloseRequiresEvidence(t *testing.T) {
 		Description: "review_only: true\n",
 	}
 
-	reason, fatal := doneReviewOnlyCloseSkipReason(nil, issue.ID, issue)
+	reason, fatal := doneReviewOnlyCloseSkipReasonForHead(nil, issue.ID, issue, "abc123")
 	if reason == "" {
 		t.Fatal("expected review-only close skip reason")
 	}
 	if !fatal {
 		t.Fatal("review-only close without evidence should fail closed")
 	}
-	if !strings.Contains(reason, "no report/evidence") {
+	if !strings.Contains(reason, "no fresh assignment timestamp") {
 		t.Fatalf("reason = %q, want missing evidence", reason)
 	}
 }
 
-func TestReviewOnlyCloseAllowsEvidence(t *testing.T) {
+func TestReviewOnlyCloseRejectsNotesAndDesignEvidence(t *testing.T) {
 	issue := &beads.Issue{
 		ID:          "gt-review",
-		Description: "review_only: true\n",
+		Description: "review_only: true\nattached_at: 2026-07-01T12:00:00Z\n",
+		Assignee:    "gastown/polecats/toast",
 		Notes:       "FINDINGS: reviewed and no code changes needed",
+		Design:      "PR-SHERIFF-EVIDENCE: pass\nhead_sha: abc123",
 	}
 
-	reason, fatal := doneReviewOnlyCloseSkipReason(nil, issue.ID, issue)
+	reason, fatal := doneReviewOnlyCloseSkipReasonForHead(nil, issue.ID, issue, "abc123")
+	if reason == "" || !fatal {
+		t.Fatalf("notes/design should not satisfy review evidence: reason=%q fatal=%v", reason, fatal)
+	}
+}
+
+func TestReviewOnlyCloseAllowsFreshEvidenceComment(t *testing.T) {
+	issue := &beads.Issue{
+		ID:          "gt-review",
+		Description: "review_only: true\nattached_at: 2026-07-01T12:00:00Z\n",
+		Assignee:    "gastown/polecats/toast",
+		Comments: []beads.Comment{
+			{
+				Author:    "gastown/polecats/toast",
+				CreatedAt: "2026-07-01T12:05:00Z",
+				Text:      "PR-SHERIFF-EVIDENCE: pass\nhead_sha: abc123",
+			},
+		},
+	}
+
+	reason, fatal := doneReviewOnlyCloseSkipReasonForHead(nil, issue.ID, issue, "abc123")
 	if reason != "" || fatal {
 		t.Fatalf("doneReviewOnlyCloseSkipReason = %q, %v; want allowed", reason, fatal)
 	}
@@ -156,16 +178,99 @@ func TestReviewOnlyCloseAllowsEvidence(t *testing.T) {
 func TestReviewOnlyGeneratedCommentsDoNotCountAsEvidence(t *testing.T) {
 	issue := &beads.Issue{
 		ID:          "gt-review",
-		Description: "review_only: true\n",
+		Description: "review_only: true\nattached_at: 2026-07-01T12:00:00Z\n",
+		Assignee:    "gastown/polecats/toast",
 		Comments: []beads.Comment{
-			{Text: "verified_push_skipped: --skip-verify on no-MR close"},
-			{Text: "MR created: gt-wisp-abc"},
+			{Author: "gastown/polecats/toast", CreatedAt: "2026-07-01T12:05:00Z", Text: "verified_push_skipped: --skip-verify on no-MR close\nPR-SHERIFF-EVIDENCE: pass\nhead_sha: abc123"},
+			{Author: "gastown/polecats/toast", CreatedAt: "2026-07-01T12:06:00Z", Text: "MR created: gt-wisp-abc\nPR-SHERIFF-EVIDENCE: pass\nhead_sha: abc123"},
 		},
 	}
 
-	reason, fatal := doneReviewOnlyCloseSkipReason(nil, issue.ID, issue)
+	reason, fatal := doneReviewOnlyCloseSkipReasonForHead(nil, issue.ID, issue, "abc123")
 	if reason == "" || !fatal {
 		t.Fatalf("generated comments should not satisfy review evidence: reason=%q fatal=%v", reason, fatal)
+	}
+}
+
+func TestReviewOnlyCloseRejectsStaleComment(t *testing.T) {
+	issue := &beads.Issue{
+		ID:          "gt-review",
+		Description: "review_only: true\nattached_at: 2026-07-01T12:00:00Z\n",
+		Assignee:    "gastown/polecats/toast",
+		Comments: []beads.Comment{{
+			Author:    "gastown/polecats/toast",
+			CreatedAt: "2026-07-01T11:59:59Z",
+			Text:      "PR-SHERIFF-EVIDENCE: pass\nhead_sha: abc123",
+		}},
+	}
+
+	reason, fatal := doneReviewOnlyCloseSkipReasonForHead(nil, issue.ID, issue, "abc123")
+	if reason == "" || !fatal {
+		t.Fatalf("stale comment should not satisfy review evidence: reason=%q fatal=%v", reason, fatal)
+	}
+}
+
+func TestReviewOnlyCloseRejectsWrongAuthorOrHead(t *testing.T) {
+	tests := []struct {
+		name    string
+		author  string
+		head    string
+		current string
+	}{
+		{name: "wrong author", author: "gastown/polecats/other", head: "abc123", current: "abc123"},
+		{name: "wrong head", author: "gastown/polecats/toast", head: "def456", current: "abc123"},
+		{name: "missing head", author: "gastown/polecats/toast", head: "", current: "abc123"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text := "PR-SHERIFF-EVIDENCE: pass"
+			if tt.head != "" {
+				text += "\nhead_sha: " + tt.head
+			}
+			issue := &beads.Issue{
+				ID:          "gt-review",
+				Description: "review_only: true\nattached_at: 2026-07-01T12:00:00Z\n",
+				Assignee:    "gastown/polecats/toast",
+				Comments: []beads.Comment{{
+					Author:    tt.author,
+					CreatedAt: "2026-07-01T12:05:00Z",
+					Text:      text,
+				}},
+			}
+			reason, fatal := doneReviewOnlyCloseSkipReasonForHead(nil, issue.ID, issue, tt.current)
+			if reason == "" || !fatal {
+				t.Fatalf("invalid evidence should fail closed: reason=%q fatal=%v", reason, fatal)
+			}
+		})
+	}
+}
+
+func TestReviewOnlyCloseRejectsMissingAssigneeOrInvalidCommentTime(t *testing.T) {
+	tests := []struct {
+		name      string
+		assignee  string
+		createdAt string
+	}{
+		{name: "missing assignee", assignee: "", createdAt: "2026-07-01T12:05:00Z"},
+		{name: "invalid comment time", assignee: "gastown/polecats/toast", createdAt: "not-a-time"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &beads.Issue{
+				ID:          "gt-review",
+				Description: "review_only: true\nattached_at: 2026-07-01T12:00:00Z\n",
+				Assignee:    tt.assignee,
+				Comments: []beads.Comment{{
+					Author:    "gastown/polecats/toast",
+					CreatedAt: tt.createdAt,
+					Text:      "PR-SHERIFF-EVIDENCE: pass\nhead_sha: abc123",
+				}},
+			}
+			reason, fatal := doneReviewOnlyCloseSkipReasonForHead(nil, issue.ID, issue, "abc123")
+			if reason == "" || !fatal {
+				t.Fatalf("invalid metadata should fail closed: reason=%q fatal=%v", reason, fatal)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -997,6 +997,26 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		// - Base bead left orphaned after gt done
 	}
 
+	actor := detectActor()
+	mode := ""
+	if slingRalph {
+		mode = "ralph"
+	}
+	fieldUpdates := buildSlingFieldUpdates(
+		actor,
+		slingArgs,
+		varsForAttachment,
+		attachedMoleculeID,
+		formulaName,
+		slingNoMerge,
+		slingReviewOnly,
+		mode,
+		formulaVarsForAttachment,
+		convoyID,
+		slingMerge,
+		slingOwned,
+	)
+
 	// Hook the bead with retry and verification.
 	// See: https://github.com/steveyegge/gastown/issues/148
 	//
@@ -1008,6 +1028,12 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		return fmt.Errorf("serializing hook write for %s: %w", targetAgent, assigneeLockErr)
 	}
 	defer assigneeUnlock()
+	if attachedMoleculeID == "" && (slingNoMerge || slingReviewOnly) {
+		if err := storeFieldsInBeadFromTownRoot(townRoot, beadID, fieldUpdates); err != nil {
+			rollbackSpawnedPolecat("Raw sling metadata failed")
+			return fmt.Errorf("storing raw sling metadata before hook: %w", err)
+		}
+	}
 	hookDir := beads.ResolveHookDir(townRoot, beadID, hookWorkDir)
 	if err := hookBeadWithRetryFn(beadID, targetAgent, hookDir); err != nil {
 		rollbackSpawnedPolecat("Hook failed")
@@ -1031,7 +1057,6 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	fmt.Printf("%s Work attached to hook (status=hooked)\n", style.Bold.Render("✓"))
 
 	// Log sling event to activity feed
-	actor := detectActor()
 	_ = events.LogFeed(events.TypeSling, actor, events.SlingPayload(beadID, targetAgent))
 
 	// Update agent bead's hook_bead field (ZFC: agents track their current work)
@@ -1045,24 +1070,6 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// Store all attachment fields in a single read-modify-write cycle.
 	// This eliminates the race condition where sequential independent updates
 	// (dispatcher, args, no_merge, attached_molecule) could overwrite each other.
-	mode := ""
-	if slingRalph {
-		mode = "ralph"
-	}
-	fieldUpdates := buildSlingFieldUpdates(
-		actor,
-		slingArgs,
-		varsForAttachment,
-		attachedMoleculeID,
-		formulaName,
-		slingNoMerge,
-		slingReviewOnly,
-		mode,
-		formulaVarsForAttachment,
-		convoyID,
-		slingMerge,
-		slingOwned,
-	)
 	if err := storeFieldsInBeadFromTownRoot(townRoot, beadID, fieldUpdates); err != nil {
 		// Warn but don't fail - polecat will still complete work
 		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -1210,6 +1210,32 @@ var getBeadInfoForRollback = getBeadInfo
 var collectExistingMoleculesForRollback = collectExistingMolecules
 var burnExistingMoleculesForRollback = burnExistingMolecules
 
+func clearRollbackRawWorkflowFields(beadID, townRoot, hookWorkDir string, info *beadInfo) (bool, error) {
+	if info == nil {
+		return false, nil
+	}
+	issue := &beads.Issue{Description: info.Description}
+	fields := beads.ParseAttachmentFields(issue)
+	if fields == nil || (!fields.NoMerge && !fields.ReviewOnly) {
+		return false, nil
+	}
+	fields.NoMerge = false
+	fields.ReviewOnly = false
+	newDesc := beads.SetAttachmentFields(issue, fields)
+	if newDesc == info.Description {
+		return false, nil
+	}
+	updateDir := beads.ResolveHookDir(townRoot, beadID, hookWorkDir)
+	if err := BdCmd("update", beadID, "--description="+newDesc).
+		Dir(updateDir).
+		StripBeadsDir().
+		WithAutoCommit().
+		Run(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func restorePinnedBead(townRoot, beadID, assignee string) {
 	if townRoot == "" || beadID == "" {
 		return
@@ -1330,6 +1356,10 @@ func rollbackSlingArtifacts(spawnInfo *SpawnedPolecatInfo, beadID, hookWorkDir, 
 						fmt.Printf("  %s Burned %d stale molecule(s): %s\n",
 							style.Dim.Render("○"), len(existingMolecules), strings.Join(existingMolecules, ", "))
 					}
+				} else if cleared, clearErr := clearRollbackRawWorkflowFields(beadID, townRoot, hookWorkDir, info); clearErr != nil {
+					fmt.Printf("  %s Could not clear raw workflow metadata from %s: %v\n", style.Dim.Render("Warning:"), beadID, clearErr)
+				} else if cleared {
+					fmt.Printf("  %s Cleared raw workflow metadata from %s\n", style.Dim.Render("○"), beadID)
 				}
 			}
 

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -748,11 +748,11 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	newPolecatInfo := resolved.NewPolecatInfo
 	isSelfSling := resolved.IsSelfSling
 	rollbackSpawnedPolecat := func(reason string) {
-		if newPolecatInfo == nil {
-			return
+		if newPolecatInfo != nil {
+			fmt.Printf("%s %s, rolling back spawned polecat %s...\n", style.Warning.Render("⚠"), reason, newPolecatInfo.PolecatName)
+			rollbackSlingArtifactsFn(newPolecatInfo, beadID, hookWorkDir, "")
 		}
-		fmt.Printf("%s %s, rolling back spawned polecat %s...\n", style.Warning.Render("⚠"), reason, newPolecatInfo.PolecatName)
-		rollbackSlingArtifactsFn(newPolecatInfo, beadID, hookWorkDir, "")
+		restoreRollbackRawWorkflowFieldsFromCurrent(beadID, townRoot, hookWorkDir, info)
 		// Under --force, rollback's unhook can clear a pinned bead's original state.
 		if force && originalStatus == "pinned" {
 			restorePinnedBead(townRoot, beadID, originalAssignee)
@@ -960,14 +960,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 			// If we spawned a fresh polecat (rig target), rollback the partial artifacts.
 			// Otherwise, a wisp creation failure (e.g., missing required vars) leaves an orphaned polecat.
 			if newPolecatInfo != nil {
-				fmt.Printf("%s Formula instantiation failed, rolling back spawned polecat %s...\n",
-					style.Warning.Render("⚠"), newPolecatInfo.PolecatName)
-				rollbackSlingArtifactsFn(newPolecatInfo, beadID, hookWorkDir, "")
-				// Under --force, if this bead was previously pinned, rollback's unhook would otherwise
-				// clear the pinned state. Restore pinned state so we don't lose the original hook.
-				if force && originalStatus == "pinned" {
-					restorePinnedBead(townRoot, beadID, originalAssignee)
-				}
+				rollbackSpawnedPolecat("Formula instantiation failed")
 			}
 			return fmt.Errorf("instantiating formula %s: %w", formulaName, err)
 		}
@@ -1030,7 +1023,11 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	defer assigneeUnlock()
 	if attachedMoleculeID == "" && (slingNoMerge || slingReviewOnly) {
 		if err := storeFieldsInBeadFromTownRoot(townRoot, beadID, fieldUpdates); err != nil {
-			rollbackSpawnedPolecat("Raw sling metadata failed")
+			if newPolecatInfo != nil {
+				fmt.Printf("%s Raw sling metadata failed, cleaning up spawned polecat %s...\n", style.Warning.Render("⚠"), newPolecatInfo.PolecatName)
+				cleanupSpawnedPolecat(newPolecatInfo, newPolecatInfo.RigName, convoyID)
+			}
+			restoreRollbackRawWorkflowFieldsFromCurrent(beadID, townRoot, hookWorkDir, info)
 			return fmt.Errorf("storing raw sling metadata before hook: %w", err)
 		}
 	}
@@ -1106,8 +1103,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		if err != nil {
 			// Rollback: session failed, clean up zombie artifacts (worktree, hooked bead).
 			// Without rollback, next sling attempt fails with "bead already hooked" (gt-jn40ft).
-			fmt.Printf("%s Session failed, rolling back spawned polecat %s...\n", style.Warning.Render("⚠"), newPolecatInfo.PolecatName)
-			rollbackSlingArtifactsFn(newPolecatInfo, beadID, hookWorkDir, "")
+			rollbackSpawnedPolecat("Session failed")
 			return fmt.Errorf("starting polecat session: %w", err)
 		}
 		targetPane = pane
@@ -1210,17 +1206,36 @@ var getBeadInfoForRollback = getBeadInfo
 var collectExistingMoleculesForRollback = collectExistingMolecules
 var burnExistingMoleculesForRollback = burnExistingMolecules
 
-func clearRollbackRawWorkflowFields(beadID, townRoot, hookWorkDir string, info *beadInfo) (bool, error) {
+func rawWorkflowFieldValues(info *beadInfo) (noMerge, reviewOnly bool) {
 	if info == nil {
-		return false, nil
+		return false, false
 	}
 	issue := &beads.Issue{Description: info.Description}
 	fields := beads.ParseAttachmentFields(issue)
-	if fields == nil || (!fields.NoMerge && !fields.ReviewOnly) {
+	if fields == nil {
+		return false, false
+	}
+	return fields.NoMerge, fields.ReviewOnly
+}
+
+func restoreRollbackRawWorkflowFields(beadID, townRoot, hookWorkDir string, info, originalInfo *beadInfo) (bool, error) {
+	if info == nil {
 		return false, nil
 	}
-	fields.NoMerge = false
-	fields.ReviewOnly = false
+	originalNoMerge, originalReviewOnly := rawWorkflowFieldValues(originalInfo)
+	issue := &beads.Issue{Description: info.Description}
+	fields := beads.ParseAttachmentFields(issue)
+	if fields == nil {
+		if !originalNoMerge && !originalReviewOnly {
+			return false, nil
+		}
+		fields = &beads.AttachmentFields{}
+	}
+	if fields.NoMerge == originalNoMerge && fields.ReviewOnly == originalReviewOnly {
+		return false, nil
+	}
+	fields.NoMerge = originalNoMerge
+	fields.ReviewOnly = originalReviewOnly
 	newDesc := beads.SetAttachmentFields(issue, fields)
 	if newDesc == info.Description {
 		return false, nil
@@ -1234,6 +1249,26 @@ func clearRollbackRawWorkflowFields(beadID, townRoot, hookWorkDir string, info *
 		return false, err
 	}
 	return true, nil
+}
+
+func clearRollbackRawWorkflowFields(beadID, townRoot, hookWorkDir string, info *beadInfo) (bool, error) {
+	return restoreRollbackRawWorkflowFields(beadID, townRoot, hookWorkDir, info, nil)
+}
+
+func restoreRollbackRawWorkflowFieldsFromCurrent(beadID, townRoot, hookWorkDir string, originalInfo *beadInfo) {
+	if beadID == "" || townRoot == "" {
+		return
+	}
+	info, err := getBeadInfoForRollback(beadID)
+	if err != nil {
+		fmt.Printf("  %s Could not inspect bead %s for raw workflow metadata rollback: %v\n", style.Dim.Render("Warning:"), beadID, err)
+		return
+	}
+	if restored, restoreErr := restoreRollbackRawWorkflowFields(beadID, townRoot, hookWorkDir, info, originalInfo); restoreErr != nil {
+		fmt.Printf("  %s Could not restore raw workflow metadata on %s: %v\n", style.Dim.Render("Warning:"), beadID, restoreErr)
+	} else if restored {
+		fmt.Printf("  %s Restored raw workflow metadata on %s\n", style.Dim.Render("○"), beadID)
+	}
 }
 
 func restorePinnedBead(townRoot, beadID, assignee string) {
@@ -1349,17 +1384,27 @@ func rollbackSlingArtifacts(spawnInfo *SpawnedPolecatInfo, beadID, hookWorkDir, 
 				} else {
 					existingMolecules = appendUniqueMolecules(existingMolecules, depMolecules...)
 				}
+				canClearWorkflowFields := len(existingMolecules) == 0
 				if len(existingMolecules) > 0 {
 					if burnErr := burnExistingMoleculesForRollback(existingMolecules, beadID, townRoot); burnErr != nil {
 						fmt.Printf("  %s Could not burn stale molecule(s) from %s: %v\n", style.Dim.Render("Warning:"), beadID, burnErr)
 					} else {
 						fmt.Printf("  %s Burned %d stale molecule(s): %s\n",
 							style.Dim.Render("○"), len(existingMolecules), strings.Join(existingMolecules, ", "))
+						if refreshed, refreshErr := getBeadInfoForRollback(beadID); refreshErr != nil {
+							fmt.Printf("  %s Could not refresh bead %s after molecule cleanup: %v\n", style.Dim.Render("Warning:"), beadID, refreshErr)
+						} else {
+							info = refreshed
+							canClearWorkflowFields = true
+						}
 					}
-				} else if cleared, clearErr := clearRollbackRawWorkflowFields(beadID, townRoot, hookWorkDir, info); clearErr != nil {
-					fmt.Printf("  %s Could not clear raw workflow metadata from %s: %v\n", style.Dim.Render("Warning:"), beadID, clearErr)
-				} else if cleared {
-					fmt.Printf("  %s Cleared raw workflow metadata from %s\n", style.Dim.Render("○"), beadID)
+				}
+				if canClearWorkflowFields {
+					if cleared, clearErr := clearRollbackRawWorkflowFields(beadID, townRoot, hookWorkDir, info); clearErr != nil {
+						fmt.Printf("  %s Could not clear raw workflow metadata from %s: %v\n", style.Dim.Render("Warning:"), beadID, clearErr)
+					} else if cleared {
+						fmt.Printf("  %s Cleared raw workflow metadata from %s\n", style.Dim.Render("○"), beadID)
+					}
 				}
 			}
 

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -1206,23 +1206,23 @@ var getBeadInfoForRollback = getBeadInfo
 var collectExistingMoleculesForRollback = collectExistingMolecules
 var burnExistingMoleculesForRollback = burnExistingMolecules
 
-func rawWorkflowFieldValues(info *beadInfo) (noMerge, reviewOnly bool) {
+func rawWorkflowFieldValues(info *beadInfo) (noMerge, reviewOnly bool, attachedAt string) {
 	if info == nil {
-		return false, false
+		return false, false, ""
 	}
 	issue := &beads.Issue{Description: info.Description}
 	fields := beads.ParseAttachmentFields(issue)
 	if fields == nil {
-		return false, false
+		return false, false, ""
 	}
-	return fields.NoMerge, fields.ReviewOnly
+	return fields.NoMerge, fields.ReviewOnly, fields.AttachedAt
 }
 
 func restoreRollbackRawWorkflowFields(beadID, townRoot, hookWorkDir string, info, originalInfo *beadInfo) (bool, error) {
 	if info == nil {
 		return false, nil
 	}
-	originalNoMerge, originalReviewOnly := rawWorkflowFieldValues(originalInfo)
+	originalNoMerge, originalReviewOnly, originalAttachedAt := rawWorkflowFieldValues(originalInfo)
 	issue := &beads.Issue{Description: info.Description}
 	fields := beads.ParseAttachmentFields(issue)
 	if fields == nil {
@@ -1231,11 +1231,12 @@ func restoreRollbackRawWorkflowFields(beadID, townRoot, hookWorkDir string, info
 		}
 		fields = &beads.AttachmentFields{}
 	}
-	if fields.NoMerge == originalNoMerge && fields.ReviewOnly == originalReviewOnly {
+	if fields.NoMerge == originalNoMerge && fields.ReviewOnly == originalReviewOnly && fields.AttachedAt == originalAttachedAt {
 		return false, nil
 	}
 	fields.NoMerge = originalNoMerge
 	fields.ReviewOnly = originalReviewOnly
+	fields.AttachedAt = originalAttachedAt
 	newDesc := beads.SetAttachmentFields(issue, fields)
 	if newDesc == info.Description {
 		return false, nil

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -260,6 +260,14 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 
 	// 4. Auto-convoy (if !NoConvoy)
 	convoyID := ""
+	rollbackSpawnedPolecat := func(rollbackBeadID, reason string) {
+		fmt.Printf("  %s %s, rolling back spawned polecat %s...\n", style.Warning.Render("⚠"), reason, spawnInfo.PolecatName)
+		rollbackSlingArtifactsFn(spawnInfo, rollbackBeadID, hookWorkDir, convoyID)
+		restoreRollbackRawWorkflowFieldsFromCurrent(rollbackBeadID, townRoot, hookWorkDir, info)
+		if params.Force && info.Status == "pinned" {
+			restorePinnedBead(townRoot, params.BeadID, info.Assignee)
+		}
+	}
 	if !params.NoConvoy {
 		existingConvoy := isTrackedByConvoy(params.BeadID)
 		if existingConvoy == "" {
@@ -282,7 +290,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 		if err := CookFormula(params.FormulaName, workDir, townRoot); err != nil {
 			if params.FormulaFailFatal {
 				// Rollback spawned polecat on fatal cook failure
-				rollbackSlingArtifactsFn(spawnInfo, params.BeadID, hookWorkDir, convoyID)
+				rollbackSpawnedPolecat(params.BeadID, "Formula cook failed")
 				result.ErrMsg = fmt.Sprintf("cook failed: %v", err)
 				return result, fmt.Errorf("cooking formula %s: %w", params.FormulaName, err)
 			}
@@ -321,7 +329,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 		if err != nil {
 			if params.FormulaFailFatal {
 				// Rollback spawned polecat on fatal formula failure
-				rollbackSlingArtifactsFn(spawnInfo, params.BeadID, hookWorkDir, convoyID)
+				rollbackSpawnedPolecat(params.BeadID, "Formula instantiation failed")
 				result.ErrMsg = fmt.Sprintf("formula failed: %v", err)
 				return result, fmt.Errorf("instantiating formula %s: %w", params.FormulaName, err)
 			}
@@ -374,6 +382,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	if attachedMoleculeID == "" && (params.NoMerge || params.ReviewOnly) {
 		if err := storeFieldsInBeadFromTownRoot(townRoot, beadToHook, fieldUpdates); err != nil {
 			cleanupSpawnedPolecat(spawnInfo, params.RigName, convoyID)
+			restoreRollbackRawWorkflowFieldsFromCurrent(beadToHook, townRoot, hookWorkDir, info)
 			result.ErrMsg = "raw sling metadata failed"
 			return result, fmt.Errorf("storing raw sling metadata before hook: %w", err)
 		}
@@ -381,10 +390,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	hookDir := beads.ResolveHookDir(townRoot, beadToHook, hookWorkDir)
 	if err := hookBeadWithRetryWithTownRootFn(beadToHook, targetAgent, hookDir, townRoot); err != nil {
 		// Clean up all partial sling state, including raw metadata stored before hook.
-		rollbackSlingArtifactsFn(spawnInfo, beadToHook, hookWorkDir, convoyID)
-		if params.Force && info.Status == "pinned" {
-			restorePinnedBead(townRoot, params.BeadID, info.Assignee)
-		}
+		rollbackSpawnedPolecat(beadToHook, "Hook failed")
 		result.ErrMsg = "hook failed"
 		return result, fmt.Errorf("failed to hook bead: %w", err)
 	}
@@ -412,7 +418,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	pane, err := spawnInfo.StartSession()
 	if err != nil {
 		fmt.Printf("  %s Could not start session: %v, cleaning up partial state...\n", style.Dim.Render("✗"), err)
-		rollbackSlingArtifactsFn(spawnInfo, beadToHook, hookWorkDir, convoyID)
+		rollbackSpawnedPolecat(beadToHook, "Session failed")
 		result.ErrMsg = fmt.Sprintf("session failed: %v", err)
 		return result, fmt.Errorf("starting polecat session: %w", err)
 	}

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -341,33 +341,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	}
 	result.AttachedMolecule = attachedMoleculeID
 
-	// 7. Hook bead with retry
-	// Acquire per-assignee lock to serialize concurrent hook writes (issue #3114).
-	assigneeUnlock, assigneeLockErr := tryAcquireSlingAssigneeLock(townRoot, targetAgent)
-	if assigneeLockErr != nil {
-		cleanupSpawnedPolecat(spawnInfo, params.RigName, convoyID)
-		result.ErrMsg = "assignee lock failed"
-		return result, fmt.Errorf("serializing hook write for %s: %w", targetAgent, assigneeLockErr)
-	}
-	defer assigneeUnlock()
-	hookDir := beads.ResolveHookDir(townRoot, beadToHook, hookWorkDir)
-	if err := hookBeadWithRetryWithTownRootFn(beadToHook, targetAgent, hookDir, townRoot); err != nil {
-		// Clean up orphaned polecat to avoid leaving spawned-but-unhookable polecats
-		cleanupSpawnedPolecat(spawnInfo, params.RigName, convoyID)
-		result.ErrMsg = "hook failed"
-		return result, fmt.Errorf("failed to hook bead: %w", err)
-	}
-
-	fmt.Printf("  %s Work attached to %s\n", style.Bold.Render("✓"), spawnInfo.PolecatName)
-
-	// 8. Log sling event
 	actor := detectActor()
-	_ = events.LogFeed(events.TypeSling, actor, events.SlingPayload(beadToHook, targetAgent))
-
-	// 9. Update agent hook_bead state
-	updateAgentHookBead(targetAgent, beadToHook, hookWorkDir, beadsDir)
-
-	// 10. Store fields in bead (dispatcher, args, attached_molecule, no_merge, mode)
 	fieldUpdates := beadFieldUpdates{
 		Dispatcher:       actor,
 		Args:             params.Args,
@@ -387,6 +361,40 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 			fieldUpdates.FormulaVars = ""
 		}
 	}
+
+	// 7. Hook bead with retry
+	// Acquire per-assignee lock to serialize concurrent hook writes (issue #3114).
+	assigneeUnlock, assigneeLockErr := tryAcquireSlingAssigneeLock(townRoot, targetAgent)
+	if assigneeLockErr != nil {
+		cleanupSpawnedPolecat(spawnInfo, params.RigName, convoyID)
+		result.ErrMsg = "assignee lock failed"
+		return result, fmt.Errorf("serializing hook write for %s: %w", targetAgent, assigneeLockErr)
+	}
+	defer assigneeUnlock()
+	if attachedMoleculeID == "" && (params.NoMerge || params.ReviewOnly) {
+		if err := storeFieldsInBeadFromTownRoot(townRoot, beadToHook, fieldUpdates); err != nil {
+			cleanupSpawnedPolecat(spawnInfo, params.RigName, convoyID)
+			result.ErrMsg = "raw sling metadata failed"
+			return result, fmt.Errorf("storing raw sling metadata before hook: %w", err)
+		}
+	}
+	hookDir := beads.ResolveHookDir(townRoot, beadToHook, hookWorkDir)
+	if err := hookBeadWithRetryWithTownRootFn(beadToHook, targetAgent, hookDir, townRoot); err != nil {
+		// Clean up orphaned polecat to avoid leaving spawned-but-unhookable polecats
+		cleanupSpawnedPolecat(spawnInfo, params.RigName, convoyID)
+		result.ErrMsg = "hook failed"
+		return result, fmt.Errorf("failed to hook bead: %w", err)
+	}
+
+	fmt.Printf("  %s Work attached to %s\n", style.Bold.Render("✓"), spawnInfo.PolecatName)
+
+	// 8. Log sling event
+	_ = events.LogFeed(events.TypeSling, actor, events.SlingPayload(beadToHook, targetAgent))
+
+	// 9. Update agent hook_bead state
+	updateAgentHookBead(targetAgent, beadToHook, hookWorkDir, beadsDir)
+
+	// 10. Store fields in bead (dispatcher, args, attached_molecule, no_merge, mode)
 	// Use beadToHook for the update target (may differ from beadID when formula-on-bead)
 	if err := storeFieldsInBeadFromTownRoot(townRoot, beadToHook, fieldUpdates); err != nil {
 		fmt.Printf("  %s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -380,8 +380,11 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	}
 	hookDir := beads.ResolveHookDir(townRoot, beadToHook, hookWorkDir)
 	if err := hookBeadWithRetryWithTownRootFn(beadToHook, targetAgent, hookDir, townRoot); err != nil {
-		// Clean up orphaned polecat to avoid leaving spawned-but-unhookable polecats
-		cleanupSpawnedPolecat(spawnInfo, params.RigName, convoyID)
+		// Clean up all partial sling state, including raw metadata stored before hook.
+		rollbackSlingArtifactsFn(spawnInfo, beadToHook, hookWorkDir, convoyID)
+		if params.Force && info.Status == "pinned" {
+			restorePinnedBead(townRoot, params.BeadID, info.Assignee)
+		}
 		result.ErrMsg = "hook failed"
 		return result, fmt.Errorf("failed to hook bead: %w", err)
 	}

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -541,6 +541,7 @@ type beadFieldUpdates struct {
 	AttachedMolecule string   // Wisp root ID
 	AttachedFormula  string   // Formula name (e.g., "mol-polecat-work") for inline step display
 	ClearAttachment  bool     // Clear stale workflow attachment fields before applying updates
+	AttachedAt       string   // Assignment timestamp; refreshed when workflow metadata is written
 	NoMerge          bool     // Skip merge queue on completion
 	ReviewOnly       bool     // Review-only mode: assignee must not merge/commit/push
 	Mode             *string  // Execution mode: nil means unchanged, "" clears, "ralph" enables Ralph mode
@@ -564,7 +565,7 @@ func buildSlingFieldUpdates(
 	mergeStrategy string,
 	convoyOwned bool,
 ) beadFieldUpdates {
-	return beadFieldUpdates{
+	updates := beadFieldUpdates{
 		Dispatcher:       dispatcher,
 		Args:             args,
 		Vars:             vars,
@@ -578,6 +579,10 @@ func buildSlingFieldUpdates(
 		ConvoyOwned:      convoyOwned,
 		FormulaVars:      formulaVars,
 	}
+	if attachedMolecule != "" || attachedFormula != "" || noMerge || reviewOnly {
+		updates.AttachedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	return updates
 }
 
 // storeFieldsInBead performs a single read-modify-write to update all attachment fields
@@ -641,7 +646,9 @@ func storeFieldsInBeadFromTownRoot(townRoot, beadID string, updates beadFieldUpd
 	if updates.AttachedFormula != "" {
 		fields.AttachedFormula = updates.AttachedFormula
 	}
-	if (updates.AttachedMolecule != "" || updates.AttachedFormula != "") && fields.AttachedAt == "" {
+	if updates.AttachedAt != "" {
+		fields.AttachedAt = updates.AttachedAt
+	} else if updates.AttachedMolecule != "" || updates.AttachedFormula != "" || updates.NoMerge || updates.ReviewOnly {
 		fields.AttachedAt = time.Now().UTC().Format(time.RFC3339Nano)
 	}
 	if updates.NoMerge {

--- a/internal/cmd/sling_schedule.go
+++ b/internal/cmd/sling_schedule.go
@@ -252,6 +252,7 @@ func runBatchSchedule(beadIDs []string, rigName, townRoot string) error {
 			DryRun:       false,
 			Force:        slingForce,
 			NoMerge:      slingNoMerge,
+			ReviewOnly:   slingReviewOnly,
 			Account:      slingAccount,
 			Agent:        slingAgent,
 			HookRawBead:  slingHookRawBead,
@@ -422,7 +423,7 @@ func detectSchedulerIDType(id string) (string, error) {
 // not convoy or epic mode.
 var schedulerTaskOnlyFlagNames = []string{
 	"account", "agent", "ralph", "args", "var",
-	"merge", "base-branch", "no-convoy", "owned", "no-merge",
+	"merge", "base-branch", "no-convoy", "owned", "no-merge", "review-only",
 }
 
 // validateNoTaskOnlySchedulerFlags checks that no task-only flags were set.

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -35,6 +35,143 @@ func writeBDStub(t *testing.T, binDir string, unixScript string, windowsScript s
 	return path
 }
 
+func setupMutableBDRawSlingTest(t *testing.T, initialDescription string) (townRoot, rigPath, descPath string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("mutable POSIX bd stub")
+	}
+
+	townRoot = t.TempDir()
+	rigPath = filepath.Join(townRoot, "gastown", "mayor", "rig")
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"version":1}`), 0644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigPath, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir town beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(`{"prefix":"gt-","path":"gastown/mayor/rig"}`+"\n"), 0644); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+	rigs := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{
+		"gastown": {GitURL: "git@github.com:test/gastown.git", AddedAt: time.Now().Truncate(time.Second), BeadsConfig: &config.BeadsConfig{Repo: "local", Prefix: "gt"}},
+	}}
+	if err := config.SaveRigsConfig(filepath.Join(townRoot, "mayor", "rigs.json"), rigs); err != nil {
+		t.Fatalf("SaveRigsConfig: %v", err)
+	}
+
+	descPath = filepath.Join(townRoot, "description.txt")
+	statusPath := filepath.Join(townRoot, "status.txt")
+	assigneePath := filepath.Join(townRoot, "assignee.txt")
+	if err := os.WriteFile(descPath, []byte(initialDescription), 0644); err != nil {
+		t.Fatalf("write description: %v", err)
+	}
+	if err := os.WriteFile(statusPath, []byte("open"), 0644); err != nil {
+		t.Fatalf("write status: %v", err)
+	}
+	if err := os.WriteFile(assigneePath, []byte(""), 0644); err != nil {
+		t.Fatalf("write assignee: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	bdScript := `#!/bin/sh
+set -eu
+if [ "${1:-}" = "--allow-stale" ] && [ "${2:-}" = "version" ]; then
+  echo "bd test"
+  exit 0
+fi
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --allow-stale) shift ;;
+    *) break ;;
+  esac
+done
+cmd="${1:-}"
+if [ "$#" -gt 0 ]; then shift; fi
+case "$cmd" in
+  show)
+    desc=""
+    if [ -f "$BD_DESC_FILE" ]; then
+      desc=$(awk 'BEGIN{first=1} {gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); if(!first){printf "\\n"} printf "%s",$0; first=0}' "$BD_DESC_FILE")
+    fi
+    status="open"
+    if [ -f "$BD_STATUS_FILE" ]; then status=$(cat "$BD_STATUS_FILE"); fi
+    assignee=""
+    if [ -f "$BD_ASSIGNEE_FILE" ]; then assignee=$(cat "$BD_ASSIGNEE_FILE"); fi
+    printf '[{"id":"gt-rawrollback","title":"Test issue","status":"%s","assignee":"%s","description":"%s","dependencies":[]}]\n' "$status" "$assignee" "$desc"
+    ;;
+  update)
+    for arg in "$@"; do
+      case "$arg" in
+        --description=*) printf "%s" "${arg#--description=}" > "$BD_DESC_FILE" ;;
+        --status=*) printf "%s" "${arg#--status=}" > "$BD_STATUS_FILE" ;;
+        --assignee=*) printf "%s" "${arg#--assignee=}" > "$BD_ASSIGNEE_FILE" ;;
+      esac
+    done
+    ;;
+  version)
+    echo "bd test"
+    ;;
+esac
+exit 0
+`
+	writeBDStub(t, binDir, bdScript, "")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_DESC_FILE", descPath)
+	t.Setenv("BD_STATUS_FILE", statusPath)
+	t.Setenv("BD_ASSIGNEE_FILE", assigneePath)
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", "")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	return townRoot, rigPath, descPath
+}
+
+func readMutableBDDescription(t *testing.T, descPath string) string {
+	t.Helper()
+	b, err := os.ReadFile(descPath)
+	if err != nil {
+		t.Fatalf("read description: %v", err)
+	}
+	return string(b)
+}
+
+func assertNoRawReviewMetadata(t *testing.T, desc string) {
+	t.Helper()
+	if strings.Contains(desc, "no_merge: true") || strings.Contains(desc, "review_only: true") {
+		t.Fatalf("stale raw review metadata remains in description:\n%s", desc)
+	}
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: desc})
+	if fields != nil && (fields.NoMerge || fields.ReviewOnly) {
+		t.Fatalf("parsed stale raw review metadata from description: %+v", fields)
+	}
+}
+
+func assertHasRawReviewMetadata(t *testing.T, desc string) {
+	t.Helper()
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: desc})
+	if fields == nil || !fields.NoMerge || !fields.ReviewOnly {
+		t.Fatalf("raw review metadata missing from description:\n%s", desc)
+	}
+}
+
 func containsVarArg(line, key, value string) bool {
 	plain := "--var " + key + "=" + value
 	if strings.Contains(line, plain) {
@@ -1499,6 +1636,148 @@ exit /b 0
 	if !burnCalled {
 		t.Fatalf("expected rollbackSlingArtifacts to burn attached molecules")
 	}
+}
+
+func TestRollbackSlingArtifactsClearsRawReviewOnlyMetadata(t *testing.T) {
+	initial := strings.Join([]string{
+		"no_merge: true",
+		"review_only: true",
+		"dispatched_by: mayor/",
+		"",
+		"Keep this body.",
+	}, "\n")
+	townRoot, _, descPath := setupMutableBDRawSlingTest(t, initial)
+
+	rollbackSlingArtifacts(&SpawnedPolecatInfo{
+		RigName:     "gastown",
+		PolecatName: "toast",
+		ClonePath:   filepath.Join(townRoot, "gastown", "polecats", "toast"),
+	}, "gt-rawrollback", filepath.Join(townRoot, "gastown", "polecats", "toast"), "")
+
+	desc := readMutableBDDescription(t, descPath)
+	assertNoRawReviewMetadata(t, desc)
+	if !strings.Contains(desc, "dispatched_by: mayor/") {
+		t.Fatalf("rollback did not preserve unrelated dispatch metadata:\n%s", desc)
+	}
+	if !strings.Contains(desc, "Keep this body.") {
+		t.Fatalf("rollback did not preserve description body:\n%s", desc)
+	}
+}
+
+func TestRollbackSlingArtifactsKeepsMetadataWhenMoleculeBurnFails(t *testing.T) {
+	initial := strings.Join([]string{
+		"attached_molecule: gt-wisp-stale",
+		"no_merge: true",
+		"review_only: true",
+		"",
+		"Keep this body.",
+	}, "\n")
+	townRoot, _, descPath := setupMutableBDRawSlingTest(t, initial)
+
+	prevCollect := collectExistingMoleculesForRollback
+	prevBurn := burnExistingMoleculesForRollback
+	t.Cleanup(func() {
+		collectExistingMoleculesForRollback = prevCollect
+		burnExistingMoleculesForRollback = prevBurn
+	})
+	collectExistingMoleculesForRollback = func(info *beadInfo) []string {
+		return []string{"gt-wisp-stale"}
+	}
+	burnExistingMoleculesForRollback = func(molecules []string, beadID, townRoot string) error {
+		return errors.New("forced burn failure")
+	}
+
+	rollbackSlingArtifacts(&SpawnedPolecatInfo{
+		RigName:     "gastown",
+		PolecatName: "toast",
+		ClonePath:   filepath.Join(townRoot, "gastown", "polecats", "toast"),
+	}, "gt-rawrollback", filepath.Join(townRoot, "gastown", "polecats", "toast"), "")
+
+	desc := readMutableBDDescription(t, descPath)
+	if !strings.Contains(desc, "attached_molecule: gt-wisp-stale") {
+		t.Fatalf("rollback hid attached molecule after burn failure:\n%s", desc)
+	}
+	assertHasRawReviewMetadata(t, desc)
+}
+
+func TestExecuteSlingRawReviewOnlyHookFailureClearsPreHookMetadata(t *testing.T) {
+	townRoot, rigPath, descPath := setupMutableBDRawSlingTest(t, "Keep this body.")
+
+	prevSpawn := spawnPolecatForSling
+	prevHook := hookBeadWithRetryWithTownRootFn
+	t.Cleanup(func() {
+		spawnPolecatForSling = prevSpawn
+		hookBeadWithRetryWithTownRootFn = prevHook
+	})
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		return &SpawnedPolecatInfo{
+			RigName:     rigName,
+			PolecatName: "toast",
+			ClonePath:   filepath.Join(townRoot, "gastown", "polecats", "toast"),
+		}, nil
+	}
+	hookBeadWithRetryWithTownRootFn = func(beadID, targetAgent, hookDir, townRoot string) error {
+		assertHasRawReviewMetadata(t, readMutableBDDescription(t, descPath))
+		return errors.New("forced hook failure")
+	}
+
+	_, err := executeSling(SlingParams{
+		BeadID:      "gt-rawrollback",
+		RigName:     "gastown",
+		TownRoot:    townRoot,
+		BeadsDir:    filepath.Join(rigPath, ".beads"),
+		HookRawBead: true,
+		NoMerge:     true,
+		ReviewOnly:  true,
+		NoConvoy:    true,
+		NoBoot:      true,
+	})
+	if err == nil {
+		t.Fatal("expected hook failure from executeSling")
+	}
+	assertNoRawReviewMetadata(t, readMutableBDDescription(t, descPath))
+}
+
+func TestExecuteSlingRawReviewOnlySuccessKeepsMetadata(t *testing.T) {
+	townRoot, rigPath, descPath := setupMutableBDRawSlingTest(t, "Keep this body.")
+
+	prevSpawn := spawnPolecatForSling
+	prevHook := hookBeadWithRetryWithTownRootFn
+	t.Cleanup(func() {
+		spawnPolecatForSling = prevSpawn
+		hookBeadWithRetryWithTownRootFn = prevHook
+	})
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		return &SpawnedPolecatInfo{
+			RigName:     rigName,
+			PolecatName: "toast",
+			ClonePath:   filepath.Join(townRoot, "gastown", "polecats", "toast"),
+			Pane:        "%1",
+		}, nil
+	}
+	hookBeadWithRetryWithTownRootFn = func(beadID, targetAgent, hookDir, townRoot string) error {
+		assertHasRawReviewMetadata(t, readMutableBDDescription(t, descPath))
+		return nil
+	}
+
+	result, err := executeSling(SlingParams{
+		BeadID:      "gt-rawrollback",
+		RigName:     "gastown",
+		TownRoot:    townRoot,
+		BeadsDir:    filepath.Join(rigPath, ".beads"),
+		HookRawBead: true,
+		NoMerge:     true,
+		ReviewOnly:  true,
+		NoConvoy:    true,
+		NoBoot:      true,
+	})
+	if err != nil {
+		t.Fatalf("executeSling succeeded with error: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("executeSling result not successful: %+v", result)
+	}
+	assertHasRawReviewMetadata(t, readMutableBDDescription(t, descPath))
 }
 
 func TestSlingFormulaRollsBackSpawnedPolecatOnWispFailure(t *testing.T) {

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 )
@@ -169,6 +170,8 @@ log_args=""
 for arg in "$@"; do
   case "$arg" in
     --description=*attached_molecule:*gt-wisp-xyz*attached_formula:*mol-polecat-work*) arg="--description=<attached-molecule-and-formula-fields>" ;;
+    --description=*no_merge:*true*review_only:*true*) arg="--description=<review-only-fields>" ;;
+    --description=*review_only:*true*no_merge:*true*) arg="--description=<review-only-fields>" ;;
     --description=*) arg="--description=<redacted>" ;;
   esac
   log_args="${log_args}${log_args:+ }${arg}"
@@ -274,17 +277,26 @@ exit /b 0
 	prevVars := slingVars
 	prevDryRun := slingDryRun
 	prevNoConvoy := slingNoConvoy
+	prevHookRawBead := slingHookRawBead
+	prevReviewOnly := slingReviewOnly
+	prevNoMerge := slingNoMerge
 	prevResolveTargetAgent := resolveTargetAgentFn
 	t.Cleanup(func() {
 		slingOnTarget = prevOn
 		slingVars = prevVars
 		slingDryRun = prevDryRun
 		slingNoConvoy = prevNoConvoy
+		slingHookRawBead = prevHookRawBead
+		slingReviewOnly = prevReviewOnly
+		slingNoMerge = prevNoMerge
 		resolveTargetAgentFn = prevResolveTargetAgent
 	})
 
 	slingDryRun = false
 	slingNoConvoy = true
+	slingHookRawBead = false
+	slingReviewOnly = false
+	slingNoMerge = false
 	slingVars = nil
 	slingOnTarget = ""
 	resolveTargetAgentFn = func(target string) (agentID string, pane string, hookRoot string, err error) {
@@ -326,6 +338,14 @@ exit /b 0
 		t.Fatalf("runSling: %v", err)
 	}
 
+	slingOnTarget = ""
+	slingHookRawBead = true
+	slingReviewOnly = true
+	slingNoMerge = true
+	if err := runSling(nil, []string{newBeadID, "gastown/polecats/toast"}); err != nil {
+		t.Fatalf("runSling raw review-only: %v", err)
+	}
+
 	logBytes, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("read bd log: %v", err)
@@ -348,6 +368,7 @@ exit /b 0
 	gotFormulaShow := false
 	gotHook := false
 	gotMetadata := false
+	gotReviewOnlyMetadata := false
 	assertTargetRig := func(kind, dir, beadsDir, database, beadsDB, bdDB, dataDir, args string) {
 		t.Helper()
 		if dir != wantDir {
@@ -364,7 +385,9 @@ exit /b 0
 		}
 	}
 
-	for _, line := range logLines {
+	firstReviewOnlyMetadataIndex := -1
+	lastHookIndex := -1
+	for i, line := range logLines {
 		parts := strings.SplitN(line, "|", 7)
 		if len(parts) != 7 {
 			t.Fatalf("malformed bd log line: %q", line)
@@ -413,10 +436,17 @@ exit /b 0
 			assertTargetRig("mol bond", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
 		case strings.Contains(args, "update "+newBeadID) && strings.Contains(args, "--status=hooked"):
 			gotHook = true
+			lastHookIndex = i
 			assertTargetRig("hook update", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
 		case strings.Contains(args, "update "+newBeadID) && strings.Contains(args, "--description=<attached-molecule-and-formula-fields>"):
 			gotMetadata = true
 			assertTargetRig("metadata update", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
+		case strings.Contains(args, "update "+newBeadID) && strings.Contains(args, "--description=<review-only-fields>"):
+			gotReviewOnlyMetadata = true
+			if firstReviewOnlyMetadataIndex == -1 {
+				firstReviewOnlyMetadataIndex = i
+			}
+			assertTargetRig("review-only metadata update", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
 		case strings.Contains(args, "update "+newBeadID) && strings.Contains(args, "--description="):
 			assertTargetRig("description update", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
 		case args == "--version" || strings.HasPrefix(args, "version") || strings.Contains(args, " version") || strings.Contains(args, "show gt-rig-") || strings.Contains(args, "show mol-"):
@@ -427,9 +457,12 @@ exit /b 0
 		}
 	}
 
-	if !gotCreate || !gotTargetDBCheck || !gotFormulaShow || !gotPolecatCook || !gotReviewCook || gotBondCount < 2 || !gotHook || !gotMetadata {
-		t.Fatalf("missing expected bd commands: create=%v targetDBCheck=%v formulaShow=%v polecatCook=%v reviewCook=%v bondCount=%d hook=%v metadata=%v (log: %q)",
-			gotCreate, gotTargetDBCheck, gotFormulaShow, gotPolecatCook, gotReviewCook, gotBondCount, gotHook, gotMetadata, string(logBytes))
+	if !gotCreate || !gotTargetDBCheck || !gotFormulaShow || !gotPolecatCook || !gotReviewCook || gotBondCount < 2 || !gotHook || !gotMetadata || !gotReviewOnlyMetadata {
+		t.Fatalf("missing expected bd commands: create=%v targetDBCheck=%v formulaShow=%v polecatCook=%v reviewCook=%v bondCount=%d hook=%v metadata=%v reviewOnlyMetadata=%v (log: %q)",
+			gotCreate, gotTargetDBCheck, gotFormulaShow, gotPolecatCook, gotReviewCook, gotBondCount, gotHook, gotMetadata, gotReviewOnlyMetadata, string(logBytes))
+	}
+	if firstReviewOnlyMetadataIndex == -1 || lastHookIndex == -1 || firstReviewOnlyMetadataIndex > lastHookIndex {
+		t.Fatalf("review-only metadata must be stored before raw hook assignment: metadataIndex=%d hookIndex=%d log: %q", firstReviewOnlyMetadataIndex, lastHookIndex, string(logBytes))
 	}
 }
 
@@ -1204,6 +1237,24 @@ func TestBatchSlingRejectsMissingTargetRigDatabaseBeforeSpawn(t *testing.T) {
 	}
 	if spawnCalled {
 		t.Fatal("spawnPolecatForSling was called before target-rig database validation rejected the bead")
+	}
+}
+
+func TestSchedulerRejectsReviewOnlyForEpicConvoy(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("review-only", false, "")
+	if err := cmd.Flags().Set("review-only", "true"); err != nil {
+		t.Fatalf("set review-only flag: %v", err)
+	}
+
+	for _, mode := range []string{"epic", "convoy"} {
+		err := validateNoTaskOnlySchedulerFlags(cmd, mode)
+		if err == nil {
+			t.Fatalf("validateNoTaskOnlySchedulerFlags(%s) accepted --review-only", mode)
+		}
+		if !strings.Contains(err.Error(), "--review-only") {
+			t.Fatalf("validateNoTaskOnlySchedulerFlags(%s) error = %v, want --review-only", mode, err)
+		}
 	}
 }
 

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -1700,6 +1700,131 @@ func TestRollbackSlingArtifactsKeepsMetadataWhenMoleculeBurnFails(t *testing.T) 
 	assertHasRawReviewMetadata(t, desc)
 }
 
+func TestRollbackSlingArtifactsClearsRawReviewOnlyMetadataAfterMoleculeBurnSucceeds(t *testing.T) {
+	initial := strings.Join([]string{
+		"attached_molecule: gt-wisp-stale",
+		"no_merge: true",
+		"review_only: true",
+		"",
+		"Keep this body.",
+	}, "\n")
+	townRoot, _, descPath := setupMutableBDRawSlingTest(t, initial)
+
+	prevCollect := collectExistingMoleculesForRollback
+	prevBurn := burnExistingMoleculesForRollback
+	t.Cleanup(func() {
+		collectExistingMoleculesForRollback = prevCollect
+		burnExistingMoleculesForRollback = prevBurn
+	})
+	collectExistingMoleculesForRollback = func(info *beadInfo) []string {
+		return []string{"gt-wisp-stale"}
+	}
+	burnExistingMoleculesForRollback = func(molecules []string, beadID, townRoot string) error {
+		if len(molecules) != 1 || molecules[0] != "gt-wisp-stale" {
+			t.Fatalf("unexpected molecules: %#v", molecules)
+		}
+		updated := strings.Join([]string{
+			"no_merge: true",
+			"review_only: true",
+			"",
+			"Keep this body.",
+		}, "\n")
+		if err := os.WriteFile(descPath, []byte(updated), 0644); err != nil {
+			t.Fatalf("simulate molecule burn: %v", err)
+		}
+		return nil
+	}
+
+	rollbackSlingArtifacts(&SpawnedPolecatInfo{
+		RigName:     "gastown",
+		PolecatName: "toast",
+		ClonePath:   filepath.Join(townRoot, "gastown", "polecats", "toast"),
+	}, "gt-rawrollback", filepath.Join(townRoot, "gastown", "polecats", "toast"), "")
+
+	desc := readMutableBDDescription(t, descPath)
+	assertNoRawReviewMetadata(t, desc)
+	if strings.Contains(desc, "attached_molecule: gt-wisp-stale") {
+		t.Fatalf("rollback reintroduced stale attached molecule:\n%s", desc)
+	}
+	if !strings.Contains(desc, "Keep this body.") {
+		t.Fatalf("rollback did not preserve description body:\n%s", desc)
+	}
+}
+
+func TestRestoreRollbackRawWorkflowFieldsFromCurrentRestoresOriginalValues(t *testing.T) {
+	current := strings.Join([]string{
+		"no_merge: true",
+		"review_only: true",
+		"dispatched_by: mayor/",
+		"",
+		"Keep this body.",
+	}, "\n")
+	townRoot, _, descPath := setupMutableBDRawSlingTest(t, current)
+	original := &beadInfo{Description: strings.Join([]string{
+		"no_merge: true",
+		"",
+		"Original body.",
+	}, "\n")}
+
+	restoreRollbackRawWorkflowFieldsFromCurrent("gt-rawrollback", townRoot, filepath.Join(townRoot, "gastown", "polecats", "toast"), original)
+
+	desc := readMutableBDDescription(t, descPath)
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: desc})
+	if fields == nil || !fields.NoMerge || fields.ReviewOnly {
+		t.Fatalf("rollback did not restore original workflow values: %+v\n%s", fields, desc)
+	}
+	if !strings.Contains(desc, "dispatched_by: mayor/") || !strings.Contains(desc, "Keep this body.") {
+		t.Fatalf("rollback did not preserve current metadata/body:\n%s", desc)
+	}
+}
+
+func TestRunSlingRawReviewOnlyExistingTargetHookFailureClearsPreHookMetadata(t *testing.T) {
+	townRoot, _, descPath := setupMutableBDRawSlingTest(t, "Keep this body.")
+	workDir := filepath.Join(townRoot, "gastown", "crew", "toast")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatalf("mkdir workDir: %v", err)
+	}
+
+	prevHookRaw := slingHookRawBead
+	prevNoMerge := slingNoMerge
+	prevReviewOnly := slingReviewOnly
+	prevNoConvoy := slingNoConvoy
+	prevDryRun := slingDryRun
+	prevResolve := resolveTargetAgentFn
+	prevHook := hookBeadWithRetryFn
+	t.Cleanup(func() {
+		slingHookRawBead = prevHookRaw
+		slingNoMerge = prevNoMerge
+		slingReviewOnly = prevReviewOnly
+		slingNoConvoy = prevNoConvoy
+		slingDryRun = prevDryRun
+		resolveTargetAgentFn = prevResolve
+		hookBeadWithRetryFn = prevHook
+	})
+	slingHookRawBead = true
+	slingNoMerge = true
+	slingReviewOnly = true
+	slingNoConvoy = true
+	slingDryRun = false
+	resolveTargetAgentFn = func(target string) (string, string, string, error) {
+		return "gastown/crew/toast", "", workDir, nil
+	}
+	hookBeadWithRetryFn = func(beadID, targetAgent, hookDir string) error {
+		assertHasRawReviewMetadata(t, readMutableBDDescription(t, descPath))
+		return errors.New("forced hook failure")
+	}
+
+	err := runSling(nil, []string{"gt-rawrollback", "gastown/crew/toast"})
+	if err == nil {
+		t.Fatal("expected hook failure from runSling")
+	}
+	desc := readMutableBDDescription(t, descPath)
+	assertNoRawReviewMetadata(t, desc)
+	if !strings.Contains(desc, "Keep this body.") {
+		t.Fatalf("rollback did not preserve description body:\n%s", desc)
+	}
+}
+
 func TestExecuteSlingRawReviewOnlyHookFailureClearsPreHookMetadata(t *testing.T) {
 	townRoot, rigPath, descPath := setupMutableBDRawSlingTest(t, "Keep this body.")
 
@@ -1736,6 +1861,56 @@ func TestExecuteSlingRawReviewOnlyHookFailureClearsPreHookMetadata(t *testing.T)
 		t.Fatal("expected hook failure from executeSling")
 	}
 	assertNoRawReviewMetadata(t, readMutableBDDescription(t, descPath))
+}
+
+func TestExecuteSlingRawReviewOnlyHookFailureRestoresOriginalMetadata(t *testing.T) {
+	initial := strings.Join([]string{
+		"no_merge: true",
+		"",
+		"Keep this body.",
+	}, "\n")
+	townRoot, rigPath, descPath := setupMutableBDRawSlingTest(t, initial)
+
+	prevSpawn := spawnPolecatForSling
+	prevHook := hookBeadWithRetryWithTownRootFn
+	t.Cleanup(func() {
+		spawnPolecatForSling = prevSpawn
+		hookBeadWithRetryWithTownRootFn = prevHook
+	})
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		return &SpawnedPolecatInfo{
+			RigName:     rigName,
+			PolecatName: "toast",
+			ClonePath:   filepath.Join(townRoot, "gastown", "polecats", "toast"),
+		}, nil
+	}
+	hookBeadWithRetryWithTownRootFn = func(beadID, targetAgent, hookDir, townRoot string) error {
+		assertHasRawReviewMetadata(t, readMutableBDDescription(t, descPath))
+		return errors.New("forced hook failure")
+	}
+
+	_, err := executeSling(SlingParams{
+		BeadID:      "gt-rawrollback",
+		RigName:     "gastown",
+		TownRoot:    townRoot,
+		BeadsDir:    filepath.Join(rigPath, ".beads"),
+		HookRawBead: true,
+		NoMerge:     true,
+		ReviewOnly:  true,
+		NoConvoy:    true,
+		NoBoot:      true,
+	})
+	if err == nil {
+		t.Fatal("expected hook failure from executeSling")
+	}
+	desc := readMutableBDDescription(t, descPath)
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: desc})
+	if fields == nil || !fields.NoMerge || fields.ReviewOnly {
+		t.Fatalf("rollback did not restore original asymmetric metadata: %+v\n%s", fields, desc)
+	}
+	if !strings.Contains(desc, "Keep this body.") {
+		t.Fatalf("rollback did not preserve description body:\n%s", desc)
+	}
 }
 
 func TestExecuteSlingRawReviewOnlySuccessKeepsMetadata(t *testing.T) {

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -170,6 +170,12 @@ func assertHasRawReviewMetadata(t *testing.T, desc string) {
 	if fields == nil || !fields.NoMerge || !fields.ReviewOnly {
 		t.Fatalf("raw review metadata missing from description:\n%s", desc)
 	}
+	if fields.AttachedAt == "" {
+		t.Fatalf("raw review metadata missing attached_at:\n%s", desc)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, fields.AttachedAt); err != nil {
+		t.Fatalf("attached_at %q is not RFC3339Nano: %v", fields.AttachedAt, err)
+	}
 }
 
 func containsVarArg(line, key, value string) bool {
@@ -1640,6 +1646,7 @@ exit /b 0
 
 func TestRollbackSlingArtifactsClearsRawReviewOnlyMetadata(t *testing.T) {
 	initial := strings.Join([]string{
+		"attached_at: 2026-06-30T12:00:00Z",
 		"no_merge: true",
 		"review_only: true",
 		"dispatched_by: mayor/",
@@ -1667,6 +1674,7 @@ func TestRollbackSlingArtifactsClearsRawReviewOnlyMetadata(t *testing.T) {
 func TestRollbackSlingArtifactsKeepsMetadataWhenMoleculeBurnFails(t *testing.T) {
 	initial := strings.Join([]string{
 		"attached_molecule: gt-wisp-stale",
+		"attached_at: 2026-06-30T12:00:00Z",
 		"no_merge: true",
 		"review_only: true",
 		"",
@@ -1703,6 +1711,7 @@ func TestRollbackSlingArtifactsKeepsMetadataWhenMoleculeBurnFails(t *testing.T) 
 func TestRollbackSlingArtifactsClearsRawReviewOnlyMetadataAfterMoleculeBurnSucceeds(t *testing.T) {
 	initial := strings.Join([]string{
 		"attached_molecule: gt-wisp-stale",
+		"attached_at: 2026-06-30T12:00:00Z",
 		"no_merge: true",
 		"review_only: true",
 		"",
@@ -1724,6 +1733,7 @@ func TestRollbackSlingArtifactsClearsRawReviewOnlyMetadataAfterMoleculeBurnSucce
 			t.Fatalf("unexpected molecules: %#v", molecules)
 		}
 		updated := strings.Join([]string{
+			"attached_at: 2026-06-30T12:00:00Z",
 			"no_merge: true",
 			"review_only: true",
 			"",
@@ -3637,6 +3647,38 @@ func TestStoreFieldsInBeadFormulaSetsAttachedAt(t *testing.T) {
 	fields := beads.ParseAttachmentFields(&beads.Issue{Description: string(body)})
 	if fields == nil || fields.AttachedFormula != "mol-dog-reaper" || fields.AttachedAt == "" {
 		t.Fatalf("formula attachment fields = %#v, want formula and attached_at", fields)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, fields.AttachedAt); err != nil {
+		t.Fatalf("attached_at %q is not RFC3339Nano: %v", fields.AttachedAt, err)
+	}
+}
+
+func TestStoreFieldsInBeadRawReviewRefreshesAttachedAt(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "raw-review.log")
+	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", logPath)
+
+	stale := "2026-06-30T12:00:00Z"
+	if err := os.WriteFile(logPath, []byte("attached_at: "+stale+"\nno_merge: true\nreview_only: true\n"), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	if err := storeFieldsInBead("gt-test123", beadFieldUpdates{
+		NoMerge:    true,
+		ReviewOnly: true,
+	}); err != nil {
+		t.Fatalf("storeFieldsInBead: %v", err)
+	}
+
+	body, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	fields := beads.ParseAttachmentFields(&beads.Issue{Description: string(body)})
+	if fields == nil || !fields.NoMerge || !fields.ReviewOnly {
+		t.Fatalf("raw review fields = %#v", fields)
+	}
+	if fields.AttachedAt == "" || fields.AttachedAt == stale {
+		t.Fatalf("attached_at = %q, want refreshed from %q", fields.AttachedAt, stale)
 	}
 	if _, err := time.Parse(time.RFC3339Nano, fields.AttachedAt); err != nil {
 		t.Fatalf("attached_at %q is not RFC3339Nano: %v", fields.AttachedAt, err)

--- a/internal/formula/formulas/mol-polecat-code-review.formula.toml
+++ b/internal/formula/formulas/mol-polecat-code-review.formula.toml
@@ -277,7 +277,16 @@ Overall assessment:
 bd sync
 ```
 
-**Exit criteria:** Tracking issue updated with summary."""
+**3. Add close evidence for review-only completion:**
+```bash
+HEAD_SHA=$(git rev-parse HEAD)
+bd comments add {{issue}} "PR-SHERIFF-EVIDENCE: code review complete
+head_sha: ${HEAD_SHA}
+verdict: <pass|block>
+summary: <brief summary>"
+```
+
+**Exit criteria:** Tracking issue updated with summary and fresh review evidence comment."""
 
 [[steps]]
 id = "complete-and-exit"

--- a/internal/formula/formulas/mol-polecat-work.formula.toml
+++ b/internal/formula/formulas/mol-polecat-work.formula.toml
@@ -249,6 +249,18 @@ deliverable. There are no code changes to commit. You MUST persist all findings
 to the bead via --notes or --design. Without this, your entire work product is
 lost when the session ends.
 
+**Review-only close evidence:** If the bead has `review_only: true`, notes/design
+are durable report content but do NOT satisfy `gt done`. Add a fresh evidence
+comment after the current assignment, authored by the assignee, with the current
+head SHA before completing:
+```bash
+HEAD_SHA=$(git rev-parse HEAD)
+bd comments add {{issue}} "PR-SHERIFF-EVIDENCE: review complete
+head_sha: ${HEAD_SHA}
+verdict: <pass|block>
+summary: <brief findings>"
+```
+
 **Commit frequently (for code tasks):**
 ```bash
 # After each logical unit of work:
@@ -329,8 +341,10 @@ If your task produced no code changes, verify your findings are persisted to the
 ```bash
 bd show {{issue}}    # Check notes/design fields have your findings
 ```
-If findings are persisted, proceed to review. Report-only tasks with findings
-persisted can skip commit verification.
+If the bead is `review_only: true`, also verify a fresh assignee-authored
+`PR-SHERIFF-EVIDENCE` comment exists for the current `HEAD`.
+If findings/evidence are persisted, proceed to review. Report-only tasks with
+findings persisted can skip commit verification.
 
 **Exit criteria:** Working tree clean AND either (a) at least 1 commit ahead of origin/{{base_branch}}, or (b) report-only task with findings persisted to bead."""
 

--- a/internal/scheduler/capacity/pipeline_test.go
+++ b/internal/scheduler/capacity/pipeline_test.go
@@ -175,6 +175,7 @@ func TestReconstructFromContext(t *testing.T) {
 		Agent:       "codex",
 		Mode:        "ralph",
 		NoMerge:     true,
+		ReviewOnly:  true,
 		HookRawBead: true,
 	}
 
@@ -212,6 +213,9 @@ func TestReconstructFromContext(t *testing.T) {
 	}
 	if !params.NoMerge {
 		t.Error("NoMerge: expected true")
+	}
+	if !params.ReviewOnly {
+		t.Error("ReviewOnly: expected true")
 	}
 	if !params.HookRawBead {
 		t.Error("HookRawBead: expected true")


### PR DESCRIPTION
Clean upstream-main port of gt-clean-port-review-only-raw-sling-upstream-20260629.

This squashes the completed fury branch to remove auto-checkpoint commit history while preserving the final verified diff.
Source branch: Bella-Giraffety:polecat/fury/gt-clean-port-review-only-raw-sling-upstream-20260629@upstream-e13efa at dcfd86d3a704943d5f650b5e30178c04c56b6de3.
Internal MR gt-wisp-h8om will be closed as superseded by this upstream PR; refinery must not process it.

Verification:
- CGO_ENABLED=0 go test -short -timeout=10m ./internal/cmd ./internal/beads ./internal/scheduler/capacity
- CGO_ENABLED=0 go build ./cmd/gt

Beads:
- Source: gt-clean-port-review-only-raw-sling-upstream-20260629
- Internal MR: gt-wisp-h8om

Do not merge before PR Sheriff merge-gate evidence is produced.