### PR TITLE
fix(refinery): clear agent active_mr on every MR close path

### DIFF
--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1629,6 +1629,19 @@ func (e *Engineer) closeMRWithReason(mr *MRInfo, closeReason string) error {
 		return fmt.Errorf("close MR: %w", err)
 	}
 	_, _ = fmt.Fprintf(e.output, "[Engineer] Closed MR bead: %s (%s)\n", mr.ID, closeReason)
+
+	// Clear the agent bead's active_mr reference now that this MR has reached
+	// a terminal state. Without this, check-recovery's fail-closed
+	// classification (polecat.AssessActiveMR) can report a permanent false
+	// active_mr blocker for an MR that was closed here — e.g. rejected as
+	// policy-ineligible via closeIneligibleMR, or closed as already-merged by
+	// recheckMRStillMergeable — since those paths previously never touched
+	// active_mr (only the separate HandleMRInfoSuccess merge path did).
+	if mr.AgentBead != "" {
+		if err := e.clearAgentActiveMR(mr.AgentBead); err != nil {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to clear agent bead %s active_mr: %v\n", mr.AgentBead, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -205,6 +205,122 @@ esac
 	}
 }
 
+// TestCloseMRWithReasonClearsAgentActiveMR is a regression test for
+// hci-ek35r / gt polecat check-recovery false active_mr blockers.
+//
+// Before this fix, closeMRWithReason (used by closeIneligibleMR for
+// rejected/policy-ineligible MRs, and by recheckMRStillMergeable's
+// already-merged dedup path) closed the MR bead but never cleared the
+// originating agent bead's active_mr reference — only the separate
+// HandleMRInfoSuccess happy-path merge did that. That left active_mr
+// permanently pointing at a closed (or later-purged) MR bead, which
+// AssessActiveMR's fail-closed classification then reports as a
+// permanent pending blocker in `gt polecat check-recovery`.
+func TestCloseMRWithReasonClearsAgentActiveMR(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+
+	townRoot := t.TempDir()
+	rigName := "gastown"
+	rigPath := filepath.Join(townRoot, rigName)
+	mayorRig := filepath.Join(rigPath, "mayor", "rig")
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	rigBeadsDir := filepath.Join(mayorRig, ".beads")
+
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor"),
+		townBeadsDir,
+		rigBeadsDir,
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+	if err := beads.WriteRoutes(townBeadsDir, []beads.Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: "gt-", Path: filepath.Join(rigName, "mayor", "rig")},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "bd.log")
+	script := fmt.Sprintf(`#!/bin/sh
+LOG=%q
+printf 'args=%%s\n' "$*" >> "$LOG"
+cmd=""
+id=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *)
+      if [ -z "$cmd" ]; then cmd="$arg"; else if [ -z "$id" ]; then id="$arg"; fi; fi
+      ;;
+  esac
+done
+case "$cmd" in
+  version)
+    exit 0
+    ;;
+  show)
+    case "$id" in
+      gt-mr1)
+        printf '%%s\n' '[{"id":"gt-mr1","title":"gt-mr1","issue_type":"task","labels":[],"status":"open","description":"branch: polecat/nitro/gt-src1\ntarget: main\nsource_issue: gt-src1"}]'
+        ;;
+      gt-agent1)
+        printf '%%s\n' '[{"id":"gt-agent1","title":"gt-agent1","issue_type":"task","labels":["gt:agent"],"status":"open","description":"role_type: polecat\nrig: gastown\nagent_state: idle\nactive_mr: gt-mr1"}]'
+        ;;
+      *)
+        printf '%%s\n' '[]'
+        ;;
+    esac
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, logPath)
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write mock bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	e := &Engineer{
+		rig:    &rig.Rig{Name: rigName, Path: rigPath},
+		beads:  beads.NewWithBeadsDir(mayorRig, rigBeadsDir),
+		output: io.Discard,
+	}
+
+	mr := &MRInfo{ID: "gt-mr1", AgentBead: "gt-agent1", SourceIssue: "gt-src1"}
+	if err := e.closeMRWithReason(mr, "rejected: policy test"); err != nil {
+		t.Fatalf("closeMRWithReason: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read mock log: %v", err)
+	}
+	logOutput := string(logBytes)
+
+	if !strings.Contains(logOutput, "args=show gt-mr1") {
+		t.Fatalf("expected MR bead to be shown; log:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "args=close gt-mr1") {
+		t.Fatalf("expected MR bead to be closed; log:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "args=show gt-agent1") {
+		t.Fatalf("expected agent bead to be looked up to clear active_mr; log:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "args=update gt-agent1") {
+		t.Fatalf("expected agent bead active_mr to be cleared via update; log:\n%s", logOutput)
+	}
+}
+
 func TestEngineer_LoadConfig_NoFile(t *testing.T) {
 	// Create a temp directory without config.json
 	tmpDir, err := os.MkdirTemp("", "engineer-test-*")


### PR DESCRIPTION
## Summary

`closeMRWithReason()` closed the MR bead but never cleared the originating
agent bead's `active_mr` reference. Only the separate `HandleMRInfoSuccess`
happy-path merge did that clear, via its own inline close logic.

Two other paths route through `closeMRWithReason` and left `active_mr` stale
forever:

- `closeIneligibleMR` (rejected/policy-ineligible MRs — e.g. missing
  `source_issue`, owned-direct, stale branch)
- `recheckMRStillMergeable`'s already-merged dedup close

Once `active_mr` pointed at a closed or later-purged MR bead,
`polecat.AssessActiveMR`'s fail-closed classification permanently blocked
`gt polecat check-recovery` from marking the polecat safe-to-reuse — even
though the underlying work was already merged or correctly rejected. This
matches the reported symptoms exactly: `fib/nitro` reporting `active_mr` for
an MR that `bd show` confirms is closed/merged, and `hci/rust` reporting
`active_mr` for an MR bead that no longer exists.

## Fix

Move the `active_mr` clear into `closeMRWithReason` itself, so every current
and future caller gets it — not just the merge-success path. Guarded by
`mr.AgentBead != ""`, and a clear failure is a non-fatal logged warning,
consistent with the existing pattern.

`polecat.AssessActiveMR`'s fail-closed read-side policy is intentionally left
untouched — its own doc comment states the conservatism is deliberate. The
actual bug was write-side (the field was never cleared), so the write-side
fix is the surgical, root-cause fix.

## Test plan

- [x] `go build ./internal/refinery/... ./internal/polecat/... ./internal/beads/...`
- [x] `go vet` on the same packages — clean
- [x] `go test ./internal/refinery/...` — all pass, including new
      `TestCloseMRWithReasonClearsAgentActiveMR` regression test (mocks the
      `bd` subprocess to assert the agent bead is looked up and updated when
      an MR is closed via `closeMRWithReason`)
- [x] `go test ./internal/polecat/...` — all pass (unchanged, confirms
      fail-closed policy untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)