### PR TITLE
feat: add Kiro CLI runtime support

### DIFF
--- a/.kiro/README.md
+++ b/.kiro/README.md
@@ -1,0 +1,35 @@
+# Kiro CLI in this repo
+
+This directory contains workspace-scoped Kiro CLI context for Gas Town.
+
+## Gas Town runtime preset
+
+Gas Town has a built-in `kiro` agent preset. After building `gt`, use Kiro CLI
+as a Gas Town runtime with:
+
+```bash
+gt config default-agent kiro
+gt start --agent kiro
+```
+
+The preset launches:
+
+```bash
+kiro-cli chat --trust-all-tools
+```
+
+Gas Town passes startup beacons as positional chat input, uses
+`kiro-cli chat --resume` for latest-session resume, and uses
+`kiro-cli chat --resume-id <id>` for explicit session resume.
+
+## Kiro workspace context
+
+Kiro CLI reads project steering files from `.kiro/steering/`. The files here
+cover:
+
+- `product.md` - what Gas Town is and why it exists
+- `tech.md` - the main stack, build/test commands, and runtime assumptions
+- `structure.md` - where core packages and docs live
+
+For agent workflow rules that apply across tools, read the root `AGENTS.md`.
+

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,24 @@
+# Product Overview
+
+Gas Town is a multi-agent workspace manager for coordinating AI coding agents
+across git-backed projects. It gives each agent a role, persistent identity,
+mailbox, work queue, and reproducible workspace so long-running work can survive
+session restarts, context loss, and concurrent execution.
+
+Primary users are developers and operators running multiple coding agents over
+one or more repositories. Gas Town should make those agents easier to supervise:
+tasks are tracked through Beads, agents communicate through `gt mail` and
+`gt nudge`, and completed work flows through the refinery merge queue.
+
+Important product principles:
+
+- Preserve work state in files, git worktrees, and Beads rather than transient
+  chat memory.
+- Keep runtime integration loose. Gas Town launches agents through tmux,
+  environment variables, settings files, hooks, and CLI flags rather than
+  linking to agent SDKs.
+- Prefer explicit status and handoff paths. Agents should leave enough context
+  for another session to resume safely.
+- Treat Claude Code as the default runtime while keeping Codex, Gemini, Cursor,
+  OpenCode, Copilot, Kiro, and other runtimes selectable through presets.
+

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,29 @@
+# Project Structure
+
+Important top-level paths:
+
+- `cmd/` - Go entry points for binaries such as `gt`
+- `internal/cmd/` - Cobra command implementations
+- `internal/config/` - settings, runtime presets, environment construction, and
+  startup command generation
+- `internal/hooks/` - hook configuration parsing, merge logic, installers, and
+  embedded templates for supported agent runtimes
+- `internal/crew/`, `internal/polecat/`, `internal/witness/`,
+  `internal/refinery/` - role-specific lifecycle and orchestration code
+- `internal/templates/` - embedded command and town-root templates
+- `docs/` - design notes, operational guides, and provider integration docs
+- `.beads/` - git-backed issue data used by Beads
+- `.cursor/` and `.kiro/` - runtime-specific onboarding and steering files
+
+Runtime integration pattern:
+
+1. Add or update the built-in preset in `internal/config/agents.go`.
+2. Ensure default command, args, process names, resume style, prompt mode, and
+   readiness behavior are covered in `internal/config/agents_test.go`.
+3. If the runtime has executable hooks, add templates under
+   `internal/hooks/templates/<provider>/` and cover install/sync behavior.
+4. Update README or docs when users need new setup commands or prerequisites.
+
+Keep changes narrow. Prefer extending the preset registry over adding new
+provider-specific switch statements.
+

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,33 @@
+# Technology Stack
+
+Gas Town is a Go CLI application. The module is
+`github.com/steveyegge/gastown`, with command entry points under `cmd/` and most
+implementation under `internal/`.
+
+Core technologies:
+
+- Go 1.26.x as declared in `go.mod`
+- Cobra for CLI command wiring
+- tmux for agent session orchestration
+- Beads (`bd`) for git-native issue and work tracking
+- Dolt for durable shared Beads storage
+- Docker and Docker Compose for sandboxed local execution
+- Embedded templates for runtime hooks, slash commands, formulas, and setup
+  files
+
+Common local commands:
+
+```bash
+make build
+go test ./...
+go test ./internal/config/... ./internal/crew/... ./internal/hooks/... -count=1
+```
+
+Use the repository's container or devcontainer for dependency installation,
+builds, tests, and long-running commands when available. Avoid host-level
+package changes during development.
+
+Runtime preset work usually starts in `internal/config/agents.go`, with tests in
+`internal/config/agents_test.go`. Hook-capable runtimes may also need templates
+under `internal/hooks/templates/` plus installer or sync test coverage.
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Gas Town
 
-**Multi-agent orchestration system for Claude Code, GitHub Copilot, and other AI agents with persistent work tracking**
+**Multi-agent orchestration system for Claude Code, Kiro CLI, GitHub Copilot, and other AI agents with persistent work tracking**
 
 ## Overview
 
-Gas Town is a workspace manager that lets you coordinate multiple AI coding agents (Claude Code, GitHub Copilot, Codex, Gemini, and others) working on different tasks. Instead of losing context when agents restart, Gas Town persists work state in git-backed hooks, enabling reliable multi-agent workflows.
+Gas Town is a workspace manager that lets you coordinate multiple AI coding agents (Claude Code, Kiro CLI, GitHub Copilot, Codex, Gemini, and others) working on different tasks. Instead of losing context when agents restart, Gas Town persists work state in git-backed hooks, enabling reliable multi-agent workflows.
 
 ### What Problem Does This Solve?
 
@@ -129,6 +129,7 @@ Federated work coordination network linking Gas Towns through DoltHub. Rigs post
 - **sqlite3** - for convoy database queries (usually pre-installed on macOS/Linux)
 - **tmux 3.0+** - recommended for full experience
 - **Claude Code CLI** (default runtime) - [claude.ai/code](https://claude.ai/code)
+- **Kiro CLI** (optional runtime) - [kiro.dev/docs/cli](https://kiro.dev/docs/cli/)
 - **Codex CLI** (optional runtime) - [developers.openai.com/codex/cli](https://developers.openai.com/codex/cli)
 - **GitHub Copilot CLI** (optional runtime) - [cli.github.com](https://cli.github.com) (requires Copilot seat)
 
@@ -413,7 +414,7 @@ gt feed                     # Real-time activity feed (TUI)
 gt feed --problems          # Start in problems view (stuck agent detection)
 ```
 
-**Built-in agent presets**: `claude`, `gemini`, `codex`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`, `pi`, `omp`
+**Built-in agent presets**: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`, `pi`, `omp`, `vibe`, `groq-compound`
 
 ### Convoy (Work Tracking)
 

--- a/docs/CLEANUP.md
+++ b/docs/CLEANUP.md
@@ -8,11 +8,11 @@ A comprehensive catalog of all cleanup-related commands in the gastown/beads eco
 
 | Command | What it does |
 |---------|-------------|
-| `gt cleanup` | Kills orphaned Claude processes not tied to active tmux sessions |
-| `gt orphans procs list` | Lists orphaned Claude processes (PPID=1) |
-| `gt orphans procs kill` | Kills orphaned Claude processes (`--aggressive` for tmux-verified) |
-| `gt deacon cleanup-orphans` | Kills orphaned Claude subagent processes (no controlling TTY) |
-| `gt deacon zombie-scan` | Finds/kills zombie Claude processes not in active tmux sessions |
+| `gt cleanup` | Kills orphaned agent processes not tied to active tmux sessions |
+| `gt orphans procs list` | Lists orphaned agent processes (PPID=1) |
+| `gt orphans procs kill` | Kills orphaned agent processes (`--aggressive` for tmux-verified) |
+| `gt deacon cleanup-orphans` | Kills orphaned agent subprocesses (no controlling TTY) |
+| `gt deacon zombie-scan` | Finds/kills zombie agent processes not in active tmux sessions |
 
 ## Polecat (Agent Sandbox) Cleanup
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -11,7 +11,7 @@ Gas Town manages context injection for all supported agents. The mechanism varie
 | Claude Code, Gemini | `settings.json` lifecycle hooks | `<role>/.claude/settings.json` |
 | OpenCode | JS plugin | `workDir/.opencode/plugins/gastown.js` |
 | GitHub Copilot | JSON lifecycle hooks | `workDir/.github/hooks/gastown.json` |
-| Codex, others | Startup nudge fallback | *(no file — nudge only)* |
+| Codex, Kiro, others | Startup nudge fallback | *(no file — nudge only)* |
 
 > **GitHub Copilot note**: Copilot CLI supports full executable lifecycle hooks
 > (`sessionStart`, `userPromptSubmitted`, `preToolUse`, `sessionEnd`) via

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -153,7 +153,7 @@ gt status              # Show workspace status
 
 ### Step 5: Configure Agents (Optional)
 
-Gas Town supports built-in runtimes (`claude`, `gemini`, `codex`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`) plus custom agent aliases.
+Gas Town supports built-in runtimes (`claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`, `pi`, `omp`, `vibe`, `groq-compound`) plus custom agent aliases.
 
 ```bash
 # List available agents

--- a/docs/agent-provider-integration.md
+++ b/docs/agent-provider-integration.md
@@ -10,7 +10,7 @@ Gas City provider contract.
 ## What Gas Town Is
 
 Gas Town is a multi-agent workspace manager that orchestrates coding agents
-(Claude, Gemini, Codex, Cursor, AMP, OpenCode, Copilot, and others) through
+(Claude, Kiro, Gemini, Codex, Cursor, AMP, OpenCode, Copilot, and others) through
 tmux sessions. It provides:
 
 - **Identity and role management** — each agent gets a role (polecat, crew,
@@ -139,7 +139,7 @@ Every field from the `AgentPresetInfo` struct in `internal/config/agents.go`:
 | `prompt_flag` | string | Flag for passing prompts (e.g., `"-p"`) |
 | `output_flag` | string | Flag for structured output (e.g., `"--json"`) |
 
-### Example: Kiro preset
+### Built-in preset: Kiro CLI
 
 ```json
 {
@@ -147,24 +147,29 @@ Every field from the `AgentPresetInfo` struct in `internal/config/agents.go`:
   "agents": {
     "kiro": {
       "name": "kiro",
-      "command": "kiro",
-      "args": ["--autonomous"],
-      "process_names": ["kiro", "node"],
-      "session_id_env": "KIRO_SESSION_ID",
-      "resume_flag": "--resume",
+      "command": "kiro-cli",
+      "args": ["chat", "--trust-all-tools"],
+      "process_names": ["kiro-cli", "kiro"],
+      "resume_flag": "--resume-id",
+      "continue_flag": "--resume",
       "resume_style": "flag",
       "prompt_mode": "arg",
-      "ready_prompt_prefix": "> ",
       "ready_delay_ms": 5000,
       "instructions_file": "AGENTS.md",
       "non_interactive": {
-        "prompt_flag": "-p",
-        "output_flag": "--json"
+        "subcommand": "chat",
+        "output_flag": "--no-interactive"
       }
     }
   }
 }
 ```
+
+`kiro` ships as a built-in preset. Gas Town launches it as `kiro-cli chat
+--trust-all-tools`, passes the startup beacon as the positional chat input, and
+uses `kiro-cli chat --resume-id <id>` for explicit session resume. Kiro CLI also
+supports workspace configuration under `.kiro/`; see the repo-local `.kiro/`
+directory for Gas Town steering files and onboarding notes.
 
 ### Built-in preset: GitHub Copilot CLI
 
@@ -447,7 +452,7 @@ helpers) for headless execution. Configure via the `non_interactive` preset fiel
 }
 ```
 
-Gas Town builds the command as: `kiro exec -p "prompt" --json`
+Gas Town builds the command as: `agent-cli exec -p "prompt" --json`
 
 ### Session forking
 

--- a/docs/design/agent-api-inventory.md
+++ b/docs/design/agent-api-inventory.md
@@ -230,9 +230,9 @@ or `POST /telemetry` with rate limit event
 - `internal/config/env.go` — `AgentEnv()` (line ~65): generates 30+ env vars
   including GT_ROLE, GT_RIG, GT_POLECAT, GT_CREW, BD_ACTOR, GIT_AUTHOR_NAME,
   GT_ROOT, GT_AGENT, GT_SESSION, plus OTEL and credential passthrough
-- `internal/config/agents.go` — `builtinPresets` (line ~164): 10 agent presets
-  (Claude, Gemini, Codex, Cursor, Auggie, AMP, OpenCode, Copilot, Pi, OMP)
-  with 21 fields each (Command, Args, ProcessNames, SessionIDEnv, etc.)
+- `internal/config/agents.go` — `builtinPresets` registry: 13 agent presets
+  (Claude, Gemini, Codex, Kiro, Cursor, Auggie, AMP, OpenCode, Copilot, Pi, OMP, Vibe, Groq Compound)
+  with runtime settings such as Command, Args, ProcessNames, SessionIDEnv, hooks, readiness, and instructions
 - `internal/session/identity.go` — `ParseSessionName()` (line ~84),
   `ParseAddress()` (line ~30), `SessionName()` (line ~163): identity parsing
   and formatting
@@ -519,6 +519,7 @@ returns allow/deny with reason
   - Claude: `--dangerously-skip-permissions`
   - Gemini: `--approval-mode yolo`
   - Codex: `--dangerously-bypass-approvals-and-sandbox`
+  - Kiro: `--trust-all-tools`
   - Cursor: `-f`
   - Auggie: `--allow-indexing`
   - AMP: `--dangerously-allow-all --no-ide`

--- a/docs/design/factory-worker-api.md
+++ b/docs/design/factory-worker-api.md
@@ -17,7 +17,7 @@ Gas Town has no stable interface with AI agents. Every integration is a hack:
 - **Account rotation**: macOS-only keychain token swapping
 - **Liveness**: walking tmux process trees via `pane_current_command` + `pgrep`
 - **Guard scripts**: exit code 2 from PreToolUse hooks to block commands
-- **Permission bypass**: 10 different `--dangerously-*` flags, one per agent vendor
+- **Permission bypass**: many vendor-specific trust/approval flags, one per agent runtime
 
 28+ touch points cataloged. All depend on implementation details of Claude Code,
 tmux, macOS Keychain, or filesystem conventions that can change without notice.
@@ -28,7 +28,7 @@ tmux, macOS Keychain, or filesystem conventions that can change without notice.
    terminal output.
 2. **Structured, not string-matched.** JSON messages, not regex on pane content.
 3. **Agent-agnostic.** One API, regardless of whether the worker is Claude, Gemini,
-   Codex, or a custom runtime.
+   Codex, Kiro, or a custom runtime.
 4. **Correlation by design.** A single `run_id` threads through every event from
    spawn to death.
 5. **Fail-closed defaults.** Unknown state = don't send work, don't kill session.

--- a/docs/design/otel/otel-architecture.md
+++ b/docs/design/otel/otel-architecture.md
@@ -410,7 +410,7 @@ run.id:uuid-1234
 | `GT_POLECAT` | `Toast`, `Shadow`, `Furiosa` | Polecat name (rig-specific) |
 | `GT_CREW` | `max`, `jane` | Crew member name |
 | `GT_SESSION` | `gt-gastown-Toast`, `hq-mayor` | Tmux session name |
-| `GT_AGENT` | Preset names: `claude`, `gemini`, `codex`, `cursor`, `copilot`, `opencode`, … | Agent override (if specified) |
+| `GT_AGENT` | Preset names: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `copilot`, `opencode`, … | Agent override (if specified) |
 | `GT_RUN` | UUID v4 | **PR #2199** — Run identifier, primary waterfall correlation key |
 | `GT_ROOT` | `/Users/pa/gt` | Town root path |
 | `CLAUDE_CONFIG_DIR` | `~/gt/.claude` | Runtime config directory (for agent overrides) |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -461,7 +461,7 @@ gt config agent remove <name>     # Remove custom agent (built-ins protected)
 gt config default-agent [name]    # Get or set town default agent
 ```
 
-**Built-in agents**: `claude`, `gemini`, `codex`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`
+**Built-in agents**: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`, `pi`, `omp`, `vibe`, `groq-compound`
 
 > **Note on GitHub Copilot**: The `copilot` preset uses executable lifecycle hooks in
 > `.github/hooks/gastown.json` (`sessionStart`, `userPromptSubmitted`, `preToolUse`,

--- a/internal/cmd/agents.go
+++ b/internal/cmd/agents.go
@@ -105,7 +105,7 @@ var agentsCheckCmd = &cobra.Command{
 	Short: "Check for identity collisions and stale locks",
 	Long: `Check for identity collisions and stale locks.
 
-This command helps detect situations where multiple Claude processes
+This command helps detect situations where multiple agent processes
 think they own the same worker identity.
 
 Output shows:

--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -16,13 +16,13 @@ var (
 var cleanupCmd = &cobra.Command{
 	Use:     "cleanup",
 	GroupID: GroupWork,
-	Short:   "Clean up orphaned Claude processes",
-	Long: `Clean up orphaned Claude processes that survived session termination.
+	Short:   "Clean up orphaned agent processes",
+	Long: `Clean up orphaned agent processes that survived session termination.
 
-This command finds and kills Claude processes that are not associated with
+This command finds and kills agent processes that are not associated with
 any active Gas Town tmux session. These orphans can accumulate when:
 - Polecat sessions are killed without proper cleanup
-- Claude spawns subagent processes that outlive their parent
+- Agent runtimes spawn subprocesses that outlive their parent
 - Network or system issues interrupt normal shutdown
 
 Uses aggressive tmux session verification to detect ALL orphaned processes,
@@ -50,12 +50,12 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(zombies) == 0 {
-		fmt.Printf("%s No orphaned Claude processes found\n", style.Bold.Render("✓"))
+		fmt.Printf("%s No orphaned agent processes found\n", style.Bold.Render("✓"))
 		return nil
 	}
 
 	// Show what we found
-	fmt.Printf("%s Found %d orphaned Claude process(es):\n\n", style.Warning.Render("⚠"), len(zombies))
+	fmt.Printf("%s Found %d orphaned agent process(es):\n\n", style.Warning.Render("⚠"), len(zombies))
 	for _, z := range zombies {
 		ageStr := formatProcessAgeCleanup(z.Age)
 		fmt.Printf("  %s %s (age: %s, tty: %s)\n",

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -253,18 +253,18 @@ Example:
 var deaconZombieScanCmd = &cobra.Command{
 	Use:        "zombie-scan",
 	SuggestFor: []string{"orphan-scan", "orphan_scan", "orphan"},
-	Short:      "Find and clean zombie Claude processes not in active tmux sessions",
-	Long: `Find and clean zombie Claude processes not in active tmux sessions.
+	Short:      "Find and clean zombie agent processes not in active tmux sessions",
+	Long: `Find and clean zombie agent processes not in active tmux sessions.
 
-Unlike cleanup-orphans (which uses TTY detection), zombie-scan uses tmux
-verification: it checks if each Claude process is in an active tmux session
-by comparing against actual pane PIDs.
+	Unlike cleanup-orphans (which uses TTY detection), zombie-scan uses tmux
+	verification: it checks if each agent process is in an active tmux session
+	by comparing against actual pane PIDs.
 
-A process is a zombie if:
-- It's a Claude/codex process
-- It's NOT the pane PID of any active tmux session
-- It's NOT a child of any pane PID
-- It's older than 60 seconds
+	A process is a zombie if:
+	- It's a tracked agent process
+	- It's NOT the pane PID of any active tmux session
+	- It's NOT a child of any pane PID
+	- It's older than 60 seconds
 
 This catches "ghost" processes that have a TTY (from a dead tmux session)
 but are no longer part of any active Gas Town session.
@@ -1419,7 +1419,7 @@ func runDeaconCleanupOrphans(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runDeaconZombieScan finds and cleans zombie Claude processes not in active tmux sessions.
+// runDeaconZombieScan finds and cleans zombie agent processes not in active tmux sessions.
 func runDeaconZombieScan(cmd *cobra.Command, args []string) error {
 	// Find zombies using tmux verification
 	zombies, err := util.FindZombieClaudeProcesses()

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -52,7 +52,7 @@ Infrastructure checks:
 Cleanup checks (fixable):
   - orphan-sessions          Detect orphaned tmux sessions
   - stalled-polecats         Detect polecats with dead sessions and unpushed work (fixable)
-  - orphan-processes         Detect orphaned Claude processes
+  - orphan-processes         Detect orphaned agent processes
   - session-name-format      Detect sessions with outdated naming format (fixable)
   - wisp-gc                  Detect and clean abandoned wisps (>1h)
   - misclassified-wisps      Detect issues that should be wisps (purges to wisps table, fixable)

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -384,7 +384,7 @@ func runDown(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  PID cleanup warning: %s\n", e)
 		}
 
-		fmt.Println("Cleaning up orphaned Claude processes...")
+		fmt.Println("Cleaning up orphaned agent processes...")
 		cleanupOrphanedClaude(defaultDownOrphanGraceSecs)
 
 		time.Sleep(500 * time.Millisecond)
@@ -723,10 +723,10 @@ func verifyShutdown(t *tmux.Tmux, townRoot string) []string {
 		}
 	}
 
-	// Check for orphaned Claude/node processes
+	// Check for orphaned agent processes
 	// These can be left behind if tmux sessions were killed but child processes didn't terminate
 	if pids := findOrphanedClaudeProcesses(townRoot); len(pids) > 0 {
-		respawned = append(respawned, fmt.Sprintf("orphaned Claude processes (PIDs: %v)", pids))
+		respawned = append(respawned, fmt.Sprintf("orphaned agent processes (PIDs: %v)", pids))
 	}
 
 	// Check for respawned idle-monitors
@@ -742,7 +742,7 @@ func verifyShutdown(t *tmux.Tmux, townRoot string) []string {
 	return respawned
 }
 
-// findOrphanedClaudeProcesses finds Gas Town agent processes (claude/codex/opencode/cursor-agent/copilot/node)
+// findOrphanedClaudeProcesses finds Gas Town agent processes (claude/codex/kiro/opencode/cursor-agent/copilot/node)
 // that are running in the town directory but aren't associated with any active tmux session.
 // This can happen when tmux sessions are killed but child processes don't terminate.
 //
@@ -778,7 +778,7 @@ func findOrphanedClaudeProcesses(townRoot string) []int {
 		// Only consider known Gas Town process names
 		comm := strings.ToLower(fields[1])
 		switch comm {
-		case "claude", "claude-code", "codex", "opencode", "cursor-agent", "agent", "copilot", "node":
+		case "claude", "claude-code", "codex", "kiro-cli", "kiro", "opencode", "cursor-agent", "agent", "copilot", "node":
 			// Potential Gas Town process
 		default:
 			continue

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -758,6 +758,10 @@ func findOrphanedClaudeProcesses(townRoot string) []int {
 		return nil
 	}
 
+	return findOrphanedAgentPIDsFromPS(out, townRoot)
+}
+
+func findOrphanedAgentPIDsFromPS(out []byte, townRoot string) []int {
 	var orphaned []int
 	for _, line := range strings.Split(string(out), "\n") {
 		line = strings.TrimSpace(line)
@@ -777,10 +781,7 @@ func findOrphanedClaudeProcesses(townRoot string) []int {
 
 		// Only consider known Gas Town process names
 		comm := strings.ToLower(fields[1])
-		switch comm {
-		case "claude", "claude-code", "codex", "kiro-cli", "kiro", "opencode", "cursor-agent", "agent", "copilot", "node":
-			// Potential Gas Town process
-		default:
+		if !isShutdownOrphanAgentCommName(comm) {
 			continue
 		}
 
@@ -794,6 +795,15 @@ func findOrphanedClaudeProcesses(townRoot string) []int {
 	}
 
 	return orphaned
+}
+
+func isShutdownOrphanAgentCommName(comm string) bool {
+	switch comm {
+	case "claude", "claude-code", "codex", "kiro-cli", "kiro", "opencode", "cursor-agent", "agent", "copilot", "node":
+		return true
+	default:
+		return false
+	}
 }
 
 // cleanupLegacyDefaultSocket removes Gas Town sessions left on the "default"

--- a/internal/cmd/down_test.go
+++ b/internal/cmd/down_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -20,5 +21,45 @@ func TestIsProcessRunning_InvalidPID(t *testing.T) {
 func TestIsProcessRunning_MaxPID(t *testing.T) {
 	if isProcessRunning(2147483647) {
 		t.Error("max PID should not be running")
+	}
+}
+
+func TestFindOrphanedAgentPIDsFromPSIncludesKiro(t *testing.T) {
+	townRoot := "/tmp/gastown-test"
+	psOutput := []byte(`  PID COMM ARGS
+101 kiro-cli kiro-cli chat --trust-all-tools /tmp/gastown-test
+102 kiro kiro chat --trust-all-tools /tmp/gastown-test/rigs/demo
+103 KIRO-CLI KIRO-CLI chat --trust-all-tools /tmp/gastown-test
+104 node node /tmp/gastown-test/tool.js
+105 kiro-cli kiro-cli chat --trust-all-tools /tmp/other-town
+106 zsh zsh -lc kiro-cli chat --trust-all-tools /tmp/gastown-test
+bad kiro-cli kiro-cli chat --trust-all-tools /tmp/gastown-test
+`)
+
+	got := findOrphanedAgentPIDsFromPS(psOutput, townRoot)
+	want := []int{101, 102, 103, 104}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("findOrphanedAgentPIDsFromPS() = %v, want %v", got, want)
+	}
+}
+
+func TestIsShutdownOrphanAgentCommNameIncludesKiro(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"kiro-cli", true},
+		{"kiro", true},
+		{"codex", true},
+		{"node", true},
+		{"zsh", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isShutdownOrphanAgentCommName(tt.name); got != tt.want {
+				t.Fatalf("isShutdownOrphanAgentCommName(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -119,7 +119,7 @@ the rig's settings/config.json under workflow.default_formula.
 Options:
   --pr=N        Run formula on GitHub PR #N
   --rig=NAME    Target specific rig (default: inferred from cwd, or sole registered rig)
-  --agent=ALIAS Override agent/runtime for all legs (e.g., gemini, codex)
+  --agent=ALIAS Override agent/runtime for all legs (e.g., gemini, codex, kiro)
   --dry-run     Show what would happen without executing
 
 Agent precedence (highest to lowest):
@@ -171,7 +171,7 @@ func init() {
 	formulaRunCmd.Flags().IntVar(&formulaRunPR, "pr", 0, "GitHub PR number to run formula on")
 	formulaRunCmd.Flags().StringVar(&formulaRunRig, "rig", "", "Target rig (default: inferred from cwd, or sole registered rig)")
 	formulaRunCmd.Flags().BoolVar(&formulaRunDryRun, "dry-run", false, "Preview execution without running")
-	formulaRunCmd.Flags().StringVar(&formulaRunAgent, "agent", "", "Override agent/runtime for all legs (e.g., gemini, codex, claude-haiku)")
+	formulaRunCmd.Flags().StringVar(&formulaRunAgent, "agent", "", "Override agent/runtime for all legs (e.g., gemini, codex, kiro, claude-haiku)")
 	formulaRunCmd.Flags().StringSliceVar(&formulaRunFiles, "files", nil, "Files to pass to formula legs (available as {{.files}} in templates)")
 	formulaRunCmd.Flags().StringSliceVar(&formulaRunSet, "set", nil, "Set input variables as key=value pairs (available as {{.key}} in templates)")
 

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -374,7 +374,7 @@ var versionChanges = []VersionChange{
 		Date:    "2026-01-17",
 		Changes: []string{
 			"NEW: gt show/cat - Inspect bead contents and metadata",
-			"NEW: gt orphans list/kill - Detect and clean up orphaned Claude processes",
+			"NEW: gt orphans list/kill - Detect and clean up orphaned agent processes",
 			"NEW: gt convoy close - Manual convoy closure command",
 			"NEW: gt commit/trail - Git wrappers with bead awareness",
 			"NEW: Plugin system - gt plugin run/history, gt dispatch --plugin",
@@ -388,7 +388,7 @@ var versionChanges = []VersionChange{
 			"CHANGED: MR tracking via beads - Removed mrqueue package",
 			"CHANGED: Desire-path commands - Agent ergonomics shortcuts",
 			"CHANGED: Explicit escalation in polecat templates",
-			"FIX: Kill process tree on shutdown - Prevents orphaned Claude processes",
+			"FIX: Kill process tree on shutdown - Prevents orphaned agent processes",
 			"FIX: Agent bead prefix alignment - Multi-hyphen IDs for consistency",
 			"FIX: Idle Polecat Heresy warnings in templates",
 			"FIX: Zombie session detection in doctor",

--- a/internal/cmd/orphans.go
+++ b/internal/cmd/orphans.go
@@ -66,11 +66,11 @@ var (
 var orphansKillCmd = &cobra.Command{
 	Use:   "kill",
 	Short: "Remove all orphans (commits and processes)",
-	Long: `Remove orphaned commits and kill orphaned Claude processes.
+	Long: `Remove orphaned commits and kill orphaned agent processes.
 
 This command performs a complete orphan cleanup:
 1. Finds and removes orphaned commits via 'git gc --prune=now'
-2. Finds and kills orphaned Claude processes (PPID=1)
+2. Finds and kills orphaned agent processes (PPID=1)
 
 WARNING: This operation is irreversible. Once commits are pruned,
 they cannot be recovered.
@@ -80,7 +80,7 @@ branches (shown by 'gt orphans') must be recovered or cleaned up manually.
 
 The command will:
 1. Find orphaned commits (same as 'gt orphans')
-2. Find orphaned Claude processes (same as 'gt orphans procs')
+2. Find orphaned agent processes (same as 'gt orphans procs')
 3. Show what will be removed/killed
 4. Ask for confirmation (unless --force)
 5. Run git gc and kill processes
@@ -97,19 +97,19 @@ Examples:
 // Process orphan commands
 var orphansProcsCmd = &cobra.Command{
 	Use:   "procs",
-	Short: "Manage orphaned Claude processes",
-	Long: `Find and kill Claude processes that have become orphaned (PPID=1).
+	Short: "Manage orphaned agent processes",
+	Long: `Find and kill agent processes that have become orphaned (PPID=1).
 
 These are processes that survived session termination and are now
 parented to init/launchd. They consume resources and should be killed.
 
-Use --aggressive to detect ALL orphaned Claude processes by cross-referencing
-against active tmux sessions. Any Claude process NOT in a gt-* or hq-* session
-is considered an orphan. This catches processes that have been reparented to
-something other than init (PPID != 1).
+	Use --aggressive to detect ALL orphaned agent processes by cross-referencing
+	against active tmux sessions. Any tracked agent process NOT in a gt-* or hq-* session
+	is considered an orphan. This catches processes that have been reparented to
+	something other than init (PPID != 1).
 
-Examples:
-  gt orphans procs              # List orphaned Claude processes (PPID=1 only)
+	Examples:
+	  gt orphans procs              # List orphaned agent processes (PPID=1 only)
   gt orphans procs list         # Same as above
   gt orphans procs --aggressive # List ALL orphaned processes (tmux verification)
   gt orphans procs kill         # Kill orphaned processes`,
@@ -118,15 +118,15 @@ Examples:
 
 var orphansProcsListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List orphaned Claude processes",
-	Long: `List Claude processes that have become orphaned (PPID=1).
+	Short: "List orphaned agent processes",
+	Long: `List agent processes that have become orphaned (PPID=1).
 
 These are processes that survived session termination and are now
 parented to init/launchd. They consume resources and should be killed.
 
-Use --aggressive to detect ALL orphaned Claude processes by cross-referencing
-against active tmux sessions. Any Claude process NOT in a gt-* or hq-* session
-is considered an orphan.
+	Use --aggressive to detect ALL orphaned agent processes by cross-referencing
+	against active tmux sessions. Any tracked agent process NOT in a gt-* or hq-* session
+	is considered an orphan.
 
 Excludes:
 - tmux server processes
@@ -140,8 +140,8 @@ Examples:
 
 var orphansProcsKillCmd = &cobra.Command{
 	Use:   "kill",
-	Short: "Kill orphaned Claude processes",
-	Long: `Kill Claude processes that have become orphaned (PPID=1).
+	Short: "Kill orphaned agent processes",
+	Long: `Kill agent processes that have become orphaned (PPID=1).
 
 Without flags, prompts for confirmation before killing.
 Use -f/--force to kill without confirmation.
@@ -588,7 +588,7 @@ func runOrphansKill(cmd *cobra.Command, args []string) error {
 	}
 
 	// Find orphaned processes
-	fmt.Printf("Scanning for orphaned Claude processes...\n\n")
+	fmt.Printf("Scanning for orphaned agent processes...\n\n")
 	procOrphans, err := findOrphanProcesses()
 	if err != nil {
 		return fmt.Errorf("finding orphan processes: %w", err)
@@ -614,7 +614,7 @@ func runOrphansKill(cmd *cobra.Command, args []string) error {
 
 	// Show orphaned processes
 	if len(procOrphans) > 0 {
-		fmt.Printf("%s Found %d orphaned Claude process(es) to kill:\n\n", style.Warning.Render("⚠"), len(procOrphans))
+		fmt.Printf("%s Found %d orphaned agent process(es) to kill:\n\n", style.Warning.Render("⚠"), len(procOrphans))
 		for _, o := range procOrphans {
 			displayArgs := o.Args
 			if len(displayArgs) > 80 {
@@ -699,13 +699,13 @@ func runOrphansKill(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// OrphanProcess represents a Claude process that has become orphaned (PPID=1)
+// OrphanProcess represents an agent process that has become orphaned (PPID=1)
 type OrphanProcess struct {
 	PID  int
 	Args string
 }
 
-// findOrphanProcesses finds Claude processes with PPID=1 (orphaned)
+// findOrphanProcesses finds agent processes with PPID=1 (orphaned)
 func findOrphanProcesses() ([]OrphanProcess, error) {
 	// Run ps to get all processes with PID, PPID, and args
 	cmd := exec.Command("ps", "-eo", "pid,ppid,args")
@@ -775,7 +775,7 @@ func isClaudeProcess(args string) bool {
 // isExcludedProcess checks if the process should be excluded from orphan list
 func isExcludedProcess(args string) bool {
 	// Exclude any tmux process (server, new-session, etc.)
-	// These may contain "claude" in args but are tmux processes, not actual Claude processes
+	// These may contain agent names in args but are tmux processes, not actual agent processes
 	if strings.HasPrefix(args, "tmux ") || strings.HasPrefix(args, "/usr/bin/tmux") {
 		return true
 	}
@@ -793,7 +793,7 @@ func isExcludedProcess(args string) bool {
 	return false
 }
 
-// runOrphansListProcesses lists orphaned Claude processes
+// runOrphansListProcesses lists orphaned agent processes
 func runOrphansListProcesses(cmd *cobra.Command, args []string) error {
 	if orphansProcsAggressive {
 		return runOrphansListProcessesAggressive()
@@ -805,12 +805,12 @@ func runOrphansListProcesses(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(orphans) == 0 {
-		fmt.Printf("%s No orphaned Claude processes found (PPID=1)\n", style.Bold.Render("✓"))
+		fmt.Printf("%s No orphaned agent processes found (PPID=1)\n", style.Bold.Render("✓"))
 		fmt.Printf("%s Use --aggressive to find orphans via tmux session verification\n", style.Dim.Render("Hint:"))
 		return nil
 	}
 
-	fmt.Printf("%s Found %d orphaned Claude process(es) with PPID=1:\n\n", style.Warning.Render("⚠"), len(orphans))
+	fmt.Printf("%s Found %d orphaned agent process(es) with PPID=1:\n\n", style.Warning.Render("⚠"), len(orphans))
 
 	for _, o := range orphans {
 		// Truncate args for display
@@ -828,7 +828,7 @@ func runOrphansListProcesses(cmd *cobra.Command, args []string) error {
 }
 
 // runOrphansListProcessesAggressive lists orphans using tmux session verification.
-// This finds ALL Claude processes not in any gt-* or hq-* tmux session.
+// This finds ALL tracked agent processes not in any gt-* or hq-* tmux session.
 func runOrphansListProcessesAggressive() error {
 	zombies, err := util.FindZombieClaudeProcesses()
 	if err != nil {
@@ -836,11 +836,11 @@ func runOrphansListProcessesAggressive() error {
 	}
 
 	if len(zombies) == 0 {
-		fmt.Printf("%s No orphaned Claude processes found (aggressive mode)\n", style.Bold.Render("✓"))
+		fmt.Printf("%s No orphaned agent processes found (aggressive mode)\n", style.Bold.Render("✓"))
 		return nil
 	}
 
-	fmt.Printf("%s Found %d orphaned Claude process(es) not in any tmux session:\n\n", style.Warning.Render("⚠"), len(zombies))
+	fmt.Printf("%s Found %d orphaned agent process(es) not in any tmux session:\n\n", style.Warning.Render("⚠"), len(zombies))
 
 	for _, z := range zombies {
 		ageStr := formatProcessAge(z.Age)
@@ -869,7 +869,7 @@ func formatProcessAge(seconds int) string {
 	return fmt.Sprintf("%dh%dm", hours, mins)
 }
 
-// runOrphansKillProcesses kills orphaned Claude processes
+// runOrphansKillProcesses kills orphaned agent processes
 func runOrphansKillProcesses(cmd *cobra.Command, args []string) error {
 	if orphansProcsAggressive {
 		return runOrphansKillProcessesAggressive()
@@ -881,13 +881,13 @@ func runOrphansKillProcesses(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(orphans) == 0 {
-		fmt.Printf("%s No orphaned Claude processes found (PPID=1)\n", style.Bold.Render("✓"))
+		fmt.Printf("%s No orphaned agent processes found (PPID=1)\n", style.Bold.Render("✓"))
 		fmt.Printf("%s Use --aggressive to find orphans via tmux session verification\n", style.Dim.Render("Hint:"))
 		return nil
 	}
 
 	// Show what we're about to kill
-	fmt.Printf("%s Found %d orphaned Claude process(es) with PPID=1:\n\n", style.Warning.Render("⚠"), len(orphans))
+	fmt.Printf("%s Found %d orphaned agent process(es) with PPID=1:\n\n", style.Warning.Render("⚠"), len(orphans))
 	for _, o := range orphans {
 		displayArgs := o.Args
 		if len(displayArgs) > 80 {
@@ -950,7 +950,7 @@ func runOrphansKillProcesses(cmd *cobra.Command, args []string) error {
 }
 
 // runOrphansKillProcessesAggressive kills orphans using tmux session verification.
-// This kills ALL Claude processes not in any gt-* or hq-* tmux session.
+// This kills ALL tracked agent processes not in any gt-* or hq-* tmux session.
 func runOrphansKillProcessesAggressive() error {
 	zombies, err := util.FindZombieClaudeProcesses()
 	if err != nil {
@@ -958,12 +958,12 @@ func runOrphansKillProcessesAggressive() error {
 	}
 
 	if len(zombies) == 0 {
-		fmt.Printf("%s No orphaned Claude processes found (aggressive mode)\n", style.Bold.Render("✓"))
+		fmt.Printf("%s No orphaned agent processes found (aggressive mode)\n", style.Bold.Render("✓"))
 		return nil
 	}
 
 	// Show what we're about to kill
-	fmt.Printf("%s Found %d orphaned Claude process(es) not in any tmux session:\n\n", style.Warning.Render("⚠"), len(zombies))
+	fmt.Printf("%s Found %d orphaned agent process(es) not in any tmux session:\n\n", style.Warning.Render("⚠"), len(zombies))
 	for _, z := range zombies {
 		ageStr := formatProcessAge(z.Age)
 		fmt.Printf("  %s %s (age: %s, tty: %s)\n",

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1801,7 +1801,7 @@ func runPolecatNuke(cmd *cobra.Command, args []string) error {
 		fmt.Printf("\n%s Nuked %d polecat(s).\n", style.SuccessPrefix, nuked)
 	}
 
-	// Final cleanup: Kill any orphaned Claude processes that escaped the session termination.
+	// Final cleanup: Kill any orphaned agent processes that escaped the session termination.
 	// This catches processes that called setsid() or were reparented during session shutdown.
 	if !polecatNukeDryRun {
 		cleanupOrphanedProcesses()
@@ -2002,7 +2002,7 @@ func nukeCleanupMolecules(workBeadID string, r *rig.Rig) {
 	}
 }
 
-// cleanupOrphanedProcesses kills Claude processes that survived session termination.
+// cleanupOrphanedProcesses kills agent processes that survived session termination.
 // Uses aggressive zombie detection via tmux session verification.
 func cleanupOrphanedProcesses() {
 	results, err := util.CleanupZombieClaudeProcesses()

--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -57,7 +57,7 @@ type SlingSpawnOptions struct {
 	Account       string // Claude Code account handle to use
 	Create        bool   // Create polecat if it doesn't exist (currently always true for sling)
 	HookBead      string // Bead ID to set as hook_bead at spawn time (atomic assignment)
-	Agent         string // Agent override for this spawn (e.g., "gemini", "codex", "claude-haiku")
+	Agent         string // Agent override for this spawn (e.g., "gemini", "codex", "kiro", "claude-haiku")
 	BaseBranch    string // Override base branch for polecat worktree (e.g., "develop", "release/v2")
 	ResumeBranch  string // Resume an existing branch (e.g. PR head) instead of creating polecat/<name>/<bead>@<ts>
 	SkipAdmission bool   // Caller already holds a polecat admission reservation

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -152,7 +152,7 @@ func init() {
 	slingCmd.Flags().BoolVar(&slingCreate, "create", false, "Create polecat if it doesn't exist")
 	slingCmd.Flags().BoolVar(&slingForce, "force", false, "Force spawn even if polecat has unread mail")
 	slingCmd.Flags().StringVar(&slingAccount, "account", "", "Claude Code account handle to use")
-	slingCmd.Flags().StringVar(&slingAgent, "agent", "", "Override agent/runtime for this sling (e.g., claude, gemini, codex, or custom alias)")
+	slingCmd.Flags().StringVar(&slingAgent, "agent", "", "Override agent/runtime for this sling (e.g., claude, gemini, codex, kiro, or custom alias)")
 	slingCmd.Flags().BoolVar(&slingNoConvoy, "no-convoy", false, "Skip auto-convoy creation for single-issue sling")
 	slingCmd.Flags().BoolVar(&slingOwned, "owned", false, "Mark auto-convoy as caller-managed lifecycle (no automatic witness/refinery registration)")
 	slingCmd.Flags().BoolVar(&slingHookRawBead, "hook-raw-bead", false, "Hook raw bead without default formula (expert mode)")

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -31,7 +31,7 @@ import (
 )
 
 // defaultOrphanGraceSecs is the grace period (in seconds) between SIGTERM and SIGKILL
-// when automatically cleaning up orphaned Claude processes during shutdown.
+// when automatically cleaning up orphaned agent processes during shutdown.
 // This is shorter than the --cleanup-orphans-grace-secs default (60s) because
 // automatic cleanup runs after sessions are already killed, so processes have
 // already had time to shut down.
@@ -105,7 +105,7 @@ Use --nuclear to force cleanup even if polecats have uncommitted work (DANGER).
 Use --cleanup-orphans to use a longer grace period for orphan cleanup (default 60s).
 Use --cleanup-orphans-grace-secs to set that grace period.
 
-Orphaned Claude processes are always cleaned up after session termination.
+Orphaned agent processes are always cleaned up after session termination.
 By default, a 5-second grace period is used. The --cleanup-orphans flag
 extends this to --cleanup-orphans-grace-secs (default 60s) for stubborn processes.`,
 	RunE: runShutdown,
@@ -641,7 +641,7 @@ func runGracefulShutdown(t *tmux.Tmux, gtSessions []string, townRoot string) err
 	deaconSession := getDeaconSessionName()
 	stopped := killSessionsInOrder(t, gtSessions, mayorSession, deaconSession)
 
-	// Phase 5: Always clean up orphaned Claude processes after killing sessions.
+	// Phase 5: Always clean up orphaned agent processes after killing sessions.
 	// Processes can survive session kills if they caught/ignored SIGHUP or called setsid().
 	// Use the user-specified grace period if --cleanup-orphans was explicitly set,
 	// otherwise use a short default (5s) for the automatic sweep.
@@ -649,7 +649,7 @@ func runGracefulShutdown(t *tmux.Tmux, gtSessions []string, townRoot string) err
 	if shutdownCleanupOrphans {
 		graceSecs = shutdownCleanupOrphansGrace
 	}
-	fmt.Printf("\nPhase 5: Cleaning up orphaned Claude processes...\n")
+	fmt.Printf("\nPhase 5: Cleaning up orphaned agent processes...\n")
 	cleanupOrphanedClaude(graceSecs)
 
 	// Phase 6: Cleanup polecat worktrees and branches
@@ -664,7 +664,7 @@ func runGracefulShutdown(t *tmux.Tmux, gtSessions []string, townRoot string) err
 		stopDaemonIfRunning(townRoot)
 	}
 
-	// Phase 8: Verify no Claude processes survived
+	// Phase 8: Verify no agent processes survived
 	fmt.Printf("\nPhase 8: Verifying shutdown...\n")
 	verifyNoOrphans()
 
@@ -680,7 +680,7 @@ func runImmediateShutdown(t *tmux.Tmux, gtSessions []string, townRoot string) er
 	deaconSession := getDeaconSessionName()
 	stopped := killSessionsInOrder(t, gtSessions, mayorSession, deaconSession)
 
-	// Always clean up orphaned Claude processes after killing sessions.
+	// Always clean up orphaned agent processes after killing sessions.
 	// Processes can survive session kills if they caught/ignored SIGHUP or called setsid().
 	// Use the user-specified grace period if --cleanup-orphans was explicitly set,
 	// otherwise use a short default (5s) for the automatic sweep.
@@ -689,7 +689,7 @@ func runImmediateShutdown(t *tmux.Tmux, gtSessions []string, townRoot string) er
 		graceSecs = shutdownCleanupOrphansGrace
 	}
 	fmt.Println()
-	fmt.Println("Cleaning up orphaned Claude processes...")
+	fmt.Println("Cleaning up orphaned agent processes...")
 	cleanupOrphanedClaude(graceSecs)
 
 	// Cleanup polecat worktrees and branches
@@ -706,7 +706,7 @@ func runImmediateShutdown(t *tmux.Tmux, gtSessions []string, townRoot string) er
 		stopDaemonIfRunning(townRoot)
 	}
 
-	// Verify no Claude processes survived
+	// Verify no agent processes survived
 	fmt.Println()
 	fmt.Println("Verifying shutdown...")
 	verifyNoOrphans()

--- a/internal/cmd/start_orphan_unix.go
+++ b/internal/cmd/start_orphan_unix.go
@@ -11,7 +11,7 @@ import (
 	"github.com/steveyegge/gastown/internal/util"
 )
 
-// cleanupOrphanedClaude finds and kills orphaned Claude processes with a grace period.
+// cleanupOrphanedClaude finds and kills orphaned agent processes with a grace period.
 // This is a simpler synchronous implementation that:
 // 1. Finds orphaned processes (TTY-less, older than 60s, not in Gas Town sessions)
 // 2. Sends SIGTERM to all of them
@@ -87,7 +87,7 @@ func cleanupOrphanedClaude(graceSecs int) {
 	}
 }
 
-// verifyNoOrphans checks that no Claude processes survived shutdown.
+// verifyNoOrphans checks that no agent processes survived shutdown.
 // If any are found, it reports them and attempts a final SIGKILL.
 func verifyNoOrphans() {
 	orphans, err := util.FindOrphanedClaudeProcesses()
@@ -105,11 +105,11 @@ func verifyNoOrphans() {
 
 	totalSurvivors := len(orphans) + len(zombies)
 	if totalSurvivors == 0 {
-		fmt.Printf("  %s No orphaned Claude processes detected\n", style.Bold.Render("✓"))
+		fmt.Printf("  %s No orphaned agent processes detected\n", style.Bold.Render("✓"))
 		return
 	}
 
-	fmt.Printf("  %s %d Claude process(es) survived shutdown:\n",
+	fmt.Printf("  %s %d agent process(es) survived shutdown:\n",
 		style.Bold.Render("⚠"), totalSurvivors)
 
 	// Kill orphans (TTY-less)

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -27,6 +27,8 @@ const (
 	AgentGemini AgentPreset = "gemini"
 	// AgentCodex is OpenAI Codex.
 	AgentCodex AgentPreset = "codex"
+	// AgentKiro is Kiro CLI.
+	AgentKiro AgentPreset = "kiro"
 	// AgentCursor is Cursor Agent.
 	AgentCursor AgentPreset = "cursor"
 	// AgentAuggie is Auggie CLI.
@@ -57,7 +59,7 @@ const (
 // Adding a new agent = adding a builtinPresets entry + optional hook installer.
 // No provider-string switch statements should exist outside this registry.
 type AgentPresetInfo struct {
-	// Name is the preset identifier (e.g., "claude", "gemini", "codex", "cursor", "auggie", "amp", "copilot").
+	// Name is the preset identifier (e.g., "claude", "gemini", "codex", "kiro", "cursor", "copilot").
 	Name AgentPreset `json:"name"`
 
 	// Command is the CLI binary to invoke.
@@ -295,6 +297,28 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		ReadyPromptPrefix: "› ",
 		ReadyDelayMs:      3000,
 		InstructionsFile:  "AGENTS.md",
+	},
+	AgentKiro: {
+		Name:    AgentKiro,
+		Command: "kiro-cli",
+		// Kiro CLI routes interactive sessions through "chat"; --trust-all-tools is
+		// the documented autonomous-mode equivalent for unattended tool execution.
+		Args:                []string{"chat", "--trust-all-tools"},
+		ProcessNames:        []string{"kiro-cli", "kiro"},
+		SessionIDEnv:        "", // Kiro manages chat session state on disk.
+		ResumeFlag:          "--resume-id",
+		ContinueFlag:        "--resume",
+		ResumeStyle:         "flag",
+		SupportsHooks:       false, // Kiro hooks are agent-config based; no Gas Town template yet.
+		SupportsForkSession: false,
+		NonInteractive: &NonInteractiveConfig{
+			Subcommand: "chat",
+			OutputFlag: "--no-interactive",
+		},
+		// Runtime defaults
+		PromptMode:       "arg",
+		ReadyDelayMs:     5000,
+		InstructionsFile: "AGENTS.md",
 	},
 	AgentCursor: {
 		Name:    AgentCursor,

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -20,8 +20,8 @@ func isClaudeCmd(cmd string) bool {
 func TestBuiltInAgentPresetSummary(t *testing.T) {
 	t.Parallel()
 	s := BuiltInAgentPresetSummary()
-	if !strings.Contains(s, "cursor") || !strings.Contains(s, "claude") {
-		t.Fatalf("BuiltInAgentPresetSummary() = %q, want cursor and claude", s)
+	if !strings.Contains(s, "cursor") || !strings.Contains(s, "claude") || !strings.Contains(s, "kiro") {
+		t.Fatalf("BuiltInAgentPresetSummary() = %q, want cursor, claude, and kiro", s)
 	}
 	names := strings.Split(s, ", ")
 	if !sort.StringsAreSorted(names) {
@@ -32,7 +32,7 @@ func TestBuiltInAgentPresetSummary(t *testing.T) {
 func TestBuiltinPresets(t *testing.T) {
 	t.Parallel()
 	// Ensure all built-in presets are accessible
-	presets := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentCopilot, AgentPi, AgentOmp}
+	presets := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentKiro, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentCopilot, AgentPi, AgentOmp}
 
 	for _, preset := range presets {
 		info := GetAgentPreset(preset)
@@ -62,6 +62,7 @@ func TestGetAgentPresetByName(t *testing.T) {
 		{"claude", AgentClaude, false},
 		{"gemini", AgentGemini, false},
 		{"codex", AgentCodex, false},
+		{"kiro", AgentKiro, false},
 		{"cursor", AgentCursor, false},
 		{"auggie", AgentAuggie, false},
 		{"amp", AgentAmp, false},
@@ -98,6 +99,7 @@ func TestRuntimeConfigFromPreset(t *testing.T) {
 		{AgentClaude, "claude"}, // Note: claude may resolve to full path
 		{AgentGemini, "gemini"},
 		{AgentCodex, "codex"},
+		{AgentKiro, "kiro-cli"},
 		{AgentCursor, "cursor-agent"},
 		{AgentAuggie, "auggie"},
 		{AgentAmp, "amp"},
@@ -145,6 +147,7 @@ func TestIsKnownPreset(t *testing.T) {
 		{"claude", true},
 		{"gemini", true},
 		{"codex", true},
+		{"kiro", true},
 		{"cursor", true},
 		{"auggie", true},
 		{"amp", true},
@@ -544,6 +547,7 @@ func TestAgentPresetApprovalFlags(t *testing.T) {
 		{AgentClaude, "--dangerously-skip-permissions"},
 		{AgentGemini, "yolo"}, // Part of "--approval-mode yolo"
 		{AgentCodex, "--dangerously-bypass-approvals-and-sandbox"},
+		{AgentKiro, "--trust-all-tools"},
 		{AgentCopilot, "--yolo"},
 	}
 
@@ -634,6 +638,13 @@ func TestBuildResumeCommand(t *testing.T) {
 			contains:  []string{"codex", "resume", "codex-sess-789", "--dangerously-bypass-approvals-and-sandbox"},
 		},
 		{
+			name:      "kiro flag style",
+			agentName: "kiro",
+			sessionID: "kiro-sess-123",
+			wantEmpty: false,
+			contains:  []string{"kiro-cli", "chat", "--trust-all-tools", "--resume-id", "kiro-sess-123"},
+		},
+		{
 			name:      "empty session ID",
 			agentName: "claude",
 			sessionID: "",
@@ -683,6 +694,7 @@ func TestSupportsSessionResume(t *testing.T) {
 		{"claude", true},
 		{"gemini", true},
 		{"codex", true},
+		{"kiro", true},
 		{"cursor", true},
 		{"auggie", true},
 		{"amp", true},
@@ -708,6 +720,7 @@ func TestGetSessionIDEnvVar(t *testing.T) {
 		{"claude", "CLAUDE_SESSION_ID"},
 		{"gemini", "GEMINI_SESSION_ID"},
 		{"codex", ""},   // Codex uses JSONL output instead
+		{"kiro", ""},    // Kiro manages chat sessions on disk
 		{"cursor", ""},  // Cursor uses --resume with chatId directly
 		{"auggie", ""},  // Auggie uses --resume directly
 		{"amp", ""},     // AMP uses 'threads continue' subcommand
@@ -733,6 +746,7 @@ func TestGetProcessNames(t *testing.T) {
 		{"claude", []string{"node", "claude"}},
 		{"gemini", []string{"gemini"}},
 		{"codex", []string{"codex"}},
+		{"kiro", []string{"kiro-cli", "kiro"}},
 		{"cursor", []string{"cursor-agent", "agent"}},
 		{"auggie", []string{"auggie"}},
 		{"amp", []string{"amp"}},
@@ -761,7 +775,7 @@ func TestGetProcessNames(t *testing.T) {
 func TestListAgentPresetsMatchesConstants(t *testing.T) {
 	t.Parallel()
 	// Ensure all AgentPreset constants are returned by ListAgentPresets
-	allConstants := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentCopilot, AgentPi, AgentOmp}
+	allConstants := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentKiro, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentCopilot, AgentPi, AgentOmp}
 	presets := ListAgentPresets()
 
 	// Convert to map for quick lookup
@@ -807,6 +821,11 @@ func TestAgentCommandGeneration(t *testing.T) {
 			preset:       AgentCodex,
 			wantCommand:  "codex",
 			wantContains: []string{"--dangerously-bypass-approvals-and-sandbox"},
+		},
+		{
+			preset:       AgentKiro,
+			wantCommand:  "kiro-cli",
+			wantContains: []string{"chat", "--trust-all-tools"},
 		},
 		{
 			preset:       AgentCursor,
@@ -861,6 +880,100 @@ func TestAgentCommandGeneration(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestKiroAgentPreset(t *testing.T) {
+	t.Parallel()
+	info := GetAgentPreset(AgentKiro)
+	if info == nil {
+		t.Fatal("kiro preset not found")
+	}
+
+	if info.Command != "kiro-cli" {
+		t.Errorf("kiro command = %q, want kiro-cli", info.Command)
+	}
+
+	wantArgs := []string{"chat", "--trust-all-tools"}
+	if len(info.Args) != len(wantArgs) {
+		t.Fatalf("kiro args = %v, want %v", info.Args, wantArgs)
+	}
+	for i, want := range wantArgs {
+		if info.Args[i] != want {
+			t.Errorf("kiro Args[%d] = %q, want %q", i, info.Args[i], want)
+		}
+	}
+
+	if len(info.ProcessNames) != 2 || info.ProcessNames[0] != "kiro-cli" || info.ProcessNames[1] != "kiro" {
+		t.Errorf("kiro ProcessNames = %v, want [kiro-cli kiro]", info.ProcessNames)
+	}
+
+	if info.SessionIDEnv != "" {
+		t.Errorf("kiro SessionIDEnv = %q, want empty", info.SessionIDEnv)
+	}
+	if info.ResumeFlag != "--resume-id" {
+		t.Errorf("kiro ResumeFlag = %q, want --resume-id", info.ResumeFlag)
+	}
+	if info.ContinueFlag != "--resume" {
+		t.Errorf("kiro ContinueFlag = %q, want --resume", info.ContinueFlag)
+	}
+	if info.ResumeStyle != "flag" {
+		t.Errorf("kiro ResumeStyle = %q, want flag", info.ResumeStyle)
+	}
+	if info.SupportsHooks {
+		t.Error("kiro should not enable Gas Town hook templates until a Kiro template provider exists")
+	}
+	if info.SupportsForkSession {
+		t.Error("kiro should not support fork session")
+	}
+	if info.NonInteractive == nil {
+		t.Fatal("kiro NonInteractive is nil")
+	}
+	if info.NonInteractive.Subcommand != "chat" {
+		t.Errorf("kiro NonInteractive.Subcommand = %q, want chat", info.NonInteractive.Subcommand)
+	}
+	if info.NonInteractive.OutputFlag != "--no-interactive" {
+		t.Errorf("kiro NonInteractive.OutputFlag = %q, want --no-interactive", info.NonInteractive.OutputFlag)
+	}
+	if info.PromptMode != "arg" {
+		t.Errorf("kiro PromptMode = %q, want arg", info.PromptMode)
+	}
+	if info.ReadyDelayMs != 5000 {
+		t.Errorf("kiro ReadyDelayMs = %d, want 5000", info.ReadyDelayMs)
+	}
+	if info.InstructionsFile != "AGENTS.md" {
+		t.Errorf("kiro InstructionsFile = %q, want AGENTS.md", info.InstructionsFile)
+	}
+}
+
+func TestKiroRuntimeConfigFromPreset(t *testing.T) {
+	t.Parallel()
+	rc := RuntimeConfigFromPreset(AgentKiro)
+	if rc == nil {
+		t.Fatal("RuntimeConfigFromPreset(kiro) returned nil")
+	}
+
+	if rc.Command != "kiro-cli" {
+		t.Errorf("RuntimeConfig.Command = %q, want kiro-cli", rc.Command)
+	}
+	if got := strings.Join(rc.Args, " "); got != "chat --trust-all-tools" {
+		t.Errorf("RuntimeConfig.Args = %q, want %q", got, "chat --trust-all-tools")
+	}
+	if rc.PromptMode != "arg" {
+		t.Errorf("RuntimeConfig.PromptMode = %q, want arg", rc.PromptMode)
+	}
+	wantCommand := "kiro-cli chat --trust-all-tools " + quoteForShell("hello")
+	if rc.BuildCommandWithPrompt("hello") != wantCommand {
+		t.Errorf("BuildCommandWithPrompt = %q, want %q", rc.BuildCommandWithPrompt("hello"), wantCommand)
+	}
+	if rc.Tmux == nil {
+		t.Fatal("RuntimeConfig.Tmux is nil")
+	}
+	if rc.Tmux.ReadyDelayMs != 5000 {
+		t.Errorf("RuntimeConfig.Tmux.ReadyDelayMs = %d, want 5000", rc.Tmux.ReadyDelayMs)
+	}
+	if got := strings.Join(rc.Tmux.ProcessNames, ","); got != "kiro-cli,kiro" {
+		t.Errorf("RuntimeConfig.Tmux.ProcessNames = %v, want [kiro-cli kiro]", rc.Tmux.ProcessNames)
 	}
 }
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1119,7 +1119,7 @@ func SaveTownSettings(path string, settings *TownSettings) error {
 //  1. If rig has Runtime set directly, use it (backwards compatibility)
 //  2. If rig has Agent set, look it up in:
 //     a. Town's custom agents (from TownSettings.Agents)
-//     b. Built-in presets (claude, gemini, codex)
+//     b. Built-in presets (claude, gemini, codex, kiro, etc.)
 //  3. If rig has no Agent set, use town's default_agent
 //  4. Fall back to claude defaults
 //

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -3811,11 +3811,11 @@ func TestBuildArgsWithPromptWarnsOnDroppedPrompt(t *testing.T) {
 //	}
 //
 // Manual test procedure:
-//  1. Set role_agents.mayor to each agent (claude, gemini, codex, cursor, auggie, amp, opencode)
+//  1. Set role_agents.mayor to each agent (claude, gemini, codex, kiro, cursor, auggie, amp, opencode)
 //  2. Run: gt start
 //  3. Verify mayor starts with correct agent config
 //  4. Run: GT_NUKE_ACKNOWLEDGED=1 gt down --nuke
-//  5. Repeat for all 7 built-in agents
+//  5. Repeat for each built-in agent under validation
 func TestRoleAgentConfigWithCustomAgent(t *testing.T) {
 	skipIfAgentBinaryMissing(t, "opencode", "claude")
 	t.Parallel()
@@ -3906,8 +3906,8 @@ func TestRoleAgentConfigWithCustomAgent(t *testing.T) {
 }
 
 // TestMultipleAgentTypes tests that various built-in agent presets work correctly.
-// NOTE: Only these are actual built-in presets: claude, gemini, codex, cursor, auggie, amp, opencode.
-// Variants like "claude-opus", "claude-haiku", "claude-sonnet" are NOT built-in - they need
+// NOTE: These are representative built-in presets. Model variants like
+// "claude-opus", "claude-haiku", "claude-sonnet" are NOT built-in - they need
 // to be defined as custom agents in TownSettings.Agents if specific model selection is needed.
 func TestMultipleAgentTypes(t *testing.T) {
 	t.Parallel()
@@ -3934,6 +3934,12 @@ func TestMultipleAgentTypes(t *testing.T) {
 			name:          "gemini built-in preset",
 			agentName:     "gemini",
 			expectCommand: "gemini",
+			isBuiltIn:     true,
+		},
+		{
+			name:          "kiro built-in preset",
+			agentName:     "kiro",
+			expectCommand: "kiro-cli",
 			isBuiltIn:     true,
 		},
 		{

--- a/internal/crew/manager_test.go
+++ b/internal/crew/manager_test.go
@@ -673,6 +673,19 @@ func TestBuildResumeArgs(t *testing.T) {
 			sessionID: "abc-123",
 			wantErr:   "subcommand-style agents",
 		},
+		// Kiro: has ContinueFlag and specific resume-id flag
+		{
+			name:      "kiro last uses --resume",
+			agent:     "kiro",
+			sessionID: "last",
+			wantArgs:  "--resume",
+		},
+		{
+			name:      "kiro specific ID uses --resume-id",
+			agent:     "kiro",
+			sessionID: "abc-123",
+			wantArgs:  "--resume-id abc-123",
+		},
 		// Cursor: no ContinueFlag, flag-style resume
 		{
 			name:      "cursor last errors without ContinueFlag",

--- a/internal/doctor/orphan_check.go
+++ b/internal/doctor/orphan_check.go
@@ -426,6 +426,8 @@ func gasTownRuntimeYOLO(cmdName, args string) bool {
 	switch cmdName {
 	case "claude", "claude-code", "codex":
 		return strings.Contains(args, "--dangerously-skip-permissions")
+	case "kiro-cli", "kiro":
+		return strings.Contains(args, "chat") && argvHasFlag(args, "--trust-all-tools")
 	case "cursor-agent":
 		return argvHasFlag(args, "-f")
 	case "agent":
@@ -440,8 +442,8 @@ func gasTownRuntimeYOLO(cmdName, args string) bool {
 }
 
 // findRuntimeProcesses finds Gas Town agent processes by per-provider YOLO / launch signatures
-// in argv (not comm name alone): claude/codex --dangerously-skip-permissions, cursor-agent -f,
-// copilot --yolo, etc.
+// in argv (not comm name alone): claude/codex --dangerously-skip-permissions,
+// kiro-cli chat --trust-all-tools, cursor-agent -f, copilot --yolo, etc.
 func (c *OrphanProcessCheck) findRuntimeProcesses() ([]processInfo, error) {
 	var procs []processInfo
 

--- a/internal/doctor/orphan_check_test.go
+++ b/internal/doctor/orphan_check_test.go
@@ -469,6 +469,9 @@ func TestGasTownRuntimeYOLO(t *testing.T) {
 	}{
 		{"claude_gt", "claude", "/x/claude --dangerously-skip-permissions foo", true},
 		{"claude_personal", "claude", "/x/claude foo", false},
+		{"kiro_trust_all_tools", "kiro-cli", "kiro-cli chat --trust-all-tools", true},
+		{"kiro_alias", "kiro", "kiro chat --trust-all-tools", true},
+		{"kiro_plain", "kiro-cli", "kiro-cli chat", false},
 		{"cursor_agent", "cursor-agent", "cursor-agent -f --resume x", true},
 		{"cursor_no_f", "cursor-agent", "cursor-agent --resume x", false},
 		{"agent_symlink", "agent", "agent -f --resume x", true},

--- a/internal/util/orphan.go
+++ b/internal/util/orphan.go
@@ -409,7 +409,7 @@ func parseEtime(etime string) (int, error) {
 // TTY-less orphan / zombie cleanup (matches internal/config agent presets).
 func isAgentOrphanCommName(cmdLower string) bool {
 	switch cmdLower {
-	case "claude", "claude-code", "codex", "opencode", "cursor-agent", "agent", "copilot":
+	case "claude", "claude-code", "codex", "kiro-cli", "kiro", "opencode", "cursor-agent", "agent", "copilot":
 		return true
 	default:
 		return false
@@ -424,7 +424,7 @@ type OrphanedProcess struct {
 	TownRoot string // Gas Town workspace root, or "" if not in any workspace
 }
 
-// FindOrphanedClaudeProcesses finds Gas Town agent processes (claude/codex/opencode/cursor-agent/copilot, etc.)
+// FindOrphanedClaudeProcesses finds Gas Town agent processes (claude/codex/kiro/opencode/cursor-agent/copilot, etc.)
 // without a controlling terminal.
 // These are typically subagent processes spawned by Claude Code's Task tool that didn't
 // clean up properly after completion.
@@ -509,7 +509,7 @@ func FindOrphanedClaudeProcesses() ([]OrphanedProcess, error) {
 		}
 
 		// Skip processes NOT in a Gas Town workspace.
-		// Only kill orphaned Claude processes whose cwd is under a Gas Town
+		// Only kill orphaned agent processes whose cwd is under a Gas Town
 		// workspace root. This prevents killing user's Claude Code instances
 		// running in repos outside ~/gt/ (or wherever the workspace is).
 		townRoot := resolveTownRoot(pid)
@@ -572,7 +572,7 @@ func FindZombieClaudeProcesses() ([]ZombieProcess, error) {
 		return nil, nil
 	}
 
-	// Use ps to get PID, TTY, command, and elapsed time for all claude processes
+	// Use ps to get PID, TTY, command, and elapsed time for all tracked agent processes
 	out, err := exec.Command("ps", "-eo", "pid,tty,comm,etime").Output()
 	if err != nil {
 		return nil, fmt.Errorf("listing processes: %w", err)
@@ -768,7 +768,7 @@ func CleanupZombieClaudeProcesses() ([]ZombieCleanupResult, error) {
 	return results, lastErr
 }
 
-// CleanupOrphanedClaudeProcesses finds and kills orphaned claude/codex processes.
+// CleanupOrphanedClaudeProcesses finds and kills orphaned Gas Town agent processes.
 //
 // Uses a state machine to escalate signals:
 //  1. First encounter → SIGTERM, record in state file

--- a/internal/util/orphan_test.go
+++ b/internal/util/orphan_test.go
@@ -56,6 +56,25 @@ func TestParseEtime(t *testing.T) {
 	}
 }
 
+func TestIsAgentOrphanCommNameIncludesKiro(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"kiro-cli", true},
+		{"kiro", true},
+		{"vim", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAgentOrphanCommName(tt.name); got != tt.want {
+				t.Errorf("isAgentOrphanCommName(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFindOrphanedClaudeProcesses(t *testing.T) {
 	// Live test that checks for orphaned processes on the current system.
 	// Should not fail — just returns whatever orphans exist (likely none in CI).

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1935,7 +1935,7 @@ func (h *APIHandler) isClaudeRunningInSession(ctx context.Context, sessionName s
 }
 
 // paneCurrentCommandIsAgent returns true if tmux #{pane_current_command} names a known
-// Gas Town agent (claude/codex/opencode/cursor-agent/copilot/node, or cursor-agent as "agent").
+// Gas Town agent (claude/codex/kiro/opencode/cursor-agent/copilot/node, or cursor-agent as "agent").
 func paneCurrentCommandIsAgent(output string) bool {
 	output = strings.ToLower(strings.TrimSpace(output))
 	if output == "" {
@@ -1945,6 +1945,8 @@ func paneCurrentCommandIsAgent(output string) bool {
 	return strings.Contains(output, "claude") ||
 		strings.Contains(output, "node") ||
 		strings.Contains(output, "codex") ||
+		strings.Contains(output, "kiro-cli") ||
+		output == "kiro" ||
 		strings.Contains(output, "opencode") ||
 		strings.Contains(output, "cursor-agent") ||
 		strings.Contains(output, "copilot") ||

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -1443,6 +1443,8 @@ func TestPaneCurrentCommandIsAgent(t *testing.T) {
 		{"claude", true},
 		{"node", true},
 		{"codex", true},
+		{"kiro-cli", true},
+		{"kiro", true},
 		{"opencode", true},
 		{"cursor-agent", true},
 		{"copilot", true},


### PR DESCRIPTION
## Summary
Adds Kiro CLI as a first-class Gas Town runtime preset and wires it through the runtime surfaces that need to recognize active/autonomous agents.

## Related Issue
- None

## Related PRs
- gastownhall/beads#4535 adds the complementary `bd setup kiro` recipe for Beads project guidance under `.kiro/steering/beads.md`.

## Changes
- Add the built-in `kiro` preset using `kiro-cli chat --trust-all-tools`.
- Cover Kiro command generation, resume flags, process detection, crew resume args, runtime approval flags, and shutdown orphan process matching.
- Include Kiro in doctor orphan detection, orphan/zombie cleanup, shutdown verification, and web pane agent detection.
- Add repo-local `.kiro` onboarding/steering files and update README, install/reference/provider docs, hook/cleanup docs, and runtime design inventory docs.

## Testing
All local verification was run in containers.

- [x] Focused Kiro runtime tests passed.
- [x] `git diff --check` passed after the latest focused coverage commit.
- [x] Added and verified focused unit coverage for Kiro shutdown orphan process matching (`kiro-cli` and `kiro`).
- [x] Previous GitHub Actions `CI` passed: Test, Integration Tests, Lint, and repository policy checks.
- [x] Previous GitHub Actions `Windows CI` passed: Windows Smoke Test.
- [x] Latest GitHub Actions after commit `34e01f8a` ran after fork-workflow approval: `Windows CI`, `Lint`, policy checks, and `Integration Tests` passed.
- [ ] Latest `CI / Test` is red on `internal/tmux.TestAutoRespawnHook_RespawnWorks`; Codecov marks this test flaky on `main` at 12.50%. A failed-job rerun requires repository admin rights.

Focused commands run:
- `GOTOOLCHAIN=auto CGO_ENABLED=0 go test ./internal/cmd ./internal/config ./internal/doctor ./internal/web ./internal/util -run "Test(BuiltInAgentPresetSummary|BuiltinPresets|GetAgentPresetByName|RuntimeConfigFromPreset|KiroAgentPreset|KiroRuntimeConfigFromPreset|AgentPresetApprovalFlags|MultipleAgentTypes|GasTownRuntimeYOLO|PaneCurrentCommandIsAgent|IsAgentOrphanCommNameIncludesKiro)$" -count=1`
- `GOTOOLCHAIN=auto CGO_ENABLED=0 go test ./internal/crew -run TestBuildResumeArgs -count=1`
- `GOTOOLCHAIN=auto go test ./internal/config/... ./internal/crew/... -count=1`
- `GOTOOLCHAIN=auto CGO_ENABLED=0 go test -tags gms_pure_go ./internal/cmd -run "Test(FindOrphanedAgentPIDsFromPSIncludesKiro|IsShutdownOrphanAgentCommNameIncludesKiro|IsProcessRunning_)" -count=1`

## Checklist
- [x] Code follows project style.
- [x] Documentation updated.
- [x] No breaking changes expected.
- [x] Dedicated PR branch from upstream main.
- [x] Pushed to fork, not upstream.
- [x] Tests added for new runtime behavior.
