### PR TITLE
fix: resolve rig-local agent tracking from cwd

### DIFF
--- a/internal/cmd/agent_state.go
+++ b/internal/cmd/agent_state.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -218,9 +218,10 @@ func modifyAgentState(agentBead, beadsDir string, hasIncr bool) error {
 		args = append(args, "--set-labels=")
 	}
 
-	// Execute bd update
-	cmd := exec.Command("bd", args...)
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
+	defer cancel()
+
+	cmd := beads.CommandContext(ctx, filepath.Dir(beadsDir), beadsDir, beads.MutationPinned, args...)
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -272,8 +273,7 @@ func getAllAgentLabels(agentBead, beadsDir string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	cmd := beads.CommandContext(ctx, filepath.Dir(beadsDir), beadsDir, beads.ReadOnlyPinned, args...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/cmd/agents_resolve.go
+++ b/internal/cmd/agents_resolve.go
@@ -73,7 +73,10 @@ func runAgentsResolve(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("getting working directory: %w", err)
 	}
-	workDir, err := findLocalBeadsDir()
+	workDir, err := findCwdLocalBeadsDir()
+	if err != nil {
+		workDir, err = findLocalBeadsDir()
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/agents_resolve.go
+++ b/internal/cmd/agents_resolve.go
@@ -73,16 +73,9 @@ func runAgentsResolve(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("getting working directory: %w", err)
 	}
-	workDir, err := findCwdLocalBeadsDir()
-	if err != nil {
-		workDir, err = findLocalBeadsDir()
-	}
+	currentBeadsDir, err := resolveAgentTrackingBeadsDir()
 	if err != nil {
 		return err
-	}
-	currentBeadsDir := beads.ResolveBeadsDir(workDir)
-	if currentBeadsDir == "" {
-		return fmt.Errorf("not in a beads workspace")
 	}
 
 	candidates, err := findAgentBeadCandidates(cwd, currentBeadsDir)

--- a/internal/cmd/mail_identity.go
+++ b/internal/cmd/mail_identity.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
@@ -79,10 +80,11 @@ func findLocalBeadsDir() (string, error) {
 // findCwdLocalBeadsDir finds the nearest .beads directory by walking up from CWD.
 //
 // Unlike findLocalBeadsDir, this intentionally ignores BEADS_DIR. Agent tracking
-// commands such as `gt agents resolve --rig` and `gt mol step await-event
-// --agent-bead` need the rig-local beads redirect implied by their working
-// directory. A broader session BEADS_DIR override can point at town beads and
-// make those commands update the wrong agent bead.
+// commands such as `gt agents resolve --rig`, `gt mol step await-event
+// --agent-bead`, and `gt mol step await-signal --agent-bead` need the
+// rig-local beads redirect implied by their working directory. A broader
+// session BEADS_DIR override can point at town beads and make those commands
+// update the wrong agent bead.
 func findCwdLocalBeadsDir() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -103,6 +105,26 @@ func findCwdLocalBeadsDir() (string, error) {
 	}
 
 	return "", fmt.Errorf("no .beads directory found")
+}
+
+// resolveAgentTrackingBeadsDir resolves the bead database used for agent state.
+// Agent tracking is tied to the agent's current rig, so cwd-local redirects must
+// win over an inherited town-level BEADS_DIR. The env-first resolver remains the
+// fallback for contexts that do not have a cwd-local .beads directory.
+func resolveAgentTrackingBeadsDir() (string, error) {
+	workDir, err := findCwdLocalBeadsDir()
+	if err != nil {
+		workDir, err = findLocalBeadsDir()
+	}
+	if err != nil {
+		return "", err
+	}
+
+	beadsDir := beads.ResolveBeadsDir(workDir)
+	if beadsDir == "" {
+		return "", fmt.Errorf("not in a beads workspace")
+	}
+	return beadsDir, nil
 }
 
 // detectSender determines the current context's address.

--- a/internal/cmd/mail_identity.go
+++ b/internal/cmd/mail_identity.go
@@ -76,6 +76,35 @@ func findLocalBeadsDir() (string, error) {
 	return "", fmt.Errorf("no .beads directory found")
 }
 
+// findCwdLocalBeadsDir finds the nearest .beads directory by walking up from CWD.
+//
+// Unlike findLocalBeadsDir, this intentionally ignores BEADS_DIR. Agent tracking
+// commands such as `gt agents resolve --rig` and `gt mol step await-event
+// --agent-bead` need the rig-local beads redirect implied by their working
+// directory. A broader session BEADS_DIR override can point at town beads and
+// make those commands update the wrong agent bead.
+func findCwdLocalBeadsDir() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	path := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(path, ".beads")); err == nil {
+			return path, nil
+		}
+
+		parent := filepath.Dir(path)
+		if parent == path {
+			break
+		}
+		path = parent
+	}
+
+	return "", fmt.Errorf("no .beads directory found")
+}
+
 // detectSender determines the current context's address.
 // Priority:
 //  1. GT_ROLE env var → use the role-based identity (agent session)

--- a/internal/cmd/mail_identity_test.go
+++ b/internal/cmd/mail_identity_test.go
@@ -73,3 +73,43 @@ func TestDetectSenderFromCwdUsesAgentFileRefineryIdentity(t *testing.T) {
 		t.Fatalf("detectSender() = %q, want %q", got, "x267/refinery")
 	}
 }
+
+func TestFindCwdLocalBeadsDirIgnoresBeadsDirOverride(t *testing.T) {
+	tmp := t.TempDir()
+	townBeads := filepath.Join(tmp, ".beads")
+	rigWorkDir := filepath.Join(tmp, "gastown", "refinery", "rig")
+	rigBeads := filepath.Join(rigWorkDir, ".beads")
+
+	if err := os.MkdirAll(townBeads, 0o755); err != nil {
+		t.Fatalf("mkdir town beads: %v", err)
+	}
+	if err := os.MkdirAll(rigBeads, 0o755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+	t.Setenv("BEADS_DIR", townBeads)
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(rigWorkDir); err != nil {
+		t.Fatalf("chdir rig work dir: %v", err)
+	}
+
+	got, err := findCwdLocalBeadsDir()
+	if err != nil {
+		t.Fatalf("findCwdLocalBeadsDir() error = %v", err)
+	}
+	if got != rigWorkDir {
+		t.Fatalf("findCwdLocalBeadsDir() = %q, want %q", got, rigWorkDir)
+	}
+
+	got, err = findLocalBeadsDir()
+	if err != nil {
+		t.Fatalf("findLocalBeadsDir() error = %v", err)
+	}
+	if got != tmp {
+		t.Fatalf("findLocalBeadsDir() = %q, want BEADS_DIR parent %q", got, tmp)
+	}
+}

--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -160,7 +160,10 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 	var backoffUntil time.Time
 	var beadsDir string
 	if awaitEventAgentBead != "" {
-		workDir, wdErr := findLocalBeadsDir()
+		workDir, wdErr := findCwdLocalBeadsDir()
+		if wdErr != nil {
+			workDir, wdErr = findLocalBeadsDir()
+		}
 		if wdErr == nil {
 			beadsDir = beads.ResolveBeadsDir(workDir)
 			labels, labErr := getAgentLabels(awaitEventAgentBead, beadsDir)

--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/channelevents"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -160,12 +159,9 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 	var backoffUntil time.Time
 	var beadsDir string
 	if awaitEventAgentBead != "" {
-		workDir, wdErr := findCwdLocalBeadsDir()
-		if wdErr != nil {
-			workDir, wdErr = findLocalBeadsDir()
-		}
+		var wdErr error
+		beadsDir, wdErr = resolveAgentTrackingBeadsDir()
 		if wdErr == nil {
-			beadsDir = beads.ResolveBeadsDir(workDir)
 			labels, labErr := getAgentLabels(awaitEventAgentBead, beadsDir)
 			if labErr != nil {
 				if !awaitEventQuiet {

--- a/internal/cmd/molecule_await_signal.go
+++ b/internal/cmd/molecule_await_signal.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -134,7 +133,7 @@ func init() {
 
 func runMoleculeAwaitSignal(cmd *cobra.Command, args []string) error {
 	// Find beads directory (rig-local for bead operations)
-	workDir, err := findLocalBeadsDir()
+	beadsDir, err := resolveAgentTrackingBeadsDir()
 	if err != nil {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}
@@ -144,8 +143,6 @@ func runMoleculeAwaitSignal(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("not in a Gas Town workspace: %w", err)
 	}
-
-	beadsDir := beads.ResolveBeadsDir(workDir)
 
 	// Read current idle cycles and backoff window from agent bead (if specified)
 	var idleCycles int
@@ -457,8 +454,7 @@ func updateAgentHeartbeat(agentBead, beadsDir string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	cmd := beads.CommandContext(ctx, filepath.Dir(beadsDir), beadsDir, beads.MutationPinned, args...)
 	return cmd.Run()
 }
 
@@ -493,8 +489,7 @@ func setAgentIdleCycles(agentBead, beadsDir string, cycles int) error {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	cmd := beads.CommandContext(ctx, filepath.Dir(beadsDir), beadsDir, beads.MutationPinned, args...)
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("setting idle label: %w", err)
@@ -529,8 +524,7 @@ func setAgentBackoffUntil(agentBead, beadsDir string, until time.Time) error {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	cmd := beads.CommandContext(ctx, filepath.Dir(beadsDir), beadsDir, beads.MutationPinned, args...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("setting backoff-until label: %w", err)
 	}
@@ -571,8 +565,7 @@ func clearAgentBackoffUntil(agentBead, beadsDir string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	cmd := beads.CommandContext(ctx, filepath.Dir(beadsDir), beadsDir, beads.MutationPinned, args...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("clearing backoff-until label: %w", err)
 	}

--- a/internal/cmd/molecule_await_signal_test.go
+++ b/internal/cmd/molecule_await_signal_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -305,5 +307,129 @@ func TestBackoffWindowResumption(t *testing.T) {
 				t.Errorf("timeout = %v, want ~%v (diff: %v)", timeout, tt.wantApproxTime, diff)
 			}
 		})
+	}
+}
+
+func TestRunMoleculeAwaitSignalAgentBeadUsesCwdRigBeadsDirWhenBeadsDirPointsTown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell fake bd")
+	}
+
+	tmp := t.TempDir()
+	townRoot := filepath.Join(tmp, "gt")
+	townBeads := filepath.Join(townRoot, ".beads")
+	rigWorkDir := filepath.Join(townRoot, "gastown", "refinery", "rig")
+	rigBeads := filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
+	rigRedirect := filepath.Join(rigWorkDir, ".beads")
+
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor"),
+		townBeads,
+		rigBeads,
+		rigRedirect,
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigRedirect, "redirect"), []byte(rigBeads), 0o644); err != nil {
+		t.Fatalf("write rig redirect: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeads, "metadata.json"), []byte(`{"dolt_database":"rigdb"}`), 0o644); err != nil {
+		t.Fatalf("write rig metadata: %v", err)
+	}
+
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	logPath := filepath.Join(tmp, "bd.log")
+	bdScript := `#!/bin/sh
+printf '%s BEADS_DIR=%s DB=%s READONLY=%s AUTO=%s\n' "$1" "${BEADS_DIR-}" "${BEADS_DOLT_SERVER_DATABASE-}" "${BD_READONLY-}" "${BD_DOLT_AUTO_COMMIT-}" >> "$BD_LOG"
+case "$1" in
+  show)
+    printf '[{"labels":["gt:agent","idle:0"]}]\n'
+    ;;
+  update)
+    ;;
+  *)
+    printf 'unexpected bd command: %s\n' "$1" >&2
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("BEADS_DIR", townBeads)
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "town")
+	t.Setenv("BD_READONLY", "true")
+	t.Setenv("BD_DOLT_AUTO_COMMIT", "off")
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(rigWorkDir); err != nil {
+		t.Fatalf("chdir rig work dir: %v", err)
+	}
+
+	oldTimeout := awaitSignalTimeout
+	oldBackoffBase := awaitSignalBackoffBase
+	oldBackoffMult := awaitSignalBackoffMult
+	oldBackoffMax := awaitSignalBackoffMax
+	oldQuiet := awaitSignalQuiet
+	oldAgentBead := awaitSignalAgentBead
+	oldJSON := moleculeJSON
+	t.Cleanup(func() {
+		awaitSignalTimeout = oldTimeout
+		awaitSignalBackoffBase = oldBackoffBase
+		awaitSignalBackoffMult = oldBackoffMult
+		awaitSignalBackoffMax = oldBackoffMax
+		awaitSignalQuiet = oldQuiet
+		awaitSignalAgentBead = oldAgentBead
+		moleculeJSON = oldJSON
+	})
+
+	awaitSignalTimeout = "1ms"
+	awaitSignalBackoffBase = ""
+	awaitSignalBackoffMult = 2
+	awaitSignalBackoffMax = ""
+	awaitSignalQuiet = true
+	awaitSignalAgentBead = "gt-gastown-refinery"
+	moleculeJSON = false
+
+	if err := runMoleculeAwaitSignal(nil, nil); err != nil {
+		t.Fatalf("runMoleculeAwaitSignal() error = %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	log := strings.TrimSpace(string(data))
+	if log == "" {
+		t.Fatal("fake bd was not invoked")
+	}
+	for _, line := range strings.Split(log, "\n") {
+		if !strings.Contains(line, "BEADS_DIR="+rigBeads) {
+			t.Fatalf("bd call was not pinned to rig beads %q: %s\nfull log:\n%s", rigBeads, line, log)
+		}
+		if strings.Contains(line, "BEADS_DIR="+townBeads) {
+			t.Fatalf("bd call used inherited town BEADS_DIR %q: %s\nfull log:\n%s", townBeads, line, log)
+		}
+		if !strings.Contains(line, "DB=rigdb") {
+			t.Fatalf("bd call was not pinned to rig database: %s\nfull log:\n%s", line, log)
+		}
+		if strings.Contains(line, "DB=town") {
+			t.Fatalf("bd call used inherited town database: %s\nfull log:\n%s", line, log)
+		}
 	}
 }


### PR DESCRIPTION
Recovery PR for Gas Town bead gt-ltw after gt done could not push to the upstream remote from gastown/rust.\n\nSummary:\n- Prefer cwd-derived rig beads directory when resolving rig-local agents.\n- Route await-event agent tracking through the same cwd-aware path.\n- Add regression coverage for the bad BEADS_DIR environment case.\n\nVerification from polecat notes:\n- CGO_ENABLED=0 go test ./internal/cmd\n- Patched binary resolves gastown refinery to /home/markenkema/gt/gastown/mayor/rig/.beads even with BEADS_DIR=/home/markenkema/gt/.beads.\n\nSource bead: gt-ltw\nCommit: d274dfa6