### PR TITLE
Add issue tracker backend abstraction

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	beadsdk "github.com/steveyegge/beads"
+	"github.com/steveyegge/gastown/internal/deps"
 	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/telemetry"
 	"github.com/steveyegge/gastown/internal/util"
@@ -25,7 +26,7 @@ import (
 // ZFC: Only define errors that don't require stderr parsing for decisions.
 // ErrNotARepo and ErrSyncConflict were removed - agents should handle these directly.
 var (
-	ErrNotInstalled = errors.New("bd not installed: run 'pip install beads-cli' or see https://github.com/anthropics/beads")
+	ErrNotInstalled = errors.New("issue tracker CLI not installed")
 	ErrNotFound     = errors.New("issue not found")
 	ErrFlagTitle    = errors.New("title looks like a CLI flag (starts with '-'); use --title=\"...\" to set flag-like titles intentionally")
 )
@@ -59,7 +60,11 @@ func BdSupportsAllowStale() bool {
 // BdSupportsAllowStaleWithEnv returns true if the installed bd binary accepts
 // --allow-stale, probing with the provided environment when supplied.
 func BdSupportsAllowStaleWithEnv(env []string) bool {
-	bdPath, err := exec.LookPath("bd")
+	return supportsAllowStaleWithEnv("bd", env)
+}
+
+func supportsAllowStaleWithEnv(commandName string, env []string) bool {
+	bdPath, err := exec.LookPath(commandName)
 	if err != nil {
 		return false
 	}
@@ -114,7 +119,11 @@ func MaybePrependAllowStale(args []string) []string {
 // MaybePrependAllowStaleWithEnv prepends --allow-stale to args if bd supports it,
 // probing with the provided environment when supplied.
 func MaybePrependAllowStaleWithEnv(env []string, args []string) []string {
-	if BdSupportsAllowStaleWithEnv(env) {
+	return MaybePrependAllowStaleWithCommand("bd", env, args)
+}
+
+func MaybePrependAllowStaleWithCommand(commandName string, env []string, args []string) []string {
+	if supportsAllowStaleWithEnv(commandName, env) {
 		return append([]string{"--allow-stale"}, args...)
 	}
 	return args
@@ -644,6 +653,7 @@ func (b *Beads) run(args ...string) ([]byte, error) {
 // newlines in --description, which bd 1.0.3+ rejects).
 func (b *Beads) runWithStdin(stdinData []byte, args ...string) (_ []byte, retErr error) {
 	start := time.Now()
+	cliName := b.commandName()
 	// Declare buffers before defer so the closure captures them after cmd.Run.
 	var stdout, stderr bytes.Buffer
 	defer func() {
@@ -659,7 +669,7 @@ func (b *Beads) runWithStdin(stdinData []byte, args ...string) (_ []byte, retErr
 	// (e.g., after daemon is killed during shutdown). Only if bd supports it.
 	beadsDir := b.getResolvedBeadsDir()
 	runEnv := append(b.buildRunEnv(), "BEADS_DIR="+beadsDir)
-	fullArgs := MaybePrependAllowStaleWithEnv(runEnv, args)
+	fullArgs := MaybePrependAllowStaleWithCommand(cliName, runEnv, args)
 
 	// Bound the subprocess runtime so a slow Dolt response doesn't leave bd
 	// blocking forever (under memory pressure that invites Jetsam SIGKILL).
@@ -670,7 +680,7 @@ func (b *Beads) runWithStdin(stdinData []byte, args ...string) (_ []byte, retErr
 	// Always explicitly set BEADS_DIR to prevent inherited env vars from
 	// causing prefix mismatches. Use explicit beadsDir if set, otherwise
 	// resolve from working directory.
-	cmd := exec.CommandContext(ctx, "bd", fullArgs...) //nolint:gosec // G204: bd is a trusted internal tool
+	cmd := exec.CommandContext(ctx, cliName, fullArgs...) //nolint:gosec // G204: issue tracker CLI is trusted
 	util.SetDetachedProcessGroup(cmd)
 	cmd.Dir = b.workDir
 
@@ -697,7 +707,7 @@ func (b *Beads) runWithStdin(stdinData []byte, args ...string) (_ []byte, retErr
 		}
 		stdout.Reset()
 		stderr.Reset()
-		cmd = exec.CommandContext(ctx, "bd", retryArgs...) //nolint:gosec // G204: bd is a trusted internal tool
+		cmd = exec.CommandContext(ctx, cliName, retryArgs...) //nolint:gosec // G204: issue tracker CLI is trusted
 		util.SetDetachedProcessGroup(cmd)
 		cmd.Dir = b.workDir
 		cmd.Env = runEnv
@@ -731,18 +741,19 @@ func (b *Beads) runWithStdin(stdinData []byte, args ...string) (_ []byte, retErr
 // See: sling_helpers.go verifyBeadExists/hookBeadWithRetry for the same pattern.
 func (b *Beads) runWithRouting(args ...string) (_ []byte, retErr error) { //nolint:unparam // mirrors run() signature for consistency
 	start := time.Now()
+	cliName := b.commandName()
 	var stdout, stderr bytes.Buffer
 	defer func() {
 		telemetry.RecordBDCall(context.Background(), args, float64(time.Since(start).Milliseconds()), retErr, stdout.Bytes(), stderr.String())
 	}()
 	runEnv := b.buildRoutingEnv()
-	fullArgs := MaybePrependAllowStaleWithEnv(runEnv, args)
+	fullArgs := MaybePrependAllowStaleWithCommand(cliName, runEnv, args)
 
 	// Bound subprocess runtime — see bdSubprocessTimeout doc comment.
 	ctx, cancel := context.WithTimeout(context.Background(), resolveBdSubprocessTimeout())
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", fullArgs...) //nolint:gosec // G204: bd is a trusted internal tool
+	cmd := exec.CommandContext(ctx, cliName, fullArgs...) //nolint:gosec // G204: issue tracker CLI is trusted
 	util.SetDetachedProcessGroup(cmd)
 	cmd.Dir = b.workDir
 
@@ -777,8 +788,9 @@ func (b *Beads) Run(args ...string) ([]byte, error) {
 // acceptable as they enable basic error handling without decision-making.
 func (b *Beads) wrapError(err error, stderr string, args []string) error {
 	stderr = strings.TrimSpace(stderr)
+	cliName := b.commandName()
 
-	// Check for bd not installed
+	// Check for issue tracker CLI not installed
 	if execErr, ok := err.(*exec.Error); ok && errors.Is(execErr.Err, exec.ErrNotFound) {
 		return ErrNotInstalled
 	}
@@ -791,9 +803,13 @@ func (b *Beads) wrapError(err error, stderr string, args []string) error {
 	}
 
 	if stderr != "" {
-		return fmt.Errorf("bd %s: %s", strings.Join(args, " "), stderr)
+		return fmt.Errorf("%s %s: %s", cliName, strings.Join(args, " "), stderr)
 	}
-	return fmt.Errorf("bd %s: %w", strings.Join(args, " "), err)
+	return fmt.Errorf("%s %s: %w", cliName, strings.Join(args, " "), err)
+}
+
+func (b *Beads) commandName() string {
+	return deps.IssueTrackerCommandName(deps.IssueTrackerBackendForCommand(b.getTownRoot()))
 }
 
 // isSubprocessCrash returns true if the error indicates the subprocess crashed

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -143,7 +143,7 @@ func EnsureCustomTypes(beadsDir string) error {
 	if dbEnv := DatabaseEnv(beadsDir); dbEnv != "" {
 		bdEnv = append(bdEnv, dbEnv)
 	}
-	cmd := exec.Command("bd", "config", "set", "types.custom", typesList)
+	cmd := exec.Command(commandNameForDir(beadsDir), "config", "set", "types.custom", typesList)
 	cmd.Dir = beadsDir
 	util.SetDetachedProcessGroup(cmd)
 	// Set BEADS_DIR and BEADS_DOLT_SERVER_DATABASE explicitly to ensure bd
@@ -160,7 +160,7 @@ func EnsureCustomTypes(beadsDir string) error {
 	// database (redirect mismatch, stale metadata, server not running).
 	// Without this check, the sentinel file below would cache a lie,
 	// causing all future EnsureCustomTypes calls to skip re-configuration.
-	verifyCmd := exec.Command("bd", "config", "get", "types.custom")
+	verifyCmd := exec.Command(commandNameForDir(beadsDir), "config", "get", "types.custom")
 	verifyCmd.Dir = beadsDir
 	verifyCmd.Env = bdEnv
 	util.SetDetachedProcessGroup(verifyCmd)
@@ -249,7 +249,7 @@ func EnsureCustomStatuses(beadsDir string) error {
 	}
 
 	// Read current custom statuses and merge with required ones
-	getCmd := exec.Command("bd", "config", "get", "status.custom")
+	getCmd := exec.Command(commandNameForDir(beadsDir), "config", "get", "status.custom")
 	getCmd.Dir = beadsDir
 	util.SetDetachedProcessGroup(getCmd)
 	getEnv := append(stripEnvPrefixes(os.Environ(), "BEADS_DIR=", "BEADS_DB=", "BEADS_DOLT_SERVER_DATABASE="), "BEADS_DIR="+beadsDir)
@@ -282,7 +282,7 @@ func EnsureCustomStatuses(beadsDir string) error {
 	mergedStr := strings.Join(merged, ",")
 
 	// Configure custom statuses via bd CLI
-	cmd := exec.Command("bd", "config", "set", "status.custom", mergedStr)
+	cmd := exec.Command(commandNameForDir(beadsDir), "config", "set", "status.custom", mergedStr)
 	cmd.Dir = beadsDir
 	util.SetDetachedProcessGroup(cmd)
 	setEnv := append(stripEnvPrefixes(os.Environ(), "BEADS_DIR=", "BEADS_DB=", "BEADS_DOLT_SERVER_DATABASE="), "BEADS_DIR="+beadsDir)
@@ -369,7 +369,7 @@ func ensureDatabaseInitialized(beadsDir string) error {
 		initArgs = append(initArgs, "--prefix", prefix)
 	}
 	initArgs = append(initArgs, "--server")
-	cmd := exec.Command("bd", initArgs...)
+	cmd := exec.Command(commandNameForDir(beadsDir), initArgs...)
 	cmd.Dir = parentDir
 	util.SetDetachedProcessGroup(cmd)
 	initEnv := append(stripEnvPrefixes(os.Environ(), "BEADS_DIR=", "BEADS_DB=", "BEADS_DOLT_SERVER_DATABASE="), "BEADS_DIR="+beadsDir)
@@ -391,7 +391,7 @@ func ensureDatabaseInitialized(beadsDir string) error {
 	// Explicitly set issue_prefix — bd init --prefix may not persist it
 	// in newer versions (see rig/manager.go InitBeads).
 	if prefix != "" {
-		pfxCmd := exec.Command("bd", "config", "set", "issue_prefix", prefix)
+		pfxCmd := exec.Command(commandNameForDir(beadsDir), "config", "set", "issue_prefix", prefix)
 		pfxCmd.Dir = parentDir
 		util.SetDetachedProcessGroup(pfxCmd)
 		pfxEnv := append(stripEnvPrefixes(os.Environ(), "BEADS_DIR=", "BEADS_DB=", "BEADS_DOLT_SERVER_DATABASE="), "BEADS_DIR="+beadsDir)
@@ -413,7 +413,7 @@ func ensureDatabaseInitialized(beadsDir string) error {
 	if dbEnv := DatabaseEnv(beadsDir); dbEnv != "" {
 		migrateEnv = append(migrateEnv, dbEnv)
 	}
-	migrateCmd := exec.Command("bd", "migrate", "--yes")
+	migrateCmd := exec.Command(commandNameForDir(beadsDir), "migrate", "--yes")
 	migrateCmd.Dir = parentDir
 	migrateCmd.Env = migrateEnv
 	util.SetDetachedProcessGroup(migrateCmd)
@@ -421,7 +421,7 @@ func ensureDatabaseInitialized(beadsDir string) error {
 		// First attempt failed — server may not have registered the database yet.
 		// Wait briefly and retry once.
 		time.Sleep(500 * time.Millisecond)
-		retryCmd := exec.Command("bd", "migrate", "--yes")
+		retryCmd := exec.Command(commandNameForDir(beadsDir), "migrate", "--yes")
 		retryCmd.Dir = parentDir
 		retryCmd.Env = migrateEnv
 		util.SetDetachedProcessGroup(retryCmd)

--- a/internal/beads/exec.go
+++ b/internal/beads/exec.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/steveyegge/gastown/internal/deps"
 	"github.com/steveyegge/gastown/internal/util"
 )
 
@@ -23,7 +24,7 @@ const (
 
 // Command builds a bd command with the shared Gas Town bd environment policy.
 func Command(dir, fallbackBeadsDir string, mode SubprocessEnvMode, args ...string) *exec.Cmd {
-	cmd := exec.Command("bd", args...) //nolint:gosec // G204: args are constructed internally
+	cmd := exec.Command(commandNameForDir(dir), args...) //nolint:gosec // G204: args are constructed internally
 	ConfigureCommand(cmd, dir, fallbackBeadsDir, mode)
 	return cmd
 }
@@ -31,9 +32,13 @@ func Command(dir, fallbackBeadsDir string, mode SubprocessEnvMode, args ...strin
 // CommandContext builds a context-bound bd command with the shared Gas Town bd
 // environment policy.
 func CommandContext(ctx context.Context, dir, fallbackBeadsDir string, mode SubprocessEnvMode, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: args are constructed internally
+	cmd := exec.CommandContext(ctx, commandNameForDir(dir), args...) //nolint:gosec // G204: args are constructed internally
 	ConfigureCommand(cmd, dir, fallbackBeadsDir, mode)
 	return cmd
+}
+
+func commandNameForDir(dir string) string {
+	return deps.IssueTrackerCommandName(deps.IssueTrackerBackendForCommand(FindTownRoot(dir)))
 }
 
 // ConfigureCommand applies the shared bd subprocess policy to an existing

--- a/internal/cmd/agent_state.go
+++ b/internal/cmd/agent_state.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -219,7 +218,7 @@ func modifyAgentState(agentBead, beadsDir string, hasIncr bool) error {
 	}
 
 	// Execute bd update
-	cmd := exec.Command("bd", args...)
+	cmd := issueTrackerCommand(args...)
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 
 	var stderr bytes.Buffer
@@ -272,7 +271,7 @@ func getAllAgentLabels(agentBead, beadsDir string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
+	cmd := issueTrackerCommandContext(ctx, args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 
 	var stdout, stderr bytes.Buffer

--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -160,7 +160,7 @@ func (b *bdCmd) buildEnv() []string {
 // This allows callers to further customize the command before execution.
 func (b *bdCmd) Build() *exec.Cmd {
 	args := b.resolvedArgs()
-	cmd := exec.Command("bd", args...)
+	cmd := issueTrackerCommand(args...)
 	cmd.Dir = b.dir
 	cmd.Env = b.buildEnv()
 	cmd.Stderr = b.stderr
@@ -178,7 +178,7 @@ func resolveBdCmdTimeout() time.Duration {
 
 func (b *bdCmd) buildContextCommand(ctx context.Context) *exec.Cmd {
 	args := b.resolvedArgs()
-	cmd := exec.CommandContext(ctx, "bd", args...)
+	cmd := issueTrackerCommandContext(ctx, args...)
 	util.SetProcessGroup(cmd)
 	cmd.Dir = b.dir
 	cmd.Env = b.buildEnv()
@@ -273,7 +273,7 @@ func (b *bdCmd) CombinedOutput() ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), deadline)
 	defer cancel()
 	args := b.resolvedArgs()
-	cmd := exec.CommandContext(ctx, "bd", args...)
+	cmd := issueTrackerCommandContext(ctx, args...)
 	util.SetProcessGroup(cmd)
 	cmd.Dir = b.dir
 	cmd.Env = b.buildEnv()

--- a/internal/cmd/bead.go
+++ b/internal/cmd/bead.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -180,7 +179,7 @@ func runBeadMove(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the new bead
-	createCmd := exec.Command("bd", createArgs...)
+	createCmd := issueTrackerCommand(createArgs...)
 	createCmd.Stderr = os.Stderr
 	newIDBytes, err := createCmd.Output()
 	if err != nil {
@@ -192,12 +191,12 @@ func runBeadMove(cmd *cobra.Command, args []string) error {
 
 	// Close the source bead with reference
 	closeReason := fmt.Sprintf("Moved to %s", newID)
-	closeCmd := exec.Command("bd", "close", sourceID, "--reason", closeReason)
+	closeCmd := issueTrackerCommand("close", sourceID, "--reason", closeReason)
 	closeCmd.Stderr = os.Stderr
 	if err := closeCmd.Run(); err != nil {
 		// Clean up the new bead since we couldn't close the source
 		fmt.Fprintf(os.Stderr, "Warning: failed to close source bead: %v\n", err)
-		cleanupCmd := exec.Command("bd", "close", newID, "--reason", "Cleanup: source bead close failed during move")
+		cleanupCmd := issueTrackerCommand("close", newID, "--reason", "Cleanup: source bead close failed during move")
 		if cleanupErr := cleanupCmd.Run(); cleanupErr != nil {
 			fmt.Fprintf(os.Stderr, "Warning: also failed to clean up new bead %s: %v\n", newID, cleanupErr)
 			fmt.Fprintf(os.Stderr, "Both %s and %s remain open - manual cleanup needed\n", sourceID, newID)

--- a/internal/cmd/beads_version.go
+++ b/internal/cmd/beads_version.go
@@ -13,19 +13,36 @@ var (
 	versionCheckOnce         sync.Once
 )
 
-// CheckBeadsVersion verifies that the installed beads version meets the minimum requirement.
+// CheckBeadsVersion verifies that the env-requested issue tracker version meets
+// the minimum requirement. Most command paths should call
+// CheckBeadsVersionForTown so persisted town backend config is honored.
 // Returns nil if the version is sufficient, or an error with details if not.
 // The check is performed only once per process execution.
 func CheckBeadsVersion() error {
+	return CheckBeadsVersionForTown("")
+}
+
+// CheckBeadsVersionForTown verifies the effective issue tracker backend for a
+// town. For minibeads-backed towns this checks mb, not bd.
+func CheckBeadsVersionForTown(townRoot string) error {
 	versionCheckOnce.Do(func() {
-		status, version := deps.CheckBeads()
+		backend := deps.EffectiveIssueTrackerBackend(townRoot)
+		status, version := deps.CheckBeadsForBackend(backend)
 		switch status {
 		case deps.BeadsOK:
 			cachedVersionCheckResult = nil
 		case deps.BeadsUnknown:
-			cachedVersionCheckResult = fmt.Errorf("beads (bd) version could not be determined\n\nTry reinstalling: go install %s", deps.BeadsInstallPath)
+			if backend == deps.IssueTrackerBackendMinibeads {
+				cachedVersionCheckResult = fmt.Errorf("minibeads (mb) version could not be determined")
+			} else {
+				cachedVersionCheckResult = fmt.Errorf("beads (bd) version could not be determined\n\nTry reinstalling: go install %s", deps.BeadsInstallPath)
+			}
 		case deps.BeadsNotFound:
-			cachedVersionCheckResult = fmt.Errorf("beads (bd) not found in PATH\n\nInstall with: go install %s", deps.BeadsInstallPath)
+			if backend == deps.IssueTrackerBackendMinibeads {
+				cachedVersionCheckResult = fmt.Errorf("minibeads (mb) not found in PATH")
+			} else {
+				cachedVersionCheckResult = fmt.Errorf("beads (bd) not found in PATH\n\nInstall with: go install %s", deps.BeadsInstallPath)
+			}
 		case deps.BeadsTooOld:
 			cachedVersionCheckResult = fmt.Errorf("beads %s is required, but %s is installed\n\nUpgrade: go install %s",
 				deps.MinBeadsVersion, version, deps.BeadsInstallPath)

--- a/internal/cmd/cat.go
+++ b/internal/cmd/cat.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -48,7 +47,7 @@ func runCat(cmd *cobra.Command, args []string) error {
 		bdArgs = append(bdArgs, "--json")
 	}
 
-	bdCmd := exec.Command("bd", bdArgs...)
+	bdCmd := issueTrackerCommand(bdArgs...)
 	bdCmd.Stdout = os.Stdout
 	bdCmd.Stderr = os.Stderr
 	// Route to the correct rig database via prefix resolution.

--- a/internal/cmd/changelog.go
+++ b/internal/cmd/changelog.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -64,12 +63,12 @@ type ChangelogEntry struct {
 
 // closedBead is the raw shape from bd list --status=closed --json.
 type closedBead struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	IssueType   string `json:"issue_type"`
-	Ephemeral   bool   `json:"ephemeral"`
-	ClosedAt    string `json:"closed_at"`
-	CloseReason string `json:"close_reason"`
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	IssueType   string   `json:"issue_type"`
+	Ephemeral   bool     `json:"ephemeral"`
+	ClosedAt    string   `json:"closed_at"`
+	CloseReason string   `json:"close_reason"`
 	Labels      []string `json:"labels"`
 }
 
@@ -166,7 +165,7 @@ func collectChangelogEntries(townRoot string, since time.Time) ([]ChangelogEntry
 
 // fetchClosedBeads queries a single beads location for non-ephemeral closed beads since cutoff.
 func fetchClosedBeads(dir, rig string, since time.Time) ([]ChangelogEntry, error) {
-	cmd := exec.Command("bd", "list", "--status=closed", "--all", "--limit=0", "--json")
+	cmd := issueTrackerCommand("list", "--status=closed", "--all", "--limit=0", "--json")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/cmd/close.go
+++ b/internal/cmd/close.go
@@ -82,7 +82,7 @@ func runClose(cmd *cobra.Command, args []string) error {
 	// the bead's prefix to the owning rig's directory and strip BEADS_DIR so
 	// bd discovers the database from the working directory.
 	bdArgs := append([]string{"close"}, convertedArgs...)
-	bdCmd := exec.Command("bd", bdArgs...)
+	bdCmd := issueTrackerCommand(bdArgs...)
 	bdCmd.Stdin = os.Stdin
 	bdCmd.Stdout = os.Stdout
 	bdCmd.Stderr = os.Stderr
@@ -145,7 +145,7 @@ func closeChildren(parentID string, visited map[string]bool, depth int) error {
 
 	// Query children via bd children --json.
 	// Route to the correct rig database via prefix resolution.
-	childCmd := exec.Command("bd", "children", parentID, "--json")
+	childCmd := issueTrackerCommand("children", parentID, "--json")
 	if dir := resolveBeadDir(parentID); dir != "" && dir != "." {
 		childCmd.Dir = dir
 		childCmd.Env = filterEnvKey(os.Environ(), "BEADS_DIR")
@@ -192,7 +192,7 @@ func closeChildren(parentID string, visited map[string]bool, depth int) error {
 
 	fmt.Fprintf(os.Stderr, "Cascade: closing %d children of %s\n", len(childIDs), parentID)
 
-	closeBd := exec.Command("bd", closeArgs...)
+	closeBd := issueTrackerCommand(closeArgs...)
 	closeBd.Stdout = os.Stdout
 	closeBd.Stderr = os.Stderr
 	if dir := resolveBeadDir(parentID); dir != "" && dir != "." {
@@ -208,9 +208,9 @@ func extractBeadIDs(args []string) []string {
 	// Flags that consume a following argument (value flags without = form)
 	valueFlags := map[string]bool{
 		"--reason": true, "-r": true,
-		"--session": true,
-		"--actor": true,
-		"--db": true,
+		"--session":          true,
+		"--actor":            true,
+		"--db":               true,
 		"--dolt-auto-commit": true,
 		// Also handle the --comment alias (before conversion)
 		"--comment": true,

--- a/internal/cmd/compact_report.go
+++ b/internal/cmd/compact_report.go
@@ -375,7 +375,7 @@ func createCompactReportBead(report *compactReport, markdown string) (string, er
 		"--silent",
 	}
 
-	bdCmd := exec.Command("bd", bdArgs...)
+	bdCmd := issueTrackerCommand(bdArgs...)
 	output, err := bdCmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("creating report bead: %w\nOutput: %s", err, string(output))
@@ -389,7 +389,7 @@ func createCompactReportBead(report *compactReport, markdown string) (string, er
 	// Auto-close (audit record, not work). Surface failures: if close fails,
 	// the bead stays open and findExistingCompactReport (filter status=closed)
 	// will never match, causing the digest to re-fire every patrol cycle.
-	closeCmd := exec.Command("bd", "close", beadID, "--reason=daily compaction report")
+	closeCmd := issueTrackerCommand("close", beadID, "--reason=daily compaction report")
 	if out, err := closeCmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("auto-closing report bead %s: %w\nOutput: %s", beadID, err, string(out))
 	}
@@ -492,7 +492,7 @@ func runWeeklyRollup() error {
 
 // queryCompactionReports queries compaction report event beads in a date range.
 func queryCompactionReports(startDate, endDate string) ([]*compactReport, error) {
-	listCmd := exec.Command("bd", "list",
+	listCmd := issueTrackerCommand("list",
 		"--type=event",
 		"--json",
 		"--limit=0",
@@ -600,7 +600,7 @@ func formatWeeklyRollup(rollup *weeklyRollup) string {
 func findExistingCompactReport(dateStr string) (string, error) {
 	expectedTitle := fmt.Sprintf("Compaction Report %s", dateStr)
 
-	listCmd := exec.Command("bd", "list",
+	listCmd := issueTrackerCommand("list",
 		"--type=event",
 		"--status=closed",
 		"--json",
@@ -632,7 +632,7 @@ func findExistingCompactReport(dateStr string) (string, error) {
 func findExistingWeeklyRollup(weekStart, weekEnd string) (string, error) {
 	expectedTitle := fmt.Sprintf("Weekly Compaction Rollup %s to %s", weekStart, weekEnd)
 
-	listCmd := exec.Command("bd", "list",
+	listCmd := issueTrackerCommand("list",
 		"--type=event",
 		"--json",
 		"--limit=20",
@@ -686,7 +686,7 @@ func createWeeklyRollupBead(rollup *weeklyRollup, markdown string) (string, erro
 		"--silent",
 	}
 
-	bdCmd := exec.Command("bd", bdArgs...)
+	bdCmd := issueTrackerCommand(bdArgs...)
 	output, err := bdCmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("creating weekly rollup bead: %w\nOutput: %s", err, string(output))
@@ -699,7 +699,7 @@ func createWeeklyRollupBead(rollup *weeklyRollup, markdown string) (string, erro
 
 	// Auto-close (audit record, not work). Surface failures so mail is not sent
 	// without a matching audit record for future idempotency checks.
-	closeCmd := exec.Command("bd", "close", beadID, "--reason=weekly compaction rollup")
+	closeCmd := issueTrackerCommand("close", beadID, "--reason=weekly compaction rollup")
 	if out, err := closeCmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("auto-closing rollup bead %s: %w\nOutput: %s", beadID, err, string(out))
 	}

--- a/internal/cmd/convoy_launch.go
+++ b/internal/cmd/convoy_launch.go
@@ -94,7 +94,7 @@ func bdUpdateStatus(beadID, status string) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command("bd", "update", beadID, "--status="+status)
+	cmd := issueTrackerCommand("update", beadID, "--status="+status)
 	cmd.Dir = townBeads
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("bd update %s --status=%s: %w\noutput: %s", beadID, status, err, out)

--- a/internal/cmd/convoy_watch.go
+++ b/internal/cmd/convoy_watch.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -241,7 +240,7 @@ type convoyForWatch struct {
 
 // getConvoyForWatch fetches and validates a convoy for watch/unwatch operations.
 func getConvoyForWatch(townBeads, convoyID string) (*convoyForWatch, error) {
-	showCmd := exec.Command("bd", "show", convoyID, "--json")
+	showCmd := issueTrackerCommand("show", convoyID, "--json")
 	showCmd.Dir = townBeads
 	var stdout bytes.Buffer
 	showCmd.Stdout = &stdout
@@ -282,7 +281,7 @@ func getConvoyForWatch(townBeads, convoyID string) (*convoyForWatch, error) {
 
 // updateConvoyDescription updates a convoy's description via bd update.
 func updateConvoyDescription(townBeads, convoyID, newDesc string) error {
-	updateCmd := exec.Command("bd", "update", convoyID, "--description", newDesc)
+	updateCmd := issueTrackerCommand("update", convoyID, "--description", newDesc)
 	updateCmd.Dir = townBeads
 	var stderr bytes.Buffer
 	updateCmd.Stderr = &stderr

--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -39,7 +38,6 @@ var (
 	digestYesterday bool
 	digestDate      string
 	digestDryRun    bool
-
 )
 
 var costsCmd = &cobra.Command{
@@ -173,8 +171,8 @@ type TranscriptMessage struct {
 
 // TranscriptMessageBody contains the message content and usage info.
 type TranscriptMessageBody struct {
-	Model string          `json:"model"`
-	Role  string          `json:"role"`
+	Model string           `json:"model"`
+	Role  string           `json:"role"`
 	Usage *TranscriptUsage `json:"usage,omitempty"`
 }
 
@@ -465,7 +463,7 @@ func querySessionEventsFromLocation(location string) ([]CostEntry, error) {
 		"--json",
 	}
 
-	listCmd := exec.Command("bd", listArgs...)
+	listCmd := issueTrackerCommand(listArgs...)
 	listCmd.Dir = location
 	listOutput, err := listCmd.Output()
 	if err != nil {
@@ -489,7 +487,7 @@ func querySessionEventsFromLocation(location string) ([]CostEntry, error) {
 		showArgs = append(showArgs, item.ID)
 	}
 
-	showCmd := exec.Command("bd", showArgs...)
+	showCmd := issueTrackerCommand(showArgs...)
 	showCmd.Dir = location
 	showOutput, err := showCmd.Output()
 	if err != nil {
@@ -549,7 +547,7 @@ func queryDigestBeads(days int) ([]CostEntry, error) {
 		"--json",
 	}
 
-	listCmd := exec.Command("bd", listArgs...)
+	listCmd := issueTrackerCommand(listArgs...)
 	listOutput, err := listCmd.Output()
 	if err != nil {
 		return nil, nil
@@ -570,7 +568,7 @@ func queryDigestBeads(days int) ([]CostEntry, error) {
 		showArgs = append(showArgs, item.ID)
 	}
 
-	showCmd := exec.Command("bd", showArgs...)
+	showCmd := issueTrackerCommand(showArgs...)
 	showOutput, err := showCmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("showing events: %w", err)
@@ -1331,7 +1329,7 @@ func createCostDigestBead(digest CostDigest) (string, error) {
 		"--silent",
 	}
 
-	bdCmd := exec.Command("bd", bdArgs...)
+	bdCmd := issueTrackerCommand(bdArgs...)
 	output, err := bdCmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("creating digest bead: %w\nOutput: %s", err, string(output))
@@ -1340,7 +1338,7 @@ func createCostDigestBead(digest CostDigest) (string, error) {
 	digestID := strings.TrimSpace(string(output))
 
 	// Auto-close the digest (it's an audit record, not work)
-	closeCmd := exec.Command("bd", "close", digestID, "--reason=daily cost digest")
+	closeCmd := issueTrackerCommand("close", digestID, "--reason=daily cost digest")
 	_ = closeCmd.Run() // Best effort
 
 	return digestID, nil
@@ -1404,4 +1402,3 @@ func deleteSessionCostEntries(targetDate time.Time) (int, error) {
 
 	return deletedCount, nil
 }
-

--- a/internal/cmd/crew_lifecycle.go
+++ b/internal/cmd/crew_lifecycle.go
@@ -127,7 +127,7 @@ func runCrewRemove(cmd *cobra.Command, args []string) error {
 		if crewPurge {
 			// --purge: DELETE the agent bead entirely (obliterate)
 			deleteArgs := []string{"delete", agentBeadID, "--force"}
-			deleteCmd := exec.Command("bd", deleteArgs...)
+			deleteCmd := issueTrackerCommand(deleteArgs...)
 			deleteCmd.Dir = r.Path
 			if output, err := deleteCmd.CombinedOutput(); err != nil {
 				// Non-fatal: bead might not exist
@@ -142,7 +142,7 @@ func runCrewRemove(cmd *cobra.Command, args []string) error {
 			// Unassign any beads assigned to this crew member
 			agentAddr := fmt.Sprintf("%s/crew/%s", r.Name, name)
 			unassignArgs := []string{"list", "--assignee=" + agentAddr, "--format=id"}
-			unassignCmd := exec.Command("bd", unassignArgs...)
+			unassignCmd := issueTrackerCommand(unassignArgs...)
 			unassignCmd.Dir = r.Path
 			if output, err := unassignCmd.CombinedOutput(); err == nil {
 				ids := strings.Fields(strings.TrimSpace(string(output)))
@@ -150,7 +150,7 @@ func runCrewRemove(cmd *cobra.Command, args []string) error {
 					if id == "" {
 						continue
 					}
-					updateCmd := exec.Command("bd", "update", id, "--unassign")
+					updateCmd := issueTrackerCommand("update", id, "--unassign")
 					updateCmd.Dir = r.Path
 					if _, err := updateCmd.CombinedOutput(); err == nil {
 						fmt.Printf("Unassigned: %s\n", id)
@@ -170,7 +170,7 @@ func runCrewRemove(cmd *cobra.Command, args []string) error {
 			if sessionID := runtime.SessionIDFromEnv(); sessionID != "" {
 				closeArgs = append(closeArgs, "--session="+sessionID)
 			}
-			closeCmd := exec.Command("bd", closeArgs...)
+			closeCmd := issueTrackerCommand(closeArgs...)
 			closeCmd.Dir = r.Path
 			if output, err := closeCmd.CombinedOutput(); err != nil {
 				// Non-fatal: bead might not exist or already be closed

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -1153,7 +1153,7 @@ func agentAddressToIDs(address string) (beadID, sessionName string, err error) {
 
 // getAgentBeadUpdateTime gets the update time from an agent bead.
 func getAgentBeadUpdateTime(townRoot, beadID string) (time.Time, error) {
-	cmd := exec.Command("bd", "show", beadID, "--json")
+	cmd := issueTrackerCommand("show", beadID, "--json")
 	cmd.Dir = townRoot
 
 	output, err := cmd.Output()

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/deps"
 	"github.com/steveyegge/gastown/internal/doctor"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
@@ -151,6 +152,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 
 	// Create doctor and register checks
 	d := doctor.NewDoctor()
+	usingMiniBeads := deps.UsingMiniBeadsForTown(townRoot)
 
 	// Register workspace-level checks first (fundamental)
 	d.RegisterAll(doctor.WorkspaceChecks()...)
@@ -170,10 +172,14 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// 4. Dolt server is reachable (everything downstream depends on this)
 	d.Register(doctor.NewStaleBinaryCheck())
 	d.Register(doctor.NewBeadsBinaryCheck())
-	d.Register(doctor.NewDoltBinaryCheck())
+	if !usingMiniBeads {
+		d.Register(doctor.NewDoltBinaryCheck())
+	}
 	d.Register(doctor.NewClaudeBinaryCheck())
 	d.Register(doctor.NewGroqCompoundCheck())
-	d.Register(doctor.NewDoltServerReachableCheck())
+	if !usingMiniBeads {
+		d.Register(doctor.NewDoltServerReachableCheck())
+	}
 
 	d.Register(doctor.NewTownGitCheck())
 	d.Register(doctor.NewTownRootBranchCheck())
@@ -188,19 +194,25 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewTmuxGlobalEnvCheck())
 	d.Register(doctor.NewBootHealthCheck())
 	d.Register(doctor.NewTownBeadsConfigCheck())
-	d.Register(doctor.NewDoltConfigCheck())
+	if !usingMiniBeads {
+		d.Register(doctor.NewDoltConfigCheck())
+	}
 	d.Register(doctor.NewCustomTypesCheck())
 	d.Register(doctor.NewCustomStatusesCheck())
 	d.Register(doctor.NewFormulaCheck())
 	d.Register(doctor.NewOverlayHealthCheck())
 	d.Register(doctor.NewPrefixConflictCheck())
 	d.Register(doctor.NewRigNameMismatchCheck())
-	d.Register(doctor.NewRigConfigSyncCheck())      // Check all registered rigs have config.json
-	d.Register(doctor.NewStaleDoltPortCheck())      // Check for stale Dolt port files
-	d.Register(doctor.NewStaleSQLServerInfoCheck()) // Check for stale sql-server.info files (GH#2770)
+	d.Register(doctor.NewRigConfigSyncCheck()) // Check all registered rigs have config.json
+	if !usingMiniBeads {
+		d.Register(doctor.NewStaleDoltPortCheck())      // Check for stale Dolt port files
+		d.Register(doctor.NewStaleSQLServerInfoCheck()) // Check for stale sql-server.info files (GH#2770)
+	}
 	d.Register(doctor.NewPrefixMismatchCheck())
 	d.Register(doctor.NewDatabasePrefixCheck())
-	d.Register(doctor.NewIdleTimeoutCheck()) // Verify dolt.idle-timeout: "0" for all rigs
+	if !usingMiniBeads {
+		d.Register(doctor.NewIdleTimeoutCheck()) // Verify dolt.idle-timeout: "0" for all rigs
+	}
 	d.Register(doctor.NewRoutesCheck())
 	d.Register(doctor.NewRigRoutesJSONLCheck())
 	d.Register(doctor.NewRoutingModeCheck())
@@ -277,8 +289,10 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewHooksBaseCheck())
 
 	// Dolt data health checks (binary + server reachability moved to top as prerequisites)
-	d.Register(doctor.NewDoltMetadataCheck())
-	d.Register(doctor.NewDoltOrphanedDatabaseCheck())
+	if !usingMiniBeads {
+		d.Register(doctor.NewDoltMetadataCheck())
+		d.Register(doctor.NewDoltOrphanedDatabaseCheck())
+	}
 	d.Register(doctor.NewUnregisteredBeadsDirsCheck())
 	d.Register(doctor.NewNullAssigneeCheck())
 

--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -1491,7 +1491,7 @@ func runDoltRollback(cmd *cobra.Command, args []string) error {
 
 	// Validate restored state
 	fmt.Println("\nValidating restored state...")
-	validateCmd := exec.Command("bd", "list", "--limit", "5")
+	validateCmd := issueTrackerCommand("list", "--limit", "5")
 	validateCmd.Dir = townRoot
 	output, validateErr := validateCmd.CombinedOutput()
 	if validateErr != nil {

--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -194,7 +194,7 @@ func runFormulaList(cmd *cobra.Command, args []string) error {
 		bdArgs = append(bdArgs, "--json")
 	}
 
-	bdCmd := exec.Command("bd", bdArgs...)
+	bdCmd := issueTrackerCommand(bdArgs...)
 	bdCmd.Stdout = os.Stdout
 	bdCmd.Stderr = os.Stderr
 	return bdCmd.Run()
@@ -208,7 +208,7 @@ func runFormulaShow(cmd *cobra.Command, args []string) error {
 		bdArgs = append(bdArgs, "--json")
 	}
 
-	bdCmd := exec.Command("bd", bdArgs...)
+	bdCmd := issueTrackerCommand(bdArgs...)
 	bdCmd.Stdout = os.Stdout
 	bdCmd.Stderr = os.Stderr
 	return bdCmd.Run()
@@ -485,7 +485,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		createArgs = append(createArgs, "--force")
 	}
 
-	createCmd := exec.Command("bd", createArgs...)
+	createCmd := issueTrackerCommand(createArgs...)
 	createCmd.Dir = townBeads
 	createCmd.Stderr = os.Stderr
 	if err := createCmd.Run(); err != nil {
@@ -682,7 +682,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 				style.Dim.Render("Warning:"), leg.ID, err)
 			// Add comment to bead about failure
 			commentArgs := []string{"comments", "add", legBeadID, fmt.Sprintf("Failed to sling: %v", err)}
-			commentCmd := exec.Command("bd", commentArgs...)
+			commentCmd := issueTrackerCommand(commentArgs...)
 			commentCmd.Dir = townBeads
 			_ = commentCmd.Run()
 			continue

--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -1425,7 +1425,7 @@ func looksLikeBeadID(s string) bool {
 // hookBeadForHandoff attaches a bead to the current agent's hook.
 func hookBeadForHandoff(beadID string) error {
 	// Verify the bead exists first
-	verifyCmd := exec.Command("bd", "show", beadID, "--json")
+	verifyCmd := issueTrackerCommand("show", beadID, "--json")
 	if err := verifyCmd.Run(); err != nil {
 		return fmt.Errorf("bead '%s' not found", beadID)
 	}
@@ -1444,7 +1444,7 @@ func hookBeadForHandoff(beadID string) error {
 	}
 
 	// Pin the bead using bd update (discovery-based approach)
-	pinCmd := exec.Command("bd", "update", beadID, "--status=pinned", "--assignee="+agentID)
+	pinCmd := issueTrackerCommand("update", beadID, "--status=pinned", "--assignee="+agentID)
 	pinCmd.Stderr = os.Stderr
 	if err := pinCmd.Run(); err != nil {
 		return fmt.Errorf("pinning bead: %w", err)
@@ -1490,7 +1490,7 @@ func collectHandoffState() string {
 	}
 
 	// Get ready beads
-	readyOutput, err := exec.Command("bd", "ready").Output()
+	readyOutput, err := issueTrackerCommand("ready").Output()
 	if err == nil {
 		readyStr := strings.TrimSpace(string(readyOutput))
 		if readyStr != "" && !strings.Contains(readyStr, "No issues ready") {
@@ -1504,7 +1504,7 @@ func collectHandoffState() string {
 	}
 
 	// Get in-progress beads
-	inProgressOutput, err := exec.Command("bd", "list", "--status=in_progress").Output()
+	inProgressOutput, err := issueTrackerCommand("list", "--status=in_progress").Output()
 	if err == nil {
 		ipStr := strings.TrimSpace(string(inProgressOutput))
 		if ipStr != "" && !strings.Contains(ipStr, "No issues") {

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -161,9 +161,9 @@ func updateGitExclude(repoPath string) error {
 // This is best-effort: returns nil if beads isn't available or DB doesn't exist.
 // Handles gracefully: beads not installed, no .beads directory, or config errors.
 func registerCustomTypes(workDir string) error {
-	// Check if bd command is available
-	if _, err := exec.LookPath("bd"); err != nil {
-		return nil // beads not installed, skip silently
+	// Check if issue tracker command is available.
+	if _, err := exec.LookPath(issueTrackerCommandName()); err != nil {
+		return nil // issue tracker not installed, skip silently
 	}
 
 	// Check if .beads directory exists
@@ -173,7 +173,7 @@ func registerCustomTypes(workDir string) error {
 	}
 
 	// Try to set custom types
-	cmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
+	cmd := issueTrackerCommand("config", "set", "types.custom", constants.BeadsCustomTypes)
 	cmd.Dir = workDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	goruntime "runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -143,56 +142,15 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			"Use --force to override (not recommended).", absPath, existingRoot)
 	}
 
+	issueTracker := selectedIssueTrackerBackendForTown(absPath)
+
 	// Ensure beads (bd) is available before proceeding
 	if !installNoBeads {
-		if err := deps.EnsureBeads(true); err != nil {
-			return fmt.Errorf("beads dependency check failed: %w", err)
+		if err := issueTracker.EnsureAvailable(true); err != nil {
+			return fmt.Errorf("%s dependency check failed: %w", issueTracker.Name(), err)
 		}
-		if err := ensureInstallDoltReady(); err != nil {
+		if err := issueTracker.PreflightInstall(absPath, installDoltPort); err != nil {
 			return err
-		}
-
-		// Preflight: ensure dolt identity before any workspace mutations.
-		// This prevents a partial install that can't be retried without --force.
-		if err := doltserver.EnsureDoltIdentity(); err != nil {
-			return fmt.Errorf("dolt identity setup failed (required for beads): %w\n\nTo fix, run:\n  dolt config --global --add user.name \"Your Name\"\n  dolt config --global --add user.email \"you@example.com\"", err)
-		}
-
-		// Preflight: check Dolt port availability before creating any files.
-		// A port conflict would leave a partial install that needs --force to retry.
-		port := doltserver.DefaultPort
-		if installDoltPort != 0 {
-			port = installDoltPort
-			os.Setenv("GT_DOLT_PORT", strconv.Itoa(port))
-		} else if p := os.Getenv("GT_DOLT_PORT"); p != "" {
-			if envPort, err := strconv.Atoi(p); err == nil {
-				port = envPort
-			}
-		}
-		externalTestDolt := useExternalTestDoltServer(port)
-		if err := doltserver.CheckPortAvailable(port); err != nil {
-			// Port is in use — but if a Dolt server is already running
-			// for this same town, we can reuse it instead of starting a new one.
-			if canReuseInstallDoltServer(absPath, port) || externalTestDolt {
-				fmt.Printf("   %s Using existing Dolt server on port %d\n",
-					style.Dim.Render("ℹ"), port)
-			} else {
-				pid, dataDir := doltserver.PortHolder(port)
-				msg := fmt.Sprintf("Dolt port %d is already in use", port)
-				if pid > 0 && dataDir != "" {
-					msg += fmt.Sprintf("\nPort is held by dolt PID %d serving %s", pid, dataDir)
-				} else if pid > 0 {
-					msg += fmt.Sprintf("\nPort is held by PID %d", pid)
-				}
-				msg += "\n\nAnother Gas Town instance is using this port. Specify a free port:"
-				origArgs := strings.Join(os.Args[1:], " ")
-				if freePort := doltserver.FindFreePort(port + 1); freePort > 0 {
-					msg += fmt.Sprintf("\n\n  gt %s --dolt-port %d", origArgs, freePort)
-				} else {
-					msg += fmt.Sprintf("\n\n  gt %s --dolt-port <port>", origArgs)
-				}
-				return fmt.Errorf("%s", msg)
-			}
 		}
 	}
 
@@ -230,12 +188,13 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	townPath := filepath.Join(mayorDir, "town.json")
 	if townInfo, err := os.Stat(townPath); os.IsNotExist(err) {
 		townConfig := &config.TownConfig{
-			Type:       "town",
-			Version:    config.CurrentTownVersion,
-			Name:       townName,
-			Owner:      owner,
-			PublicName: publicName,
-			CreatedAt:  time.Now(),
+			Type:                "town",
+			Version:             config.CurrentTownVersion,
+			Name:                townName,
+			Owner:               owner,
+			PublicName:          publicName,
+			IssueTrackerBackend: issueTracker.Name(),
+			CreatedAt:           time.Now(),
 		}
 		if err := config.SaveTownConfig(townPath, townConfig); err != nil {
 			return fmt.Errorf("writing town.json: %w", err)
@@ -349,30 +308,11 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	// Town beads (hq- prefix) stores mayor mail, cross-rig coordination, and handoffs.
 	// Rig beads are separate and have their own prefixes.
 	if !installNoBeads {
-		port := doltserver.DefaultConfig(absPath).Port
-		externalTestDolt := useExternalTestDoltServer(port)
-
-		// Set up Dolt: identity → init-rig hq → server start.
-		// This ordering works because InitRig falls through to `dolt init`
-		// when the server isn't running yet.
-		// Identity was verified in preflight above.
-		// Create HQ database before starting server.
-		if !externalTestDolt {
-			if _, _, err := doltserver.InitRig(absPath, "hq"); err != nil {
-				return fmt.Errorf("initializing HQ Dolt database: %w", err)
-			}
-
-			// Start the Dolt server — bd commands need a running server.
-			// The server stays running after install (it's lightweight infrastructure,
-			// like a database). Stop it with 'gt dolt stop' when not needed.
-			if err := doltserver.Start(absPath); err != nil {
-				if !strings.Contains(err.Error(), "already running") {
-					return fmt.Errorf("starting Dolt server for beads: %w", err)
-				}
-			}
+		if err := issueTracker.InitializeStorage(absPath); err != nil {
+			return err
 		}
 
-		if err := initTownBeads(absPath); err != nil {
+		if err := initTownBeads(absPath, issueTracker); err != nil {
 			return fmt.Errorf("initializing town beads: %w", err)
 		} else {
 			fmt.Printf("   ✓ Initialized .beads/ (town-level beads with hq- prefix)\n")
@@ -394,7 +334,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		}
 
 		// Set beads routing mode to explicit (required by gt doctor).
-		routingCmd := exec.Command("bd", "config", "set", "routing.mode", "explicit")
+		routingCmd := exec.Command(issueTracker.CommandName(), "config", "set", "routing.mode", "explicit")
 		routingCmd.Dir = absPath
 		routingCmd.Env = withBeadsDirEnv(filepath.Join(absPath, ".beads"))
 		if out, err := routingCmd.CombinedOutput(); err != nil {
@@ -491,7 +431,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	step++
 	fmt.Printf("  %d. Enter the Mayor's office: %s\n", step, style.Dim.Render("gt mayor attach"))
 	fmt.Println()
-	if !installNoBeads {
+	if !installNoBeads && issueTracker.ShowPostInstallDoltHint() {
 		fmt.Printf("Note: Dolt server is running (stop with %s)\n", style.Dim.Render("gt dolt stop"))
 	}
 
@@ -656,52 +596,26 @@ func writeJSON(path string, data interface{}) error {
 	return os.WriteFile(path, content, 0644)
 }
 
-// buildBdInitArgs returns the arguments for `bd init` including the correct
-// --server-port derived from the town's Dolt configuration.
 func buildBdInitArgs(townPath string) []string {
-	cfg := doltserver.DefaultConfig(townPath)
-	// gt install --force preserves town state; bd reinit flags would destroy town beads.
-	return []string{"init", "--prefix", "hq", "--server",
-		"--server-port", strconv.Itoa(cfg.Port)}
+	return selectedIssueTrackerBackendForTown(townPath).InitArgs(townPath)
 }
 
-// initTownBeads initializes town-level beads database using bd init.
+// initTownBeads initializes town-level beads database using the selected issue
+// tracker backend.
 // Town beads use the "hq-" prefix for mayor mail and cross-rig coordination.
-// Uses Dolt backend in server mode (Gas Town requires a running Dolt sql-server).
-func initTownBeads(townPath string) error {
-	// Dolt server is required — wait for it to accept queries before proceeding.
-	// The server may have just been started by gt install and TCP reachability
-	// alone is not sufficient; we need MySQL protocol readiness.
-	cfg := doltserver.DefaultConfig(townPath)
-	// wa-d6f: socket-first DSN (TCP fallback) — same rationale.
-	dsn := buildDoltDSNFromConfig(cfg, "", dsnOpts{})
-	var lastErr error
-	for attempt := 0; attempt < 20; attempt++ {
-		db, err := sql.Open("mysql", dsn)
-		if err == nil {
-			err = db.Ping()
-			db.Close()
-		}
-		if err == nil {
-			lastErr = nil
-			break
-		}
-		lastErr = err
-		time.Sleep(500 * time.Millisecond)
-	}
-	if lastErr != nil {
-		return fmt.Errorf("Dolt server is not ready after 10s: %w", lastErr)
+func initTownBeads(townPath string, backend issueTrackerBackend) error {
+	if err := backend.WaitUntilReady(townPath); err != nil {
+		return err
 	}
 
-	// Run: bd init --prefix hq --server --server-port <port>
-	// Dolt is the only backend since bd v0.51.0; no --backend flag needed.
-	// Filter inherited BEADS_DIR so bd init targets this town, not a parent .beads.
-	// Always pass --server-port so bd connects to the correct Dolt server.
+	// Run the backend-specific init command.
+	// Filter inherited BEADS_DIR so init targets this town, not a parent .beads.
+	// For beads/Dolt, always pass --server-port so bd connects to the correct Dolt server.
 	// DefaultConfig resolves the port from config.yaml > GT_DOLT_PORT env > default (3307).
 	// Forward GT_DOLT_PORT so bd connects to the correct server when a
 	// non-default port is configured (e.g., ephemeral test servers in CI).
-	bdInitArgs := buildBdInitArgs(townPath)
-	cmd := exec.Command("bd", bdInitArgs...)
+	bdInitArgs := backend.InitArgs(townPath)
+	cmd := exec.Command(backend.CommandName(), bdInitArgs...)
 	cmd.Dir = townPath
 	cmd.Env = withBeadsDirEnv(filepath.Join(townPath, ".beads"))
 
@@ -711,20 +625,18 @@ func initTownBeads(townPath string) error {
 		if strings.Contains(string(output), "already initialized") {
 			// Already initialized - still need to ensure fingerprint exists
 		} else {
-			return fmt.Errorf("bd init failed: %s", strings.TrimSpace(string(output)))
+			return fmt.Errorf("%s init failed: %s", backend.CommandName(), strings.TrimSpace(string(output)))
 		}
 	}
 
 	// Verify .beads directory was actually created (bd init can exit 0 without creating it)
 	beadsDir := filepath.Join(townPath, ".beads")
 	if _, statErr := os.Stat(beadsDir); os.IsNotExist(statErr) {
-		return fmt.Errorf("bd init succeeded but .beads directory not created (check bd daemon interference)")
+		return fmt.Errorf("%s init succeeded but .beads directory not created", backend.CommandName())
 	}
 
-	// Ensure metadata.json has dolt_database set (EnsureMetadata fills missing
-	// values but does not overwrite existing ones).
-	if err := doltserver.EnsureMetadata(townPath, "hq"); err != nil {
-		return fmt.Errorf("ensuring hq metadata: %w", err)
+	if err := backend.PostInit(townPath); err != nil {
+		return err
 	}
 
 	// Ensure config.yaml exists with a stable prefix for clone/adopt workflows.
@@ -798,7 +710,7 @@ func withBeadsDirEnv(beadsDir string) []string {
 // Gas Town needs custom types: agent, role, rig, convoy, slot.
 // This is idempotent - safe to call multiple times.
 func ensureCustomTypes(beadsPath string) error {
-	cmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
+	cmd := issueTrackerCommand("config", "set", "types.custom", constants.BeadsCustomTypes)
 	cmd.Dir = beadsPath
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -889,7 +801,7 @@ func ensureBeadsCustomTypes(workDir string, types []string) error {
 		return nil
 	}
 
-	cmd := exec.Command("bd", "config", "set", "types.custom", strings.Join(types, ","))
+	cmd := issueTrackerCommand("config", "set", "types.custom", strings.Join(types, ","))
 	cmd.Dir = workDir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -18,6 +18,8 @@ import (
 
 func TestBuildBdInitArgs_AlwaysIncludesServerPortWithoutReinit(t *testing.T) {
 	townDir := t.TempDir()
+	t.Setenv("GT_BEADS_BACKEND", "")
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "beads")
 	t.Setenv("GT_DOLT_PORT", "")
 	t.Setenv("BEADS_DOLT_PORT", "")
 
@@ -42,6 +44,8 @@ func TestBuildBdInitArgs_AlwaysIncludesServerPortWithoutReinit(t *testing.T) {
 func TestBuildBdInitArgs_RespectsGTDoltPortEnv(t *testing.T) {
 	townDir := t.TempDir()
 
+	t.Setenv("GT_BEADS_BACKEND", "")
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "beads")
 	t.Setenv("GT_DOLT_PORT", "4400")
 
 	args := buildBdInitArgs(townDir)
@@ -62,6 +66,8 @@ func TestBuildBdInitArgs_ConfigYAMLTakesPrecedence(t *testing.T) {
 		t.Fatalf("write config.yaml: %v", err)
 	}
 
+	t.Setenv("GT_BEADS_BACKEND", "")
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "beads")
 	t.Setenv("GT_DOLT_PORT", "4400")
 
 	args := buildBdInitArgs(townDir)
@@ -73,6 +79,8 @@ func TestBuildBdInitArgs_ConfigYAMLTakesPrecedence(t *testing.T) {
 
 func TestBuildBdInitArgs_PortMatchesDefaultConfig(t *testing.T) {
 	townDir := t.TempDir()
+	t.Setenv("GT_BEADS_BACKEND", "")
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "beads")
 
 	args := buildBdInitArgs(townDir)
 	cfg := doltserver.DefaultConfig(townDir)
@@ -80,6 +88,79 @@ func TestBuildBdInitArgs_PortMatchesDefaultConfig(t *testing.T) {
 	if args[5] != strconv.Itoa(cfg.Port) {
 		t.Fatalf("port should match DefaultConfig: args=%q, config=%d", args[5], cfg.Port)
 	}
+}
+
+func TestBuildBdInitArgs_MiniBeadsUsesRepoLocalInit(t *testing.T) {
+	t.Setenv("GT_BEADS_BACKEND", "")
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "minibeads")
+
+	args := buildBdInitArgs(t.TempDir())
+
+	want := []string{"init", "--prefix", "hq"}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("minibeads init args = %v, want %v", args, want)
+	}
+}
+
+func TestBuildBdInitArgs_MiniBeadsFromTownConfig(t *testing.T) {
+	townDir := t.TempDir()
+	t.Setenv("GT_BEADS_BACKEND", "")
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "")
+	mayorDir := filepath.Join(townDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "town.json"), []byte(`{
+  "type": "town",
+  "version": 1,
+  "name": "test-town",
+  "issue_tracker_backend": "minibeads",
+  "created_at": "2026-07-01T00:00:00Z"
+}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	args := buildBdInitArgs(townDir)
+
+	want := []string{"init", "--prefix", "hq"}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("minibeads init args = %v, want %v", args, want)
+	}
+}
+
+func TestSelectedIssueTrackerBackend(t *testing.T) {
+	t.Run("default beads dolt", func(t *testing.T) {
+		t.Setenv("GT_BEADS_BACKEND", "")
+		t.Setenv("GT_ISSUE_TRACKER_BACKEND", "beads")
+		backend := selectedIssueTrackerBackend()
+		if backend.Name() != "beads" {
+			t.Fatalf("backend.Name() = %q, want beads", backend.Name())
+		}
+		if !backend.ShowPostInstallDoltHint() {
+			t.Fatal("beads backend should show Dolt stop hint")
+		}
+	})
+
+	t.Run("minibeads", func(t *testing.T) {
+		t.Setenv("GT_BEADS_BACKEND", "")
+		t.Setenv("GT_ISSUE_TRACKER_BACKEND", "mb")
+		backend := selectedIssueTrackerBackend()
+		if backend.Name() != "minibeads" {
+			t.Fatalf("backend.Name() = %q, want minibeads", backend.Name())
+		}
+		if backend.ShowPostInstallDoltHint() {
+			t.Fatal("minibeads backend should not show Dolt stop hint")
+		}
+		if err := backend.PreflightInstall(t.TempDir(), 3307); err != nil {
+			t.Fatalf("minibeads preflight should not require Dolt: %v", err)
+		}
+		if err := backend.InitializeStorage(t.TempDir()); err != nil {
+			t.Fatalf("minibeads storage init should not require Dolt: %v", err)
+		}
+		if err := backend.WaitUntilReady(t.TempDir()); err != nil {
+			t.Fatalf("minibeads readiness should not require Dolt: %v", err)
+		}
+	})
 }
 
 func TestEnsureBeadsConfigYAML_CreatesWhenMissing(t *testing.T) {

--- a/internal/cmd/issue_tracker_backend.go
+++ b/internal/cmd/issue_tracker_backend.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/deps"
+	"github.com/steveyegge/gastown/internal/doltserver"
+	"github.com/steveyegge/gastown/internal/style"
+)
+
+type issueTrackerBackend interface {
+	Name() string
+	CommandName() string
+	EnsureAvailable(autoInstall bool) error
+	PreflightInstall(townPath string, requestedDoltPort int) error
+	InitializeStorage(townPath string) error
+	InitArgs(townPath string) []string
+	WaitUntilReady(townPath string) error
+	PostInit(townPath string) error
+	ShowPostInstallDoltHint() bool
+}
+
+func selectedIssueTrackerBackend() issueTrackerBackend {
+	return selectedIssueTrackerBackendForTown("")
+}
+
+func selectedIssueTrackerBackendForTown(townPath string) issueTrackerBackend {
+	return issueTrackerBackendForKind(deps.EffectiveIssueTrackerBackend(townPath))
+}
+
+func issueTrackerBackendForKind(kind deps.IssueTrackerBackend) issueTrackerBackend {
+	if kind == deps.IssueTrackerBackendMinibeads {
+		return miniBeadsIssueTracker{}
+	}
+	return beadsDoltIssueTracker{}
+}
+
+type beadsDoltIssueTracker struct{}
+
+func (beadsDoltIssueTracker) Name() string {
+	return "beads"
+}
+
+func (beadsDoltIssueTracker) CommandName() string {
+	return deps.IssueTrackerCommandName(deps.IssueTrackerBackendDefault)
+}
+
+func (beadsDoltIssueTracker) EnsureAvailable(autoInstall bool) error {
+	return deps.EnsureBeads(autoInstall)
+}
+
+func (beadsDoltIssueTracker) PreflightInstall(townPath string, requestedDoltPort int) error {
+	if err := ensureInstallDoltReady(); err != nil {
+		return err
+	}
+
+	// Preflight: ensure dolt identity before any workspace mutations.
+	// This prevents a partial install that can't be retried without --force.
+	if err := doltserver.EnsureDoltIdentity(); err != nil {
+		return fmt.Errorf("dolt identity setup failed (required for beads): %w\n\nTo fix, run:\n  dolt config --global --add user.name \"Your Name\"\n  dolt config --global --add user.email \"you@example.com\"", err)
+	}
+
+	// Preflight: check Dolt port availability before creating any files.
+	// A port conflict would leave a partial install that needs --force to retry.
+	port := doltserver.DefaultPort
+	if requestedDoltPort != 0 {
+		port = requestedDoltPort
+		os.Setenv("GT_DOLT_PORT", strconv.Itoa(port))
+	} else if p := os.Getenv("GT_DOLT_PORT"); p != "" {
+		if envPort, err := strconv.Atoi(p); err == nil {
+			port = envPort
+		}
+	}
+	externalTestDolt := useExternalTestDoltServer(port)
+	if err := doltserver.CheckPortAvailable(port); err != nil {
+		// Port is in use, but if a Dolt server is already running for this
+		// same town, we can reuse it instead of starting a new one.
+		if canReuseInstallDoltServer(townPath, port) || externalTestDolt {
+			fmt.Printf("   %s Using existing Dolt server on port %d\n",
+				style.Dim.Render("ℹ"), port)
+			return nil
+		}
+
+		pid, dataDir := doltserver.PortHolder(port)
+		msg := fmt.Sprintf("Dolt port %d is already in use", port)
+		if pid > 0 && dataDir != "" {
+			msg += fmt.Sprintf("\nPort is held by dolt PID %d serving %s", pid, dataDir)
+		} else if pid > 0 {
+			msg += fmt.Sprintf("\nPort is held by PID %d", pid)
+		}
+		msg += "\n\nAnother Gas Town instance is using this port. Specify a free port:"
+		origArgs := strings.Join(os.Args[1:], " ")
+		if freePort := doltserver.FindFreePort(port + 1); freePort > 0 {
+			msg += fmt.Sprintf("\n\n  gt %s --dolt-port %d", origArgs, freePort)
+		} else {
+			msg += fmt.Sprintf("\n\n  gt %s --dolt-port <port>", origArgs)
+		}
+		return fmt.Errorf("%s", msg)
+	}
+
+	return nil
+}
+
+func (beadsDoltIssueTracker) InitializeStorage(townPath string) error {
+	port := doltserver.DefaultConfig(townPath).Port
+	externalTestDolt := useExternalTestDoltServer(port)
+	if externalTestDolt {
+		return nil
+	}
+
+	// Set up Dolt: identity -> init-rig hq -> server start. This ordering
+	// works because InitRig falls through to `dolt init` when the server is not
+	// running yet. Identity was verified in preflight above.
+	if _, _, err := doltserver.InitRig(townPath, "hq"); err != nil {
+		return fmt.Errorf("initializing HQ Dolt database: %w", err)
+	}
+
+	// Start the Dolt server. It stays running after install; stop it with
+	// `gt dolt stop` when not needed.
+	if err := doltserver.Start(townPath); err != nil {
+		if !strings.Contains(err.Error(), "already running") {
+			return fmt.Errorf("starting Dolt server for beads: %w", err)
+		}
+	}
+	return nil
+}
+
+func (beadsDoltIssueTracker) InitArgs(townPath string) []string {
+	cfg := doltserver.DefaultConfig(townPath)
+	// gt install --force preserves town state; bd reinit flags would destroy town beads.
+	return []string{"init", "--prefix", "hq", "--server",
+		"--server-port", strconv.Itoa(cfg.Port)}
+}
+
+func (beadsDoltIssueTracker) WaitUntilReady(townPath string) error {
+	// Dolt server is required. TCP reachability alone is not sufficient; wait
+	// for MySQL protocol readiness.
+	cfg := doltserver.DefaultConfig(townPath)
+	dsn := buildDoltDSNFromConfig(cfg, "", dsnOpts{})
+	var lastErr error
+	for attempt := 0; attempt < 20; attempt++ {
+		db, err := sql.Open("mysql", dsn)
+		if err == nil {
+			err = db.Ping()
+			db.Close()
+		}
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("Dolt server is not ready after 10s: %w", lastErr)
+}
+
+func (beadsDoltIssueTracker) PostInit(townPath string) error {
+	if err := doltserver.EnsureMetadata(townPath, "hq"); err != nil {
+		return fmt.Errorf("ensuring hq metadata: %w", err)
+	}
+	return nil
+}
+
+func (beadsDoltIssueTracker) ShowPostInstallDoltHint() bool {
+	return true
+}
+
+type miniBeadsIssueTracker struct{}
+
+func (miniBeadsIssueTracker) Name() string {
+	return "minibeads"
+}
+
+func (miniBeadsIssueTracker) CommandName() string {
+	return deps.IssueTrackerCommandName(deps.IssueTrackerBackendMinibeads)
+}
+
+func (miniBeadsIssueTracker) EnsureAvailable(autoInstall bool) error {
+	return deps.EnsureBeadsForBackend(deps.IssueTrackerBackendMinibeads, autoInstall)
+}
+
+func (miniBeadsIssueTracker) PreflightInstall(_ string, _ int) error {
+	return nil
+}
+
+func (miniBeadsIssueTracker) InitializeStorage(_ string) error {
+	return nil
+}
+
+func (miniBeadsIssueTracker) InitArgs(_ string) []string {
+	return []string{"init", "--prefix", "hq"}
+}
+
+func (miniBeadsIssueTracker) WaitUntilReady(_ string) error {
+	return nil
+}
+
+func (miniBeadsIssueTracker) PostInit(_ string) error {
+	return nil
+}
+
+func (miniBeadsIssueTracker) ShowPostInstallDoltHint() bool {
+	return false
+}

--- a/internal/cmd/issue_tracker_command.go
+++ b/internal/cmd/issue_tracker_command.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/steveyegge/gastown/internal/deps"
+)
+
+func issueTrackerCommand(args ...string) *exec.Cmd {
+	return issueTrackerCommandForTown(detectTownRootFromCwd(), args...)
+}
+
+func issueTrackerCommandName() string {
+	return deps.IssueTrackerCommandName(deps.IssueTrackerBackendForCommand(detectTownRootFromCwd()))
+}
+
+func issueTrackerCommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	return issueTrackerCommandContextForTown(ctx, detectTownRootFromCwd(), args...)
+}
+
+func issueTrackerCommandForTown(townRoot string, args ...string) *exec.Cmd {
+	name := deps.IssueTrackerCommandName(deps.IssueTrackerBackendForCommand(townRoot))
+	return exec.Command(name, args...) //nolint:gosec // G204: args are constructed internally
+}
+
+func issueTrackerCommandContextForTown(ctx context.Context, townRoot string, args ...string) *exec.Cmd {
+	name := deps.IssueTrackerCommandName(deps.IssueTrackerBackendForCommand(townRoot))
+	return exec.CommandContext(ctx, name, args...) //nolint:gosec // G204: args are constructed internally
+}

--- a/internal/cmd/mail_announce.go
+++ b/internal/cmd/mail_announce.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -184,11 +183,11 @@ func listAnnounceMessages(townRoot, channelName string) ([]announceMessage, erro
 		"--label", "gt:message",
 		"--label", "announce_channel:" + channelName,
 		"--sort", "-created", // Newest first
-		"--limit", "0",       // No limit
+		"--limit", "0", // No limit
 		"--json",
 	}
 
-	cmd := exec.Command("bd", args...)
+	cmd := issueTrackerCommand(args...)
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 
 	var stdout, stderr bytes.Buffer

--- a/internal/cmd/mail_channel.go
+++ b/internal/cmd/mail_channel.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -499,7 +498,7 @@ func listChannelMessages(townRoot, channelName string) ([]channelMessage, error)
 		"--json",
 	}
 
-	cmd := exec.Command("bd", args...)
+	cmd := issueTrackerCommand(args...)
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 
 	var stdout, stderr bytes.Buffer

--- a/internal/cmd/mail_queue.go
+++ b/internal/cmd/mail_queue.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"sort"
 	"strings"
 	"time"
@@ -182,7 +181,7 @@ func listUnclaimedQueueMessages(beadsDir, queueName string) ([]queueMessage, err
 		"--limit", "0",
 	}
 
-	cmd := exec.Command("bd", args...)
+	cmd := issueTrackerCommand(args...)
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 
 	var stdout, stderr bytes.Buffer
@@ -263,7 +262,7 @@ func claimQueueMessage(beadsDir, messageID, claimant string) error {
 		"claimed-at:" + now,
 	}
 
-	cmd := exec.Command("bd", args...)
+	cmd := issueTrackerCommand(args...)
 	cmd.Env = append(os.Environ(),
 		"BEADS_DIR="+beadsDir,
 		"BD_ACTOR="+claimant,
@@ -343,7 +342,7 @@ type queueMessageInfo struct {
 func getQueueMessageInfo(beadsDir, messageID string) (*queueMessageInfo, error) {
 	args := []string{"show", messageID, "--json"}
 
-	cmd := exec.Command("bd", args...)
+	cmd := issueTrackerCommand(args...)
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 
 	var stdout, stderr bytes.Buffer
@@ -425,7 +424,7 @@ func releaseQueueMessage(beadsDir, messageID, actor string) error {
 
 	// Remove all claim labels in a single bd command
 	args := append([]string{"label", "remove", messageID}, labelsToRemove...)
-	cmd := exec.Command("bd", args...)
+	cmd := issueTrackerCommand(args...)
 	cmd.Env = append(os.Environ(),
 		"BEADS_DIR="+beadsDir,
 		"BD_ACTOR="+actor,

--- a/internal/cmd/mayor.go
+++ b/internal/cmd/mayor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/daemon"
+	"github.com/steveyegge/gastown/internal/deps"
 	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/mayor"
 	"github.com/steveyegge/gastown/internal/session"
@@ -401,10 +402,9 @@ func runMayorRestart(cmd *cobra.Command, args []string) error {
 	return runMayorStart(cmd, args)
 }
 
-// ensureMayorInfra checks that daemon and dolt are running before attaching
-// to the Mayor session. Warns and auto-starts each if absent.
-// Returns an error if Dolt fails to start — a missing Dolt server is fatal
-// for the Mayor (it cannot operate without database access).
+// ensureMayorInfra checks that daemon and, for upstream beads towns, Dolt are
+// running before attaching to the Mayor session. Warns and auto-starts each if
+// absent. Returns an error if Dolt fails to start for an upstream beads town.
 // Daemon failures are non-fatal (warned but do not block).
 func ensureMayorInfra(townRoot string) error {
 	// Load daemon.json env vars (e.g., GT_DOLT_PORT) so Dolt uses the right port.
@@ -423,6 +423,10 @@ func ensureMayorInfra(townRoot string) error {
 		} else {
 			fmt.Printf("  %s Daemon started\n", style.Bold.Render("✓"))
 		}
+	}
+
+	if deps.UsingMiniBeadsForTown(townRoot) {
+		return nil
 	}
 
 	// Dolt (fatal on failure — Mayor requires database access)

--- a/internal/cmd/molecule_await_signal.go
+++ b/internal/cmd/molecule_await_signal.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -457,7 +456,7 @@ func updateAgentHeartbeat(agentBead, beadsDir string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
+	cmd := issueTrackerCommandContext(ctx, args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 	return cmd.Run()
 }
@@ -493,7 +492,7 @@ func setAgentIdleCycles(agentBead, beadsDir string, cycles int) error {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
+	cmd := issueTrackerCommandContext(ctx, args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 
 	if err := cmd.Run(); err != nil {
@@ -529,7 +528,7 @@ func setAgentBackoffUntil(agentBead, beadsDir string, until time.Time) error {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
+	cmd := issueTrackerCommandContext(ctx, args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("setting backoff-until label: %w", err)
@@ -571,7 +570,7 @@ func clearAgentBackoffUntil(agentBead, beadsDir string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
+	cmd := issueTrackerCommandContext(ctx, args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("clearing backoff-until label: %w", err)

--- a/internal/cmd/molecule_step.go
+++ b/internal/cmd/molecule_step.go
@@ -294,7 +294,7 @@ func handleStepContinue(cwd, townRoot string, nextStep *beads.Issue, dryRun bool
 	}
 
 	// Pin the next step bead
-	pinCmd := exec.Command("bd", "update", nextStep.ID, "--status=pinned", "--assignee="+agentID)
+	pinCmd := issueTrackerCommand("update", nextStep.ID, "--status=pinned", "--assignee="+agentID)
 	pinCmd.Dir = gitRoot
 	pinCmd.Stderr = os.Stderr
 	if err := pinCmd.Run(); err != nil {
@@ -373,7 +373,7 @@ func handleParallelSteps(cwd, townRoot, _ string, steps []*beads.Issue, dryRun b
 	}
 
 	for _, step := range steps {
-		markCmd := exec.Command("bd", "update", step.ID, "--status=in_progress")
+		markCmd := issueTrackerCommand("update", step.ID, "--status=in_progress")
 		markCmd.Dir = gitRoot
 		markCmd.Stderr = os.Stderr
 		if err := markCmd.Run(); err != nil {
@@ -471,7 +471,7 @@ func handleMoleculeComplete(cwd, townRoot, moleculeID string, dryRun bool) error
 		})
 		if err == nil && len(pinnedBeads) > 0 {
 			// Unpin by setting status to open
-			unpinCmd := exec.Command("bd", "update", pinnedBeads[0].ID, "--status=open")
+			unpinCmd := issueTrackerCommand("update", pinnedBeads[0].ID, "--status=open")
 			unpinCmd.Dir = gitRoot
 			unpinCmd.Stderr = os.Stderr
 			if err := unpinCmd.Run(); err != nil {

--- a/internal/cmd/mountain.go
+++ b/internal/cmd/mountain.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"sort"
 	"strings"
 
@@ -275,7 +274,7 @@ func bdAddLabelTown(beadID, label string) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command("bd", "update", beadID, "--add-label="+label)
+	cmd := issueTrackerCommand("update", beadID, "--add-label="+label)
 	cmd.Dir = townBeads
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("bd update %s --add-label=%s: %w\noutput: %s", beadID, label, err, out)
@@ -289,7 +288,7 @@ func bdRemoveLabelTown(beadID, label string) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command("bd", "update", beadID, "--remove-label="+label)
+	cmd := issueTrackerCommand("update", beadID, "--remove-label="+label)
 	cmd.Dir = townBeads
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("bd update %s --remove-label=%s: %w\noutput: %s", beadID, label, err, out)

--- a/internal/cmd/patrol.go
+++ b/internal/cmd/patrol.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"sort"
 	"strings"
 	"time"
@@ -70,16 +69,16 @@ func init() {
 
 // PatrolDigest represents the aggregated daily patrol report.
 type PatrolDigest struct {
-	Date         string                   `json:"date"`
-	TotalCycles  int                      `json:"total_cycles"`
-	ByRole       map[string]int           `json:"by_role"`        // deacon, witness, refinery
-	Cycles       []PatrolCycleEntry       `json:"cycles"`
+	Date        string             `json:"date"`
+	TotalCycles int                `json:"total_cycles"`
+	ByRole      map[string]int     `json:"by_role"` // deacon, witness, refinery
+	Cycles      []PatrolCycleEntry `json:"cycles"`
 }
 
 // PatrolCycleEntry represents a single patrol cycle in the digest.
 type PatrolCycleEntry struct {
 	ID          string    `json:"id"`
-	Role        string    `json:"role"`         // deacon, witness, refinery
+	Role        string    `json:"role"` // deacon, witness, refinery
 	Title       string    `json:"title"`
 	Description string    `json:"description"`
 	CreatedAt   time.Time `json:"created_at"`
@@ -186,7 +185,7 @@ func runPatrolDigest(cmd *cobra.Command, args []string) error {
 func queryPatrolDigests(targetDate time.Time) ([]PatrolCycleEntry, error) {
 	// List closed issues with "digest" label that are ephemeral
 	// Patrol digests have titles like "Digest: mol-deacon-patrol", "Digest: mol-witness-patrol"
-	listCmd := exec.Command("bd", "list",
+	listCmd := issueTrackerCommand("list",
 		"--status=closed",
 		"--label=digest",
 		"--json",
@@ -308,7 +307,7 @@ func createPatrolDigestBead(digest PatrolDigest) (string, error) {
 		"--silent",
 	}
 
-	bdCmd := exec.Command("bd", bdArgs...)
+	bdCmd := issueTrackerCommand(bdArgs...)
 	output, err := bdCmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("creating digest bead: %w\nOutput: %s", err, string(output))
@@ -317,7 +316,7 @@ func createPatrolDigestBead(digest PatrolDigest) (string, error) {
 	digestID := strings.TrimSpace(string(output))
 
 	// Auto-close the digest (it's an audit record, not work)
-	closeCmd := exec.Command("bd", "close", digestID, "--reason=daily patrol digest")
+	closeCmd := issueTrackerCommand("close", digestID, "--reason=daily patrol digest")
 	_ = closeCmd.Run() // Best effort
 
 	return digestID, nil
@@ -329,7 +328,7 @@ func findExistingPatrolDigest(dateStr string) (string, error) {
 	expectedTitle := fmt.Sprintf("Patrol Report %s", dateStr)
 
 	// Query event beads with patrol.digest category
-	listCmd := exec.Command("bd", "list",
+	listCmd := issueTrackerCommand("list",
 		"--type=event",
 		"--json",
 		"--limit=50", // Recent events only
@@ -377,7 +376,7 @@ func deletePatrolDigests(targetDate time.Time) (int, error) {
 
 	// Delete in batch
 	deleteArgs := append([]string{"delete", "--force"}, idsToDelete...)
-	deleteCmd := exec.Command("bd", deleteArgs...)
+	deleteCmd := issueTrackerCommand(deleteArgs...)
 	if err := deleteCmd.Run(); err != nil {
 		return 0, fmt.Errorf("deleting patrol digests: %w", err)
 	}

--- a/internal/cmd/polecat_identity.go
+++ b/internal/cmd/polecat_identity.go
@@ -809,7 +809,7 @@ func queryAssignedIssues(rigPath, assignee, status string) ([]IssueInfo, error) 
 		args = append(args, "--status="+status)
 	}
 
-	cmd := exec.Command("bd", args...)
+	cmd := issueTrackerCommand(args...)
 	cmd.Dir = rigPath
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -37,7 +36,7 @@ type MoleculeCurrentOutput struct {
 // with execution instructions. This is the core of the Propulsion Principle.
 func showMoleculeExecutionPrompt(workDir, moleculeID string) {
 	// Call bd mol current with JSON output
-	cmd := exec.Command("bd", "mol", "current", moleculeID, "--json")
+	cmd := issueTrackerCommand("mol", "current", moleculeID, "--json")
 	cmd.Dir = workDir
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/cmd/remember.go
+++ b/internal/cmd/remember.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -193,14 +192,14 @@ func sanitizeKey(key string) string {
 
 // bdKvSet calls bd kv set <key> <value>.
 func bdKvSet(key, value string) error {
-	cmd := exec.Command("bd", "kv", "set", key, value)
+	cmd := issueTrackerCommand("kv", "set", key, value)
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
 // bdKvGet calls bd kv get <key> and returns the value.
 func bdKvGet(key string) (string, error) {
-	cmd := exec.Command("bd", "kv", "get", key)
+	cmd := issueTrackerCommand("kv", "get", key)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -210,7 +209,7 @@ func bdKvGet(key string) (string, error) {
 
 // bdKvClear calls bd kv clear <key>.
 func bdKvClear(key string) error {
-	cmd := exec.Command("bd", "kv", "clear", key)
+	cmd := issueTrackerCommand("kv", "clear", key)
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
@@ -235,7 +234,7 @@ func parseBdKvListJSON(data []byte) (map[string]string, error) {
 
 // bdKvListJSON calls bd kv list --json and returns the parsed string values.
 func bdKvListJSON() (map[string]string, error) {
-	cmd := exec.Command("bd", "kv", "list", "--json")
+	cmd := issueTrackerCommand("kv", "list", "--json")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -1222,7 +1222,7 @@ func runRigAdopt(_ *cobra.Command, args []string) error {
 			}
 			if json.Unmarshal(metaBytes, &meta) == nil && meta.Backend == "dolt" {
 				workDir := filepath.Dir(beadsDir)
-				bdCmd := exec.Command("bd", "config", "get", "issue_prefix")
+				bdCmd := issueTrackerCommand("config", "get", "issue_prefix")
 				bdCmd.Dir = workDir
 				if out, bdErr := bdCmd.Output(); bdErr == nil {
 					detected := strings.TrimSpace(string(out))

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -122,7 +122,8 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 	// Env var fallback ensures commands invoked from outside the town directory
 	// (e.g., "gt agents menu" via a cross-socket tmux binding) still connect to
 	// the correct town socket rather than silently using the wrong server.
-	if townRoot := detectTownRootFromCwd(); townRoot != "" {
+	townRoot := detectTownRootFromCwd()
+	if townRoot != "" {
 		if err := session.InitRegistry(townRoot); err != nil {
 			fmt.Fprintf(os.Stderr, "WARNING: failed to initialize town registry: %v\n", err)
 		}
@@ -151,10 +152,13 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 	if beadsExempt || isRoleCommand(cmd) {
 		return nil
 	}
+	if townRoot == "" {
+		return nil
+	}
 
 	// Check beads version (non-blocking - warn only)
-	if err := CheckBeadsVersion(); err != nil {
-		fmt.Fprintf(os.Stderr, "\n%s beads (bd) version issue:\n", style.Bold.Render("⚠️  WARNING:"))
+	if err := CheckBeadsVersionForTown(townRoot); err != nil {
+		fmt.Fprintf(os.Stderr, "\n%s issue tracker version issue:\n", style.Bold.Render("⚠️  WARNING:"))
 		fmt.Fprintf(os.Stderr, "   %v\n", err)
 		fmt.Fprintf(os.Stderr, "   Run %s for details.\n\n", style.Dim.Render("gt doctor"))
 	}

--- a/internal/cmd/show_unix.go
+++ b/internal/cmd/show_unix.go
@@ -15,12 +15,13 @@ import (
 // so that rig-prefixed beads (e.g., myproject-abc) are found in their rig
 // database rather than only the town-level hq database. (GH#2126)
 func execBdShow(args []string) error {
-	bdPath, err := exec.LookPath("bd")
+	invocation := currentBdShowInvocation(args)
+	cliName := invocation.ExecArgs[0]
+	bdPath, err := exec.LookPath(cliName)
 	if err != nil {
-		return fmt.Errorf("bd not found in PATH: %w", err)
+		return fmt.Errorf("%s not found in PATH: %w", cliName, err)
 	}
 
-	invocation := currentBdShowInvocation(args)
 	bdPath, err = prepareBdShowExec(bdPath, invocation)
 	if err != nil {
 		return err

--- a/internal/cmd/show_windows.go
+++ b/internal/cmd/show_windows.go
@@ -13,12 +13,12 @@ import (
 // so that rig-prefixed beads (e.g., myproject-abc) are found in their rig
 // database rather than only the town-level hq database. (GH#2126)
 func execBdShow(args []string) error {
-	bdPath, err := exec.LookPath("bd")
-	if err != nil {
-		return fmt.Errorf("bd not found in PATH: %w", err)
-	}
-
 	invocation := currentBdShowInvocation(args)
+	cliName := invocation.ExecArgs[0]
+	bdPath, err := exec.LookPath(cliName)
+	if err != nil {
+		return fmt.Errorf("%s not found in PATH: %w", cliName, err)
+	}
 
 	cmd := exec.Command(bdPath, invocation.CommandArgs...)
 	cmd.Dir = invocation.Dir

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -19,6 +19,7 @@ import (
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/crew"
 	"github.com/steveyegge/gastown/internal/daemon"
+	"github.com/steveyegge/gastown/internal/deps"
 	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/mail"
@@ -809,35 +810,37 @@ func gatherStatus() (TownStatus, error) {
 		status.Daemon = &ServiceInfo{Running: daemonRunning, PID: daemonPid}
 	}
 
-	// Dolt status
-	doltCfg := doltserver.DefaultConfig(townRoot)
-	if doltCfg.IsRemote() {
-		status.Dolt = &DoltInfo{Remote: true, Port: doltCfg.Port}
-	} else {
-		doltRunning, doltPid, _ := doltserver.IsRunning(townRoot)
-		port := doltCfg.Port
-		if doltRunning {
-			// Read the actual port from state — doltCfg.Port comes from
-			// DefaultConfig which reads GT_DOLT_PORT from the shell env,
-			// but gt status is typically run without that env var set.
-			if state, err := doltserver.LoadState(townRoot); err == nil && state.Port > 0 {
-				port = state.Port
+	if !deps.UsingMiniBeadsForTown(townRoot) {
+		// Dolt status
+		doltCfg := doltserver.DefaultConfig(townRoot)
+		if doltCfg.IsRemote() {
+			status.Dolt = &DoltInfo{Remote: true, Port: doltCfg.Port}
+		} else {
+			doltRunning, doltPid, _ := doltserver.IsRunning(townRoot)
+			port := doltCfg.Port
+			if doltRunning {
+				// Read the actual port from state — doltCfg.Port comes from
+				// DefaultConfig which reads GT_DOLT_PORT from the shell env,
+				// but gt status is typically run without that env var set.
+				if state, err := doltserver.LoadState(townRoot); err == nil && state.Port > 0 {
+					port = state.Port
+				}
 			}
-		}
-		doltInfo := &DoltInfo{
-			Running: doltRunning,
-			PID:     doltPid,
-			Port:    port,
-			DataDir: doltCfg.DataDir,
-		}
-		// Check if port is held by another town's Dolt
-		if !doltRunning {
-			if conflictPid, conflictDir := doltserver.CheckPortConflict(townRoot); conflictPid > 0 {
-				doltInfo.PortConflict = true
-				doltInfo.ConflictOwner = conflictDir
+			doltInfo := &DoltInfo{
+				Running: doltRunning,
+				PID:     doltPid,
+				Port:    port,
+				DataDir: doltCfg.DataDir,
 			}
+			// Check if port is held by another town's Dolt
+			if !doltRunning {
+				if conflictPid, conflictDir := doltserver.CheckPortConflict(townRoot); conflictPid > 0 {
+					doltInfo.PortConflict = true
+					doltInfo.ConflictOwner = conflictDir
+				}
+			}
+			status.Dolt = doltInfo
 		}
-		status.Dolt = doltInfo
 	}
 
 	// Tmux status

--- a/internal/cmd/synthesis.go
+++ b/internal/cmd/synthesis.go
@@ -324,7 +324,7 @@ func runSynthesisClose(cmd *cobra.Command, args []string) error {
 
 	// Read convoy to validate lifecycle state before closing
 	showArgs := []string{"show", convoyID, "--json"}
-	showCmd := exec.Command("bd", showArgs...)
+	showCmd := issueTrackerCommand(showArgs...)
 	showCmd.Dir = townBeads
 	var showOut bytes.Buffer
 	showCmd.Stdout = &showOut
@@ -354,7 +354,7 @@ func runSynthesisClose(cmd *cobra.Command, args []string) error {
 	if sessionID := runtime.SessionIDFromEnv(); sessionID != "" {
 		closeArgs = append(closeArgs, "--session="+sessionID)
 	}
-	closeCmd := exec.Command("bd", closeArgs...)
+	closeCmd := issueTrackerCommand(closeArgs...)
 	closeCmd.Dir = townBeads
 	closeCmd.Stderr = os.Stderr
 
@@ -377,7 +377,7 @@ func getConvoyMeta(convoyID string) (*ConvoyMeta, error) {
 		return nil, err
 	}
 
-	showCmd := exec.Command("bd", "show", convoyID, "--json")
+	showCmd := issueTrackerCommand("show", convoyID, "--json")
 	showCmd.Dir = townBeads
 	var stdout bytes.Buffer
 	showCmd.Stdout = &stdout
@@ -601,7 +601,7 @@ func createSynthesisBead(convoyID string, meta *ConvoyMeta, f *formula.Formula,
 		return "", err
 	}
 
-	createCmd := exec.Command("bd", createArgs...)
+	createCmd := issueTrackerCommand(createArgs...)
 	createCmd.Dir = townBeads
 	var stdout bytes.Buffer
 	createCmd.Stdout = &stdout

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -59,10 +59,11 @@ func TestTownConfigRoundTrip(t *testing.T) {
 	path := filepath.Join(dir, "mayor", "town.json")
 
 	original := &TownConfig{
-		Type:      "town",
-		Version:   1,
-		Name:      "test-town",
-		CreatedAt: time.Now().Truncate(time.Second),
+		Type:                "town",
+		Version:             1,
+		Name:                "test-town",
+		IssueTrackerBackend: "minibeads",
+		CreatedAt:           time.Now().Truncate(time.Second),
 	}
 
 	if err := SaveTownConfig(path, original); err != nil {
@@ -79,6 +80,9 @@ func TestTownConfigRoundTrip(t *testing.T) {
 	}
 	if loaded.Type != original.Type {
 		t.Errorf("Type = %q, want %q", loaded.Type, original.Type)
+	}
+	if loaded.IssueTrackerBackend != original.IssueTrackerBackend {
+		t.Errorf("IssueTrackerBackend = %q, want %q", loaded.IssueTrackerBackend, original.IssueTrackerBackend)
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -15,12 +15,13 @@ import (
 
 // TownConfig represents the main town identity (mayor/town.json).
 type TownConfig struct {
-	Type       string    `json:"type"`                  // "town"
-	Version    int       `json:"version"`               // schema version
-	Name       string    `json:"name"`                  // town identifier (internal)
-	Owner      string    `json:"owner,omitempty"`       // owner email (entity identity)
-	PublicName string    `json:"public_name,omitempty"` // public display name
-	CreatedAt  time.Time `json:"created_at"`
+	Type                string    `json:"type"`                            // "town"
+	Version             int       `json:"version"`                         // schema version
+	Name                string    `json:"name"`                            // town identifier (internal)
+	Owner               string    `json:"owner,omitempty"`                 // owner email (entity identity)
+	PublicName          string    `json:"public_name,omitempty"`           // public display name
+	IssueTrackerBackend string    `json:"issue_tracker_backend,omitempty"` // "beads" or "minibeads"
+	CreatedAt           time.Time `json:"created_at"`
 }
 
 // MayorConfig represents town-level behavioral configuration (mayor/config.json).

--- a/internal/deps/beads.go
+++ b/internal/deps/beads.go
@@ -3,6 +3,7 @@ package deps
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -21,6 +22,20 @@ const MinBeadsVersion = "0.57.0"
 // BeadsInstallPath is the go install path for beads.
 const BeadsInstallPath = "github.com/steveyegge/beads/cmd/bd@latest"
 
+// IssueTrackerBackend identifies the issue-store implementation used by Gas Town.
+type IssueTrackerBackend string
+
+const (
+	IssueTrackerBackendDefault   IssueTrackerBackend = ""
+	IssueTrackerBackendUpstream  IssueTrackerBackend = "beads"
+	IssueTrackerBackendMinibeads IssueTrackerBackend = "minibeads"
+
+	// Backward-compatible aliases for callers still using Beads terminology.
+	BeadsBackendDefault   = IssueTrackerBackendDefault
+	BeadsBackendUpstream  = IssueTrackerBackendUpstream
+	BeadsBackendMinibeads = IssueTrackerBackendMinibeads
+)
+
 // BeadsStatus represents the state of the beads installation.
 type BeadsStatus int
 
@@ -31,29 +46,127 @@ const (
 	BeadsUnknown                     // bd found but couldn't parse version
 )
 
-// CheckBeads checks if bd is installed and compatible.
+// RequestedIssueTrackerBackend returns the explicitly requested Beads-compatible
+// issue tracker backend. Empty means the default upstream Beads/Dolt backend.
+func RequestedIssueTrackerBackend() IssueTrackerBackend {
+	backend, ok := requestedIssueTrackerBackendFromEnv()
+	if !ok {
+		return IssueTrackerBackendDefault
+	}
+	return backend
+}
+
+func requestedIssueTrackerBackendFromEnv() (IssueTrackerBackend, bool) {
+	value := os.Getenv("GT_ISSUE_TRACKER_BACKEND")
+	if value == "" {
+		value = os.Getenv("GT_BEADS_BACKEND")
+	}
+	if strings.TrimSpace(value) == "" {
+		return IssueTrackerBackendDefault, false
+	}
+	backend := normalizeIssueTrackerBackend(value)
+	return backend, true
+}
+
+func normalizeIssueTrackerBackend(value string) IssueTrackerBackend {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "beads", "bd", "upstream":
+		return IssueTrackerBackendDefault
+	case "mb", "minibeads":
+		return IssueTrackerBackendMinibeads
+	default:
+		return IssueTrackerBackendDefault
+	}
+}
+
+// EffectiveIssueTrackerBackend returns the backend selected by explicit env vars,
+// then by mayor/town.json when available, then by the running gt distribution
+// or issue tracker CLIs on PATH, otherwise by the default upstream Beads/Dolt
+// backend.
+func EffectiveIssueTrackerBackend(townRoot string) IssueTrackerBackend {
+	if backend, ok := requestedIssueTrackerBackendFromEnv(); ok {
+		return backend
+	}
+	if backend, ok := issueTrackerBackendFromTown(townRoot); ok {
+		return backend
+	}
+	if backend, ok := installedIssueTrackerBackend(); ok {
+		return backend
+	}
+	return IssueTrackerBackendDefault
+}
+
+// IssueTrackerBackendForCommand returns the backend to use when dispatching an
+// issue-tracker subprocess. It intentionally does not probe bd/mb versions,
+// because command construction must not perform extra issue-tracker calls.
+func IssueTrackerBackendForCommand(townRoot string) IssueTrackerBackend {
+	if backend, ok := requestedIssueTrackerBackendFromEnv(); ok {
+		return backend
+	}
+	if backend, ok := issueTrackerBackendFromTown(townRoot); ok {
+		return backend
+	}
+	if runningFromMiniBeadsEdition() {
+		return IssueTrackerBackendMinibeads
+	}
+	return IssueTrackerBackendDefault
+}
+
+// RequestedBeadsBackend is kept for compatibility with older internal callers.
+func RequestedBeadsBackend() IssueTrackerBackend {
+	return RequestedIssueTrackerBackend()
+}
+
+// UsingMiniBeads reports whether Gas Town should use minibeads for local
+// compatibility paths.
+func UsingMiniBeads() bool {
+	return RequestedIssueTrackerBackend() == IssueTrackerBackendMinibeads
+}
+
+// UsingMiniBeadsForTown reports whether the effective backend for a town is
+// minibeads, honoring env overrides first and persisted town config second.
+func UsingMiniBeadsForTown(townRoot string) bool {
+	return EffectiveIssueTrackerBackend(townRoot) == IssueTrackerBackendMinibeads
+}
+
+// CheckBeads checks if the env-requested issue tracker is installed and compatible.
 // Returns status and the installed version (if found).
 func CheckBeads() (BeadsStatus, string) {
-	// Check if bd exists in PATH
-	path, err := exec.LookPath("bd")
+	return CheckBeadsForBackend(RequestedIssueTrackerBackend())
+}
+
+// IssueTrackerCommandName returns the executable name for an issue tracker
+// backend. Upstream Beads is exposed as bd; minibeads is exposed as mb.
+func IssueTrackerCommandName(backend IssueTrackerBackend) string {
+	if backend == IssueTrackerBackendMinibeads {
+		return "mb"
+	}
+	return "bd"
+}
+
+// CheckBeadsForBackend checks if the configured issue tracker CLI is installed
+// and compatible with a backend.
+func CheckBeadsForBackend(backend IssueTrackerBackend) (BeadsStatus, string) {
+	cliName := IssueTrackerCommandName(backend)
+	path, err := exec.LookPath(cliName)
 	if err != nil {
 		return BeadsNotFound, ""
 	}
-	_ = path // bd found
 
-	// Get version (with timeout to prevent hanging on broken bd installs).
-	// 10s is generous but necessary: under heavy CI load (parallel test
-	// packages), even a trivial shell script can take >3s to start.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "bd", "version")
-	util.SetDetachedProcessGroup(cmd)
-	output, err := cmd.Output()
-	if err != nil {
+	outputStr, ok := issueTrackerVersionOutput(path)
+	if !ok {
 		return BeadsUnknown, ""
 	}
 
-	version := parseBeadsVersion(string(output))
+	if backend == IssueTrackerBackendMinibeads {
+		version := parseMiniBeadsVersion(outputStr)
+		if version == "" {
+			return BeadsUnknown, ""
+		}
+		return BeadsOK, "minibeads " + version
+	}
+
+	version := parseBeadsVersion(outputStr)
 	if version == "" {
 		return BeadsUnknown, ""
 	}
@@ -66,17 +179,20 @@ func CheckBeads() (BeadsStatus, string) {
 	return BeadsOK, version
 }
 
-// EnsureBeads checks for bd and installs it if missing or outdated.
-// Returns nil if bd is available and compatible.
-// If autoInstall is true, will attempt to install bd when missing.
-func EnsureBeads(autoInstall bool) error {
-	status, version := CheckBeads()
+// EnsureBeadsForBackend checks for the selected issue tracker CLI and installs
+// upstream beads only for the default upstream backend. Minibeads must already
+// be available as mb.
+func EnsureBeadsForBackend(backend IssueTrackerBackend, autoInstall bool) error {
+	status, version := CheckBeadsForBackend(backend)
 
 	switch status {
 	case BeadsOK:
 		return nil
 
 	case BeadsNotFound:
+		if backend == IssueTrackerBackendMinibeads {
+			return fmt.Errorf("minibeads (mb) not found in PATH\n\nBuild minibeads and ensure the mb binary is on PATH")
+		}
 		if !autoInstall {
 			return fmt.Errorf("beads (bd) not found in PATH\n\nInstall with: go install %s", BeadsInstallPath)
 		}
@@ -87,11 +203,21 @@ func EnsureBeads(autoInstall bool) error {
 			version, MinBeadsVersion, BeadsInstallPath)
 
 	case BeadsUnknown:
+		if backend == IssueTrackerBackendMinibeads {
+			return fmt.Errorf("mb was found but its version response was not recognized; expected `mb version X.Y.Z`")
+		}
 		// Found bd but couldn't determine version - proceed with warning
 		return nil
 	}
 
 	return nil
+}
+
+// EnsureBeads checks for bd and installs it if missing or outdated.
+// Returns nil if bd is available and compatible.
+// If autoInstall is true, will attempt to install bd when missing.
+func EnsureBeads(autoInstall bool) error {
+	return EnsureBeadsForBackend(RequestedIssueTrackerBackend(), autoInstall)
 }
 
 // installBeads runs go install to install the latest beads.
@@ -149,4 +275,89 @@ func parseBeadsVersion(output string) string {
 		return matches[1]
 	}
 	return ""
+}
+
+func parseMiniBeadsVersion(output string) string {
+	re := regexp.MustCompile(`mb version (\d+\.\d+\.\d+)`)
+	matches := re.FindStringSubmatch(output)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+	return ""
+}
+
+func installedIssueTrackerBackend() (IssueTrackerBackend, bool) {
+	if runningFromMiniBeadsEdition() {
+		return IssueTrackerBackendMinibeads, true
+	}
+
+	if path, ok := lookPathIssueTracker("bd"); ok {
+		if versionOutput, ok := issueTrackerVersionOutput(path); ok && parseBeadsVersion(versionOutput) != "" {
+			return IssueTrackerBackendDefault, true
+		}
+	}
+
+	return IssueTrackerBackendDefault, false
+}
+
+func runningFromMiniBeadsEdition() bool {
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	siblingMB := filepath.Join(filepath.Dir(exe), "mb")
+	if runtimePathExecutable(siblingMB) {
+		if versionOutput, ok := issueTrackerVersionOutput(siblingMB); ok && parseMiniBeadsVersion(versionOutput) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func lookPathIssueTracker(name string) (string, bool) {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return "", false
+	}
+	return path, true
+}
+
+func issueTrackerVersionOutput(path string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path, "version")
+	util.SetDetachedProcessGroup(cmd)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	return string(output), true
+}
+
+func runtimePathExecutable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode()&0111 != 0
+}
+
+func issueTrackerBackendFromTown(townRoot string) (IssueTrackerBackend, bool) {
+	if townRoot == "" {
+		return IssueTrackerBackendDefault, false
+	}
+	data, err := os.ReadFile(filepath.Join(townRoot, "mayor", "town.json"))
+	if err != nil {
+		return IssueTrackerBackendDefault, false
+	}
+	var town struct {
+		IssueTrackerBackend string `json:"issue_tracker_backend"`
+	}
+	if err := json.Unmarshal(data, &town); err != nil {
+		return IssueTrackerBackendDefault, false
+	}
+	if strings.TrimSpace(town.IssueTrackerBackend) == "" {
+		return IssueTrackerBackendDefault, false
+	}
+	return normalizeIssueTrackerBackend(town.IssueTrackerBackend), true
 }

--- a/internal/deps/beads_test.go
+++ b/internal/deps/beads_test.go
@@ -1,6 +1,11 @@
 package deps
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
 
 func TestParseBeadsVersion(t *testing.T) {
 	tests := []struct {
@@ -20,6 +25,169 @@ func TestParseBeadsVersion(t *testing.T) {
 		if result != tt.expected {
 			t.Errorf("parseBeadsVersion(%q) = %q, want %q", tt.input, result, tt.expected)
 		}
+	}
+}
+
+func TestParseMiniBeadsVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"mb version 0.21.3", "0.21.3"},
+		{"bd version 0.21.3 (minibeads shim)", ""},
+		{"bd version 1.0.5", ""},
+		{"some other output", ""},
+	}
+
+	for _, tt := range tests {
+		result := parseMiniBeadsVersion(tt.input)
+		if result != tt.expected {
+			t.Errorf("parseMiniBeadsVersion(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestRequestedIssueTrackerBackend(t *testing.T) {
+	tests := []struct {
+		env      string
+		expected IssueTrackerBackend
+	}{
+		{"", IssueTrackerBackendDefault},
+		{"beads", IssueTrackerBackendDefault},
+		{"bd", IssueTrackerBackendDefault},
+		{"upstream", IssueTrackerBackendDefault},
+		{"mb", IssueTrackerBackendMinibeads},
+		{"minibeads", IssueTrackerBackendMinibeads},
+		{"MINIBEADS", IssueTrackerBackendMinibeads},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.env, func(t *testing.T) {
+			t.Setenv("GT_BEADS_BACKEND", tt.env)
+			t.Setenv("GT_ISSUE_TRACKER_BACKEND", "")
+			if got := RequestedIssueTrackerBackend(); got != tt.expected {
+				t.Fatalf("RequestedIssueTrackerBackend() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRequestedIssueTrackerBackend_GenericEnvTakesPrecedence(t *testing.T) {
+	t.Setenv("GT_BEADS_BACKEND", "minibeads")
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "beads")
+
+	if got := RequestedIssueTrackerBackend(); got != IssueTrackerBackendDefault {
+		t.Fatalf("RequestedIssueTrackerBackend() = %q, want default beads backend", got)
+	}
+}
+
+func TestEffectiveIssueTrackerBackend_ReadsTownConfig(t *testing.T) {
+	t.Setenv("GT_BEADS_BACKEND", "")
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "")
+
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{
+  "type": "town",
+  "version": 1,
+  "name": "test-town",
+  "issue_tracker_backend": "minibeads",
+  "created_at": "2026-07-01T00:00:00Z"
+}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := EffectiveIssueTrackerBackend(townRoot); got != IssueTrackerBackendMinibeads {
+		t.Fatalf("EffectiveIssueTrackerBackend() = %q, want minibeads", got)
+	}
+}
+
+func TestEffectiveIssueTrackerBackend_EnvOverridesTownConfig(t *testing.T) {
+	t.Setenv("GT_BEADS_BACKEND", "")
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "beads")
+
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{
+  "type": "town",
+  "version": 1,
+  "name": "test-town",
+  "issue_tracker_backend": "minibeads",
+  "created_at": "2026-07-01T00:00:00Z"
+}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := EffectiveIssueTrackerBackend(townRoot); got != IssueTrackerBackendDefault {
+		t.Fatalf("EffectiveIssueTrackerBackend() = %q, want default beads backend", got)
+	}
+}
+
+func TestEffectiveIssueTrackerBackend_DoesNotInferMiniBeadsFromPathOnly(t *testing.T) {
+	fakeDir := t.TempDir()
+	writeFakeIssueTrackerVersion(t, fakeDir, "mb", "mb version 0.21.4")
+	t.Setenv("PATH", fakeDir)
+	t.Setenv("GT_BEADS_BACKEND", "")
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "")
+
+	if got := EffectiveIssueTrackerBackend(t.TempDir()); got != IssueTrackerBackendDefault {
+		t.Fatalf("EffectiveIssueTrackerBackend() = %q, want default beads backend", got)
+	}
+}
+
+func TestEffectiveIssueTrackerBackend_DetectsUpstreamBeadsFromPath(t *testing.T) {
+	fakeDir := t.TempDir()
+	writeFakeIssueTrackerVersion(t, fakeDir, "bd", "bd version "+MinBeadsVersion)
+	t.Setenv("PATH", fakeDir)
+	t.Setenv("GT_BEADS_BACKEND", "")
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "")
+
+	if got := EffectiveIssueTrackerBackend(t.TempDir()); got != IssueTrackerBackendDefault {
+		t.Fatalf("EffectiveIssueTrackerBackend() = %q, want default beads backend", got)
+	}
+}
+
+func TestCheckBeadsForBackend_MiniBeadsUsesMB(t *testing.T) {
+	fakeDir := t.TempDir()
+	writeFakeIssueTrackerVersion(t, fakeDir, "mb", "mb version 0.21.4")
+	t.Setenv("PATH", fakeDir)
+
+	status, version := CheckBeadsForBackend(IssueTrackerBackendMinibeads)
+	if status != BeadsOK {
+		t.Fatalf("CheckBeadsForBackend(minibeads) status = %v, want BeadsOK", status)
+	}
+	if version != "minibeads 0.21.4" {
+		t.Fatalf("CheckBeadsForBackend(minibeads) version = %q", version)
+	}
+}
+
+func TestCheckBeadsForBackend_MiniBeadsDoesNotUseBD(t *testing.T) {
+	fakeDir := t.TempDir()
+	writeFakeIssueTrackerVersion(t, fakeDir, "bd", "bd version "+MinBeadsVersion)
+	t.Setenv("PATH", fakeDir)
+
+	status, _ := CheckBeadsForBackend(IssueTrackerBackendMinibeads)
+	if status != BeadsNotFound {
+		t.Fatalf("CheckBeadsForBackend(minibeads) status = %v, want BeadsNotFound without mb", status)
+	}
+}
+
+func writeFakeIssueTrackerVersion(t *testing.T, dir, name, output string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, name+".bat")
+		if err := os.WriteFile(path, []byte("@echo off\r\necho "+output+"\r\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho '"+output+"'\n"), 0755); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/doctor/beads_binary_check.go
+++ b/internal/doctor/beads_binary_check.go
@@ -6,9 +6,9 @@ import (
 	"github.com/steveyegge/gastown/internal/deps"
 )
 
-// BeadsBinaryCheck verifies that the beads (bd) binary is installed and meets
-// the minimum version requirement. This is an informational check with no
-// auto-fix — the user must install or upgrade bd manually.
+// BeadsBinaryCheck verifies that the selected issue tracker binary is installed
+// and meets the minimum version requirement. This is an informational check
+// with no auto-fix — the user must install or upgrade the CLI manually.
 type BeadsBinaryCheck struct {
 	BaseCheck
 }
@@ -18,28 +18,42 @@ func NewBeadsBinaryCheck() *BeadsBinaryCheck {
 	return &BeadsBinaryCheck{
 		BaseCheck: BaseCheck{
 			CheckName:        "beads-binary",
-			CheckDescription: "Check that beads (bd) is installed and meets minimum version",
+			CheckDescription: "Check that the issue tracker CLI is installed and meets minimum version",
 			CheckCategory:    CategoryInfrastructure,
 		},
 	}
 }
 
-// Run checks if bd is available in PATH and reports its version status.
+// Run checks if the selected issue tracker CLI is available in PATH and reports
+// its version status.
 func (c *BeadsBinaryCheck) Run(ctx *CheckContext) *CheckResult {
-	status, version := deps.CheckBeads()
+	backend := deps.EffectiveIssueTrackerBackend(ctx.TownRoot)
+	cliName := deps.IssueTrackerCommandName(backend)
+	status, version := deps.CheckBeadsForBackend(backend)
 
 	switch status {
 	case deps.BeadsOK:
 		return &CheckResult{
 			Name:    c.Name(),
 			Status:  StatusOK,
-			Message: fmt.Sprintf("bd %s", version),
+			Message: fmt.Sprintf("%s %s", cliName, version),
 		}
 
 	case deps.BeadsNotFound:
+		if backend == deps.IssueTrackerBackendMinibeads {
+			return &CheckResult{
+				Name:    c.Name(),
+				Status:  StatusError,
+				Message: "minibeads (mb) not found in PATH",
+				Details: []string{
+					"The mb CLI is required for minibeads operations",
+				},
+				FixHint: "Build minibeads and ensure mb is on PATH",
+			}
+		}
 		return &CheckResult{
-			Name:   c.Name(),
-			Status: StatusError,
+			Name:    c.Name(),
+			Status:  StatusError,
 			Message: "beads (bd) not found in PATH",
 			Details: []string{
 				"The bd CLI is required for beads operations",
@@ -49,8 +63,8 @@ func (c *BeadsBinaryCheck) Run(ctx *CheckContext) *CheckResult {
 
 	case deps.BeadsTooOld:
 		return &CheckResult{
-			Name:   c.Name(),
-			Status: StatusError,
+			Name:    c.Name(),
+			Status:  StatusError,
 			Message: fmt.Sprintf("bd %s is too old (minimum: %s)", version, deps.MinBeadsVersion),
 			Details: []string{
 				fmt.Sprintf("Installed version %s does not meet the minimum requirement of %s", version, deps.MinBeadsVersion),
@@ -59,6 +73,14 @@ func (c *BeadsBinaryCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 
 	case deps.BeadsUnknown:
+		if backend == deps.IssueTrackerBackendMinibeads {
+			return &CheckResult{
+				Name:    c.Name(),
+				Status:  StatusWarning,
+				Message: "mb found but version could not be determined",
+				FixHint: "Check that mb version prints: mb version X.Y.Z",
+			}
+		}
 		return &CheckResult{
 			Name:    c.Name(),
 			Status:  StatusWarning,
@@ -70,6 +92,6 @@ func (c *BeadsBinaryCheck) Run(ctx *CheckContext) *CheckResult {
 	return &CheckResult{
 		Name:    c.Name(),
 		Status:  StatusOK,
-		Message: "bd available",
+		Message: fmt.Sprintf("%s available", cliName),
 	}
 }

--- a/internal/doctor/beads_binary_check_test.go
+++ b/internal/doctor/beads_binary_check_test.go
@@ -18,7 +18,7 @@ func TestBeadsBinaryCheck_Metadata(t *testing.T) {
 	if check.Name() != "beads-binary" {
 		t.Errorf("Name() = %q, want %q", check.Name(), "beads-binary")
 	}
-	if check.Description() != "Check that beads (bd) is installed and meets minimum version" {
+	if check.Description() != "Check that the issue tracker CLI is installed and meets minimum version" {
 		t.Errorf("Description() = %q", check.Description())
 	}
 	if check.Category() != CategoryInfrastructure {
@@ -33,6 +33,11 @@ func TestBeadsBinaryCheck_BdInstalled(t *testing.T) {
 	// Skip if bd is not actually installed in the test environment
 	if _, err := exec.LookPath("bd"); err != nil {
 		t.Skip("bd not installed, skipping installed-path test")
+	}
+	if output, err := exec.Command("bd", "version").Output(); err == nil {
+		if !strings.Contains(string(output), "bd version") {
+			t.Skipf("installed bd is not upstream beads, skipping installed-path test: %s", strings.TrimSpace(string(output)))
+		}
 	}
 
 	check := NewBeadsBinaryCheck()
@@ -57,14 +62,18 @@ func TestBeadsBinaryCheck_BdInstalled(t *testing.T) {
 
 // writeFakeBd creates a platform-appropriate fake "bd" executable in dir.
 func writeFakeBd(t *testing.T, dir string, script string, batScript string) {
+	writeFakeTool(t, dir, "bd", script, batScript)
+}
+
+func writeFakeTool(t *testing.T, dir string, name string, script string, batScript string) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
-		path := filepath.Join(dir, "bd.bat")
+		path := filepath.Join(dir, name+".bat")
 		if err := os.WriteFile(path, []byte(batScript), 0755); err != nil {
 			t.Fatal(err)
 		}
 	} else {
-		path := filepath.Join(dir, "bd")
+		path := filepath.Join(dir, name)
 		if err := os.WriteFile(path, []byte(script), 0755); err != nil {
 			t.Fatal(err)
 		}
@@ -164,5 +173,49 @@ func TestBeadsBinaryCheck_BdVersionUnparseable(t *testing.T) {
 	result := check.Run(ctx)
 	if result.Status != StatusWarning {
 		t.Errorf("expected StatusWarning when bd version unparseable, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestBeadsBinaryCheck_MiniBeadsUsesMB(t *testing.T) {
+	fakeDir := t.TempDir()
+	writeFakeTool(t, fakeDir, "mb",
+		"#!/bin/sh\necho 'mb version 0.21.4'\n",
+		"@echo off\r\necho mb version 0.21.4\r\n",
+	)
+	t.Setenv("PATH", fakeDir)
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "minibeads")
+	t.Setenv("GT_BEADS_BACKEND", "")
+
+	check := NewBeadsBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Fatalf("expected StatusOK, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "mb minibeads 0.21.4") {
+		t.Errorf("expected mb version message, got %q", result.Message)
+	}
+}
+
+func TestBeadsBinaryCheck_MiniBeadsDoesNotUseBD(t *testing.T) {
+	fakeDir := t.TempDir()
+	writeFakeBd(t, fakeDir,
+		fmt.Sprintf("#!/bin/sh\necho 'bd version %s'\n", deps.MinBeadsVersion),
+		fmt.Sprintf("@echo off\r\necho bd version %s\r\n", deps.MinBeadsVersion),
+	)
+	t.Setenv("PATH", fakeDir)
+	t.Setenv("GT_ISSUE_TRACKER_BACKEND", "minibeads")
+	t.Setenv("GT_BEADS_BACKEND", "")
+
+	check := NewBeadsBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	if result.Status != StatusError {
+		t.Fatalf("expected StatusError without mb, got %v: %s", result.Status, result.Message)
+	}
+	if result.Message != "minibeads (mb) not found in PATH" {
+		t.Errorf("unexpected message: %q", result.Message)
 	}
 }


### PR DESCRIPTION
## Summary

- add an issue-tracker backend abstraction for install-time storage setup
- support minibeads as a repo-local issue tracker backend without Dolt
- use mb directly for minibeads-backed towns instead of requiring a bd alias
- persist the selected backend in mayor/town.json and infer the minibeads edition from a sibling mb binary next to gt
- route internal cmd/beads issue-tracker subprocesses through backend-aware helpers
- skip Dolt-specific status/doctor/mayor attach checks for minibeads-backed towns

## Validation

- go test ./internal/deps ./internal/beads ./internal/cmd ./internal/doctor
- fresh minibeads-edition smoke with ~/gt_mb_bin first on PATH and no bd available:
  - gt install <town> --git succeeds
  - mayor/town.json records issue_tracker_backend: minibeads
  - gt config agent list succeeds
  - gt status --json omits Dolt
  - gt doctor --no-start reports zero failures
  - gt mayor attach outside a town reports only the workspace error, with no tracker warning

## Notes

This PR is intentionally scoped to Gastown. Minibeads compatibility improvements live separately in rrnewton/minibeads branch integration commit 842fdf7.