### PR TITLE
fix: use supported bd delete flags

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -1885,6 +1885,11 @@ func (b *Beads) Update(id string, opts UpdateOptions) error {
 	return err
 }
 
+func (b *Beads) deleteBead(id string) error {
+	_, err := b.run("delete", id, "--force")
+	return err
+}
+
 // Close closes one or more issues.
 // If a runtime session ID is set in the environment, it is passed to bd close
 // for work attribution tracking (see decision 009-session-events-architecture.md).

--- a/internal/beads/beads_channel.go
+++ b/internal/beads/beads_channel.go
@@ -322,8 +322,7 @@ func (b *Beads) UpdateChannelStatus(name, status string) error {
 // DeleteChannelBead permanently deletes a channel bead.
 func (b *Beads) DeleteChannelBead(name string) error {
 	id := ChannelBeadID(name)
-	_, err := b.run("delete", id, "--hard", "--force")
-	return err
+	return b.deleteBead(id)
 }
 
 // ListChannelBeads returns all channel beads.

--- a/internal/beads/beads_group.go
+++ b/internal/beads/beads_group.go
@@ -313,8 +313,7 @@ func (b *Beads) RemoveGroupMember(name string, member string) (*Issue, error) {
 // DeleteGroupBead permanently deletes a group bead.
 func (b *Beads) DeleteGroupBead(name string) error {
 	id := GroupBeadID(name)
-	_, err := b.run("delete", id, "--hard", "--force")
-	return err
+	return b.deleteBead(id)
 }
 
 // ListGroupBeads returns all group beads.

--- a/internal/beads/beads_queue.go
+++ b/internal/beads/beads_queue.go
@@ -291,10 +291,8 @@ func (b *Beads) ListQueueBeads() (map[string]*Issue, error) {
 }
 
 // DeleteQueueBead permanently deletes a queue bead.
-// Uses --hard --force for immediate permanent deletion (no tombstone).
 func (b *Beads) DeleteQueueBead(id string) error {
-	_, err := b.run("delete", id, "--hard", "--force")
-	return err
+	return b.deleteBead(id)
 }
 
 // LookupQueueByName finds a queue by its name field (not by ID).

--- a/internal/beads/beads_rig.go
+++ b/internal/beads/beads_rig.go
@@ -244,8 +244,7 @@ func (b *Beads) UpdateRigBead(name string, fields *RigFields) (*Issue, error) {
 // DeleteRigBead permanently deletes a rig bead.
 func (b *Beads) DeleteRigBead(name string) error {
 	id := RigBeadID(name)
-	_, err := b.run("delete", id, "--hard", "--force")
-	return err
+	return b.deleteBead(id)
 }
 
 // ListRigBeads returns all rig beads.

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -451,6 +451,59 @@ func TestBuildMutationBDEnvForcesWritableCommit(t *testing.T) {
 	}
 }
 
+func TestDeleteBeadsUseSupportedBdDeleteFlags(t *testing.T) {
+	ResetBdAllowStaleCacheForTest()
+	t.Cleanup(ResetBdAllowStaleCacheForTest)
+
+	logPath := installMockBDRecorder(t)
+	b := NewIsolated(t.TempDir())
+
+	cases := []struct {
+		name   string
+		delete func() error
+		want   string
+	}{
+		{
+			name:   "group",
+			delete: func() error { return b.DeleteGroupBead("ops-team") },
+			want:   "delete hq-group-ops-team --force",
+		},
+		{
+			name:   "channel",
+			delete: func() error { return b.DeleteChannelBead("alerts") },
+			want:   "delete hq-channel-alerts --force",
+		},
+		{
+			name:   "queue",
+			delete: func() error { return b.DeleteQueueBead("hq-q-work") },
+			want:   "delete hq-q-work --force",
+		},
+		{
+			name:   "rig",
+			delete: func() error { return b.DeleteRigBead("gastown") },
+			want:   "delete gt-rig-gastown --force",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.delete(); err != nil {
+				t.Fatalf("delete error = %v", err)
+			}
+		})
+	}
+
+	logOutput := readMockBDLog(t, logPath)
+	if strings.Contains(logOutput, "--hard") {
+		t.Fatalf("delete call used unsupported --hard flag:\n%s", logOutput)
+	}
+	for _, tc := range cases {
+		if !strings.Contains(logOutput, tc.want) {
+			t.Fatalf("bd log missing %q\nlog:\n%s", tc.want, logOutput)
+		}
+	}
+}
+
 func TestArgsAreReadOnlyClassifiesKnownReadCommands(t *testing.T) {
 	cases := [][]string{
 		{"--version"},


### PR DESCRIPTION
Fixes #4335.

## Summary
- Replace unsupported `bd delete --hard --force` wrapper calls with a single supported `bd delete <id> --force` helper.
- Route group/channel/queue/rig bead deletes through that helper.
- Add a regression test covering all four delete paths and rejecting `--hard`.

## Verification
- `CGO_ENABLED=0 go test ./internal/beads -run TestDeleteBeadsUseSupportedBdDeleteFlags`
- `CGO_ENABLED=0 go test ./internal/beads`
- `CGO_ENABLED=0 go test ./...` reaches unrelated existing/environment failures in `internal/doltserver` (`TestCleanStaleSocket_RemovesStaleFile`) and `internal/tmux` (`sleep` reported as `coreutils`); `internal/beads` passes.

Normal CGO test invocation is blocked in this environment by missing ICU development headers (`unicode/uregex.h`) from `github.com/dolthub/go-icu-regex`.

## Workflow Evidence
- 15 independent research legs completed and converged on the same minimal fix.
- 5 pre-implementation reviews approved the patch plan.
- 5 post-implementation reviews approved the final head; the only operational block was publishing this branch/PR, now addressed.
- Old local MQ `gt-wisp-qvk` appears already superseded/rejected (`gt mq list gastown --verify` empty; polecat bead active MR cleared).
