### PR TITLE
fix: repair patrol active work lookup after #4344

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -902,12 +902,18 @@ func stripEnvPrefixes(environ []string, prefixes ...string) []string {
 // "bd list" only searches the issues table and misses wisps entirely.
 func (b *Beads) List(opts ListOptions) ([]*Issue, error) {
 	if b.store != nil {
+		if !opts.Ephemeral {
+			return b.storeListIssues(opts)
+		}
 		return b.storeList(opts)
 	}
 	if opts.Ephemeral {
 		return b.listEphemeral(opts)
 	}
+	return b.listIssues(opts)
+}
 
+func (b *Beads) listIssues(opts ListOptions) ([]*Issue, error) {
 	args := []string{"list", "--json"}
 
 	if opts.Status != "" {
@@ -961,11 +967,11 @@ func (b *Beads) List(opts ListOptions) ([]*Issue, error) {
 // ListIssues searches the durable issues table directly. Unlike bd list, this
 // cannot be confused by duplicate IDs that also exist in the wisps table.
 func (b *Beads) ListIssues(opts ListOptions) ([]*Issue, error) {
+	opts.Ephemeral = false
 	if b.store != nil {
-		opts.Ephemeral = false
-		return b.storeList(opts)
+		return b.storeListIssues(opts)
 	}
-	return b.listByEphemeral(opts, false)
+	return b.listIssues(opts)
 }
 
 // listEphemeral searches the wisps table using "bd query" with ephemeral=true.

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -958,13 +958,27 @@ func (b *Beads) List(opts ListOptions) ([]*Issue, error) {
 	return issues, nil
 }
 
+// ListIssues searches the durable issues table directly. Unlike bd list, this
+// cannot be confused by duplicate IDs that also exist in the wisps table.
+func (b *Beads) ListIssues(opts ListOptions) ([]*Issue, error) {
+	if b.store != nil {
+		opts.Ephemeral = false
+		return b.storeList(opts)
+	}
+	return b.listByEphemeral(opts, false)
+}
+
 // listEphemeral searches the wisps table using "bd query" with ephemeral=true.
 // This is necessary because "bd list" only searches the issues table and does
 // not support an --ephemeral flag. Wisps (ephemeral issues like merge-request
 // beads) live in a separate table since beads v0.59.
 func (b *Beads) listEphemeral(opts ListOptions) ([]*Issue, error) {
-	// Build query expression: ephemeral=true AND <filters>
-	clauses := []string{"ephemeral=true"}
+	return b.listByEphemeral(opts, true)
+}
+
+func (b *Beads) listByEphemeral(opts ListOptions, ephemeral bool) ([]*Issue, error) {
+	// Build query expression: ephemeral=<value> AND <filters>
+	clauses := []string{fmt.Sprintf("ephemeral=%t", ephemeral)}
 
 	if opts.Label != "" {
 		clauses = append(clauses, "label="+quoteBDQueryValue(opts.Label))
@@ -982,6 +996,9 @@ func (b *Beads) listEphemeral(opts ListOptions) ([]*Issue, error) {
 	}
 	if opts.Assignee != "" {
 		clauses = append(clauses, "assignee="+quoteBDQueryValue(opts.Assignee))
+	}
+	if opts.NoAssignee {
+		clauses = append(clauses, "assignee=\"\"")
 	}
 
 	queryExpr := strings.Join(clauses, " AND ")

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -991,7 +991,9 @@ func (b *Beads) listIssuesSQL(opts ListOptions) ([]*Issue, error) {
 		where = append(where, fmt.Sprintf("i.priority = %d", opts.Priority))
 	}
 	if opts.Parent != "" {
-		where = append(where, "i.id IN (SELECT depends_on_id FROM dependencies WHERE issue_id = "+quoteSQLString(opts.Parent)+" AND type = 'parent-child')")
+		parent := quoteSQLString(opts.Parent)
+		where = append(where, "EXISTS (SELECT 1 FROM dependencies d WHERE d.issue_id = i.id AND d.type = 'parent-child' AND "+
+			"(d.depends_on_issue_id = "+parent+" OR d.depends_on_wisp_id = "+parent+" OR d.depends_on_external = "+parent+"))")
 	}
 	if opts.Assignee != "" {
 		where = append(where, "i.assignee = "+quoteSQLString(opts.Assignee))

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -971,7 +971,95 @@ func (b *Beads) ListIssues(opts ListOptions) ([]*Issue, error) {
 	if b.store != nil {
 		return b.storeListIssues(opts)
 	}
-	return b.listIssues(opts)
+	return b.listIssuesSQL(opts)
+}
+
+func (b *Beads) listIssuesSQL(opts ListOptions) ([]*Issue, error) {
+	where := []string{"COALESCE(i.ephemeral, 0) = 0"}
+
+	if opts.Status == "" {
+		where = append(where, "i.status != 'closed'")
+	} else if opts.Status != "all" {
+		where = append(where, "i.status = "+quoteSQLString(opts.Status))
+	}
+	if opts.Label != "" {
+		where = append(where, "EXISTS (SELECT 1 FROM labels lf WHERE lf.issue_id = i.id AND lf.label = "+quoteSQLString(opts.Label)+")")
+	} else if opts.Type != "" {
+		where = append(where, "EXISTS (SELECT 1 FROM labels lf WHERE lf.issue_id = i.id AND lf.label = "+quoteSQLString("gt:"+opts.Type)+")")
+	}
+	if opts.Priority >= 0 {
+		where = append(where, fmt.Sprintf("i.priority = %d", opts.Priority))
+	}
+	if opts.Parent != "" {
+		where = append(where, "i.id IN (SELECT depends_on_id FROM dependencies WHERE issue_id = "+quoteSQLString(opts.Parent)+" AND type = 'parent-child')")
+	}
+	if opts.Assignee != "" {
+		where = append(where, "i.assignee = "+quoteSQLString(opts.Assignee))
+	}
+	if opts.NoAssignee {
+		where = append(where, "(i.assignee IS NULL OR i.assignee = '')")
+	}
+
+	query := "SELECT i.id, i.title, i.description, i.status, i.issue_type, i.priority, i.assignee, " +
+		"i.created_at, i.updated_at, i.created_by, COALESCE(GROUP_CONCAT(l.label), '') AS labels_csv " +
+		"FROM issues i LEFT JOIN labels l ON i.id = l.issue_id " +
+		"WHERE " + strings.Join(where, " AND ") + " " +
+		"GROUP BY i.id, i.title, i.description, i.status, i.issue_type, i.priority, i.assignee, i.created_at, i.updated_at, i.created_by " +
+		"ORDER BY i.updated_at DESC, i.created_at DESC, i.id DESC"
+	if opts.Limit > 0 {
+		query += fmt.Sprintf(" LIMIT %d", opts.Limit)
+	}
+
+	out, err := b.run("sql", "--json", query)
+	if err != nil {
+		return nil, err
+	}
+	if len(out) == 0 || !isJSONBytes(out) {
+		return nil, nil
+	}
+
+	var rows []struct {
+		ID          string `json:"id"`
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		Status      string `json:"status"`
+		Type        string `json:"issue_type"`
+		Priority    int    `json:"priority"`
+		Assignee    string `json:"assignee"`
+		CreatedAt   string `json:"created_at"`
+		UpdatedAt   string `json:"updated_at"`
+		CreatedBy   string `json:"created_by"`
+		LabelsCSV   string `json:"labels_csv"`
+	}
+	if err := json.Unmarshal(out, &rows); err != nil {
+		return nil, fmt.Errorf("parsing bd sql output: %w", err)
+	}
+
+	issues := make([]*Issue, 0, len(rows))
+	for _, row := range rows {
+		issue := &Issue{
+			ID:          row.ID,
+			Title:       row.Title,
+			Description: row.Description,
+			Status:      row.Status,
+			Type:        row.Type,
+			Priority:    row.Priority,
+			Assignee:    row.Assignee,
+			CreatedAt:   row.CreatedAt,
+			UpdatedAt:   row.UpdatedAt,
+			CreatedBy:   row.CreatedBy,
+		}
+		if row.LabelsCSV != "" {
+			issue.Labels = strings.Split(row.LabelsCSV, ",")
+		}
+		issues = append(issues, issue)
+	}
+
+	return issues, nil
+}
+
+func quoteSQLString(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
 // listEphemeral searches the wisps table using "bd query" with ephemeral=true.

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -901,7 +901,7 @@ func stripEnvPrefixes(environ []string, prefixes ...string) []string {
 // wisps table (where ephemeral issues live in beads v0.59+). Without this,
 // "bd list" only searches the issues table and misses wisps entirely.
 func (b *Beads) List(opts ListOptions) ([]*Issue, error) {
-	if b.store != nil && !opts.Ephemeral {
+	if b.store != nil {
 		return b.storeList(opts)
 	}
 	if opts.Ephemeral {

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -77,6 +77,32 @@ func TestListEphemeralQuotesQueryValuesAndDisablesLimit(t *testing.T) {
 	}
 }
 
+func TestListIssuesUsesIssueQueryAndDisablesLimit(t *testing.T) {
+	ResetBdAllowStaleCacheForTest()
+	logPath := installMockBDRecorder(t)
+
+	b := New(t.TempDir())
+	_, err := b.ListIssues(ListOptions{
+		Status:   StatusHooked,
+		Assignee: "deacon/dogs/alpha",
+		Parent:   "gt-wisp/root",
+		Priority: -1,
+		Limit:    0,
+	})
+	if err != nil {
+		t.Fatalf("ListIssues() error = %v", err)
+	}
+
+	logOutput := readMockBDLog(t, logPath)
+	for _, want := range []string{
+		`query --json ephemeral=false AND status="hooked" AND parent="gt-wisp/root" AND assignee="deacon/dogs/alpha" --limit=0`,
+	} {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("bd log missing %q\nlog:\n%s", want, logOutput)
+		}
+	}
+}
+
 // TestCreateOptions verifies CreateOptions fields.
 func TestCreateOptions(t *testing.T) {
 	opts := CreateOptions{

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -77,7 +77,7 @@ func TestListEphemeralQuotesQueryValuesAndDisablesLimit(t *testing.T) {
 	}
 }
 
-func TestListIssuesUsesBdListAndDisablesLimit(t *testing.T) {
+func TestListIssuesUsesSQLIssuesTable(t *testing.T) {
 	ResetBdAllowStaleCacheForTest()
 	logPath := installMockBDRecorder(t)
 
@@ -95,7 +95,12 @@ func TestListIssuesUsesBdListAndDisablesLimit(t *testing.T) {
 
 	logOutput := readMockBDLog(t, logPath)
 	for _, want := range []string{
-		`list --json --status=hooked --parent=gt-wisp/root --assignee=deacon/dogs/alpha --limit=0`,
+		`sql --json SELECT`,
+		`FROM issues i LEFT JOIN labels l ON i.id = l.issue_id`,
+		`COALESCE(i.ephemeral, 0) = 0`,
+		`i.status = 'hooked'`,
+		`i.id IN (SELECT depends_on_id FROM dependencies WHERE issue_id = 'gt-wisp/root' AND type = 'parent-child')`,
+		`i.assignee = 'deacon/dogs/alpha'`,
 	} {
 		if !strings.Contains(logOutput, want) {
 			t.Fatalf("bd log missing %q\nlog:\n%s", want, logOutput)

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -99,7 +99,8 @@ func TestListIssuesUsesSQLIssuesTable(t *testing.T) {
 		`FROM issues i LEFT JOIN labels l ON i.id = l.issue_id`,
 		`COALESCE(i.ephemeral, 0) = 0`,
 		`i.status = 'hooked'`,
-		`i.id IN (SELECT depends_on_id FROM dependencies WHERE issue_id = 'gt-wisp/root' AND type = 'parent-child')`,
+		`EXISTS (SELECT 1 FROM dependencies d WHERE d.issue_id = i.id AND d.type = 'parent-child'`,
+		`d.depends_on_issue_id = 'gt-wisp/root' OR d.depends_on_wisp_id = 'gt-wisp/root' OR d.depends_on_external = 'gt-wisp/root'`,
 		`i.assignee = 'deacon/dogs/alpha'`,
 	} {
 		if !strings.Contains(logOutput, want) {

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -103,6 +103,18 @@ func TestListIssuesUsesIssueQueryAndDisablesLimit(t *testing.T) {
 	}
 }
 
+func TestIssueFilterFromListOptsSetsEphemeralFilter(t *testing.T) {
+	durable := issueFilterFromListOpts(ListOptions{})
+	if durable.Ephemeral == nil || *durable.Ephemeral {
+		t.Fatalf("default issue filter Ephemeral = %v, want false", durable.Ephemeral)
+	}
+
+	wisp := issueFilterFromListOpts(ListOptions{Ephemeral: true})
+	if wisp.Ephemeral == nil || !*wisp.Ephemeral {
+		t.Fatalf("ephemeral issue filter Ephemeral = %v, want true", wisp.Ephemeral)
+	}
+}
+
 // TestCreateOptions verifies CreateOptions fields.
 func TestCreateOptions(t *testing.T) {
 	opts := CreateOptions{

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -77,7 +77,7 @@ func TestListEphemeralQuotesQueryValuesAndDisablesLimit(t *testing.T) {
 	}
 }
 
-func TestListIssuesUsesIssueQueryAndDisablesLimit(t *testing.T) {
+func TestListIssuesUsesBdListAndDisablesLimit(t *testing.T) {
 	ResetBdAllowStaleCacheForTest()
 	logPath := installMockBDRecorder(t)
 
@@ -95,7 +95,7 @@ func TestListIssuesUsesIssueQueryAndDisablesLimit(t *testing.T) {
 
 	logOutput := readMockBDLog(t, logPath)
 	for _, want := range []string{
-		`query --json ephemeral=false AND status="hooked" AND parent="gt-wisp/root" AND assignee="deacon/dogs/alpha" --limit=0`,
+		`list --json --status=hooked --parent=gt-wisp/root --assignee=deacon/dogs/alpha --limit=0`,
 	} {
 		if !strings.Contains(logOutput, want) {
 			t.Fatalf("bd log missing %q\nlog:\n%s", want, logOutput)

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -230,6 +230,22 @@ func (b *Beads) storeList(opts ListOptions) ([]*Issue, error) {
 	return sdkIssuesToIssues(sdkIssues), nil
 }
 
+// storeListIssues implements durable issue listing without merging wisps.
+func (b *Beads) storeListIssues(opts ListOptions) ([]*Issue, error) {
+	ctx, cancel := storeCtx()
+	defer cancel()
+
+	opts.Ephemeral = false
+	filter := issueFilterFromListOpts(opts)
+	filter.SkipWisps = true
+	sdkIssues, err := b.store.SearchIssues(ctx, "", filter)
+	if err != nil {
+		return nil, fmt.Errorf("store list issues: %w", err)
+	}
+
+	return sdkIssuesToIssues(sdkIssues), nil
+}
+
 // storeShow implements Show using the in-process store.
 func (b *Beads) storeShow(id string) (*Issue, error) {
 	ctx, cancel := storeCtx()

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -183,10 +183,8 @@ func issueFilterFromListOpts(opts ListOptions) beadsdk.IssueFilter {
 		f.NoAssignee = true
 	}
 
-	if opts.Ephemeral {
-		eph := true
-		f.Ephemeral = &eph
-	}
+	eph := opts.Ephemeral
+	f.Ephemeral = &eph
 
 	return f
 }

--- a/internal/beads/store_test.go
+++ b/internal/beads/store_test.go
@@ -14,22 +14,23 @@ import (
 // Embeds beadsdk.Storage to satisfy unimplemented methods (they panic if called).
 type mockStorage struct {
 	beadsdk.Storage // embedded for unimplemented methods
-	issues     map[string]*beadsdk.Issue
-	labels     map[string][]string // issueID -> labels
-	deps       map[string][]string // issueID -> depends-on IDs
-	nextID     int
-	prefix     string
-	closed     map[string]bool
-	closeErr   error
-	createErr  error
-	updateErr  error
-	searchErr  error
-	getErr     error
-	addLabelErr    error
-	removeLabelErr error
-	addDepErr      error
-	removeDepErr   error
-	getLabelsErr   error
+	issues          map[string]*beadsdk.Issue
+	labels          map[string][]string // issueID -> labels
+	deps            map[string][]string // issueID -> depends-on IDs
+	nextID          int
+	prefix          string
+	closed          map[string]bool
+	closeErr        error
+	createErr       error
+	updateErr       error
+	searchErr       error
+	getErr          error
+	addLabelErr     error
+	removeLabelErr  error
+	addDepErr       error
+	removeDepErr    error
+	getLabelsErr    error
+	lastFilter      beadsdk.IssueFilter
 }
 
 func newMockStorage() *mockStorage {
@@ -127,6 +128,7 @@ func (m *mockStorage) DeleteIssue(_ context.Context, id string) error {
 }
 
 func (m *mockStorage) SearchIssues(_ context.Context, query string, filter beadsdk.IssueFilter) ([]*beadsdk.Issue, error) {
+	m.lastFilter = filter
 	if m.searchErr != nil {
 		return nil, m.searchErr
 	}
@@ -213,7 +215,6 @@ func (m *mockStorage) RemoveDependency(_ context.Context, issueID, dependsOnID, 
 	}
 	return nil
 }
-
 
 func (m *mockStorage) AddLabel(_ context.Context, issueID, label, _ string) error {
 	if m.addLabelErr != nil {
@@ -313,6 +314,21 @@ func TestStoreListWithStatusFilter(t *testing.T) {
 	}
 }
 
+func TestStoreListIssuesSkipsWisps(t *testing.T) {
+	store := newMockStorage()
+	b := newTestBeads(store)
+
+	if _, err := b.ListIssues(ListOptions{Status: StatusHooked, Assignee: "agent", Priority: -1}); err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if !store.lastFilter.SkipWisps {
+		t.Fatal("ListIssues store filter SkipWisps = false, want true")
+	}
+	if store.lastFilter.Ephemeral == nil || *store.lastFilter.Ephemeral {
+		t.Fatalf("ListIssues store filter Ephemeral = %v, want false", store.lastFilter.Ephemeral)
+	}
+}
+
 func TestStoreListError(t *testing.T) {
 	store := newMockStorage()
 	store.searchErr = errors.New("db down")
@@ -322,7 +338,7 @@ func TestStoreListError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !errors.Is(err, store.searchErr) && err.Error() != "store list: db down" {
+	if !errors.Is(err, store.searchErr) && err.Error() != "store list issues: db down" {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/cmd/done_closeDescendants_test.go
+++ b/internal/cmd/done_closeDescendants_test.go
@@ -74,7 +74,7 @@ case "$cmd" in
     ;;
   list|query|sql)
     # Return children when listing with parent=gt-wisp-xyz
-    if echo "$*" | grep -Eq 'parent="?gt-wisp-xyz"?'; then
+    if echo "$*" | grep -q "gt-wisp-xyz"; then
       echo '[{"id":"gt-step-1","title":"Step 1","status":"open"},{"id":"gt-step-2","title":"Step 2","status":"open"}]'
     else
       echo '[]'
@@ -381,7 +381,7 @@ case "$cmd" in
     ;;
   list|query|sql)
     # Return one open child and one already-closed child
-    if echo "$*" | grep -Eq 'parent="?gt-wisp-xyz"?'; then
+    if echo "$*" | grep -q "gt-wisp-xyz"; then
       echo '[{"id":"gt-step-open","title":"Step Open","status":"open"},{"id":"gt-step-closed","title":"Step Closed","status":"closed"}]'
     else
       echo '[]'
@@ -529,10 +529,10 @@ case "$cmd" in
     ;;
   list|query|sql)
     # Return children based on parent
-    if echo "$*" | grep -Eq 'parent="?gt-wisp-xyz"?'; then
+    if echo "$*" | grep -q "gt-wisp-xyz"; then
       # Wisp has one child
       echo '[{"id":"gt-child","title":"Child","status":"open"}]'
-    elif echo "$*" | grep -Eq 'parent="?gt-child"?'; then
+    elif echo "$*" | grep -q "gt-child"; then
       # Child has one grandchild
       echo '[{"id":"gt-grandchild","title":"Grandchild","status":"open"}]'
     else

--- a/internal/cmd/done_closeDescendants_test.go
+++ b/internal/cmd/done_closeDescendants_test.go
@@ -72,7 +72,7 @@ case "$cmd" in
         ;;
     esac
     ;;
-  list|query)
+  list|query|sql)
     # Return children when listing with parent=gt-wisp-xyz
     if echo "$*" | grep -Eq 'parent="?gt-wisp-xyz"?'; then
       echo '[{"id":"gt-step-1","title":"Step 1","status":"open"},{"id":"gt-step-2","title":"Step 2","status":"open"}]'
@@ -379,7 +379,7 @@ case "$cmd" in
         ;;
     esac
     ;;
-  list|query)
+  list|query|sql)
     # Return one open child and one already-closed child
     if echo "$*" | grep -Eq 'parent="?gt-wisp-xyz"?'; then
       echo '[{"id":"gt-step-open","title":"Step Open","status":"open"},{"id":"gt-step-closed","title":"Step Closed","status":"closed"}]'
@@ -527,7 +527,7 @@ case "$cmd" in
         ;;
     esac
     ;;
-  list|query)
+  list|query|sql)
     # Return children based on parent
     if echo "$*" | grep -Eq 'parent="?gt-wisp-xyz"?'; then
       # Wisp has one child

--- a/internal/cmd/done_closeDescendants_test.go
+++ b/internal/cmd/done_closeDescendants_test.go
@@ -72,9 +72,9 @@ case "$cmd" in
         ;;
     esac
     ;;
-  list)
+  list|query)
     # Return children when listing with parent=gt-wisp-xyz
-    if echo "$*" | grep -q "parent=gt-wisp-xyz"; then
+    if echo "$*" | grep -Eq 'parent="?gt-wisp-xyz"?'; then
       echo '[{"id":"gt-step-1","title":"Step 1","status":"open"},{"id":"gt-step-2","title":"Step 2","status":"open"}]'
     else
       echo '[]'
@@ -379,9 +379,9 @@ case "$cmd" in
         ;;
     esac
     ;;
-  list)
+  list|query)
     # Return one open child and one already-closed child
-    if echo "$*" | grep -q "parent=gt-wisp-xyz"; then
+    if echo "$*" | grep -Eq 'parent="?gt-wisp-xyz"?'; then
       echo '[{"id":"gt-step-open","title":"Step Open","status":"open"},{"id":"gt-step-closed","title":"Step Closed","status":"closed"}]'
     else
       echo '[]'
@@ -527,12 +527,12 @@ case "$cmd" in
         ;;
     esac
     ;;
-  list)
+  list|query)
     # Return children based on parent
-    if echo "$*" | grep -q "parent=gt-wisp-xyz"; then
+    if echo "$*" | grep -Eq 'parent="?gt-wisp-xyz"?'; then
       # Wisp has one child
       echo '[{"id":"gt-child","title":"Child","status":"open"}]'
-    elif echo "$*" | grep -q "parent=gt-child"; then
+    elif echo "$*" | grep -Eq 'parent="?gt-child"?'; then
       # Child has one grandchild
       echo '[{"id":"gt-grandchild","title":"Grandchild","status":"open"}]'
     else

--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -512,25 +512,9 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 	}
 
 	b := beads.New(workDir)
-	// Query for hooked beads assigned to the target
-	hookedBeads, err := b.List(beads.ListOptions{
-		Status:   beads.StatusHooked,
-		Assignee: target,
-		Priority: -1,
-	})
+	hookedBeads, err := listAssignedActiveWork(b, target)
 	if err != nil {
-		return fmt.Errorf("listing hooked beads: %w", err)
-	}
-	if len(hookedBeads) == 0 {
-		inProgressBeads, err := b.List(beads.ListOptions{
-			Status:   "in_progress",
-			Assignee: target,
-			Priority: -1,
-		})
-		if err != nil {
-			return fmt.Errorf("listing in-progress beads: %w", err)
-		}
-		hookedBeads = inProgressBeads
+		return fmt.Errorf("listing active hook work: %w", err)
 	}
 
 	// If nothing found in local beads, also check town beads for hooked convoys.
@@ -543,22 +527,8 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 			townBeadsDir := filepath.Join(townRoot, ".beads")
 			if _, err := os.Stat(townBeadsDir); err == nil {
 				townBeads := beads.New(townBeadsDir)
-				townHooked, err := townBeads.List(beads.ListOptions{
-					Status:   beads.StatusHooked,
-					Assignee: target,
-					Priority: -1,
-				})
-				if err == nil && len(townHooked) > 0 {
-					hookedBeads = townHooked
-				} else if err == nil {
-					townInProgress, err := townBeads.List(beads.ListOptions{
-						Status:   "in_progress",
-						Assignee: target,
-						Priority: -1,
-					})
-					if err == nil && len(townInProgress) > 0 {
-						hookedBeads = townInProgress
-					}
+				if townWork, err := listAssignedActiveWork(townBeads, target); err == nil && len(townWork) > 0 {
+					hookedBeads = townWork
 				}
 			}
 

--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -495,19 +495,12 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}
-	if len(args) > 0 && !isTownLevelRole(target) {
+	if len(args) > 0 {
 		townRoot, townErr := workspace.FindFromCwd()
 		if townErr == nil && townRoot != "" {
-			rigName := strings.Split(target, "/")[0]
-			if rigName != "" && rigName != "mayor" && rigName != "deacon" {
-				// Agent beads can be stale or missing during recovery. The source
-				// work assignment is authoritative, so query the target rig DB directly.
-				if rigDir := beads.GetRigDirForName(townRoot, rigName); rigDir != "" {
-					workDir = rigDir
-				} else {
-					workDir = filepath.Join(townRoot, rigName)
-				}
-			}
+			// Agent beads can be stale or missing during recovery. The source
+			// work assignment is authoritative, so query the target rig DB directly.
+			workDir = resolveHookLookupWorkDir(workDir, target, townRoot)
 		}
 	}
 

--- a/internal/cmd/hook_show_integration_test.go
+++ b/internal/cmd/hook_show_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/constants"
 )
 
 type hookShowJSON struct {
@@ -116,5 +117,120 @@ func TestHookShowShorthandResolvesToCanonical(t *testing.T) {
 	if active.BeadID != issue.ID || active.Status != "in_progress" {
 		t.Fatalf("in-progress target mismatch: got bead=%q status=%q, want bead=%q status=in_progress",
 			active.BeadID, active.Status, issue.ID)
+	}
+}
+
+func TestHookShowAndStatusFindEphemeralPatrolWisp(t *testing.T) {
+	if _, err := exec.LookPath("bd"); err != nil {
+		t.Skip("bd not installed, skipping integration test")
+	}
+
+	_, polecatDir, rigPrefix := setupHookTestTown(t)
+	rigDir := filepath.Join(polecatDir, "..", "..", "mayor", "rig")
+	initBeadsDBWithPrefix(t, rigDir, rigPrefix)
+
+	b := beads.New(rigDir)
+	patrol, err := b.Create(beads.CreateOptions{
+		Title:     constants.MolRefineryPatrol + " (wisp)",
+		Type:      "molecule",
+		Priority:  -1,
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("create patrol wisp: %v", err)
+	}
+
+	hooked := beads.StatusHooked
+	assignee := "gastown/refinery"
+	if err := b.Update(patrol.ID, beads.UpdateOptions{
+		Status:   &hooked,
+		Assignee: &assignee,
+	}); err != nil {
+		t.Fatalf("hook patrol wisp: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(polecatDir); err != nil {
+		t.Fatalf("chdir to polecat dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+
+	prevJSON := moleculeJSON
+	moleculeJSON = true
+	t.Cleanup(func() {
+		moleculeJSON = prevJSON
+	})
+
+	showOut := captureStdout(t, func() {
+		if err := runHookShow(nil, []string{assignee}); err != nil {
+			t.Fatalf("runHookShow(%q): %v", assignee, err)
+		}
+	})
+	var show hookShowJSON
+	if err := json.Unmarshal([]byte(showOut), &show); err != nil {
+		t.Fatalf("parse hook show output %q: %v", showOut, err)
+	}
+	if show.BeadID != patrol.ID || show.Status != beads.StatusHooked {
+		t.Fatalf("hook show mismatch: got bead=%q status=%q, want bead=%q status=%q",
+			show.BeadID, show.Status, patrol.ID, beads.StatusHooked)
+	}
+
+	statusOut := captureStdout(t, func() {
+		if err := runMoleculeStatus(nil, []string{assignee}); err != nil {
+			t.Fatalf("runMoleculeStatus(%q): %v", assignee, err)
+		}
+	})
+	var status MoleculeStatusInfo
+	if err := json.Unmarshal([]byte(statusOut), &status); err != nil {
+		t.Fatalf("parse hook status output %q: %v", statusOut, err)
+	}
+	if !status.HasWork || status.PinnedBead == nil || status.PinnedBead.ID != patrol.ID {
+		t.Fatalf("hook status mismatch: has_work=%v pinned=%+v, want patrol %s",
+			status.HasWork, status.PinnedBead, patrol.ID)
+	}
+}
+
+func TestPrimeStateFindsEphemeralPatrolWisp(t *testing.T) {
+	if _, err := exec.LookPath("bd"); err != nil {
+		t.Skip("bd not installed, skipping integration test")
+	}
+
+	townRoot, polecatDir, rigPrefix := setupHookTestTown(t)
+	rigDir := filepath.Join(polecatDir, "..", "..", "mayor", "rig")
+	initBeadsDBWithPrefix(t, rigDir, rigPrefix)
+
+	b := beads.New(rigDir)
+	patrol, err := b.Create(beads.CreateOptions{
+		Title:     constants.MolRefineryPatrol + " (wisp)",
+		Type:      "molecule",
+		Priority:  -1,
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("create patrol wisp: %v", err)
+	}
+
+	hooked := beads.StatusHooked
+	assignee := "gastown/refinery"
+	if err := b.Update(patrol.ID, beads.UpdateOptions{
+		Status:   &hooked,
+		Assignee: &assignee,
+	}); err != nil {
+		t.Fatalf("hook patrol wisp: %v", err)
+	}
+
+	state := detectSessionState(RoleContext{
+		Role:     RoleRefinery,
+		Rig:      "gastown",
+		WorkDir:  polecatDir,
+		TownRoot: townRoot,
+	})
+	if state.State != "autonomous" || state.HookedBead != patrol.ID {
+		t.Fatalf("prime state = %+v, want autonomous with hooked bead %s", state, patrol.ID)
 	}
 }

--- a/internal/cmd/hooked_work.go
+++ b/internal/cmd/hooked_work.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
@@ -78,6 +80,21 @@ func listChildrenAcrossTables(b *beads.Beads, parentID string) ([]*beads.Issue, 
 		Status:   "all",
 		Priority: -1,
 	})
+}
+
+func resolveHookLookupWorkDir(workDir, target, townRoot string) string {
+	if townRoot == "" || isTownLevelRole(target) {
+		return workDir
+	}
+
+	rigName := strings.Split(target, "/")[0]
+	if rigName == "" || rigName == "mayor" || rigName == "deacon" {
+		return workDir
+	}
+	if rigDir := beads.GetRigDirForName(townRoot, rigName); rigDir != "" {
+		return rigDir
+	}
+	return filepath.Join(townRoot, rigName)
 }
 
 func mergeBeadLists(primary, secondary []*beads.Issue) []*beads.Issue {

--- a/internal/cmd/hooked_work.go
+++ b/internal/cmd/hooked_work.go
@@ -56,6 +56,22 @@ func listAssignedActiveWork(b *beads.Beads, assignee string) ([]*beads.Issue, er
 	return nil, nil
 }
 
+func listAssignedActiveWorkAcrossStatuses(b *beads.Beads, assignee string) ([]*beads.Issue, error) {
+	var assigned []*beads.Issue
+	for _, status := range []string{beads.StatusHooked, statusInProgress} {
+		beadsForStatus, err := listBeadsAcrossTables(b, beads.ListOptions{
+			Status:   status,
+			Assignee: assignee,
+			Priority: -1,
+		})
+		if err != nil {
+			return nil, err
+		}
+		assigned = append(assigned, beadsForStatus...)
+	}
+	return mergeBeadLists(assigned, nil), nil
+}
+
 func listChildrenAcrossTables(b *beads.Beads, parentID string) ([]*beads.Issue, error) {
 	return listBeadsAcrossTables(b, beads.ListOptions{
 		Parent:   parentID,

--- a/internal/cmd/hooked_work.go
+++ b/internal/cmd/hooked_work.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"sort"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+const statusInProgress = "in_progress"
+
+// listBeadsAcrossTables lists matching durable issues and ephemeral wisps.
+// Hook state is stored on the work bead itself, and patrol work lives in the
+// wisps table, so readers must not use issue-only bd list results as the source
+// of truth.
+func listBeadsAcrossTables(b *beads.Beads, opts beads.ListOptions) ([]*beads.Issue, error) {
+	limit := opts.Limit
+
+	issueOpts := opts
+	issueOpts.Ephemeral = false
+	issueOpts.Limit = 0
+	issues, err := b.ListIssues(issueOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	wispOpts := opts
+	wispOpts.Ephemeral = true
+	wispOpts.Limit = 0
+	wisps, err := b.List(wispOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := mergeBeadLists(issues, wisps)
+	if limit > 0 && len(merged) > limit {
+		return merged[:limit], nil
+	}
+	return merged, nil
+}
+
+func listAssignedActiveWork(b *beads.Beads, assignee string) ([]*beads.Issue, error) {
+	for _, status := range []string{beads.StatusHooked, statusInProgress} {
+		beadsForStatus, err := listBeadsAcrossTables(b, beads.ListOptions{
+			Status:   status,
+			Assignee: assignee,
+			Priority: -1,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if len(beadsForStatus) > 0 {
+			return beadsForStatus, nil
+		}
+	}
+	return nil, nil
+}
+
+func listChildrenAcrossTables(b *beads.Beads, parentID string) ([]*beads.Issue, error) {
+	return listBeadsAcrossTables(b, beads.ListOptions{
+		Parent:   parentID,
+		Status:   "all",
+		Priority: -1,
+	})
+}
+
+func mergeBeadLists(primary, secondary []*beads.Issue) []*beads.Issue {
+	merged := make([]*beads.Issue, 0, len(primary)+len(secondary))
+	seen := make(map[string]struct{}, len(primary)+len(secondary))
+	for _, issue := range append(primary, secondary...) {
+		if issue == nil || issue.ID == "" {
+			continue
+		}
+		if _, ok := seen[issue.ID]; ok {
+			continue
+		}
+		seen[issue.ID] = struct{}{}
+		merged = append(merged, issue)
+	}
+
+	sort.SliceStable(merged, func(i, j int) bool {
+		return beadRecencyKey(merged[i]) > beadRecencyKey(merged[j])
+	})
+	return merged
+}
+
+func beadRecencyKey(issue *beads.Issue) string {
+	if issue == nil {
+		return ""
+	}
+	if issue.UpdatedAt != "" {
+		return issue.UpdatedAt
+	}
+	if issue.CreatedAt != "" {
+		return issue.CreatedAt
+	}
+	return issue.ID
+}

--- a/internal/cmd/hooked_work.go
+++ b/internal/cmd/hooked_work.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"sort"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
 )
@@ -78,20 +79,40 @@ func mergeBeadLists(primary, secondary []*beads.Issue) []*beads.Issue {
 	}
 
 	sort.SliceStable(merged, func(i, j int) bool {
-		return beadRecencyKey(merged[i]) > beadRecencyKey(merged[j])
+		left := beadRecencyTime(merged[i])
+		right := beadRecencyTime(merged[j])
+		if !left.Equal(right) {
+			return left.After(right)
+		}
+		return beadSortID(merged[i]) > beadSortID(merged[j])
 	})
 	return merged
 }
 
-func beadRecencyKey(issue *beads.Issue) string {
+func beadRecencyTime(issue *beads.Issue) time.Time {
+	if issue == nil {
+		return time.Time{}
+	}
+	if ts := parseBeadTime(issue.UpdatedAt); !ts.IsZero() {
+		return ts
+	}
+	return parseBeadTime(issue.CreatedAt)
+}
+
+func parseBeadTime(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+	ts, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return ts
+}
+
+func beadSortID(issue *beads.Issue) string {
 	if issue == nil {
 		return ""
-	}
-	if issue.UpdatedAt != "" {
-		return issue.UpdatedAt
-	}
-	if issue.CreatedAt != "" {
-		return issue.CreatedAt
 	}
 	return issue.ID
 }

--- a/internal/cmd/hooked_work_test.go
+++ b/internal/cmd/hooked_work_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestActiveWorkMergeBeadListsDedupeAndSort(t *testing.T) {
+	primary := []*beads.Issue{
+		{ID: "gt-older", UpdatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "gt-same", UpdatedAt: "2026-01-02T00:00:00Z", Title: "durable"},
+	}
+	secondary := []*beads.Issue{
+		{ID: "gt-newer", UpdatedAt: "2026-01-03T00:00:00Z"},
+		{ID: "gt-same", UpdatedAt: "2026-01-04T00:00:00Z", Title: "wisp"},
+	}
+
+	got := mergeBeadLists(primary, secondary)
+	if len(got) != 3 {
+		t.Fatalf("mergeBeadLists length = %d, want 3", len(got))
+	}
+
+	wantIDs := []string{"gt-newer", "gt-same", "gt-older"}
+	for i, want := range wantIDs {
+		if got[i].ID != want {
+			t.Fatalf("mergeBeadLists[%d].ID = %q, want %q (all=%v)", i, got[i].ID, want, got)
+		}
+	}
+	if got[1].Title != "durable" {
+		t.Fatalf("duplicate should keep primary issue, got title %q", got[1].Title)
+	}
+}

--- a/internal/cmd/hooked_work_test.go
+++ b/internal/cmd/hooked_work_test.go
@@ -1,10 +1,44 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
 )
+
+func TestResolveHookLookupWorkDirUsesRouteOwnedRigDir(t *testing.T) {
+	townRoot := t.TempDir()
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir town beads: %v", err)
+	}
+	rigDir := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+	if err := beads.WriteRoutes(townBeadsDir, []beads.Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: "ht-", Path: "gastown/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	localWorkDir := filepath.Join(townRoot, "gastown", "polecats", "toast")
+	got := resolveHookLookupWorkDir(localWorkDir, "gastown/refinery", townRoot)
+	if got != rigDir {
+		t.Fatalf("resolveHookLookupWorkDir() = %q, want %q", got, rigDir)
+	}
+}
+
+func TestResolveHookLookupWorkDirLeavesTownLevelTargetLocal(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "mayor")
+	got := resolveHookLookupWorkDir(workDir, "mayor/", t.TempDir())
+	if got != workDir {
+		t.Fatalf("resolveHookLookupWorkDir() = %q, want %q", got, workDir)
+	}
+}
 
 func TestActiveWorkMergeBeadListsDedupeAndSort(t *testing.T) {
 	primary := []*beads.Issue{

--- a/internal/cmd/hooked_work_test.go
+++ b/internal/cmd/hooked_work_test.go
@@ -10,24 +10,25 @@ func TestActiveWorkMergeBeadListsDedupeAndSort(t *testing.T) {
 	primary := []*beads.Issue{
 		{ID: "gt-older", UpdatedAt: "2026-01-01T00:00:00Z"},
 		{ID: "gt-same", UpdatedAt: "2026-01-02T00:00:00Z", Title: "durable"},
+		{ID: "gt-whole", UpdatedAt: "2026-01-03T00:00:00Z"},
 	}
 	secondary := []*beads.Issue{
-		{ID: "gt-newer", UpdatedAt: "2026-01-03T00:00:00Z"},
+		{ID: "gt-fractional", UpdatedAt: "2026-01-03T00:00:00.1Z"},
 		{ID: "gt-same", UpdatedAt: "2026-01-04T00:00:00Z", Title: "wisp"},
 	}
 
 	got := mergeBeadLists(primary, secondary)
-	if len(got) != 3 {
-		t.Fatalf("mergeBeadLists length = %d, want 3", len(got))
+	if len(got) != 4 {
+		t.Fatalf("mergeBeadLists length = %d, want 4", len(got))
 	}
 
-	wantIDs := []string{"gt-newer", "gt-same", "gt-older"}
+	wantIDs := []string{"gt-fractional", "gt-whole", "gt-same", "gt-older"}
 	for i, want := range wantIDs {
 		if got[i].ID != want {
 			t.Fatalf("mergeBeadLists[%d].ID = %q, want %q (all=%v)", i, got[i].ID, want, got)
 		}
 	}
-	if got[1].Title != "durable" {
-		t.Fatalf("duplicate should keep primary issue, got title %q", got[1].Title)
+	if got[2].Title != "durable" {
+		t.Fatalf("duplicate should keep primary issue, got title %q", got[2].Title)
 	}
 }

--- a/internal/cmd/molecule_lifecycle.go
+++ b/internal/cmd/molecule_lifecycle.go
@@ -283,9 +283,9 @@ squashed_at: %s
 			Title:       digestTitle,
 			Description: digestDesc,
 			Labels:      []string{"gt:task"},
-			Priority:    4,       // P4 - backlog priority for digests
+			Priority:    4, // P4 - backlog priority for digests
 			Actor:       target,
-			Ephemeral:   true,    // Don't export to JSONL - daily aggregation handles permanent record
+			Ephemeral:   true, // Don't export to JSONL - daily aggregation handles permanent record
 		})
 		if err != nil {
 			return fmt.Errorf("creating digest: %w", err)
@@ -376,10 +376,7 @@ func forceCloseDescendants(b *beads.Beads, parentID string) (int, error) {
 }
 
 func closeDescendantsImpl(b *beads.Beads, parentID string, force bool) (int, error) {
-	children, err := b.List(beads.ListOptions{
-		Parent: parentID,
-		Status: "all",
-	})
+	children, err := listChildrenAcrossTables(b, parentID)
 	if err != nil {
 		return 0, fmt.Errorf("listing children of %s: %w", parentID, err)
 	}

--- a/internal/cmd/molecule_lifecycle_test.go
+++ b/internal/cmd/molecule_lifecycle_test.go
@@ -775,12 +775,12 @@ func TestSquashClosesDescendantsAndRoot(t *testing.T) {
 while [ "$1" = "--allow-stale" ]; do shift; done
 cmd="$1"; shift
 case "$cmd" in
-  list)
+  list|query)
     if echo "$*" | grep -q "status=pinned"; then
       echo '[{"id":"gt-handoff-1","title":"witness Handoff","status":"pinned","description":"attached_molecule: gt-wisp-mol2"}]'
-    elif echo "$*" | grep -q "parent=gt-wisp-mol2"; then
+    elif echo "$*" | grep -Eq 'parent="?gt-wisp-mol2"?'; then
       echo '[{"id":"gt-step-1","title":"Step 1","status":"open"},{"id":"gt-step-2","title":"Step 2","status":"closed"}]'
-    elif echo "$*" | grep -q "parent=gt-step"; then
+    elif echo "$*" | grep -Eq 'parent="?gt-step'; then
       echo '[]'
     else
       echo '[]'

--- a/internal/cmd/molecule_lifecycle_test.go
+++ b/internal/cmd/molecule_lifecycle_test.go
@@ -775,7 +775,7 @@ func TestSquashClosesDescendantsAndRoot(t *testing.T) {
 while [ "$1" = "--allow-stale" ]; do shift; done
 cmd="$1"; shift
 case "$cmd" in
-  list|query)
+  list|query|sql)
     if echo "$*" | grep -q "status=pinned"; then
       echo '[{"id":"gt-handoff-1","title":"witness Handoff","status":"pinned","description":"attached_molecule: gt-wisp-mol2"}]'
     elif echo "$*" | grep -Eq 'parent="?gt-wisp-mol2"?'; then

--- a/internal/cmd/molecule_lifecycle_test.go
+++ b/internal/cmd/molecule_lifecycle_test.go
@@ -778,9 +778,9 @@ case "$cmd" in
   list|query|sql)
     if echo "$*" | grep -q "status=pinned"; then
       echo '[{"id":"gt-handoff-1","title":"witness Handoff","status":"pinned","description":"attached_molecule: gt-wisp-mol2"}]'
-    elif echo "$*" | grep -Eq 'parent="?gt-wisp-mol2"?'; then
+    elif echo "$*" | grep -q "gt-wisp-mol2"; then
       echo '[{"id":"gt-step-1","title":"Step 1","status":"open"},{"id":"gt-step-2","title":"Step 2","status":"closed"}]'
-    elif echo "$*" | grep -Eq 'parent="?gt-step'; then
+    elif echo "$*" | grep -q "gt-step"; then
       echo '[]'
     else
       echo '[]'

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -412,27 +412,10 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		// Query for hooked beads using the authoritative source: bead status + assignee.
-		// First try status=hooked (work that's been slung but not yet claimed)
-		hookedBeads, err := b.List(beads.ListOptions{
-			Status:   beads.StatusHooked,
-			Assignee: target,
-			Priority: -1,
-		})
+		// Query for active work using the authoritative source: bead status + assignee.
+		hookedBeads, err := listAssignedActiveWork(b, target)
 		if err != nil {
 			return nil
-		}
-
-		// If no hooked beads found, also check in_progress beads assigned to this agent.
-		// This handles the case where work was claimed (status changed to in_progress)
-		// but the session was interrupted before completion. The hook should persist.
-		if len(hookedBeads) == 0 {
-			inProgressBeads, _ := b.List(beads.ListOptions{
-				Status:   "in_progress",
-				Assignee: target,
-				Priority: -1,
-			})
-			hookedBeads = inProgressBeads
 		}
 
 		// For town-level roles (mayor, deacon), scan all rigs if nothing found locally
@@ -446,18 +429,8 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 		// See: https://github.com/steveyegge/gastown/issues/1438
 		if len(hookedBeads) == 0 && !isTownLevelRole(target) && townRoot != "" {
 			townB := beads.New(filepath.Join(townRoot, ".beads"))
-			if townHooked, err := townB.List(beads.ListOptions{
-				Status:   beads.StatusHooked,
-				Assignee: target,
-				Priority: -1,
-			}); err == nil && len(townHooked) > 0 {
-				hookedBeads = townHooked
-			} else if townInProgress, err := townB.List(beads.ListOptions{
-				Status:   "in_progress",
-				Assignee: target,
-				Priority: -1,
-			}); err == nil && len(townInProgress) > 0 {
-				hookedBeads = townInProgress
+			if townWork, err := listAssignedActiveWork(townB, target); err == nil && len(townWork) > 0 {
+				hookedBeads = townWork
 			}
 		}
 
@@ -1222,32 +1195,13 @@ func scanAllRigsForHookedBeads(townRoot, target string) []*beads.Issue {
 		}
 
 		b := beads.New(rigBeadsDir)
-		// First check for hooked beads
-		hookedBeads, err := b.List(beads.ListOptions{
-			Status:   beads.StatusHooked,
-			Assignee: target,
-			Priority: -1,
-		})
+		hookedBeads, err := listAssignedActiveWork(b, target)
 		if err != nil {
 			continue
 		}
 
 		if len(hookedBeads) > 0 {
 			return hookedBeads
-		}
-
-		// Also check for in_progress beads (work that was claimed but session interrupted)
-		inProgressBeads, err := b.List(beads.ListOptions{
-			Status:   "in_progress",
-			Assignee: target,
-			Priority: -1,
-		})
-		if err != nil {
-			continue
-		}
-
-		if len(inProgressBeads) > 0 {
-			return inProgressBeads
 		}
 	}
 

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -337,7 +337,7 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 
 	if len(args) > 0 {
 		// Explicit target provided
-		target = args[0]
+		target = normalizeHookShowTarget(args[0])
 		callerCtx := detectRole(cwd, townRoot)
 		validationRole = callerCtx.Role
 	} else {
@@ -374,15 +374,7 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 	// Resolve to the agent's rig beads directory if CWD-based discovery
 	// found the wrong database. This matches runHookShow's resolution logic.
 	if !isTownLevelRole(target) && townRoot != "" {
-		agentBeadID := buildAgentBeadID(target, roleCtx.Role, townRoot)
-		if agentBeadID != "" {
-			rigName := strings.Split(target, "/")[0]
-			fallbackPath := filepath.Join(townRoot, rigName)
-			resolvedDir := beads.ResolveHookDir(townRoot, agentBeadID, fallbackPath)
-			if resolvedDir != "" {
-				workDir = resolvedDir
-			}
-		}
+		workDir = resolveHookLookupWorkDir(workDir, target, townRoot)
 	}
 
 	b := beads.New(workDir)

--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -52,7 +52,7 @@ func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool
 	}
 
 	// Find active patrol beads for this agent across durable issues and wisps.
-	hookedBeads, listErr := listAssignedActiveWork(b, cfg.Assignee)
+	hookedBeads, listErr := listAssignedActiveWorkAcrossStatuses(b, cfg.Assignee)
 	if listErr != nil {
 		return "", "", false, fmt.Errorf("listing active patrol work: %w", listErr)
 	}
@@ -157,7 +157,7 @@ func burnPreviousPatrolWisps(cfg PatrolConfig) {
 	}
 
 	// Find all active patrol beads for this agent across durable issues and wisps.
-	hookedBeads, err := listAssignedActiveWork(b, cfg.Assignee)
+	hookedBeads, err := listAssignedActiveWorkAcrossStatuses(b, cfg.Assignee)
 	if err != nil {
 		style.PrintWarning("burn: could not list hooked beads: %v", err)
 		return

--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -51,14 +51,10 @@ func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool
 		b = beads.New(cfg.BeadsDir)
 	}
 
-	// Find hooked patrol beads for this agent
-	hookedBeads, listErr := b.List(beads.ListOptions{
-		Status:   beads.StatusHooked,
-		Assignee: cfg.Assignee,
-		Priority: -1,
-	})
+	// Find active patrol beads for this agent across durable issues and wisps.
+	hookedBeads, listErr := listAssignedActiveWork(b, cfg.Assignee)
 	if listErr != nil {
-		return "", "", false, fmt.Errorf("listing hooked beads: %w", listErr)
+		return "", "", false, fmt.Errorf("listing active patrol work: %w", listErr)
 	}
 
 	// Identify active patrol and collect stale ones for cleanup.
@@ -128,11 +124,7 @@ func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool
 // children materialized yet. This prevents findActivePatrol from closing a
 // just-created patrol during the window between root creation and step population.
 func checkHasOpenChildren(b *beads.Beads, parentID string) (bool, error) {
-	children, err := b.List(beads.ListOptions{
-		Parent:   parentID,
-		Status:   "all",
-		Priority: -1,
-	})
+	children, err := listChildrenAcrossTables(b, parentID)
 	if err != nil {
 		return false, err
 	}
@@ -164,12 +156,8 @@ func burnPreviousPatrolWisps(cfg PatrolConfig) {
 		b = beads.New(cfg.BeadsDir)
 	}
 
-	// Find all hooked patrol beads for this agent
-	hookedBeads, err := b.List(beads.ListOptions{
-		Status:   beads.StatusHooked,
-		Assignee: cfg.Assignee,
-		Priority: -1,
-	})
+	// Find all active patrol beads for this agent across durable issues and wisps.
+	hookedBeads, err := listAssignedActiveWork(b, cfg.Assignee)
 	if err != nil {
 		style.PrintWarning("burn: could not list hooked beads: %v", err)
 		return

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -343,8 +343,8 @@ func TestBuildRefineryPatrolVars_BoolFormat(t *testing.T) {
 	trueVal := true
 	falseVal2 := false
 	mq := &config.MergeQueueConfig{
-		Enabled:                         true,
-		IntegrationBranchAutoLand:       &trueVal,
+		Enabled:                          true,
+		IntegrationBranchAutoLand:        &trueVal,
 		IntegrationBranchRefineryEnabled: &trueVal,
 		RunTests:                         &trueVal,
 		SetupCommand:                     "npm ci",
@@ -632,10 +632,20 @@ func setupPatrolTestDB(t *testing.T) (string, *beads.Beads) {
 // createHookedPatrol creates a bead with a patrol title and hooks it.
 // If withOpenChild is true, creates an open child bead to simulate an active patrol.
 func createHookedPatrol(t *testing.T, b *beads.Beads, molName, assignee string, withOpenChild bool) string {
+	return createHookedPatrolWithOptions(t, b, molName, assignee, withOpenChild, false)
+}
+
+func createHookedEphemeralPatrol(t *testing.T, b *beads.Beads, molName, assignee string, withOpenChild bool) string {
+	return createHookedPatrolWithOptions(t, b, molName, assignee, withOpenChild, true)
+}
+
+func createHookedPatrolWithOptions(t *testing.T, b *beads.Beads, molName, assignee string, withOpenChild, ephemeral bool) string {
 	t.Helper()
 	root, err := b.Create(beads.CreateOptions{
-		Title:    molName + " (wisp)",
-		Priority: -1,
+		Title:     molName + " (wisp)",
+		Type:      "molecule",
+		Priority:  -1,
+		Ephemeral: ephemeral,
 	})
 	if err != nil {
 		t.Fatalf("create patrol root: %v", err)
@@ -651,15 +661,44 @@ func createHookedPatrol(t *testing.T, b *beads.Beads, molName, assignee string, 
 
 	if withOpenChild {
 		_, err := b.Create(beads.CreateOptions{
-			Title:    "inbox-check",
-			Parent:   root.ID,
-			Priority: -1,
+			Title:     "inbox-check",
+			Parent:    root.ID,
+			Priority:  -1,
+			Ephemeral: ephemeral,
 		})
 		if err != nil {
 			t.Fatalf("create child: %v", err)
 		}
 	}
 	return root.ID
+}
+
+func TestFindActivePatrolEphemeralHookedRoot(t *testing.T) {
+	requireBd(t)
+	tmpDir, b := setupPatrolTestDB(t)
+
+	molName := "mol-test-patrol"
+	assignee := "testrig/witness"
+
+	rootID := createHookedEphemeralPatrol(t, b, molName, assignee, false /* root-only */)
+
+	cfg := PatrolConfig{
+		PatrolMolName: molName,
+		BeadsDir:      tmpDir,
+		Assignee:      assignee,
+		Beads:         b,
+	}
+
+	patrolID, _, found, findErr := findActivePatrol(cfg)
+	if findErr != nil {
+		t.Fatalf("findActivePatrol error: %v", findErr)
+	}
+	if !found {
+		t.Fatal("expected to find ephemeral active patrol, got not found")
+	}
+	if patrolID != rootID {
+		t.Errorf("patrolID = %q, want %q", patrolID, rootID)
+	}
 }
 
 func TestFindActivePatrolHooked(t *testing.T) {
@@ -696,6 +735,79 @@ func TestFindActivePatrolHooked(t *testing.T) {
 	}
 	if issue.Status != beads.StatusHooked {
 		t.Errorf("patrol status = %q, want %q", issue.Status, beads.StatusHooked)
+	}
+}
+
+func TestRunPatrolReportNoActivePatrolStartsReplacement(t *testing.T) {
+	requireBd(t)
+	tmpDir, b := setupPatrolTestDB(t)
+
+	called := 0
+	spawner := func(cfg PatrolConfig) (string, error) {
+		called++
+		if cfg.RoleName != "witness" || cfg.PatrolMolName != "mol-test-patrol" || cfg.Assignee != "testrig/witness" {
+			t.Fatalf("unexpected patrol config: %+v", cfg)
+		}
+		return "pt-wisp-new", nil
+	}
+
+	err := runPatrolReportWithConfig(PatrolConfig{
+		RoleName:      "witness",
+		PatrolMolName: "mol-test-patrol",
+		BeadsDir:      tmpDir,
+		Assignee:      "testrig/witness",
+		Beads:         b,
+	}, spawner)
+	if err != nil {
+		t.Fatalf("runPatrolReportWithConfig: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("spawner calls = %d, want 1", called)
+	}
+}
+
+func TestRunPatrolReportClosesEphemeralHookedPatrol(t *testing.T) {
+	requireBd(t)
+	tmpDir, b := setupPatrolTestDB(t)
+
+	molName := "mol-test-patrol"
+	assignee := "testrig/witness"
+	rootID := createHookedEphemeralPatrol(t, b, molName, assignee, false /* root-only */)
+
+	oldSummary := patrolReportSummary
+	oldSteps := patrolReportSteps
+	called := 0
+	spawner := func(cfg PatrolConfig) (string, error) {
+		called++
+		return "pt-wisp-new", nil
+	}
+	patrolReportSummary = "ephemeral patrol complete"
+	patrolReportSteps = ""
+	t.Cleanup(func() {
+		patrolReportSummary = oldSummary
+		patrolReportSteps = oldSteps
+	})
+
+	err := runPatrolReportWithConfig(PatrolConfig{
+		RoleName:      "witness",
+		PatrolMolName: molName,
+		BeadsDir:      tmpDir,
+		Assignee:      assignee,
+		Beads:         b,
+	}, spawner)
+	if err != nil {
+		t.Fatalf("runPatrolReportWithConfig: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("spawner calls = %d, want 1", called)
+	}
+
+	issue, err := b.Show(rootID)
+	if err != nil {
+		t.Fatalf("show patrol: %v", err)
+	}
+	if issue.Status != "closed" {
+		t.Errorf("patrol status = %q, want closed", issue.Status)
 	}
 }
 
@@ -960,6 +1072,32 @@ func TestBurnPreviousPatrolWisps(t *testing.T) {
 		if issue.Status != "closed" {
 			t.Errorf("patrol %s status = %q, want %q after burn", id, issue.Status, "closed")
 		}
+	}
+}
+
+func TestBurnPreviousPatrolWispsBurnsEphemeralRoot(t *testing.T) {
+	requireBd(t)
+	tmpDir, b := setupPatrolTestDB(t)
+
+	molName := "mol-test-patrol"
+	assignee := "testrig/witness"
+	rootID := createHookedEphemeralPatrol(t, b, molName, assignee, false /* root-only */)
+
+	cfg := PatrolConfig{
+		PatrolMolName: molName,
+		BeadsDir:      tmpDir,
+		Assignee:      assignee,
+		Beads:         b,
+	}
+
+	burnPreviousPatrolWisps(cfg)
+
+	issue, err := b.Show(rootID)
+	if err != nil {
+		t.Fatalf("show patrol: %v", err)
+	}
+	if issue.Status != "closed" {
+		t.Errorf("patrol status = %q, want closed", issue.Status)
 	}
 }
 

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -738,6 +738,44 @@ func TestFindActivePatrolHooked(t *testing.T) {
 	}
 }
 
+func TestFindActivePatrolFindsInProgressBehindHookedNonPatrol(t *testing.T) {
+	requireBd(t)
+	tmpDir, b := setupPatrolTestDB(t)
+
+	molName := "mol-test-patrol"
+	assignee := "testrig/witness"
+
+	other, err := b.Create(beads.CreateOptions{Title: "other hooked work", Priority: -1})
+	if err != nil {
+		t.Fatalf("create other work: %v", err)
+	}
+	hooked := beads.StatusHooked
+	if err := b.Update(other.ID, beads.UpdateOptions{Status: &hooked, Assignee: &assignee}); err != nil {
+		t.Fatalf("hook other work: %v", err)
+	}
+
+	rootID := createHookedPatrol(t, b, molName, assignee, false /* root-only */)
+	inProgress := statusInProgress
+	if err := b.Update(rootID, beads.UpdateOptions{Status: &inProgress}); err != nil {
+		t.Fatalf("mark patrol in progress: %v", err)
+	}
+
+	cfg := PatrolConfig{
+		PatrolMolName: molName,
+		BeadsDir:      tmpDir,
+		Assignee:      assignee,
+		Beads:         b,
+	}
+
+	patrolID, _, found, findErr := findActivePatrol(cfg)
+	if findErr != nil {
+		t.Fatalf("findActivePatrol error: %v", findErr)
+	}
+	if !found || patrolID != rootID {
+		t.Fatalf("findActivePatrol found=%v id=%q, want %q", found, patrolID, rootID)
+	}
+}
+
 func TestRunPatrolReportNoActivePatrolStartsReplacement(t *testing.T) {
 	requireBd(t)
 	tmpDir, b := setupPatrolTestDB(t)

--- a/internal/cmd/patrol_report.go
+++ b/internal/cmd/patrol_report.go
@@ -80,18 +80,37 @@ func runPatrolReport(cmd *cobra.Command, args []string) error {
 	default:
 		return fmt.Errorf("unsupported role for patrol report: %q", roleName)
 	}
+	return runPatrolReportWithConfig(cfg, autoSpawnPatrol)
+}
 
+func runPatrolReportWithConfig(cfg PatrolConfig, spawnPatrol func(PatrolConfig) (string, error)) error {
+	if spawnPatrol == nil {
+		spawnPatrol = autoSpawnPatrol
+	}
 	// Find the active patrol
 	patrolID, _, hasPatrol, findErr := findActivePatrol(cfg)
 	if findErr != nil {
 		return fmt.Errorf("finding active patrol: %w", findErr)
 	}
 	if !hasPatrol {
-		return fmt.Errorf("no active patrol found for %s", cfg.RoleName)
+		newPatrolID, err := spawnPatrol(cfg)
+		if err != nil {
+			if newPatrolID != "" {
+				fmt.Fprintf(os.Stderr, "warning: %s\n", err.Error())
+				fmt.Printf("New patrol: %s\n", newPatrolID)
+				return nil
+			}
+			return fmt.Errorf("starting replacement patrol cycle: %w", err)
+		}
+		fmt.Printf("%s Started new patrol: %s\n", style.Success.Render("✓"), newPatrolID)
+		return nil
 	}
 
 	// Close the current patrol root with the summary
-	b := beads.New(cfg.BeadsDir)
+	b := cfg.Beads
+	if b == nil {
+		b = beads.New(cfg.BeadsDir)
+	}
 
 	// Build step audit checklist
 	stepAudit := buildStepAudit(cfg.PatrolMolName, patrolReportSteps)
@@ -123,7 +142,7 @@ func runPatrolReport(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s Closed patrol %s\n", style.Success.Render("✓"), patrolID)
 
 	// Start next cycle
-	newPatrolID, err := autoSpawnPatrol(cfg)
+	newPatrolID, err := spawnPatrol(cfg)
 	if err != nil {
 		if newPatrolID != "" {
 			fmt.Fprintf(os.Stderr, "warning: %s\n", err.Error())

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -833,29 +833,10 @@ func findAgentWorkOnce(ctx RoleContext, agentID string) (*beads.Issue, error) {
 		}
 	}
 
-	// Fallback: query by assignee
-	hookedBeads, err := b.List(beads.ListOptions{
-		Status:   beads.StatusHooked,
-		Assignee: agentID,
-		Priority: -1,
-	})
+	// Fallback: query by assignee.
+	hookedBeads, err := listAssignedActiveWork(b, agentID)
 	if err != nil {
-		return nil, fmt.Errorf("querying hooked beads: %w", err)
-	}
-
-	// Fall back to in_progress beads (session interrupted before completion)
-	if len(hookedBeads) == 0 {
-		inProgressBeads, err := b.List(beads.ListOptions{
-			Status:   "in_progress",
-			Assignee: agentID,
-			Priority: -1,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("querying in-progress beads: %w", err)
-		}
-		if len(inProgressBeads) > 0 {
-			hookedBeads = inProgressBeads
-		}
+		return nil, fmt.Errorf("querying active work: %w", err)
 	}
 
 	// Town-level fallback: rig-level agents (polecats, crew) may have hooked
@@ -863,18 +844,8 @@ func findAgentWorkOnce(ctx RoleContext, agentID string) (*beads.Issue, error) {
 	// Matches the fallback in molecule_status.go and unsling.go. (gt-dtq7)
 	if len(hookedBeads) == 0 && !isTownLevelRole(agentID) && ctx.TownRoot != "" {
 		townB := beads.New(filepath.Join(ctx.TownRoot, ".beads"))
-		if townHooked, err := townB.List(beads.ListOptions{
-			Status:   beads.StatusHooked,
-			Assignee: agentID,
-			Priority: -1,
-		}); err == nil && len(townHooked) > 0 {
-			hookedBeads = townHooked
-		} else if townIP, err := townB.List(beads.ListOptions{
-			Status:   "in_progress",
-			Assignee: agentID,
-			Priority: -1,
-		}); err == nil && len(townIP) > 0 {
-			hookedBeads = townIP
+		if townWork, err := listAssignedActiveWork(townB, agentID); err == nil && len(townWork) > 0 {
+			hookedBeads = townWork
 		}
 		// Town-level fallback errors are non-fatal — rig-level query succeeded
 	}

--- a/internal/cmd/prime_session.go
+++ b/internal/cmd/prime_session.go
@@ -338,48 +338,20 @@ func detectSessionState(ctx RoleContext) SessionState {
 			}
 		}
 
-		// Fallback: query by assignee
-		hookedBeads, err := b.List(beads.ListOptions{
-			Status:   beads.StatusHooked,
-			Assignee: agentID,
-			Priority: -1,
-		})
+		// Fallback: query active assigned work across durable issues and wisps.
+		hookedBeads, err := listAssignedActiveWork(b, agentID)
 		if err == nil && len(hookedBeads) > 0 {
 			state.State = "autonomous"
 			state.HookedBead = hookedBeads[0].ID
-			return state
-		}
-		// Also check in_progress beads
-		inProgressBeads, err := b.List(beads.ListOptions{
-			Status:   "in_progress",
-			Assignee: agentID,
-			Priority: -1,
-		})
-		if err == nil && len(inProgressBeads) > 0 {
-			state.State = "autonomous"
-			state.HookedBead = inProgressBeads[0].ID
 			return state
 		}
 		// Town-level fallback: rig-level agents may have hooked HQ beads
 		// stored in townRoot/.beads. Matches prime.go and molecule_status.go. (gt-dtq7)
 		if !isTownLevelRole(agentID) && ctx.TownRoot != "" {
 			townB := beads.New(filepath.Join(ctx.TownRoot, ".beads"))
-			if townHooked, err := townB.List(beads.ListOptions{
-				Status:   beads.StatusHooked,
-				Assignee: agentID,
-				Priority: -1,
-			}); err == nil && len(townHooked) > 0 {
+			if townWork, err := listAssignedActiveWork(townB, agentID); err == nil && len(townWork) > 0 {
 				state.State = "autonomous"
-				state.HookedBead = townHooked[0].ID
-				return state
-			}
-			if townIP, err := townB.List(beads.ListOptions{
-				Status:   "in_progress",
-				Assignee: agentID,
-				Priority: -1,
-			}); err == nil && len(townIP) > 0 {
-				state.State = "autonomous"
-				state.HookedBead = townIP[0].ID
+				state.HookedBead = townWork[0].ID
 				return state
 			}
 		}


### PR DESCRIPTION
Replacement/fixup for PR #4347.\n\nContext:\n- Original PR #4347 remains DIRTY/red after #4344.\n- This branch was produced from bead gt-pr-4347-post-4344-integration-fix by gastown/raider.\n- Scope is cleanup-first: converge active work lookup behavior without retry/shim/bandaid layers.\n\nVerification recorded by worker:\n- CGO_ENABLED=0 go test ./internal/cmd -run 'TestResolveHookLookupWorkDir|TestActiveWorkMergeBeadListsDedupeAndSort' -count=1 -v\n- CGO_ENABLED=0 go test ./internal/cmd -count=1\n- CGO_ENABLED=0 go test ./internal/beads -count=1\n- PR Sheriff non-merge checker passed.\n\nLimitation:\n- Original integration test could not run locally because rootless Docker is unavailable for the Dolt test container.\n\nDo not merge before fresh PR Sheriff merge-gate evidence is produced for this PR head.