### PR TITLE
fix: pgrep -P on a dead PID matches every process, hanging session kills on macOS

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -841,25 +841,44 @@ func collectReparentedGroupMembers(pgid string, knownPIDs map[string]bool) []str
 	return reparented
 }
 
-// getAllDescendants recursively finds all descendant PIDs of a process.
+// getAllDescendants finds all descendant PIDs of a process.
 // Returns PIDs in deepest-first order so killing them doesn't orphan grandchildren.
+//
+// Implemented as a single ps snapshot walked in memory, NOT recursive pgrep -P
+// calls: on macOS, pgrep -P <pid> returns EVERY process on the system when
+// <pid> no longer exists (exit 0), so a transient child exiting between the
+// parent listing and its own lookup made the old recursive walk explode into
+// an unbounded traversal of the whole process table (gt sling/down hangs) —
+// and the resulting kill list would have included every user process.
 func getAllDescendants(pid string) []string {
-	var result []string
-
-	// Get direct children using pgrep
-	out, err := exec.Command("pgrep", "-P", pid).Output()
+	out, err := exec.Command("ps", "-axo", "pid=,ppid=").Output()
 	if err != nil {
-		return result
+		return nil
 	}
 
-	children := strings.Fields(strings.TrimSpace(string(out)))
-	for _, child := range children {
-		// First add grandchildren (recursively) - deepest first
-		result = append(result, getAllDescendants(child)...)
-		// Then add this child
-		result = append(result, child)
+	childrenOf := make(map[string][]string)
+	for _, line := range strings.Split(string(out), "\n") {
+		f := strings.Fields(line)
+		if len(f) != 2 {
+			continue
+		}
+		childrenOf[f[1]] = append(childrenOf[f[1]], f[0])
 	}
 
+	var result []string
+	seen := map[string]bool{pid: true}
+	var walk func(string)
+	walk = func(p string) {
+		for _, child := range childrenOf[p] {
+			if seen[child] {
+				continue
+			}
+			seen[child] = true
+			walk(child) // grandchildren first - deepest first
+			result = append(result, child)
+		}
+	}
+	walk(pid)
 	return result
 }
 
@@ -2384,43 +2403,42 @@ func hasDescendantWithNames(pid string, names []string, depth int) bool {
 	return hasDescendantWithNamesPosix(pid, names, depth)
 }
 
-// hasDescendantWithNamesPosix uses pgrep to find child processes on Unix systems.
-func hasDescendantWithNamesPosix(pid string, names []string, depth int) bool {
-	const maxDepth = 10
-	if depth > maxDepth {
-		return false
-	}
-	// Use pgrep to find child processes
-	cmd := exec.Command("pgrep", "-P", pid, "-l")
-	out, err := cmd.Output()
+// hasDescendantWithNamesPosix walks the process tree from a single ps
+// snapshot. See getAllDescendants for why this must not use recursive
+// pgrep -P calls (macOS pgrep -P on a dead PID matches every process).
+func hasDescendantWithNamesPosix(pid string, names []string, _ int) bool {
+	out, err := exec.Command("ps", "-axo", "pid=,ppid=,comm=").Output()
 	if err != nil {
 		return false
 	}
-	// Build a set of names for fast lookup
 	nameSet := make(map[string]bool, len(names))
 	for _, n := range names {
 		nameSet[n] = true
 	}
-	// Check if any child matches, or recursively check grandchildren
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
+	childrenOf := make(map[string][]string)
+	nameOf := make(map[string]string)
+	for _, line := range strings.Split(string(out), "\n") {
+		f := strings.Fields(line)
+		if len(f) < 3 {
 			continue
 		}
-		// Format: "PID name" e.g., "29677 node"
-		parts := strings.Fields(line)
-		if len(parts) >= 2 {
-			childPid := parts[0]
-			childName := parts[1]
-			// Direct match
-			if nameSet[childName] {
+		childrenOf[f[1]] = append(childrenOf[f[1]], f[0])
+		nameOf[f[0]] = filepath.Base(f[2])
+	}
+	queue := []string{pid}
+	seen := map[string]bool{pid: true}
+	for len(queue) > 0 {
+		p := queue[0]
+		queue = queue[1:]
+		for _, child := range childrenOf[p] {
+			if seen[child] {
+				continue
+			}
+			seen[child] = true
+			if nameSet[nameOf[child]] {
 				return true
 			}
-			// Recursive check of descendants
-			if hasDescendantWithNames(childPid, names, depth+1) {
-				return true
-			}
+			queue = append(queue, child)
 		}
 	}
 	return false


### PR DESCRIPTION
⚠️ Disclaimer: This PR was written by AI. I scanned all contributing docs and didn't see any guidelines around this, so I'm submitting this PR, constructed by Fable 5. I am not a `go` developer, but can confirm that this PR solved a problem that I was having with gastown on my mac running MasOS 26.5.1 (25F80).

I would mention that this PR complies with the **Zero Framework Cognition (ZFC)** policy. This fix is squarely on the "transport" side (walking a process tree to kill sessions — pure plumbing, no judgment logic), so it's ZFC-aligned.

---

## Problem

On macOS, `pgrep -P <pid>` where `<pid>` no longer exists returns **every process on the system** (~1000 PIDs, exit 0) instead of nothing:

```
$ pgrep -P 99999 | wc -l
    1032
$ ps -ax | wc -l
    1030
```

`getAllDescendants` walked the process tree recursively with one `pgrep -P` call per node. Agent sessions constantly spawn short-lived children (ripgrep, git, node helpers), so whenever one exited between being listed by its parent's `pgrep` and being visited by its own, the dead PID's lookup sprayed back the entire process table and the walk recursed into every process on the machine — with each further PID that died mid-walk spraying all ~1000 again. Effectively unbounded.

## Symptoms

- `gt sling <bead> <rig>` hangs forever when **reusing** an idle polecat (`ReuseIdlePolecat` → `killExistingPolecatSession` → `KillSessionWithProcesses`), while fresh spawns work — reuse is the path that kills an existing session. Hangs reproduce right after "Auto-detected integration branch:".
- `gt down` hangs (same kill path for each session).
- Intermittent by nature: only fires when a transient child dies inside the race window, so busy agent sessions hit it constantly while quiet ones don't.

A SIGQUIT goroutine dump of a hung `gt sling` shows the main goroutine 1050+ frames deep in `getAllDescendants`, still forking `pgrep`:

```
goroutine 1 [syscall]:
...
github.com/steveyegge/gastown/internal/tmux.getAllDescendants(...)
	internal/tmux/tmux.go:858 +0xe8
github.com/steveyegge/gastown/internal/tmux.getAllDescendants(...)
	internal/tmux/tmux.go:858 +0xe8
...1033 frames elided...
github.com/steveyegge/gastown/internal/tmux.(*Tmux).KillSessionWithProcesses(...)
	internal/tmux/tmux.go:655
github.com/steveyegge/gastown/internal/polecat.(*Manager).killExistingPolecatSession(...)
github.com/steveyegge/gastown/internal/polecat.(*Manager).ReuseIdlePolecat(...)
github.com/steveyegge/gastown/internal/cmd.SpawnPolecatForSling(...)
```

One more note for severity: had the walk ever completed, the descendant list would have contained **every user process on the machine**, and `KillSessionWithProcesses` would have SIGTERM/SIGKILLed all of them. The hang was the safe failure mode.

## Fix

Take a single `ps -axo pid=,ppid=` snapshot and walk the parent/child map in memory:

- `getAllDescendants`: same deepest-first ordering, one subprocess instead of one per node, no listed-vs-visited race window, cycle-proof via a seen-set.
- `hasDescendantWithNamesPosix` had the same flaw (its depth cap bounded recursion depth but not the full-table fan-out, and a dead PID could make zombie detection match any `node`/`claude` anywhere on the system). Now walks a `ps -axo pid=,ppid=,comm=` snapshot.

## Testing

- `go test -run 'Descendant' ./internal/tmux/` passes (`TestGetAllDescendants`, `TestHasDescendantWithNames`, including the nonexistent-PID case — which is exactly the bug scenario).
- End-to-end: a `gt sling` onto an idle polecat that reliably hung forever before the fix completes in ~46s after it (reuse → hook → session start).
- Other failures in `./internal/tmux/` (key bindings, startup dialogs, nudge) are environment-dependent and fail identically on the unmodified file.

## Adjacent work (not overlapping)

I searched all PRs (open + merged/closed) and issues for this root cause before opening; nothing else touches it. `getAllDescendants` was last modified in #882 (2026-01-25) for an unrelated handoff self-kill fix. Listing the near-neighbors so reviewers can see this is distinct:

- **#4049 / issue #3903** — `gt sling --dry-run` hang. A *different* hang: it stalls in the dry-run print path, not the session-kill path this PR fixes.
- **#4342** — `fix(tmux): nudge falls back to session name when stale pane ID`. Same file, unrelated function (nudge, not process-tree walking).
- **#4150** — `fix(tmux): guard NewSession against socket-clobber`. Same file, session-creation path.
- **#4244** — `refactor(tmux): centralize agent busy-indicator detection`. Same file, unrelated.
- **#3860** (closed) — `fix(mail): kill bd subprocess group on context timeout`. Different subsystem (mail/bd), but related in spirit — another place subprocess handling caused a hang.

No open issue tracks the symptom (polecat-reuse / `gt down` hangs on macOS); this PR is both the report and the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
