### PR TITLE
fix: strip Beads data-dir from routing env

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -254,6 +254,52 @@ func TestBuildPinnedBDEnvFollowsRedirectBeforeMetadata(t *testing.T) {
 	}
 }
 
+func TestBuildBDEnvDoesNotRestoreGTDoltDataDir(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":4407}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := []string{
+		"PATH=/usr/bin",
+		"GT_DOLT_DATA=/town/.dolt-data",
+		"BEADS_DOLT_DATA_DIR=/wrong/data",
+		"BEADS_DOLT_SERVER_DATABASE=hq",
+	}
+
+	tests := []struct {
+		name       string
+		env        []string
+		wantDB     string
+		wantDBGone bool
+	}{
+		{name: "pinned", env: BuildPinnedBDEnv(base, beadsDir), wantDB: "rigdb"},
+		{name: "routing", env: BuildRoutingBDEnv(base, beadsDir), wantDBGone: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := envMap(tc.env)
+			if value, ok := got["BEADS_DOLT_DATA_DIR"]; ok {
+				t.Fatalf("BEADS_DOLT_DATA_DIR should stay stripped, got %q in %v", value, tc.env)
+			}
+			if tc.wantDBGone {
+				if value, ok := got["BEADS_DOLT_SERVER_DATABASE"]; ok {
+					t.Fatalf("BEADS_DOLT_SERVER_DATABASE should be stripped, got %q in %v", value, tc.env)
+				}
+				return
+			}
+			if got["BEADS_DOLT_SERVER_DATABASE"] != tc.wantDB {
+				t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want %q in %v", got["BEADS_DOLT_SERVER_DATABASE"], tc.wantDB, tc.env)
+			}
+		})
+	}
+}
+
 func TestBuildPinnedBDEnvStripsCaseVariantTargetEnvWhenKeysAreCaseInsensitive(t *testing.T) {
 	withCaseInsensitiveEnvKeys(t)
 

--- a/internal/beads/database.go
+++ b/internal/beads/database.go
@@ -83,7 +83,7 @@ func isBDTargetEnv(entry string) bool {
 func BuildPinnedBDEnv(base []string, beadsDir string) []string {
 	env := SuppressBDSideEffects(StripBDTargetEnv(base))
 	if beadsDir == "" {
-		return addGTDerivedDoltTargetEnv(env)
+		return addGTDerivedDoltConnectionEnv(env)
 	}
 	beadsDir = canonicalBeadsDir(beadsDir)
 	env = append(env, "BEADS_DIR="+beadsDir)
@@ -91,7 +91,7 @@ func BuildPinnedBDEnv(base []string, beadsDir string) []string {
 	if dbEnv := DatabaseEnv(beadsDir); dbEnv != "" {
 		env = append(env, dbEnv)
 	}
-	return addGTDerivedDoltTargetEnv(env)
+	return addGTDerivedDoltConnectionEnv(env)
 }
 
 // BuildRoutingBDEnv returns env for a bd subprocess that intentionally relies on
@@ -101,7 +101,7 @@ func BuildRoutingBDEnv(base []string, fallbackBeadsDir string) []string {
 	env := SuppressBDSideEffects(StripBDTargetEnv(base))
 	fallbackBeadsDir = canonicalBeadsDir(fallbackBeadsDir)
 	env = append(env, doltTargetEnvFromBeadsDir(fallbackBeadsDir)...)
-	return addGTDerivedDoltTargetEnv(env)
+	return addGTDerivedDoltConnectionEnv(env)
 }
 
 // BuildReadOnlyPinnedBDEnv returns env for a read-only bd subprocess pinned to
@@ -341,9 +341,11 @@ func envKeyHasPrefix(keyName, prefix string) bool {
 	return strings.HasPrefix(keyName, prefix)
 }
 
-func addGTDerivedDoltTargetEnv(env []string) []string {
+func addGTDerivedDoltConnectionEnv(env []string) []string {
 	gtHost := envValue(env, "GT_DOLT_HOST")
 	gtPort := envValue(env, "GT_DOLT_PORT")
+	// GT_DOLT_DATA is intentionally not translated to BEADS_DOLT_DATA_DIR here:
+	// data-dir env selects direct-mode storage and can override metadata routing.
 	if gtHost != "" && envValue(env, "BEADS_DOLT_SERVER_HOST") == "" {
 		env = append(env, "BEADS_DOLT_SERVER_HOST="+gtHost)
 	}

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -959,7 +959,7 @@ exit /b 0
 	}
 }
 
-func TestTargetRigResolverAllowsRouteResolvedGtBead(t *testing.T) {
+func TestTargetRigDatabaseAllowsRouteResolvedGtBead(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: shell stub uses POSIX env logging")
 	}
@@ -1021,8 +1021,8 @@ esac
 	t.Setenv("BEADS_DOLT_DATA_DIR", filepath.Join(townRoot, "wrong-data"))
 	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "hq")
 
-	if err := verifyBeadResolvesForTargetRig("gt-hq-oy83-cleanup", "gastown", townRoot); err != nil {
-		t.Fatalf("verifyBeadResolvesForTargetRig: %v", err)
+	if err := verifyBeadExistsInTargetRigDatabase("gt-hq-oy83-cleanup", "gastown", townRoot); err != nil {
+		t.Fatalf("verifyBeadExistsInTargetRigDatabase: %v", err)
 	}
 
 	logBytes, err := os.ReadFile(logPath)
@@ -1046,8 +1046,8 @@ esac
 	if parts[3] != "" {
 		t.Fatalf("BEADS_DOLT_DATA_DIR leaked: %q", parts[3])
 	}
-	if parts[4] != "" {
-		t.Fatalf("BEADS_DOLT_SERVER_DATABASE leaked: %q", parts[4])
+	if parts[4] != "gastown" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want gastown", parts[4])
 	}
 }
 

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -959,6 +959,98 @@ exit /b 0
 	}
 }
 
+func TestTargetRigResolverAllowsRouteResolvedGtBead(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: shell stub uses POSIX env logging")
+	}
+	beads.ResetBdAllowStaleCacheForTest()
+	t.Cleanup(beads.ResetBdAllowStaleCacheForTest)
+
+	townRoot := t.TempDir()
+	rigDir := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	for _, dir := range []string{filepath.Join(townRoot, ".beads"), filepath.Join(townRoot, "mayor", "rig"), filepath.Join(rigDir, ".beads")} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	routes := strings.Join([]string{
+		`{"prefix":"gt-","path":"gastown/mayor/rig"}`,
+		`{"prefix":"hq-","path":"."}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, ".beads", "metadata.json"), []byte(`{"dolt_database":"gastown","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`), 0644); err != nil {
+		t.Fatalf("write rig metadata: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+set -e
+if [ "$1" = "--allow-stale" ] && [ "${2:-}" = "version" ]; then
+  echo 'bd version 1.0.0'
+  exit 0
+fi
+printf '%s|%s|%s|%s|%s\n' "$*" "$(pwd)" "${BEADS_DIR:-}" "${BEADS_DOLT_DATA_DIR:-}" "${BEADS_DOLT_SERVER_DATABASE:-}" >> "${BD_LOG}"
+cmd="$1"
+shift || true
+if [ "$cmd" = "--allow-stale" ]; then
+  cmd="$1"
+  shift || true
+fi
+case "$cmd" in
+  show)
+    echo '[{"title":"Route issue","status":"open","assignee":"","description":""}]'
+    ;;
+  *)
+    echo "unexpected command: $cmd" >&2
+    exit 2
+    ;;
+esac
+`
+	_ = writeBDStub(t, binDir, bdScript, "")
+
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GT_DOLT_DATA", filepath.Join(townRoot, ".dolt-data"))
+	t.Setenv("BEADS_DOLT_DATA_DIR", filepath.Join(townRoot, "wrong-data"))
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "hq")
+
+	if err := verifyBeadResolvesForTargetRig("gt-hq-oy83-cleanup", "gastown", townRoot); err != nil {
+		t.Fatalf("verifyBeadResolvesForTargetRig: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	line := strings.TrimSpace(string(logBytes))
+	parts := strings.Split(line, "|")
+	if len(parts) != 5 {
+		t.Fatalf("malformed bd log: %q", line)
+	}
+	if !strings.Contains(parts[0], "show gt-hq-oy83-cleanup --json") {
+		t.Fatalf("bd args = %q, want route-resolved show", parts[0])
+	}
+	if parts[1] != rigDir {
+		t.Fatalf("bd cwd = %q, want %q", parts[1], rigDir)
+	}
+	if want := filepath.Join(rigDir, ".beads"); parts[2] != want {
+		t.Fatalf("BEADS_DIR = %q, want %q", parts[2], want)
+	}
+	if parts[3] != "" {
+		t.Fatalf("BEADS_DOLT_DATA_DIR leaked: %q", parts[3])
+	}
+	if parts[4] != "" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE leaked: %q", parts[4])
+	}
+}
+
 func setupCrossDatabaseSlingGuardTest(t *testing.T) (townRoot, logPath string) {
 	t.Helper()
 


### PR DESCRIPTION
Fixes live Gas Town routing failure from gt-global-beads-env-routing-sanitization.\n\nProblem reproduced by Mayor on 2026-07-02:\n- Runtime env exported BEADS_DOLT_DATA_DIR=/home/coder/gt/.dolt-data globally.\n- With that env present, bd create --repo gastown and bd create from gastown/mayor/rig selected HQ/default DB and rejected gt-* IDs with prefix mismatch.\n- gt sling/hook/formula bond could not resolve gt-* work for Gastown polecats.\n- env -u BEADS_DOLT_DATA_DIR restored correct Gastown metadata routing.\n\nFix approach:\n- Cleanup-first central env fix: stop deriving BEADS_DOLT_DATA_DIR from GT_DOLT_DATA in the central internal/beads database env policy.\n- Preserve host/port server-mode routing and selected metadata DB behavior.\n- Avoid per-command bandaids/shims.\n\nWorker verification:\n- CGO_ENABLED=0 go test ./internal/beads -run 'TestBuildBDEnv|TestBuildPinnedBDEnvFollowsRedirectBeforeMetadata|TestBuildPinnedBDEnvPinsRigDatabaseInsideTown'\n- GT_DOLT_PORT= GT_DOLT_HOST= CGO_ENABLED=0 go test ./internal/cmd -run 'TestTargetRigDatabaseAllowsRouteResolvedGtBead|TestTargetRigDatabaseLookupFailsClosedWithoutTownRoot|TestBdCmd_DirPinsBeadsDirAndStripsInheritedDatabase|TestBdCmd_WithBeadsDir_OverridesInheritedDoltTarget|TestConvoyStageBDHelpersPinRouteMetadataUnderStaleEnv'\n- git diff --check upstream/main...HEAD\n\nDo not merge before fresh PR Sheriff merge-gate evidence is produced for this PR head.