### PR TITLE
fix(polecat): generate action-compatible branch names

### DIFF
--- a/docs/concepts/polecat-lifecycle.md
+++ b/docs/concepts/polecat-lifecycle.md
@@ -155,14 +155,14 @@ When work completes and the polecat goes idle, the sandbox is synced to main:
 # In the polecat's worktree (done automatically by gt done / gt sling)
 git checkout main
 git pull origin main
-git branch -D polecat/<name>/<old-issue>@<timestamp>
+git branch -D polecat/<name>/<old-issue>+<timestamp>
 # Worktree is now clean, on main, ready for next assignment
 ```
 
 When new work is slung:
 ```bash
 # Create fresh branch from current main
-git checkout -b polecat/<name>/<new-issue>@<timestamp>
+git checkout -b polecat/<name>/<new-issue>+<timestamp>
 # Start working
 ```
 

--- a/docs/contrib-harnesses/polecat-pr-flow/README.md
+++ b/docs/contrib-harnesses/polecat-pr-flow/README.md
@@ -75,14 +75,14 @@ and adapt it. The point is a starting template, not a drop-in product.
 
 ## Fixing an existing PR (gh#3602)
 
-By default `gt sling` creates a fresh `polecat/<name>/<bead>@<ts>` branch from
+By default `gt sling` creates a fresh `polecat/<name>/<bead>+<ts>` branch from
 `main`, which means re-slinging a bead with an existing open PR opens a
 **duplicate** PR rather than reusing the original. To resume an existing PR
 branch, use `--branch` or `--pr`:
 
 ```bash
 # Resume by branch name (works for any open or stashed branch)
-gt sling <bead> <rig> --branch polecat/example/gh-1234@abcdef
+gt sling <bead> <rig> --branch polecat/example/gh-1234+abcdef
 
 # Resume by PR number (resolves the head ref via `gh pr view`)
 gt sling <bead> <rig> --pr 1234

--- a/docs/design/persistent-polecat-pool.md
+++ b/docs/design/persistent-polecat-pool.md
@@ -34,7 +34,7 @@ IDENTITY (persistent)
 
 SANDBOX (per-assignment, reusable)
   Worktree: polecats/furiosa/gastown/
-  Branch: polecat/furiosa/<issue>@<timestamp>
+  Branch: polecat/furiosa/<issue>+<timestamp>
   Lifecycle: synced to main between assignments, not destroyed
 
 SESSION (ephemeral)
@@ -95,14 +95,14 @@ When work completes and MR is merged (or no code changes):
 # In the polecat's worktree
 git checkout main
 git pull origin main
-git branch -D polecat/furiosa/<old-issue>@<timestamp>
+git branch -D polecat/furiosa/<old-issue>+<timestamp>
 # Worktree is now clean, on main, ready for next assignment
 ```
 
 When new work is slung:
 ```bash
 # Create fresh branch from current main
-git checkout -b polecat/furiosa/<new-issue>@<timestamp>
+git checkout -b polecat/furiosa/<new-issue>+<timestamp>
 # Start working
 ```
 

--- a/docs/design/polecat-lifecycle-patrol.md
+++ b/docs/design/polecat-lifecycle-patrol.md
@@ -583,7 +583,7 @@ The molecule stays in its current state (recoverable when the bug is fixed).
 Should not happen because the hook is exclusive (one `hook_bead` per agent bead,
 one agent bead per polecat name). But if it does:
 
-**Prevention:** Git branch naming includes a unique suffix (`@<timestamp>`).
+**Prevention:** Git branch naming includes a unique suffix (`+<timestamp>`).
 The TOCTOU guard in `DetectZombiePolecats()` (records `detectedAt`, re-verifies
 before destructive action) prevents racing between detection and action.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -192,7 +192,7 @@ bd update gt-rig-myrig --labels="polecat_branch_template:adam/{year}/{month}/{de
 **Default Behavior (backward compatible):**
 
 When `polecat_branch_template` is empty or not set:
-- With issue: `polecat/{name}/{issue}@{timestamp}`
+- With issue: `polecat/{name}/{issue}+{timestamp}`
 - Without issue: `polecat/{name}-{timestamp}`
 
 **Example Configurations:**

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -724,7 +724,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	if doneIssue == "" && info.Issue != "" && sender != "" {
 		if hookIssue, ambiguous := selectAssignedIssue(info.Issue, loadAssignedIssueIDs()); isStaleBranchIssue(info.Issue, hookIssue) {
 			style.PrintWarning("branch %q embeds issue %s but your hooked bead is %s — submitting for %s (stale branch reuse?)", branch, info.Issue, hookIssue, hookIssue)
-			fmt.Printf("  Fresh branches must be named polecat/<name>/<bead-id>@<suffix> for the bead you are working.\n")
+			fmt.Printf("  Fresh branches must be named polecat/<name>/<bead-id>+<suffix> for the bead you are working.\n")
 			fmt.Printf("  Use --issue to override if the branch-derived id is actually correct.\n\n")
 			issueID = hookIssue
 		} else if ambiguous {

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -12,8 +12,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
-	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/polecat"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -31,39 +31,20 @@ var issuePattern = regexp.MustCompile(`([a-z]+-[a-z0-9]+(?:\.[0-9]+)?)`)
 
 // parseBranchName extracts issue ID and worker from a branch name.
 // Supports formats:
+//   - polecat/<worker>/<issue>[+|@]<suffix>  → issue=<issue>, worker=<worker>
 //   - polecat/<worker>/<issue>  → issue=<issue>, worker=<worker>
-//   - polecat/<worker>-<timestamp>  → issue="", worker=<worker> (modern polecat branches)
+//   - polecat/<worker>-<suffix>  → issue="", worker=<worker>
 //   - <issue>                   → issue=<issue>, worker=""
 func parseBranchName(branch string) branchInfo {
 	info := branchInfo{Branch: branch}
 
-	// Try polecat/<worker>/<issue> or polecat/<worker>/<issue>@<timestamp> format
-	if strings.HasPrefix(branch, constants.BranchPolecatPrefix) {
-		parts := strings.SplitN(branch, "/", 3)
-		if len(parts) == 3 {
-			info.Worker = parts[1]
-			// Strip @timestamp suffix if present (e.g., "gt-abc@mk123" -> "gt-abc")
-			issue := parts[2]
-			if atIdx := strings.Index(issue, "@"); atIdx > 0 {
-				issue = issue[:atIdx]
-			}
-			info.Issue = issue
-			return info
-		}
-		// Modern polecat branch format: polecat/<worker>-<timestamp>
-		// The second part is "worker-timestamp", not an issue ID.
-		// Don't try to extract an issue ID - gt done will use hook_bead fallback.
-		if len(parts) == 2 {
-			// Extract worker name from "worker-timestamp" format
-			workerPart := parts[1]
-			if dashIdx := strings.LastIndex(workerPart, "-"); dashIdx > 0 {
-				info.Worker = workerPart[:dashIdx]
-			} else {
-				info.Worker = workerPart
-			}
-			// Explicitly don't set info.Issue - let hook_bead fallback handle it
-			return info
-		}
+	if meta, ok := polecat.ParseBranchName(branch); ok {
+		info.Worker = meta.Polecat
+		info.Issue = meta.Issue
+		return info
+	}
+	if strings.HasPrefix(branch, "polecat/") {
+		return info
 	}
 
 	// Try to find an issue ID pattern in the branch name

--- a/internal/cmd/mq_test.go
+++ b/internal/cmd/mq_test.go
@@ -27,10 +27,46 @@ func TestParseBranchName(t *testing.T) {
 			wantWorker: "Worker",
 		},
 		{
-			name:       "polecat branch with issue and timestamp",
+			name:       "generated polecat branch with issue and plus suffix",
+			branch:     "polecat/furiosa/gt-jns7.1+mk123456",
+			wantIssue:  "gt-jns7.1",
+			wantWorker: "furiosa",
+		},
+		{
+			name:       "legacy polecat branch with issue and at suffix",
 			branch:     "polecat/furiosa/gt-jns7.1@mk123456",
 			wantIssue:  "gt-jns7.1",
 			wantWorker: "furiosa",
+		},
+		{
+			name:       "generated polecat branch with dashed issue slug",
+			branch:     "polecat/alpha/gt-pin-bd-metadata+mk123456",
+			wantIssue:  "gt-pin-bd-metadata",
+			wantWorker: "alpha",
+		},
+		{
+			name:       "raw polecat branch with dashed issue slug",
+			branch:     "polecat/alpha/gt-pin-bd-metadata",
+			wantIssue:  "gt-pin-bd-metadata",
+			wantWorker: "alpha",
+		},
+		{
+			name:       "generated polecat branch with dotted subtask",
+			branch:     "polecat/alpha/gt-4kp9.5.5.1+mk123456",
+			wantIssue:  "gt-4kp9.5.5.1",
+			wantWorker: "alpha",
+		},
+		{
+			name:       "dash suffix stays part of issue slug",
+			branch:     "polecat/furiosa/gt-jns7.1-mk123456",
+			wantIssue:  "gt-jns7.1-mk123456",
+			wantWorker: "furiosa",
+		},
+		{
+			name:       "malformed polecat branch does not fall back to issue regex",
+			branch:     "polecat/alpha/gt-pin-bd-metadata+",
+			wantIssue:  "",
+			wantWorker: "",
 		},
 		{
 			name:       "modern polecat branch (timestamp format)",
@@ -378,7 +414,7 @@ func TestMRFilteringByLabel(t *testing.T) {
 			issue: &beads.Issue{
 				ID:     "mr-1",
 				Title:  "Merge: test-branch",
-				Type:   "task", // Wrong type (default from bd create)
+				Type:   "task",                       // Wrong type (default from bd create)
 				Labels: []string{"gt:merge-request"}, // Correct label
 			},
 			wantIsMR: true,

--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -59,7 +59,7 @@ type SlingSpawnOptions struct {
 	HookBead      string // Bead ID to set as hook_bead at spawn time (atomic assignment)
 	Agent         string // Agent override for this spawn (e.g., "gemini", "codex", "claude-haiku")
 	BaseBranch    string // Override base branch for polecat worktree (e.g., "develop", "release/v2")
-	ResumeBranch  string // Resume an existing branch (e.g. PR head) instead of creating polecat/<name>/<bead>@<ts>
+	ResumeBranch  string // Resume an existing branch (e.g. PR head) instead of creating polecat/<name>/<bead>+<ts>
 	SkipAdmission bool   // Caller already holds a polecat admission reservation
 }
 

--- a/internal/formula/formulas/mol-polecat-work-monorepo.formula.toml
+++ b/internal/formula/formulas/mol-polecat-work-monorepo.formula.toml
@@ -137,10 +137,10 @@ branch in step 2.
 **2. Create a fresh branch NAMED FOR THE HOOKED BEAD:**
 ```bash
 git fetch origin
-git checkout -b "polecat/<name>/{{issue}}@$(openssl rand -hex 3)" origin/{{base_branch}}
+git checkout -b "polecat/<name>/{{issue}}+$(openssl rand -hex 3)" origin/{{base_branch}}
 ```
 
-The format is `polecat/<your-name>/<bead-id>@<short-unique-suffix>`. The
+The format is `polecat/<your-name>/<bead-id>+<short-unique-suffix>`. The
 embedded bead-id is what makes MR attribution work; the suffix keeps the
 name unique across re-dispatches of the same bead.
 

--- a/internal/formula/formulas/mol-polecat-work.formula.toml
+++ b/internal/formula/formulas/mol-polecat-work.formula.toml
@@ -162,10 +162,10 @@ from a different bead is never reusable.
 **3. Otherwise, create a fresh branch NAMED FOR THE HOOKED BEAD:**
 ```bash
 git fetch origin
-git checkout -b "polecat/<name>/{{issue}}@$(openssl rand -hex 3)" origin/{{base_branch}}
+git checkout -b "polecat/<name>/{{issue}}+$(openssl rand -hex 3)" origin/{{base_branch}}
 ```
 
-The format is `polecat/<your-name>/<bead-id>@<short-unique-suffix>`. The
+The format is `polecat/<your-name>/<bead-id>+<short-unique-suffix>`. The
 embedded bead-id is what makes MR attribution work; the suffix keeps the
 name unique across re-dispatches of the same bead.
 

--- a/internal/polecat/branch_name.go
+++ b/internal/polecat/branch_name.go
@@ -1,0 +1,87 @@
+package polecat
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	polecatBranchPrefix           = "polecat/"
+	generatedIssueBranchSeparator = "+"
+	legacyIssueBranchSeparator    = "@"
+)
+
+// BranchNameMeta is the structured identity encoded in a polecat branch name.
+type BranchNameMeta struct {
+	Polecat   string
+	Issue     string
+	Generated bool
+}
+
+// FormatGeneratedBranchName returns the canonical generated polecat branch.
+func FormatGeneratedBranchName(polecatName, issue, suffix string) string {
+	if issue != "" {
+		return fmt.Sprintf("%s%s/%s%s%s", polecatBranchPrefix, polecatName, issue, generatedIssueBranchSeparator, suffix)
+	}
+	return fmt.Sprintf("%s%s-%s", polecatBranchPrefix, polecatName, suffix)
+}
+
+// ParseBranchName decodes polecat branch names without guessing at dashed issue IDs.
+func ParseBranchName(branch string) (BranchNameMeta, bool) {
+	if !strings.HasPrefix(branch, polecatBranchPrefix) {
+		return BranchNameMeta{}, false
+	}
+
+	rest := branch[len(polecatBranchPrefix):]
+	if rest == "" {
+		return BranchNameMeta{}, false
+	}
+
+	if slash := strings.Index(rest, "/"); slash >= 0 {
+		if slash == 0 {
+			return BranchNameMeta{}, false
+		}
+		polecatName := rest[:slash]
+		issueTail := rest[slash+1:]
+		if issueTail == "" || strings.Contains(issueTail, "/") {
+			return BranchNameMeta{}, false
+		}
+		issue, generated, ok := parseIssueTail(issueTail)
+		if !ok {
+			return BranchNameMeta{}, false
+		}
+		return BranchNameMeta{Polecat: polecatName, Issue: issue, Generated: generated}, true
+	}
+
+	dash := strings.LastIndex(rest, "-")
+	if dash <= 0 || dash == len(rest)-1 {
+		return BranchNameMeta{}, false
+	}
+	return BranchNameMeta{Polecat: rest[:dash], Generated: true}, true
+}
+
+// ParseGeneratedBranchName decodes only branch names emitted by FormatGeneratedBranchName
+// and the legacy @ issue-suffix form kept for in-flight branches.
+func ParseGeneratedBranchName(branch string) (BranchNameMeta, bool) {
+	meta, ok := ParseBranchName(branch)
+	if !ok || !meta.Generated {
+		return BranchNameMeta{}, false
+	}
+	return meta, true
+}
+
+func parseIssueTail(issueTail string) (issue string, generated bool, ok bool) {
+	delim := -1
+	for _, sep := range []string{generatedIssueBranchSeparator, legacyIssueBranchSeparator} {
+		if idx := strings.Index(issueTail, sep); idx >= 0 && (delim == -1 || idx < delim) {
+			delim = idx
+		}
+	}
+	if delim >= 0 {
+		if delim == 0 || delim == len(issueTail)-1 {
+			return "", false, false
+		}
+		return issueTail[:delim], true, true
+	}
+	return issueTail, false, true
+}

--- a/internal/polecat/branch_name_test.go
+++ b/internal/polecat/branch_name_test.go
@@ -1,0 +1,114 @@
+package polecat
+
+import (
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestFormatGeneratedBranchName_ActionCompatible(t *testing.T) {
+	branch := FormatGeneratedBranchName("alpha", "gt-pin-bd-metadata", "mk123456")
+	if strings.Contains(branch, "@") {
+		t.Fatalf("FormatGeneratedBranchName() = %q, must not contain @", branch)
+	}
+
+	claudeCodeActionBranch := regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9/_.#+,-]*$`)
+	if !claudeCodeActionBranch.MatchString(branch) {
+		t.Fatalf("FormatGeneratedBranchName() = %q, rejected by claude-code-action branch pattern", branch)
+	}
+	if err := exec.Command("git", "check-ref-format", "--branch", branch).Run(); err != nil {
+		t.Fatalf("FormatGeneratedBranchName() = %q, rejected by git check-ref-format: %v", branch, err)
+	}
+}
+
+func TestParseBranchName(t *testing.T) {
+	tests := []struct {
+		name          string
+		branch        string
+		wantOk        bool
+		wantGenerated bool
+		wantPolecat   string
+		wantIssue     string
+	}{
+		{
+			name:          "generated issue with plus suffix",
+			branch:        "polecat/alpha/gt-pin-bd-metadata+mk123456",
+			wantOk:        true,
+			wantGenerated: true,
+			wantPolecat:   "alpha",
+			wantIssue:     "gt-pin-bd-metadata",
+		},
+		{
+			name:          "generated dotted subtask with plus suffix",
+			branch:        "polecat/alpha/gt-4kp9.5.5.1+mk123456",
+			wantOk:        true,
+			wantGenerated: true,
+			wantPolecat:   "alpha",
+			wantIssue:     "gt-4kp9.5.5.1",
+		},
+		{
+			name:          "legacy generated issue with at suffix",
+			branch:        "polecat/alpha/gt-jns7.1@mk123456",
+			wantOk:        true,
+			wantGenerated: true,
+			wantPolecat:   "alpha",
+			wantIssue:     "gt-jns7.1",
+		},
+		{
+			name:        "raw dashed issue slug is not truncated",
+			branch:      "polecat/alpha/gt-pin-bd-metadata",
+			wantOk:      true,
+			wantPolecat: "alpha",
+			wantIssue:   "gt-pin-bd-metadata",
+		},
+		{
+			name:          "no issue generated branch",
+			branch:        "polecat/alpha-mk123456",
+			wantOk:        true,
+			wantGenerated: true,
+			wantPolecat:   "alpha",
+		},
+		{
+			name:   "empty generated suffix is invalid",
+			branch: "polecat/alpha/gt-abc+",
+		},
+		{
+			name:   "empty generated issue is invalid",
+			branch: "polecat/alpha/+mk123456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ParseBranchName(tt.branch)
+			if ok != tt.wantOk {
+				t.Fatalf("ParseBranchName(%q) ok = %v, want %v", tt.branch, ok, tt.wantOk)
+			}
+			if !ok {
+				return
+			}
+			if got.Generated != tt.wantGenerated {
+				t.Errorf("Generated = %v, want %v", got.Generated, tt.wantGenerated)
+			}
+			if got.Polecat != tt.wantPolecat {
+				t.Errorf("Polecat = %q, want %q", got.Polecat, tt.wantPolecat)
+			}
+			if got.Issue != tt.wantIssue {
+				t.Errorf("Issue = %q, want %q", got.Issue, tt.wantIssue)
+			}
+		})
+	}
+}
+
+func TestParseGeneratedBranchNameRejectsRawDashedIssues(t *testing.T) {
+	rejects := []string{
+		"polecat/alpha/gt-pin-bd-metadata",
+		"polecat/alpha/gt-jns7.1-mk123456",
+	}
+	for _, branch := range rejects {
+		if meta, ok := ParseGeneratedBranchName(branch); ok {
+			t.Errorf("ParseGeneratedBranchName(%q) = %+v, want ok=false", branch, meta)
+		}
+	}
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -534,7 +534,7 @@ type AddOptions struct {
 	HookBead   string // Bead ID to set as hook_bead at spawn time (atomic assignment)
 	BaseBranch string // Override base branch for worktree (e.g., "origin/integration/gt-epic")
 	// ResumeBranch reuses an existing branch (typically a PR head) for the polecat
-	// worktree instead of creating a fresh polecat/<name>/<bead>@<ts> branch (gh#3602).
+	// worktree instead of creating a fresh polecat/<name>/<bead>+<ts> branch (gh#3602).
 	// When set, the polecat's branch IS this branch — pushes go back to the same ref,
 	// updating the existing PR. Mutually exclusive with BaseBranch (resume implies its
 	// own start point). When empty, normal fresh-branch behavior is used.
@@ -555,7 +555,7 @@ type AddOptions struct {
 // - {timestamp}: unique timestamp
 //
 // If no template is configured or template is empty, uses default format:
-// - polecat/{name}/{issue}@{timestamp} when issue is available
+// - polecat/{name}/{issue}+{timestamp} when issue is available
 // - polecat/{name}-{timestamp} otherwise
 func (m *Manager) buildBranchName(name, issue string) string {
 	template := m.rig.GetStringConfig("polecat_branch_template")
@@ -563,10 +563,7 @@ func (m *Manager) buildBranchName(name, issue string) string {
 	// No template configured - use default behavior for backward compatibility
 	if template == "" {
 		timestamp := strconv.FormatInt(time.Now().UnixMilli(), 36)
-		if issue != "" {
-			return fmt.Sprintf("polecat/%s/%s@%s", name, issue, timestamp)
-		}
-		return fmt.Sprintf("polecat/%s-%s", name, timestamp)
+		return FormatGeneratedBranchName(name, issue, timestamp)
 	}
 
 	// Build template variables
@@ -1501,7 +1498,7 @@ func (m *Manager) RepairWorktreeWithOptions(name string, force bool, opts AddOpt
 
 	if opts.ResumeBranch != "" {
 		// Resume an existing branch: fetch and attach the temp worktree directly
-		// to the named branch instead of creating a fresh polecat/<name>/<bead>@<ts>.
+		// to the named branch instead of creating a fresh polecat/<name>/<bead>+<ts>.
 		if err := repoGit.FetchBranch("origin", opts.ResumeBranch); err != nil {
 			style.PrintWarning("could not fetch resume branch %s: %v", opts.ResumeBranch, err)
 		}
@@ -1779,7 +1776,7 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 
 	// Create or reset the branch tracking the start point. For resume, the branch
 	// IS opts.ResumeBranch (so pushes go back to the existing PR head). For fresh
-	// work, build a new polecat/<name>/<bead>@<ts> branch.
+	// work, build a new polecat/<name>/<bead>+<ts> branch.
 	branchName := m.buildBranchName(name, opts.HookBead)
 	if opts.ResumeBranch != "" {
 		branchName = opts.ResumeBranch

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -1097,7 +1098,7 @@ func TestBuildBranchName(t *testing.T) {
 			name:     "default_with_issue",
 			template: "", // Empty template = default behavior
 			issue:    "gt-123",
-			want:     "polecat/alpha/gt-123@", // timestamp suffix varies
+			want:     "polecat/alpha/gt-123+", // timestamp suffix varies
 		},
 		{
 			name:     "default_without_issue",
@@ -1169,6 +1170,44 @@ func TestBuildBranchName(t *testing.T) {
 						t.Errorf("buildBranchName() = %q, want %q", got, tt.want)
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestBuildBranchName_ClaudeActionCompatible(t *testing.T) {
+	tmpDir := t.TempDir()
+	gitCmd := exec.Command("git", "init")
+	gitCmd.Dir = tmpDir
+	if err := gitCmd.Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
+	g := git.NewGit(tmpDir)
+	m := NewManager(r, g, nil)
+
+	validator := regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9/_.#+,-]*$`)
+	cases := []struct {
+		name    string
+		polecat string
+		issue   string
+	}{
+		{name: "simple issue", polecat: "mutant", issue: "gt-abc"},
+		{name: "dotted subtask", polecat: "raider", issue: "gt-4kp9.5.5.1"},
+		{name: "hq prefix", polecat: "pipboy", issue: "hq-571c"},
+		{name: "no issue", polecat: "ghoul", issue: ""},
+		{name: "long polecat name", polecat: "thunderchief", issue: "gt-jns7.1"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := m.buildBranchName(c.polecat, c.issue)
+			if strings.Contains(got, "@") {
+				t.Fatalf("buildBranchName(%q, %q) = %q contains @", c.polecat, c.issue, got)
+			}
+			if !validator.MatchString(got) {
+				t.Fatalf("buildBranchName(%q, %q) = %q rejected by claude-code-action head-ref validator", c.polecat, c.issue, got)
 			}
 		})
 	}
@@ -1479,7 +1518,7 @@ func TestReuseIdlePolecat_UsesCanonicalOriginDefaultBranch(t *testing.T) {
 
 // TestAddWithOptions_ResumeBranch verifies gh#3602: when ResumeBranch is set,
 // AddWithOptions checks out the named existing branch instead of creating a
-// fresh polecat/<name>/<bead>@<ts> branch. This lets `gt sling --branch/--pr`
+// fresh polecat/<name>/<bead>+<ts> branch. This lets `gt sling --branch/--pr`
 // resume work on an existing PR branch without creating duplicates.
 func TestAddWithOptions_ResumeBranch(t *testing.T) {
 	mgr, mayorRig := setupCanonicalBranchManagerTest(t)

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -176,16 +176,13 @@ func (m *SessionManager) clonePath(polecat string) string {
 
 // freshBranchName returns a unique branch name for a new polecat session.
 // Mirrors the naming convention in Manager.buildBranchName:
-//   - polecat/<name>/<issue>@<timestamp> when an issue is known
+//   - polecat/<name>/<issue>+<timestamp> when an issue is known
 //   - polecat/<name>-<timestamp> otherwise
 //
 // parseFreshBranchName is the structural inverse.
 func (m *SessionManager) freshBranchName(polecatName, issue string) string {
 	ts := strconv.FormatInt(time.Now().UnixMilli(), 36)
-	if issue != "" {
-		return fmt.Sprintf("polecat/%s/%s@%s", polecatName, issue, ts)
-	}
-	return fmt.Sprintf("polecat/%s-%s", polecatName, ts)
+	return FormatGeneratedBranchName(polecatName, issue, ts)
 }
 
 // freshBranchMeta holds the identity decoded from a branch produced by
@@ -201,30 +198,11 @@ type freshBranchMeta struct {
 // the formatter emits. Used in place of substring heuristics so that
 // branch-naming changes can be made in a single place.
 func parseFreshBranchName(branch string) freshBranchMeta {
-	const prefix = "polecat/"
-	if !strings.HasPrefix(branch, prefix) {
+	meta, ok := ParseGeneratedBranchName(branch)
+	if !ok {
 		return freshBranchMeta{}
 	}
-	rest := branch[len(prefix):]
-	if slash := strings.Index(rest, "/"); slash >= 0 {
-		// polecat/<name>/<issue>@<ts>
-		if slash == 0 {
-			return freshBranchMeta{}
-		}
-		name := rest[:slash]
-		tail := rest[slash+1:]
-		at := strings.LastIndex(tail, "@")
-		if at <= 0 || at == len(tail)-1 {
-			return freshBranchMeta{}
-		}
-		return freshBranchMeta{polecat: name, issue: tail[:at], ok: true}
-	}
-	// polecat/<name>-<ts> (no slash in rest)
-	dash := strings.LastIndex(rest, "-")
-	if dash <= 0 || dash == len(rest)-1 {
-		return freshBranchMeta{}
-	}
-	return freshBranchMeta{polecat: rest[:dash], ok: true}
+	return freshBranchMeta{polecat: meta.Polecat, issue: meta.Issue, ok: true}
 }
 
 func (m *SessionManager) canonicalSessionStartPoint(g *git.Git) string {

--- a/internal/polecat/session_manager_test.go
+++ b/internal/polecat/session_manager_test.go
@@ -362,7 +362,7 @@ func TestEnsureCanonicalSessionBranch_UsesOriginDefaultBranch(t *testing.T) {
 
 	sm := NewSessionManager(tmux.NewTmux(), &rig.Rig{Name: "gastown", Path: workDir})
 	branch := sm.ensureCanonicalSessionBranch(repoGit, "toast", SessionStartOptions{Issue: "gt-9qb"})
-	if !strings.Contains(branch, "/gt-9qb@") {
+	if !strings.Contains(branch, "/gt-9qb+") {
 		t.Fatalf("fresh session branch = %q, want issue-scoped branch", branch)
 	}
 
@@ -642,9 +642,9 @@ func TestPromptlessFallbackIncludesPrimeAndWorkInstructions(t *testing.T) {
 // not auto-submitted; the condition triggers verifyStartupNudgeDelivery as a safety net.
 func TestModeABeaconVerificationCondition(t *testing.T) {
 	tests := []struct {
-		name            string
-		rc              *config.RuntimeConfig
-		wantModeA       bool // !SendBeaconNudge && !SendStartupNudge
+		name      string
+		rc        *config.RuntimeConfig
+		wantModeA bool // !SendBeaconNudge && !SendStartupNudge
 	}{
 		{
 			name: "Claude hook+prompt agent triggers Mode A verification",
@@ -870,6 +870,9 @@ func TestParseFreshBranchName_RoundTrip(t *testing.T) {
 		{name: "with issue", polecat: "alpha", issue: "gt-abc"},
 		{name: "no issue", polecat: "beta", issue: ""},
 		{name: "numeric issue", polecat: "nux", issue: "gt-123"},
+		{name: "dotted subtask", polecat: "furiosa", issue: "gt-jns7.1"},
+		{name: "dashed issue", polecat: "alpha", issue: "gt-pin-bd-metadata"},
+		{name: "nested dotted subtask", polecat: "alpha", issue: "gt-4kp9.5.5.1"},
 	}
 
 	for _, c := range cases {
@@ -889,18 +892,46 @@ func TestParseFreshBranchName_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseFreshBranchName_IssueTimestampSeparators(t *testing.T) {
+	cases := []struct {
+		name   string
+		branch string
+		issue  string
+	}{
+		{name: "current plus separator", branch: "polecat/alpha/gt-abc+mk123456", issue: "gt-abc"},
+		{name: "legacy at separator", branch: "polecat/alpha/gt-abc@mk123456", issue: "gt-abc"},
+		{name: "dotted subtask", branch: "polecat/alpha/gt-abc.1+mk123456", issue: "gt-abc.1"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			meta := parseFreshBranchName(c.branch)
+			if !meta.ok {
+				t.Fatalf("parseFreshBranchName(%q) not ok", c.branch)
+			}
+			if meta.polecat != "alpha" || meta.issue != c.issue {
+				t.Fatalf("parseFreshBranchName(%q) = %+v, want polecat alpha issue %s", c.branch, meta, c.issue)
+			}
+		})
+	}
+}
+
 func TestParseFreshBranchName_Rejects(t *testing.T) {
 	rejects := []string{
 		"main",
 		"master",
 		"develop",
 		"feature/x",
-		"polecat/",          // empty tail
-		"polecat/alpha",     // no ts or issue
-		"polecat/alpha-",    // trailing dash, no ts
-		"polecat//gt-abc@1", // empty polecat name
-		"polecat/alpha/@1",  // empty issue
-		"polecat/alpha/gt-abc@", // empty ts
+		"polecat/",                         // empty tail
+		"polecat/alpha",                    // no ts or issue
+		"polecat/alpha-",                   // trailing dash, no ts
+		"polecat//gt-abc@1",                // empty polecat name
+		"polecat/alpha/@1",                 // empty issue
+		"polecat/alpha/+1",                 // empty issue
+		"polecat/alpha/gt-abc@",            // empty ts
+		"polecat/alpha/gt-abc+",            // empty ts
+		"polecat/alpha/gt-pin-bd-metadata", // raw issue branch, not generated
+		"polecat/alpha/gt-jns7.1-mk123456", // dash suffix is ambiguous and not generated
 		"",
 	}
 	for _, b := range rejects {
@@ -936,6 +967,13 @@ func TestShouldCreateFreshSessionBranch_Structural(t *testing.T) {
 		},
 		{
 			name:            "same-issue respawn preserves branch",
+			currentBranch:   "polecat/alpha/gt-abc+xyz",
+			issue:           "gt-abc",
+			canonicalBranch: "main",
+			want:            false,
+		},
+		{
+			name:            "legacy same-issue respawn preserves branch",
 			currentBranch:   "polecat/alpha/gt-abc@xyz",
 			issue:           "gt-abc",
 			canonicalBranch: "main",
@@ -943,7 +981,7 @@ func TestShouldCreateFreshSessionBranch_Structural(t *testing.T) {
 		},
 		{
 			name:            "other-issue polecat branch triggers fresh",
-			currentBranch:   "polecat/alpha/gt-999@xyz",
+			currentBranch:   "polecat/alpha/gt-999+xyz",
 			issue:           "gt-abc",
 			canonicalBranch: "main",
 			want:            true,


### PR DESCRIPTION
## Summary

Clean current-main replacement for PR #4333. This carries forward only the valid branch-name bug fix and drops the unrelated MQ/daemon/witness/done/sling scope from the original dirty/conflicting PR.

## Changes

- Generate issue-bound polecat branches as `polecat/<name>/<issue>+<suffix>` instead of `polecat/<name>/<issue>@<suffix>`.
- Keep parsers compatible with legacy `@` branches and raw `polecat/<name>/<issue>` branches.
- Avoid broad dash-suffix stripping: dashed issue IDs remain part of the issue slug, and generated issue-bound suffixes use `+`.
- Add focused coverage for the claude-code-action head-ref validator and parser compatibility cases.

## Attribution

- Supersedes original PR: https://github.com/gastownhall/gastown/pull/4333
- Original PR author: @pugglepedia
- Original scoped fix commit considered: `d2ca37896c7cf878d5af8483df950bf3af5772f0`
- Replacement commit preserves a parseable `Co-authored-by: pugglepedia <pugglepedia@users.noreply.github.com>` trailer.
- Related beads/issues recorded by assignment: `hq-5w371`, `hq-1svtk`, `gt-s7cc`

## Verification

Final refreshed head: `04915e51d0d6f5a3a54096b9e8c5eb114e4f009b`
Base: `upstream/main@81e2fc8faa0b1e79dda1f7761d985601225b25f2`

- `CGO_ENABLED=0 go test ./internal/polecat -run 'TestFormatGeneratedBranchName|TestParseBranchName|TestParseGeneratedBranchNameRejectsRawDashedIssues|TestBuildBranchName|TestParseFreshBranchName|TestShouldCreateFreshSessionBranch'`
- `CGO_ENABLED=0 go test ./internal/cmd -run TestParseBranchName`
- `git diff --check upstream/main...HEAD`
- GitHub CI passed on final head: Test, Integration Tests, Lint, Reject go.mod replace directives, Reject issues.jsonl, Windows Smoke Test.

Plain full-package `go test` in this sandbox can be blocked by missing host ICU headers (`unicode/uregex.h` from `github.com/dolthub/go-icu-regex`). CI installs `libicu-dev`, so final full CI is the authoritative broad verification.

## PR Sheriff Evidence

- 15 independent research legs completed before refresh/rebase.
- 5 pre-implementation reviews approved the exact scope-neutral current-main refresh plan before changes.
- PR branch was refreshed onto current `upstream/main` as one clean attribution-safe commit without conflicts or scope expansion.
- 5 final validation reviews approved final head `04915e51d0d6f5a3a54096b9e8c5eb114e4f009b` after local verification and GitHub CI passed.
- Fresh `gt-pr-sheriff-check --merge-gate` passed with `merge_path_allowed: true`, `verdict: merge_replacement`; evidence file: `/tmp/opencode/gt-s7cc-pr4377-current-main-evidence.json`.
- Original PR #4333 should remain open until this replacement is merged and verified, then be closed as superseded.
