### PR TITLE
fix(refinery): clear agent active_mr on RejectMR and PostMerge

### DIFF
--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -481,6 +481,7 @@ func (m *Manager) issueToMR(issue *beads.Issue) *MergeRequest {
 		MergeCommit:  fields.MergeCommit,
 		Status:       MROpen,
 		CreatedAt:    parseTime(issue.CreatedAt),
+		AgentBead:    fields.AgentBead,
 	}
 }
 
@@ -587,6 +588,11 @@ func (m *Manager) RejectMR(idOrBranch string, reason string, notify bool) (*Merg
 		return nil, fmt.Errorf("failed to close MR bead: %w", err)
 	}
 
+	// Clear agent bead's active_mr reference (traceability cleanup, mm-bgf7).
+	if err := clearAgentActiveMR(b, mr.AgentBead); err != nil {
+		_, _ = fmt.Fprintf(m.output, "Warning: failed to clear agent bead %s active_mr: %v\n", mr.AgentBead, err)
+	}
+
 	// Update in-memory state for return value
 	if err := mr.Close(CloseReasonRejected); err != nil {
 		// Non-fatal: bead is already closed, just log
@@ -641,6 +647,13 @@ func (m *Manager) PostMerge(idOrBranch string) (*PostMergeResult, error) {
 		result.MRClosed = true
 	}
 
+	// Clear agent bead's active_mr reference (traceability cleanup, mm-bgf7).
+	// Runs regardless of which branch closed the MR bead, since a
+	// previously-closed MR may still have left the agent's active_mr stale.
+	if err := clearAgentActiveMR(b, mr.AgentBead); err != nil {
+		_, _ = fmt.Fprintf(m.output, "Warning: failed to clear agent bead %s active_mr: %v\n", mr.AgentBead, err)
+	}
+
 	// Close the source issue with reason and --force to bypass dependency checks.
 	// The source issue may have an attached molecule (wisp) whose open steps
 	// would block a normal bd close. ForceCloseWithReason bypasses this,
@@ -665,6 +678,17 @@ func (m *Manager) PostMerge(idOrBranch string) (*PostMergeResult, error) {
 	}
 
 	return result, nil
+}
+
+// clearAgentActiveMR clears the active_mr field on the given agent bead, if
+// set. Shared by RejectMR and PostMerge so both MR-closure paths clear the
+// owning polecat's stale active_mr reference (mm-bgf7 root cause: MR-bead
+// GC/closure previously left active_mr pointing at a dead bead).
+func clearAgentActiveMR(b *beads.Beads, agentBeadID string) error {
+	if agentBeadID == "" {
+		return nil
+	}
+	return b.ForAgentBead().UpdateAgentActiveMR(agentBeadID, "")
 }
 
 // notifyWorkerRejected sends a rejection notification to a polecat.

--- a/internal/refinery/types.go
+++ b/internal/refinery/types.go
@@ -24,6 +24,12 @@ type MergeRequest struct {
 	// IssueID is the beads issue being worked on.
 	IssueID string `json:"issue_id"`
 
+	// AgentBead is the polecat agent bead that owns this MR (if any). Used to
+	// clear the agent's active_mr field when the MR bead is closed, so GC/
+	// closure doesn't leave stale bookkeeping pointing at a dead bead
+	// (mm-bgf7).
+	AgentBead string `json:"agent_bead,omitempty"`
+
 	// SwarmID is the swarm this work belongs to (if any).
 	SwarmID string `json:"swarm_id,omitempty"`
 


### PR DESCRIPTION
## Problem

Three code paths close an MR bead, but only one clears the owning polecat's `active_mr` field:

- ✅ `engineer.go HandleMRInfoSuccess` (automatic post-merge flow) — clears it
- ❌ `manager.go RejectMR` (via `gt mq reject`) — leaves it stale
- ❌ `manager.go PostMerge` (via `gt mq post-merge`) — leaves it stale

A stale `active_mr` pointing at a closed/GC'd MR bead wedges the polecat into `NEEDS_RECOVERY`/`PENDING_MR` limbo. In our town this cascaded: all polecats accumulate stale state → scheduler classifies them `recovery_blocked` → daemon heartbeat enters recovery-focused mode → refuses to spawn fresh polecats while never recovering the wedged ones → dispatch deadlock. The only workaround was `gt polecat nuke --force` + daemon restart, discarding warm sessions.

Root cause: `MergeRequest` had no `AgentBead` field — `issueToMR` parses `beads.MRFields` (which carries `AgentBead`) but dropped it, so `RejectMR`/`PostMerge` had no way to clear the field even though the data was on the bead.

## Fix (30 lines)

1. Add `AgentBead string` to `MergeRequest` (types.go).
2. Populate it in `issueToMR` from `fields.AgentBead`.
3. Add shared `clearAgentActiveMR` helper; call it non-fatally (warn on error, matching the engineer.go pattern) from `RejectMR` after `CloseWithReason` and from `PostMerge` after the MR-close branch — including the already-closed branch, which can also carry stale `active_mr`.

## Testing

- `go vet` clean; `internal/refinery` tests: 179 passed, 1 pre-existing failure (`TestEngineerClearAgentActiveMRUsesTownBeadsDir`, reproduced identically on the parent commit without this change), 4 skipped.
- **Verified in a production town**: before the patch, every refinery-driven `gt mq post-merge` left the polecat with stale `active_mr` (verdict `PENDING_MR` on a merged+closed MR, requiring a nuke). With the patched binary, a full canary cycle (sling → dispatch → work → MR → refinery post-merge) left the polecat `idle-clean` with `active_mr` empty and `reusable: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)