### PR TITLE
Fix polecat reconciliation killing active sessions

### DIFF
--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1878,8 +1878,8 @@ func (m *Manager) killExistingPolecatSession(name, action string) error {
 // This implements ZFC: InUse is discovered from filesystem and tmux, not tracked separately.
 // Called before each allocation to ensure InUse reflects reality.
 //
-// In addition to directory checks, this also:
-// - Kills orphaned tmux sessions (sessions without directories are broken)
+// In addition to directory checks, this also kills orphaned tmux sessions
+// (sessions without directories are broken).
 func (m *Manager) ReconcilePool() {
 	fl, err := m.lockPool()
 	if err != nil {
@@ -1952,9 +1952,9 @@ func (m *Manager) ReconcilePoolWith(namesWithDirs, namesWithSessions []string) {
 		dirSet[name] = true
 	}
 
-	// Kill orphaned or stale sessions.
+	// Kill orphaned sessions only. Directory-backed sessions are lifecycle-owned by
+	// their polecat/witness paths; allocation must never reap unrelated workers.
 	// - No directory: orphan session, always kill (worktree was removed but tmux lingered)
-	// - Has directory but dead process: stale session from crashed startup (gt-jn40ft)
 	// Use KillSessionWithProcesses to ensure all descendant processes are killed.
 	if m.tmux != nil {
 		townRoot := filepath.Dir(m.rig.Path)
@@ -1962,10 +1962,6 @@ func (m *Manager) ReconcilePoolWith(namesWithDirs, namesWithSessions []string) {
 			sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
 			if !dirSet[name] {
 				// Orphan: session exists but no directory
-				_ = m.tmux.KillSessionWithProcesses(sessionName)
-				RemoveSessionHeartbeat(townRoot, sessionName)
-			} else if isSessionProcessDead(m.tmux, sessionName, townRoot) {
-				// Stale: directory exists but session's process has died
 				_ = m.tmux.KillSessionWithProcesses(sessionName)
 				RemoveSessionHeartbeat(townRoot, sessionName)
 			}

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1,6 +1,7 @@
 package polecat
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -803,6 +804,92 @@ func TestReconcilePoolWith(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcilePoolWith_KeepsDirBackedStaleSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tmux not supported on Windows")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "myrig")
+	tm := tmux.NewTmuxWithSocket(fmt.Sprintf("gt-test-reconcile-%d", time.Now().UnixNano()))
+	t.Cleanup(func() { _ = tm.KillServer() })
+
+	m := NewManager(&rig.Rig{Name: "myrig", Path: rigPath}, nil, tm)
+	activeName := "toast"
+	orphanName := "nux"
+	activeSession := session.PolecatSessionName(session.PrefixFor("myrig"), activeName)
+	orphanSession := session.PolecatSessionName(session.PrefixFor("myrig"), orphanName)
+
+	for _, sessionName := range []string{activeSession, orphanSession} {
+		if err := tm.NewSessionWithCommand(sessionName, townRoot, "sleep 300"); err != nil {
+			t.Fatalf("create tmux session %s: %v", sessionName, err)
+		}
+	}
+
+	writeStaleHeartbeat := func(sessionName string) {
+		t.Helper()
+		if err := os.MkdirAll(heartbeatsDir(townRoot), 0755); err != nil {
+			t.Fatalf("mkdir heartbeats: %v", err)
+		}
+		data, err := json.Marshal(SessionHeartbeat{
+			Timestamp: time.Now().Add(-SessionHeartbeatStaleThreshold - time.Minute).UTC(),
+			State:     HeartbeatWorking,
+		})
+		if err != nil {
+			t.Fatalf("marshal heartbeat: %v", err)
+		}
+		if err := os.WriteFile(heartbeatFile(townRoot, sessionName), data, 0644); err != nil {
+			t.Fatalf("write heartbeat %s: %v", sessionName, err)
+		}
+	}
+	writeStaleHeartbeat(activeSession)
+	writeStaleHeartbeat(orphanSession)
+
+	m.ReconcilePoolWith([]string{activeName}, []string{activeName, orphanName})
+
+	running, err := tm.HasSession(activeSession)
+	if err != nil {
+		t.Fatalf("check active session: %v", err)
+	}
+	if !running {
+		t.Fatalf("dir-backed stale session %s should survive reconciliation", activeSession)
+	}
+	if hb := ReadSessionHeartbeat(townRoot, activeSession); hb == nil {
+		t.Fatalf("dir-backed stale session heartbeat should survive reconciliation")
+	}
+
+	running, err = tm.HasSession(orphanSession)
+	if err != nil {
+		t.Fatalf("check orphan session: %v", err)
+	}
+	if running {
+		t.Fatalf("orphan session %s should be killed by reconciliation", orphanSession)
+	}
+	if hb := ReadSessionHeartbeat(townRoot, orphanSession); hb != nil {
+		t.Fatalf("orphan session heartbeat should be removed")
+	}
+
+	activeNames := m.namePool.ActiveNames()
+	if !containsString(activeNames, activeName) {
+		t.Fatalf("dir-backed name %q should remain in use; active names: %v", activeName, activeNames)
+	}
+	if containsString(activeNames, orphanName) {
+		t.Fatalf("orphan name %q should not remain in use; active names: %v", orphanName, activeNames)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 // TestReconcilePoolWith_Allocation verifies that allocation respects reconciled state.


### PR DESCRIPTION
## Summary
- Keep ReconcilePoolWith from killing directory-backed polecat sessions based on stale heartbeat state.
- Continue cleaning only true no-directory orphan sessions and their heartbeats.
- Add regression coverage for stale dir-backed session survival plus orphan cleanup.

Fixes #4329.

## Test Plan
- git diff --check upstream/main...HEAD
- CGO_ENABLED=0 go test ./internal/polecat -run 'TestReconcilePoolWith' -count=1
- CGO_ENABLED=0 go test ./internal/polecat -run 'Test(ReconcilePoolWith|ReuseIdlePolecat|RepairWorktreeWithOptions|IsSessionProcessDead|SessionHeartbeat)' -count=1
- CGO_ENABLED=0 go test ./internal/cmd -count=1
- CGO_ENABLED=0 go test ./internal/daemon -count=1
- CGO_ENABLED=0 go test ./internal/witness -count=1

## Known Local Blocker
- go test ./internal/polecat -run 'TestReconcilePoolWith' -count=1 fails locally because the environment lacks ICU headers: unicode/uregex.h from github.com/dolthub/go-icu-regex.

## Publication Notes
- Cleanly replayed source fix 233bff14e onto upstream/main at 8dbbf3ff with no conflict resolution or code changes beyond the completed source patch, so the 15+5+5 workflow rerun was not triggered.
- Supersedes local MQ gt-wisp-3ir and the WIP checkpoint branch; no scheduler, refinery, gt done, or MQ path used.