### PR TITLE
fix: reconcile polecat inventory capacity state

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -1051,6 +1051,61 @@ func (b *Beads) List(opts ListOptions) ([]*Issue, error) {
 	return issues, nil
 }
 
+// ListIssueStatuses returns durable issues matching any of the supplied
+// statuses with one bd query. Summary paths use this to avoid multiplying bd
+// subprocesses by status and polecat count.
+func (b *Beads) ListIssueStatuses(statuses ...IssueStatus) ([]*Issue, error) {
+	if len(statuses) == 0 {
+		return nil, nil
+	}
+	unique := make([]IssueStatus, 0, len(statuses))
+	seen := make(map[IssueStatus]bool, len(statuses))
+	for _, status := range statuses {
+		if status == "" || seen[status] {
+			continue
+		}
+		seen[status] = true
+		unique = append(unique, status)
+	}
+	if len(unique) == 0 {
+		return nil, nil
+	}
+
+	if b.store != nil {
+		var all []*Issue
+		for _, status := range unique {
+			issues, err := b.storeList(ListOptions{Status: string(status), Priority: -1})
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, issues...)
+		}
+		return all, nil
+	}
+
+	statusClauses := make([]string, 0, len(unique))
+	for _, status := range unique {
+		statusClauses = append(statusClauses, "status="+quoteBDQueryValue(string(status)))
+	}
+	expr := "ephemeral=false AND (" + strings.Join(statusClauses, " OR ") + ")"
+	out, err := b.run("query", "--json", expr, "--all", "--limit=0")
+	if err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	if !isJSONBytes(out) {
+		return nil, fmt.Errorf("bd query returned non-JSON output")
+	}
+
+	var issues []*Issue
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, fmt.Errorf("parsing bd query output: %w", err)
+	}
+	return issues, nil
+}
+
 // listEphemeral searches the wisps table using "bd query" with ephemeral=true.
 // This is necessary because "bd list" only searches the issues table and does
 // not support an --ephemeral flag. Wisps (ephemeral issues like merge-request

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -77,6 +77,26 @@ func TestListEphemeralQuotesQueryValuesAndDisablesLimit(t *testing.T) {
 	}
 }
 
+func TestListIssueStatusesUsesSingleQuery(t *testing.T) {
+	ResetBdAllowStaleCacheForTest()
+	logPath := installMockBDRecorder(t)
+
+	b := New(t.TempDir())
+	_, err := b.ListIssueStatuses(IssueStatusHooked, StatusInProgress, StatusOpen, StatusOpen)
+	if err != nil {
+		t.Fatalf("ListIssueStatuses() error = %v", err)
+	}
+
+	logOutput := readMockBDLog(t, logPath)
+	want := `query --json ephemeral=false AND (status="hooked" OR status="in_progress" OR status="open") --all --limit=0`
+	if !strings.Contains(logOutput, want) {
+		t.Fatalf("bd log missing %q\nlog:\n%s", want, logOutput)
+	}
+	if count := strings.Count(logOutput, "query --json"); count != 1 {
+		t.Fatalf("query count = %d, want 1\nlog:\n%s", count, logOutput)
+	}
+}
+
 // TestCreateOptions verifies CreateOptions fields.
 func TestCreateOptions(t *testing.T) {
 	opts := CreateOptions{

--- a/internal/beads/status.go
+++ b/internal/beads/status.go
@@ -75,6 +75,7 @@ const (
 	StatusInProgress IssueStatus = "in_progress"
 	StatusTombstone  IssueStatus = "tombstone"
 	StatusBlocked    IssueStatus = "blocked"
+	StatusDeferred   IssueStatus = "deferred"
 	// StatusPinned and StatusHooked are defined as untyped string constants in
 	// handoff.go. Use IssueStatusPinned/IssueStatusHooked for typed comparisons.
 	IssueStatusPinned IssueStatus = "pinned"

--- a/internal/beads/status_test.go
+++ b/internal/beads/status_test.go
@@ -63,6 +63,7 @@ func TestIssueStatusBlocksRemoval(t *testing.T) {
 		{IssueStatusPinned, false},
 		{StatusInProgress, false},
 		{StatusTombstone, false},
+		{StatusDeferred, false},
 	}
 	for _, tt := range tests {
 		if got := tt.status.BlocksRemoval(); got != tt.want {
@@ -83,6 +84,7 @@ func TestIssueStatusIsTerminal(t *testing.T) {
 		{IssueStatusHooked, false},
 		{StatusInProgress, false},
 		{IssueStatusPinned, false},
+		{StatusDeferred, false},
 	}
 	for _, tt := range tests {
 		if got := tt.status.IsTerminal(); got != tt.want {
@@ -102,6 +104,7 @@ func TestIssueStatusIsAssigned(t *testing.T) {
 		{StatusOpen, false},
 		{StatusClosed, false},
 		{IssueStatusPinned, false},
+		{StatusDeferred, false},
 	}
 	for _, tt := range tests {
 		if got := tt.status.IsAssigned(); got != tt.want {
@@ -141,6 +144,7 @@ func TestIssueStatusConstants(t *testing.T) {
 		StatusInProgress:  "in_progress",
 		StatusTombstone:   "tombstone",
 		StatusBlocked:     "blocked",
+		StatusDeferred:    "deferred",
 		IssueStatusPinned: "pinned",
 		IssueStatusHooked: "hooked",
 	}

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -399,6 +399,7 @@ type PolecatListItem struct {
 	MQStatus             string        `json:"mq_status,omitempty"`
 	CountsTowardCapacity bool          `json:"counts_toward_capacity"`
 	ReuseStatus          string        `json:"reuse_status,omitempty"`
+	Blockers             []string      `json:"blockers,omitempty"`
 	SessionRunning       bool          `json:"session_running"`
 	Zombie               bool          `json:"zombie,omitempty"`
 	SessionName          string        `json:"session_name,omitempty"`
@@ -412,7 +413,7 @@ func effectivePolecatState(item PolecatListItem) polecat.State {
 	state := item.State
 	// A running session only implies working when there is active work attached.
 	// Without an issue, rewriting idle/done to working recreates "Issue: (none)".
-	if item.SessionRunning && item.Issue != "" && (state == polecat.StateDone || state == polecat.StateIdle) {
+	if item.SessionRunning && item.Issue != "" && item.CountsTowardCapacity && (state == polecat.StateDone || state == polecat.StateIdle) {
 		return polecat.StateWorking
 	}
 	// When session is dead but beads still says "working", mark as stalled
@@ -482,45 +483,56 @@ func runPolecatList(cmd *cobra.Command, args []string) error {
 
 	// Collect polecats from all rigs
 	t := tmux.NewTmux()
+	sessionNames, err := t.ListSessions()
+	if err != nil {
+		return fmt.Errorf("listing tmux sessions: %w", err)
+	}
+	sessions := newPolecatSessionSet(sessionNames)
 	allPolecats := make([]PolecatListItem, 0)
 
 	for _, r := range rigs {
-		polecatGit := git.NewGit(r.Path)
-		mgr := polecat.NewManager(r, polecatGit, t)
-		polecatMgr := polecat.NewSessionManager(t, r)
 		bd := beads.New(r.Path)
 
-		polecats, err := mgr.List()
+		polecatNames, err := listPolecatDirectoryNames(r.Path)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to list polecats in %s: %v\n", r.Name, err)
 			continue
 		}
+		agents, agentErr := bd.ListAgentBeads()
+		if agentErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to list agent beads in %s: %v\n", r.Name, agentErr)
+			agents = nil
+		}
+		activeWork, activeWorkErr := listActivePolecatWorkByName(bd, r.Name)
+		if activeWorkErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to list active polecat work in %s: %v\n", r.Name, activeWorkErr)
+			activeWork = nil
+		}
 
 		// Track known polecat names from filesystem for zombie detection
 		knownNames := make(map[string]bool)
-		for _, p := range polecats {
-			running, _ := polecatMgr.IsRunning(p.Name)
-			cleanupStatus := ""
-			activeMR := ""
-			agentBeadID := polecatBeadIDForRig(r, r.Name, p.Name)
-			if _, fields, err := bd.GetAgentBead(agentBeadID); err == nil && fields != nil {
-				cleanupStatus = fields.CleanupStatus
-				activeMR = fields.ActiveMR
+		for _, name := range polecatNames {
+			agentBeadID := polecatBeadIDForRig(r, r.Name, name)
+			fields := parsePolecatAgentFields(agents[agentBeadID])
+			item := buildPolecatInventoryItem(r.Name, name, fields, activeWork[name], sessions)
+			if activeWorkErr != nil {
+				item = buildPolecatInventoryItemFromEvidence(r.Name, name, fields, polecatActiveWorkLookupError(activeWorkErr), sessions)
 			}
+			disposition := item.Disposition
 			state := effectivePolecatState(PolecatListItem{
-				State:          p.State,
-				Issue:          p.Issue,
-				SessionRunning: running,
+				State:                item.State,
+				Issue:                item.Issue,
+				SessionRunning:       item.SessionRunning,
+				CountsTowardCapacity: disposition.CountsTowardCapacity,
 			})
-			disposition := mgr.WorkstateDispositionForPolecat(p.Name, state, p.Issue)
 			allPolecats = append(allPolecats, PolecatListItem{
 				Rig:                  r.Name,
-				Name:                 p.Name,
+				Name:                 name,
 				State:                state,
-				Issue:                p.Issue,
-				CleanupStatus:        cleanupStatus,
-				ActiveMR:             activeMR,
-				Branch:               p.Branch,
+				Issue:                item.Issue,
+				CleanupStatus:        item.CleanupStatus,
+				ActiveMR:             item.ActiveMR,
+				Branch:               item.Branch,
 				Verdict:              disposition.Verdict,
 				Reason:               disposition.Reason,
 				Reusable:             disposition.Reusable,
@@ -530,15 +542,17 @@ func runPolecatList(cmd *cobra.Command, args []string) error {
 				MQStatus:             disposition.MQStatus,
 				CountsTowardCapacity: disposition.CountsTowardCapacity,
 				ReuseStatus:          disposition.ReuseStatus,
-				SessionRunning:       running,
+				Blockers:             disposition.Blockers,
+				SessionRunning:       item.SessionRunning,
+				SessionName:          item.SessionName,
 			})
-			knownNames[p.Name] = true
+			knownNames[name] = true
 		}
 
 		// Discover zombie tmux sessions: sessions without matching worktree directories.
 		// These occur when a worktree is deleted but the tmux session persists
 		// (incomplete nuke or session naming mismatch).
-		zombieSessions, _ := findRigPolecatSessions(r.Name)
+		zombieSessions := sessions.namesForRig(r.Name)
 		for _, sessionName := range zombieSessions {
 			_, polecatName, ok := parsePolecatSessionName(sessionName)
 			if !ok {

--- a/internal/cmd/polecat_capacity.go
+++ b/internal/cmd/polecat_capacity.go
@@ -5,17 +5,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/gofrs/flock"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
-	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/polecat"
-	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
-	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
@@ -32,10 +30,31 @@ type polecatCapacitySnapshot struct {
 	Reservations    int `json:"reservations"`
 	Free            int `json:"free"`
 	ActiveSessions  int `json:"active_sessions"`
+	capacityUsed    int
 }
 
 func (s polecatCapacitySnapshot) occupied() int {
-	return s.Working + s.RecoveryBlocked + s.Reservations
+	return s.capacityUsed + s.Reservations
+}
+
+func (s *polecatCapacitySnapshot) addWorking() {
+	s.Working++
+	s.capacityUsed++
+}
+
+func (s *polecatCapacitySnapshot) addRecoveryBlocked(countsTowardCapacity bool) {
+	s.RecoveryBlocked++
+	if countsTowardCapacity {
+		s.capacityUsed++
+	}
+}
+
+func (s *polecatCapacitySnapshot) addReusableIdle() {
+	s.ReusableIdle++
+}
+
+func (s *polecatCapacitySnapshot) addPendingMR() {
+	s.PendingMR++
 }
 
 type polecatAdmissionReservation struct {
@@ -172,9 +191,17 @@ func polecatCapacitySnapshotForTownNoCleanup(townRoot string) (polecatCapacitySn
 	}
 
 	tmuxClient := tmux.NewTmux()
+	sessionNames, err := tmuxClient.ListSessions()
+	if err != nil {
+		return snapshot, fmt.Errorf("listing tmux sessions for polecat capacity: %w", err)
+	}
+	sessions := newPolecatSessionSet(sessionNames)
 	for rigName := range rigsConfig.Rigs {
 		rigPath := filepath.Join(townRoot, rigName)
 		if _, err := os.Stat(rigPath); err != nil {
+			if !os.IsNotExist(err) {
+				return snapshot, fmt.Errorf("stat rig path for %s capacity: %w", rigName, err)
+			}
 			continue
 		}
 		polecatNames, err := listPolecatDirectoryNames(rigPath)
@@ -185,20 +212,21 @@ func polecatCapacitySnapshotForTownNoCleanup(townRoot string) (polecatCapacitySn
 			continue
 		}
 
-		agents, err := beads.New(rigPath).ListAgentBeads()
+		rigBeads := beads.New(rigPath)
+		agents, err := rigBeads.ListAgentBeads()
 		if err != nil {
 			return snapshot, fmt.Errorf("listing agent beads for %s capacity: %w", rigName, err)
+		}
+		activeWork, err := listActivePolecatWorkByName(rigBeads, rigName)
+		if err != nil {
+			return snapshot, fmt.Errorf("listing active polecat work for %s capacity: %w", rigName, err)
 		}
 		prefix := beads.GetPrefixForRig(townRoot, rigName)
 		for _, name := range polecatNames {
 			agentID := beads.PolecatBeadIDWithPrefix(prefix, rigName, name)
 			issue := agents[agentID]
-			fields := (*beads.AgentFields)(nil)
-			if issue != nil {
-				fields = beads.ParseAgentFields(issue.Description)
-				fields.AgentState = beads.ResolveAgentState(issue.Description, issue.AgentState)
-			}
-			applyAgentFieldsToCapacitySnapshot(&snapshot, rigPath, rigName, name, fields, tmuxClient)
+			fields := parsePolecatAgentFields(issue)
+			applyAgentFieldsToCapacitySnapshot(&snapshot, rigName, name, fields, activeWork[name], sessions)
 		}
 	}
 
@@ -230,97 +258,35 @@ func listPolecatDirectoryNames(rigPath string) ([]string, error) {
 			names = append(names, entry.Name())
 		}
 	}
+	sort.Strings(names)
 	return names, nil
 }
 
-func applyAgentFieldsToCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigPath, rigName, polecatName string, fields *beads.AgentFields, tmuxClient *tmux.Tmux) {
-	running := false
-	if tmuxClient != nil {
-		running, _ = tmuxClient.HasSession(session.PolecatSessionName(session.PrefixFor(rigName), polecatName))
-	}
-	if fields == nil {
-		if running {
-			snapshot.Working++
-		} else {
-			snapshot.RecoveryBlocked++
-		}
-		return
-	}
-
-	state := strings.TrimSpace(fields.AgentState)
-	if state == "working" || state == "spawning" {
-		if running {
-			snapshot.Working++
-		} else {
-			snapshot.RecoveryBlocked++
-		}
-		return
-	}
-	if fields.HookBead != "" {
-		if running {
-			snapshot.Working++
-		} else if applyCanonicalCapacitySnapshot(snapshot, rigPath, rigName, polecatName, fields, tmuxClient) {
-			return
-		} else {
-			snapshot.RecoveryBlocked++
-		}
-		return
-	}
-	if fields.PushFailed || fields.MRFailed {
-		snapshot.RecoveryBlocked++
-		return
-	}
-	if fields.ActiveMR != "" || (fields.CleanupStatus != "" && fields.CleanupStatus != "clean") {
-		if applyCanonicalCapacitySnapshot(snapshot, rigPath, rigName, polecatName, fields, tmuxClient) {
-			return
-		}
-	}
-	if fields.ActiveMR != "" {
-		snapshot.PendingMR++
-		return
-	}
-	if fields.CleanupStatus == "clean" || state == "nuked" {
-		snapshot.ReusableIdle++
-		return
-	}
-	snapshot.RecoveryBlocked++
-}
-
-func applyCanonicalCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigPath, rigName, polecatName string, fields *beads.AgentFields, tmuxClient *tmux.Tmux) bool {
-	if snapshot == nil || fields == nil || rigPath == "" {
-		return false
-	}
-	state := polecat.State(strings.TrimSpace(fields.AgentState))
-	if state == "" {
-		state = polecat.StateIdle
-	}
-	issueID := fields.LastSourceIssue
-	if issueID == "" {
-		issueID = fields.HookBead
-	}
-	mgr := polecat.NewManager(&rig.Rig{Name: rigName, Path: rigPath}, git.NewGit(rigPath), tmuxClient)
-	disposition := mgr.WorkstateDispositionForPolecat(polecatName, state, issueID)
-	applyWorkstateDispositionToCapacitySnapshot(snapshot, state, disposition)
-	return true
+func applyAgentFieldsToCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigName, polecatName string, fields *beads.AgentFields, activeWork *beads.Issue, sessions polecatSessionSet) {
+	item := buildPolecatInventoryItem(rigName, polecatName, fields, activeWork, sessions)
+	applyWorkstateDispositionToCapacitySnapshot(snapshot, item.State, item.Disposition)
 }
 
 func applyWorkstateDispositionToCapacitySnapshot(snapshot *polecatCapacitySnapshot, state polecat.State, disposition polecat.WorkstateDisposition) {
 	if disposition.ReuseStatus == "idle-pr-open" {
-		snapshot.PendingMR++
+		snapshot.addPendingMR()
 		return
 	}
 	if disposition.Reusable {
-		snapshot.ReusableIdle++
+		snapshot.addReusableIdle()
 		return
 	}
-	if !disposition.CountsTowardCapacity {
+	if disposition.NeedsRecovery {
+		snapshot.addRecoveryBlocked(disposition.CountsTowardCapacity)
 		return
 	}
 	if state == polecat.StateWorking || disposition.Verdict == polecat.WorkstateVerdictWorking {
-		snapshot.Working++
+		snapshot.addWorking()
 		return
 	}
-	snapshot.RecoveryBlocked++
+	if disposition.CountsTowardCapacity {
+		snapshot.addRecoveryBlocked(true)
+	}
 }
 
 func acquirePolecatAdmissionLock(townRoot string) (*flock.Flock, error) {

--- a/internal/cmd/polecat_capacity_test.go
+++ b/internal/cmd/polecat_capacity_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/polecat"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 )
 
@@ -287,9 +288,10 @@ func TestConcurrentPolecatAdmissionReservationsDoNotExceedCap(t *testing.T) {
 
 func TestApplyAgentFieldsToCapacitySnapshotSeparatesPendingMR(t *testing.T) {
 	tests := []struct {
-		name   string
-		fields *beads.AgentFields
-		want   polecatCapacitySnapshot
+		name       string
+		fields     *beads.AgentFields
+		activeWork *beads.Issue
+		want       polecatCapacitySnapshot
 	}{
 		{
 			name:   "active mr is pending capacity",
@@ -299,23 +301,54 @@ func TestApplyAgentFieldsToCapacitySnapshotSeparatesPendingMR(t *testing.T) {
 		{
 			name:   "push failed remains recovery blocked",
 			fields: &beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: "clean", ActiveMR: "gt-mr-open", PushFailed: true},
-			want:   polecatCapacitySnapshot{RecoveryBlocked: 1},
+			want:   polecatCapacitySnapshot{RecoveryBlocked: 1, capacityUsed: 1},
 		},
 		{
 			name:   "clean idle is reusable",
 			fields: &beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: "clean"},
 			want:   polecatCapacitySnapshot{ReusableIdle: 1},
 		},
+		{
+			name:       "active work consumes capacity",
+			fields:     &beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: "clean"},
+			activeWork: &beads.Issue{ID: "gt-work", Status: string(beads.StatusOpen), Assignee: "gastown/polecats/synth"},
+			want:       polecatCapacitySnapshot{RecoveryBlocked: 1, capacityUsed: 1},
+		},
+		{
+			name:       "deferred work blocks recovery without capacity",
+			fields:     &beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: "clean"},
+			activeWork: &beads.Issue{ID: "gt-paused", Status: string(beads.StatusDeferred), Assignee: "gastown/polecats/synth"},
+			want:       polecatCapacitySnapshot{RecoveryBlocked: 1},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			snapshot := polecatCapacitySnapshot{}
-			applyAgentFieldsToCapacitySnapshot(&snapshot, "", "gastown", "synth", tt.fields, nil)
-			if snapshot.Working != tt.want.Working || snapshot.RecoveryBlocked != tt.want.RecoveryBlocked || snapshot.ReusableIdle != tt.want.ReusableIdle || snapshot.PendingMR != tt.want.PendingMR {
+			applyAgentFieldsToCapacitySnapshot(&snapshot, "gastown", "synth", tt.fields, tt.activeWork, nil)
+			if snapshot.Working != tt.want.Working || snapshot.RecoveryBlocked != tt.want.RecoveryBlocked || snapshot.ReusableIdle != tt.want.ReusableIdle || snapshot.PendingMR != tt.want.PendingMR || snapshot.capacityUsed != tt.want.capacityUsed {
 				t.Fatalf("snapshot = %+v, want %+v", snapshot, tt.want)
 			}
 		})
+	}
+}
+
+func TestCapacitySnapshotRecoveryBlockedDoesNotAlwaysConsumeFreeCapacity(t *testing.T) {
+	snapshot := polecatCapacitySnapshot{Max: 3}
+	applyWorkstateDispositionToCapacitySnapshot(&snapshot, polecat.StateIdle, polecat.WorkstateDisposition{
+		Verdict:              polecat.WorkstateVerdictNeedsRecovery,
+		NeedsRecovery:        true,
+		CountsTowardCapacity: false,
+	})
+	applyWorkstateDispositionToCapacitySnapshot(&snapshot, polecat.StateStalled, polecat.WorkstateDisposition{
+		Verdict:              polecat.WorkstateVerdictNeedsRecovery,
+		NeedsRecovery:        true,
+		CountsTowardCapacity: true,
+	})
+	snapshot.Free = snapshot.Max - snapshot.occupied()
+
+	if snapshot.RecoveryBlocked != 2 || snapshot.capacityUsed != 1 || snapshot.Free != 2 {
+		t.Fatalf("snapshot = %+v, want recovery=2 capacityUsed=1 free=2", snapshot)
 	}
 }
 

--- a/internal/cmd/polecat_inventory.go
+++ b/internal/cmd/polecat_inventory.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/polecat"
+)
+
+const polecatSessionKeySep = "\x00"
+
+type polecatSessionSet map[string]string
+
+type polecatInventoryItem struct {
+	Rig            string
+	Name           string
+	State          polecat.State
+	Issue          string
+	CleanupStatus  string
+	ActiveMR       string
+	Branch         string
+	SessionRunning bool
+	SessionName    string
+	Disposition    polecat.WorkstateDisposition
+}
+
+type polecatActiveWorkEvidence struct {
+	BlocksCleanup        bool
+	RequiresRestart      bool
+	CountsTowardCapacity bool
+	Blocker              string
+	AssignedIssue        string
+}
+
+func newPolecatSessionSet(sessionNames []string) polecatSessionSet {
+	sessions := make(polecatSessionSet, len(sessionNames))
+	for _, sessionName := range sessionNames {
+		rigName, polecatName, ok := parsePolecatSessionName(sessionName)
+		if !ok {
+			continue
+		}
+		sessions[polecatSessionKey(rigName, polecatName)] = sessionName
+	}
+	return sessions
+}
+
+func (s polecatSessionSet) lookup(rigName, polecatName string) (string, bool) {
+	if s == nil {
+		return "", false
+	}
+	sessionName, ok := s[polecatSessionKey(rigName, polecatName)]
+	return sessionName, ok
+}
+
+func (s polecatSessionSet) namesForRig(rigName string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	var names []string
+	for _, sessionName := range s {
+		sessionRig, _, ok := parsePolecatSessionName(sessionName)
+		if ok && sessionRig == rigName {
+			names = append(names, sessionName)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func polecatSessionKey(rigName, polecatName string) string {
+	return rigName + polecatSessionKeySep + polecatName
+}
+
+func buildPolecatInventoryItem(rigName, polecatName string, fields *beads.AgentFields, activeWork *beads.Issue, sessions polecatSessionSet) polecatInventoryItem {
+	return buildPolecatInventoryItemFromEvidence(rigName, polecatName, fields, assessPolecatAssignedIssueWork(activeWork), sessions)
+}
+
+func buildPolecatInventoryItemFromEvidence(rigName, polecatName string, fields *beads.AgentFields, activeWorkEvidence polecatActiveWorkEvidence, sessions polecatSessionSet) polecatInventoryItem {
+	sessionName, running := sessions.lookup(rigName, polecatName)
+	item := polecatInventoryItem{
+		Rig:            rigName,
+		Name:           polecatName,
+		State:          polecat.StateIdle,
+		SessionRunning: running,
+		SessionName:    sessionName,
+	}
+
+	input := polecat.WorkstateInput{State: polecat.StateIdle}
+	if fields != nil {
+		item.CleanupStatus = strings.TrimSpace(fields.CleanupStatus)
+		item.ActiveMR = strings.TrimSpace(fields.ActiveMR)
+		item.Branch = strings.TrimSpace(fields.Branch)
+		input.CleanupStatus = polecat.CleanupStatus(item.CleanupStatus)
+		input.PushFailed = fields.PushFailed
+		input.MRFailed = fields.MRFailed
+		input.Branch = item.Branch
+		input.ActiveMR = item.ActiveMR
+	}
+
+	if !activeWorkEvidence.BlocksCleanup && fields != nil {
+		activeWorkEvidence = assessPolecatAgentStateWork(beads.AgentState(strings.TrimSpace(fields.AgentState)))
+	}
+
+	if activeWorkEvidence.BlocksCleanup {
+		item.Issue = activeWorkEvidence.AssignedIssue
+		if activeWorkEvidence.RequiresRestart || activeWorkEvidence.CountsTowardCapacity {
+			if running {
+				item.State = polecat.StateWorking
+			} else {
+				item.State = polecat.StateStalled
+			}
+		} else if running && !polecat.CleanupStatus(item.CleanupStatus).IsSafe() {
+			item.State = polecat.StateReviewNeeded
+		}
+		input.ActiveWorkBlocker = activeWorkEvidence.Blocker
+		input.ActiveWorkCountsTowardCapacity = activeWorkEvidence.CountsTowardCapacity
+	} else if running && !polecat.CleanupStatus(item.CleanupStatus).IsSafe() {
+		item.State = polecat.StateReviewNeeded
+	}
+
+	if fields != nil && !activeWorkEvidence.BlocksCleanup {
+		if hookBead := strings.TrimSpace(fields.HookBead); hookBead != "" {
+			input.ActiveWorkBlocker = fmt.Sprintf("hook_bead=%s status=unverified", hookBead)
+		}
+	}
+	if item.ActiveMR != "" {
+		input.ActiveMRBlocker = "active_mr=" + item.ActiveMR + " status=unknown"
+	}
+
+	input.State = item.State
+	item.Disposition = polecat.DecideWorkstate(input)
+	return item
+}
+
+var polecatSummaryWorkStatuses = []beads.IssueStatus{
+	beads.IssueStatusHooked,
+	beads.StatusInProgress,
+	beads.StatusOpen,
+	beads.StatusBlocked,
+	beads.StatusDeferred,
+}
+
+var polecatSummaryWorkStatusRank = func() map[string]int {
+	ranks := make(map[string]int, len(polecatSummaryWorkStatuses))
+	for i, status := range polecatSummaryWorkStatuses {
+		ranks[string(status)] = i
+	}
+	return ranks
+}()
+
+func listActivePolecatWorkByName(bd *beads.Beads, rigName string) (map[string]*beads.Issue, error) {
+	byName := make(map[string]*beads.Issue)
+	issues, err := bd.ListIssueStatuses(polecatSummaryWorkStatuses...)
+	if err != nil {
+		return nil, err
+	}
+	for _, issue := range issues {
+		evidence := assessPolecatAssignedIssueWork(issue)
+		if !evidence.BlocksCleanup {
+			continue
+		}
+		name, ok := polecatNameFromAssignee(rigName, issue.Assignee)
+		if !ok {
+			continue
+		}
+		if current := byName[name]; current == nil || polecatSummaryIssueRank(issue) < polecatSummaryIssueRank(current) {
+			byName[name] = issue
+		}
+	}
+	return byName, nil
+}
+
+func polecatSummaryIssueRank(issue *beads.Issue) int {
+	if issue == nil {
+		return len(polecatSummaryWorkStatuses)
+	}
+	if rank, ok := polecatSummaryWorkStatusRank[issue.Status]; ok {
+		return rank
+	}
+	return len(polecatSummaryWorkStatuses)
+}
+
+func polecatNameFromAssignee(rigName, assignee string) (string, bool) {
+	prefix := rigName + "/polecats/"
+	if !strings.HasPrefix(assignee, prefix) {
+		return "", false
+	}
+	name := strings.TrimPrefix(assignee, prefix)
+	if name == "" || strings.Contains(name, "/") {
+		return "", false
+	}
+	return name, true
+}
+
+func assessPolecatAssignedIssueWork(issue *beads.Issue) polecatActiveWorkEvidence {
+	if issue == nil || beads.IsAgentBead(issue) || beads.IsProtectedBead(issue) || beads.IssueStatus(issue.Status).IsTerminal() {
+		return polecatActiveWorkEvidence{}
+	}
+	requiresRestart := polecatSummaryIssueRequiresRestart(beads.IssueStatus(issue.Status))
+	return polecatActiveWorkEvidence{
+		BlocksCleanup:        true,
+		RequiresRestart:      requiresRestart,
+		CountsTowardCapacity: requiresRestart,
+		Blocker:              fmt.Sprintf("assigned_work=%s status=%s", issue.ID, issue.Status),
+		AssignedIssue:        issue.ID,
+	}
+}
+
+func polecatSummaryIssueRequiresRestart(status beads.IssueStatus) bool {
+	switch status {
+	case beads.IssueStatusHooked, beads.StatusInProgress, beads.StatusOpen:
+		return true
+	default:
+		return false
+	}
+}
+
+func assessPolecatAgentStateWork(state beads.AgentState) polecatActiveWorkEvidence {
+	if state == "" || state == beads.AgentStateIdle || state == beads.AgentStateDone || state == beads.AgentStateNuked {
+		return polecatActiveWorkEvidence{}
+	}
+	if state.IsActive() {
+		return polecatActiveWorkEvidence{
+			BlocksCleanup:        true,
+			RequiresRestart:      true,
+			CountsTowardCapacity: true,
+			Blocker:              fmt.Sprintf("agent_state=%s", state),
+		}
+	}
+	if state.ProtectsFromCleanup() || state == beads.AgentStateEscalated {
+		return polecatActiveWorkEvidence{
+			BlocksCleanup: true,
+			Blocker:       fmt.Sprintf("agent_state=%s", state),
+		}
+	}
+	return polecatActiveWorkEvidence{}
+}
+
+func polecatActiveWorkLookupError(err error) polecatActiveWorkEvidence {
+	if err == nil {
+		return polecatActiveWorkEvidence{}
+	}
+	return polecatActiveWorkEvidence{
+		BlocksCleanup: true,
+		Blocker:       fmt.Sprintf("assigned_work status=lookup_error: %v", err),
+	}
+}
+
+func parsePolecatAgentFields(issue *beads.Issue) *beads.AgentFields {
+	if issue == nil {
+		return nil
+	}
+	fields := beads.ParseAgentFields(issue.Description)
+	fields.AgentState = beads.ResolveAgentState(issue.Description, issue.AgentState)
+	return fields
+}

--- a/internal/cmd/polecat_inventory_test.go
+++ b/internal/cmd/polecat_inventory_test.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/polecat"
+)
+
+func TestPolecatSessionSet(t *testing.T) {
+	setupPolecatTestRegistry(t)
+	sessions := newPolecatSessionSet([]string{
+		"gt-thunder",
+		"gt-crew-dom",
+		"gp-mirelurk",
+		"not-a-polecat",
+	})
+
+	if got, ok := sessions.lookup("gastown", "thunder"); !ok || got != "gt-thunder" {
+		t.Fatalf("lookup gastown/thunder = %q, %v", got, ok)
+	}
+	if _, ok := sessions.lookup("gastown", "dom"); ok {
+		t.Fatal("crew session should not be indexed as polecat")
+	}
+	if got := sessions.namesForRig("gastown"); len(got) != 1 || got[0] != "gt-thunder" {
+		t.Fatalf("namesForRig(gastown) = %v", got)
+	}
+}
+
+func TestBuildPolecatInventoryItem(t *testing.T) {
+	setupPolecatTestRegistry(t)
+	sessions := newPolecatSessionSet([]string{"gt-running"})
+	tests := []struct {
+		name         string
+		polecatName  string
+		fields       *beads.AgentFields
+		activeWork   *beads.Issue
+		wantState    polecat.State
+		wantIssue    string
+		wantVerdict  string
+		wantReusable bool
+		wantRecovery bool
+		wantCapacity bool
+	}{
+		{
+			name:         "clean idle reusable",
+			polecatName:  "idle",
+			fields:       &beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: string(polecat.CleanupClean)},
+			wantState:    polecat.StateIdle,
+			wantVerdict:  polecat.WorkstateVerdictSafeToNuke,
+			wantReusable: true,
+		},
+		{
+			name:         "hooked running is working capacity",
+			polecatName:  "running",
+			fields:       &beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: string(polecat.CleanupClean)},
+			activeWork:   &beads.Issue{ID: "gt-hook", Status: string(beads.IssueStatusHooked), Assignee: "gastown/polecats/running"},
+			wantState:    polecat.StateWorking,
+			wantIssue:    "gt-hook",
+			wantVerdict:  polecat.WorkstateVerdictWorking,
+			wantCapacity: true,
+		},
+		{
+			name:         "open stopped is stalled capacity",
+			polecatName:  "stopped",
+			fields:       &beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: string(polecat.CleanupClean)},
+			activeWork:   &beads.Issue{ID: "gt-open", Status: string(beads.StatusOpen), Assignee: "gastown/polecats/stopped"},
+			wantState:    polecat.StateStalled,
+			wantIssue:    "gt-open",
+			wantVerdict:  polecat.WorkstateVerdictNeedsRecovery,
+			wantRecovery: true,
+			wantCapacity: true,
+		},
+		{
+			name:         "deferred protects without capacity",
+			polecatName:  "deferred",
+			fields:       &beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: string(polecat.CleanupClean)},
+			activeWork:   &beads.Issue{ID: "gt-deferred", Status: string(beads.StatusDeferred), Assignee: "gastown/polecats/deferred"},
+			wantState:    polecat.StateIdle,
+			wantIssue:    "gt-deferred",
+			wantVerdict:  polecat.WorkstateVerdictNeedsRecovery,
+			wantRecovery: true,
+		},
+		{
+			name:         "hook fallback protects without capacity",
+			polecatName:  "hookonly",
+			fields:       &beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: string(polecat.CleanupClean), HookBead: "gt-old"},
+			wantState:    polecat.StateIdle,
+			wantVerdict:  polecat.WorkstateVerdictNeedsRecovery,
+			wantRecovery: true,
+		},
+		{
+			name:         "paused agent state protects without capacity",
+			polecatName:  "paused",
+			fields:       &beads.AgentFields{AgentState: string(beads.AgentStatePaused), CleanupStatus: string(polecat.CleanupClean)},
+			wantState:    polecat.StateIdle,
+			wantVerdict:  polecat.WorkstateVerdictNeedsRecovery,
+			wantRecovery: true,
+		},
+		{
+			name:        "active mr is pending non capacity",
+			polecatName: "pendingmr",
+			fields:      &beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: string(polecat.CleanupClean), ActiveMR: "gt-mr"},
+			wantState:   polecat.StateIdle,
+			wantVerdict: polecat.WorkstateVerdictPendingMR,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := buildPolecatInventoryItem("gastown", tt.polecatName, tt.fields, tt.activeWork, sessions)
+			if item.State != tt.wantState || item.Issue != tt.wantIssue || item.Disposition.Verdict != tt.wantVerdict || item.Disposition.Reusable != tt.wantReusable || item.Disposition.NeedsRecovery != tt.wantRecovery || item.Disposition.CountsTowardCapacity != tt.wantCapacity {
+				t.Fatalf("item = %+v disposition=%+v", item, item.Disposition)
+			}
+		})
+	}
+}
+
+func TestBuildPolecatInventoryItemActiveWorkLookupErrorFailsClosed(t *testing.T) {
+	item := buildPolecatInventoryItemFromEvidence(
+		"gastown",
+		"lookup",
+		&beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: string(polecat.CleanupClean)},
+		polecatActiveWorkLookupError(errors.New("bd failed")),
+		polecatSessionSet{},
+	)
+
+	if item.Disposition.Reusable || item.Disposition.SafeToNuke || !item.Disposition.NeedsRecovery || item.Disposition.CountsTowardCapacity {
+		t.Fatalf("lookup error disposition = %+v", item.Disposition)
+	}
+	if item.Disposition.Reason != "active-work" {
+		t.Fatalf("reason = %q, want active-work", item.Disposition.Reason)
+	}
+	if len(item.Disposition.Blockers) != 1 || !strings.Contains(item.Disposition.Blockers[0], "lookup_error") {
+		t.Fatalf("blockers = %v, want lookup_error", item.Disposition.Blockers)
+	}
+}
+
+func TestPolecatSummaryIssueRankPrefersActiveWork(t *testing.T) {
+	ordered := []*beads.Issue{
+		{ID: "hook", Status: string(beads.IssueStatusHooked)},
+		{ID: "progress", Status: string(beads.StatusInProgress)},
+		{ID: "open", Status: string(beads.StatusOpen)},
+		{ID: "blocked", Status: string(beads.StatusBlocked)},
+		{ID: "deferred", Status: string(beads.StatusDeferred)},
+	}
+	for i := 1; i < len(ordered); i++ {
+		if polecatSummaryIssueRank(ordered[i-1]) >= polecatSummaryIssueRank(ordered[i]) {
+			t.Fatalf("rank(%s) should be before rank(%s)", ordered[i-1].Status, ordered[i].Status)
+		}
+	}
+}
+
+func TestPolecatNameFromAssignee(t *testing.T) {
+	tests := []struct {
+		assignee string
+		wantName string
+		wantOK   bool
+	}{
+		{assignee: "gastown/polecats/thunder", wantName: "thunder", wantOK: true},
+		{assignee: "other/polecats/thunder"},
+		{assignee: "gastown/crew/dom"},
+		{assignee: "gastown/polecats/"},
+		{assignee: "gastown/polecats/a/b"},
+	}
+	for _, tt := range tests {
+		got, ok := polecatNameFromAssignee("gastown", tt.assignee)
+		if got != tt.wantName || ok != tt.wantOK {
+			t.Fatalf("polecatNameFromAssignee(%q) = %q, %v", tt.assignee, got, ok)
+		}
+	}
+}

--- a/internal/cmd/polecat_list_state_test.go
+++ b/internal/cmd/polecat_list_state_test.go
@@ -42,9 +42,10 @@ func TestEffectivePolecatState(t *testing.T) {
 		{
 			name: "session-running-done-with-issue-becomes-working",
 			item: PolecatListItem{
-				State:          polecat.StateDone,
-				Issue:          "gt-abc",
-				SessionRunning: true,
+				State:                polecat.StateDone,
+				Issue:                "gt-abc",
+				SessionRunning:       true,
+				CountsTowardCapacity: true,
 			},
 			want: polecat.StateWorking,
 		},
@@ -92,11 +93,22 @@ func TestEffectivePolecatState(t *testing.T) {
 		{
 			name: "idle-session-running-with-issue-becomes-working",
 			item: PolecatListItem{
-				State:          polecat.StateIdle,
-				Issue:          "gt-abc",
-				SessionRunning: true,
+				State:                polecat.StateIdle,
+				Issue:                "gt-abc",
+				SessionRunning:       true,
+				CountsTowardCapacity: true,
 			},
 			want: polecat.StateWorking,
+		},
+		{
+			name: "idle-session-running-with-protected-issue-stays-idle",
+			item: PolecatListItem{
+				State:                polecat.StateIdle,
+				Issue:                "gt-blocked",
+				SessionRunning:       true,
+				CountsTowardCapacity: false,
+			},
+			want: polecat.StateIdle,
 		},
 		{
 			name: "stalled-stays-stalled-when-session-dead",

--- a/internal/polecat/workstate.go
+++ b/internal/polecat/workstate.go
@@ -27,6 +27,8 @@ type WorkstateInput struct {
 	UnpushedCommits                int
 	GitCheckFailed                 bool
 	GitCheckFailedReason           string
+	ActiveWorkBlocker              string
+	ActiveWorkCountsTowardCapacity bool
 	ActiveMR                       string
 	ActiveMRBlocker                string
 	MQCheckRequired                bool
@@ -62,32 +64,41 @@ func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
 			verdict = WorkstateVerdictWorking
 			needsRecovery = false
 		}
-		return WorkstateDisposition{
+		d := WorkstateDisposition{
 			Verdict:              verdict,
 			Reason:               "not-idle",
 			NeedsRecovery:        needsRecovery,
 			CountsTowardCapacity: true,
 		}
+		if in.ActiveWorkBlocker != "" {
+			d.Blockers = append(d.Blockers, in.ActiveWorkBlocker)
+		}
+		return d
 	}
 
 	d := WorkstateDisposition{Verdict: WorkstateVerdictSafeToNuke}
-	block := func(reason, blocker string) {
+	capacityBlocked := false
+	block := func(reason, blocker string, countsTowardCapacity bool) {
 		if d.Reason == "" {
 			d.Reason = reason
 		}
 		if blocker != "" {
 			d.Blockers = append(d.Blockers, blocker)
 		}
+		capacityBlocked = capacityBlocked || countsTowardCapacity
 	}
 
 	if in.HookBead != "" && !in.PartialSpawnWithoutDurableHook {
-		block("hook-still-set", "has work on hook ("+in.HookBead+")")
+		block("hook-still-set", "has work on hook ("+in.HookBead+")", true)
 	}
 	if in.PushFailed {
-		block("push-failed", "push_failed=true")
+		block("push-failed", "push_failed=true", true)
 	}
 	if in.MRFailed {
-		block("mr-failed", "mr_failed=true")
+		block("mr-failed", "mr_failed=true", true)
+	}
+	if in.ActiveWorkBlocker != "" {
+		block("active-work", in.ActiveWorkBlocker, in.ActiveWorkCountsTowardCapacity)
 	}
 	if !in.IgnoreCleanupStatus && !in.CleanupStatus.IsSafe() {
 		reason := "cleanup-" + string(in.CleanupStatus)
@@ -98,31 +109,31 @@ func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
 		} else if in.CleanupStatus == CleanupUnknown {
 			reason = "cleanup-unknown"
 		}
-		block(reason, blocker)
+		block(reason, blocker, true)
 	}
 	if in.GitCheckFailed {
 		blocker := in.GitCheckFailedReason
 		if blocker == "" {
 			blocker = "git_state=unknown"
 		}
-		block("git-check-failed", blocker)
+		block("git-check-failed", blocker, true)
 	}
 	if in.GitDirty {
 		blocker := in.GitDirtyReason
 		if blocker == "" {
 			blocker = "git_state=has_uncommitted"
 		}
-		block("git-dirty", blocker)
+		block("git-dirty", blocker, true)
 	}
 	if in.StashCount > 0 {
-		block("git-stash", "git_state=has_stash stash_count="+itoa(in.StashCount))
+		block("git-stash", "git_state=has_stash stash_count="+itoa(in.StashCount), true)
 	}
 	if in.UnpushedCommits > 0 {
-		block("git-unpushed", "git_state=has_unpushed unpushed_commits="+itoa(in.UnpushedCommits))
+		block("git-unpushed", "git_state=has_unpushed unpushed_commits="+itoa(in.UnpushedCommits), true)
 	}
 	activeMRBlocks := in.ActiveMRBlocker != ""
 	if activeMRBlocks {
-		block("active-mr-open", in.ActiveMRBlocker)
+		block("active-mr-open", in.ActiveMRBlocker, false)
 	}
 
 	if len(d.Blockers) > 0 {
@@ -133,7 +144,7 @@ func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
 		}
 		d.Verdict = WorkstateVerdictNeedsRecovery
 		d.NeedsRecovery = true
-		d.CountsTowardCapacity = true
+		d.CountsTowardCapacity = capacityBlocked
 		d.ReuseStatus = "idle-recovery-needed"
 		return d
 	}

--- a/internal/polecat/workstate_test.go
+++ b/internal/polecat/workstate_test.go
@@ -19,6 +19,16 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "cleanup-has_unpushed", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed"},
 		},
 		{
+			name: "protected active work fails closed without capacity",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, ActiveWorkBlocker: "assigned_work=gt-blocked status=blocked"},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "active-work", NeedsRecovery: true, CountsTowardCapacity: false, ReuseStatus: "idle-recovery-needed"},
+		},
+		{
+			name: "active work blocker consumes capacity when requested",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, ActiveWorkBlocker: "assigned_work=gt-open status=open", ActiveWorkCountsTowardCapacity: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "active-work", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed"},
+		},
+		{
 			name: "unsubmitted branch needs mq submit",
 			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", MQCheckRequired: true, HasSubmittableWork: true},
 			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsMQSubmit, Reason: "mq-not-submitted", NeedsRecovery: true, NeedsMQSubmit: true, MQStatus: "not_submitted", CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed"},
@@ -43,6 +53,11 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 			in:   WorkstateInput{State: StateWorking, CleanupStatus: CleanupClean},
 			want: WorkstateDisposition{Verdict: WorkstateVerdictWorking, Reason: "not-idle", NeedsRecovery: false, CountsTowardCapacity: true},
 		},
+		{
+			name: "stalled active work preserves blocker",
+			in:   WorkstateInput{State: StateStalled, CleanupStatus: CleanupClean, ActiveWorkBlocker: "assigned_work=gt-open status=open", ActiveWorkCountsTowardCapacity: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "not-idle", NeedsRecovery: true, CountsTowardCapacity: true, Blockers: []string{"assigned_work=gt-open status=open"}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -50,6 +65,16 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 			got := DecideWorkstate(tt.in)
 			if got.Verdict != tt.want.Verdict || got.Reason != tt.want.Reason || got.Reusable != tt.want.Reusable || got.SafeToNuke != tt.want.SafeToNuke || got.NeedsRecovery != tt.want.NeedsRecovery || got.NeedsMQSubmit != tt.want.NeedsMQSubmit || got.MQStatus != tt.want.MQStatus || got.CountsTowardCapacity != tt.want.CountsTowardCapacity || got.ReuseStatus != tt.want.ReuseStatus {
 				t.Fatalf("DecideWorkstate() = %+v, want fields %+v", got, tt.want)
+			}
+			if tt.want.Blockers != nil {
+				if len(got.Blockers) != len(tt.want.Blockers) {
+					t.Fatalf("DecideWorkstate() blockers = %v, want %v", got.Blockers, tt.want.Blockers)
+				}
+				for i := range tt.want.Blockers {
+					if got.Blockers[i] != tt.want.Blockers[i] {
+						t.Fatalf("DecideWorkstate() blockers = %v, want %v", got.Blockers, tt.want.Blockers)
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Clean upstream-main port of gt-clean-port-polecat-list-timeout-upstream-20260629.

This squashes the completed thunder branch to remove auto-checkpoint commit history while preserving the verified final diff.
Source branch: Bella-Giraffety:polecat/thunder/gt-clean-port-polecat-list-timeout-upstream-20260629@9a85c9 at 0678d8a57f99cb60fd96a661a86ede5d2ac7fb15.
Internal MR gt-wisp-156 will be closed as superseded by this upstream PR; refinery must not process it.

Verification:
- CGO_ENABLED=0 go test ./internal/beads ./internal/polecat ./internal/cmd -run 'Test(ListIssueStatuses|Polecat|.*Inventory|.*Capacity|.*Workstate)' -count=1\n- CGO_ENABLED=0 go test ./... -run '^$'\n- CGO_ENABLED=0 go build ./cmd/gt\n\nBeads:\n- Source: gt-clean-port-polecat-list-timeout-upstream-20260629\n- Internal MR: gt-wisp-156\n\nDo not merge before PR Sheriff merge-gate evidence is produced.