### PR TITLE
fix(refinery): converge terminal MR active_mr cleanup

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -565,6 +565,51 @@ func (b *Beads) UpdateAgentActiveMR(id string, activeMR string) error {
 	return b.UpdateAgentDescriptionFields(id, AgentFieldUpdates{ActiveMR: &activeMR})
 }
 
+// ClearAgentActiveMRIfMatches clears active_mr only when the agent bead still
+// points at the expected MR. This prevents an old terminal MR close from
+// erasing a newer active_mr after the agent has been reused.
+func (b *Beads) ClearAgentActiveMRIfMatches(id string, expectedMR string) (bool, error) {
+	if target := b.agentBeadTarget(); target != b {
+		return target.ClearAgentActiveMRIfMatches(id, expectedMR)
+	}
+
+	expectedMR = strings.TrimSpace(expectedMR)
+	if strings.TrimSpace(id) == "" || expectedMR == "" {
+		return false, nil
+	}
+
+	fl, lockErr := b.lockAgentBead(id)
+	if lockErr != nil {
+		return false, fmt.Errorf("locking agent bead %s: %w", id, lockErr)
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	issue, err := b.Show(id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	if issue == nil {
+		return false, nil
+	}
+	if !IsAgentBead(issue) {
+		return false, fmt.Errorf("issue %s is not an agent bead (type=%s)", id, issue.Type)
+	}
+
+	fields := ParseAgentFields(issue.Description)
+	if fields.ActiveMR != expectedMR {
+		return false, nil
+	}
+	fields.ActiveMR = ""
+	description := FormatAgentDescription(issue.Title, fields)
+	if err := b.Update(id, UpdateOptions{Description: &description}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // UpdateAgentNotificationLevel updates the notification_level field in an agent bead.
 // Valid levels: verbose, normal, muted (DND mode).
 // Pass empty string to reset to default (normal).

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	beadsdk "github.com/steveyegge/beads"
 )
 
 func installMockBDFixedShowOutput(t *testing.T, showOutput string) {
@@ -251,6 +253,85 @@ func TestUpdateAgentState_UsesExplicitBeadsDir(t *testing.T) {
 	bd := NewWithBeadsDir(workDir, targetBeadsDir)
 	if err := bd.UpdateAgentState("gt-gastown-polecat-nux", "spawning"); err != nil {
 		t.Fatalf("UpdateAgentState: %v", err)
+	}
+}
+
+func TestClearAgentActiveMRIfMatches(t *testing.T) {
+	store := newMockStorage()
+	store.issues["gt-agent"] = &beadsdk.Issue{
+		ID:          "gt-agent",
+		Title:       "agent",
+		Status:      beadsdk.StatusOpen,
+		IssueType:   beadsdk.TypeTask,
+		Labels:      []string{"gt:agent"},
+		Description: "role_type: polecat\nrig: gastown\nagent_state: idle\nactive_mr: gt-mr",
+	}
+	bd := NewWithStore(t.TempDir(), store)
+
+	cleared, err := bd.ClearAgentActiveMRIfMatches("gt-agent", "gt-mr")
+	if err != nil {
+		t.Fatalf("ClearAgentActiveMRIfMatches: %v", err)
+	}
+	if !cleared {
+		t.Fatal("ClearAgentActiveMRIfMatches cleared=false, want true")
+	}
+	if got := ParseAgentFields(store.issues["gt-agent"].Description).ActiveMR; got != "" {
+		t.Fatalf("active_mr = %q, want cleared", got)
+	}
+}
+
+func TestClearAgentActiveMRIfMatchesNoopsWhenDifferentOrMissing(t *testing.T) {
+	store := newMockStorage()
+	store.issues["gt-agent"] = &beadsdk.Issue{
+		ID:          "gt-agent",
+		Title:       "agent",
+		Status:      beadsdk.StatusOpen,
+		IssueType:   beadsdk.TypeTask,
+		Labels:      []string{"gt:agent"},
+		Description: "role_type: polecat\nrig: gastown\nagent_state: idle\nactive_mr: gt-new",
+	}
+	bd := NewWithStore(t.TempDir(), store)
+
+	cleared, err := bd.ClearAgentActiveMRIfMatches("gt-agent", "gt-old")
+	if err != nil {
+		t.Fatalf("ClearAgentActiveMRIfMatches different: %v", err)
+	}
+	if cleared {
+		t.Fatal("ClearAgentActiveMRIfMatches cleared mismatched active_mr")
+	}
+	if got := ParseAgentFields(store.issues["gt-agent"].Description).ActiveMR; got != "gt-new" {
+		t.Fatalf("active_mr = %q, want gt-new", got)
+	}
+
+	cleared, err = bd.ClearAgentActiveMRIfMatches("gt-missing-agent", "gt-old")
+	if err != nil {
+		t.Fatalf("ClearAgentActiveMRIfMatches missing: %v", err)
+	}
+	if cleared {
+		t.Fatal("ClearAgentActiveMRIfMatches cleared missing agent")
+	}
+}
+
+func TestClearAgentActiveMRIfMatchesRejectsNonAgent(t *testing.T) {
+	store := newMockStorage()
+	store.issues["gt-issue"] = &beadsdk.Issue{
+		ID:          "gt-issue",
+		Title:       "not agent",
+		Status:      beadsdk.StatusOpen,
+		IssueType:   beadsdk.TypeTask,
+		Description: "active_mr: gt-mr",
+	}
+	bd := NewWithStore(t.TempDir(), store)
+
+	cleared, err := bd.ClearAgentActiveMRIfMatches("gt-issue", "gt-mr")
+	if err == nil {
+		t.Fatal("ClearAgentActiveMRIfMatches non-agent error = nil")
+	}
+	if cleared {
+		t.Fatal("ClearAgentActiveMRIfMatches cleared non-agent")
+	}
+	if got := store.issues["gt-issue"].Description; got != "active_mr: gt-mr" {
+		t.Fatalf("non-agent description mutated to %q", got)
 	}
 }
 

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -906,7 +906,7 @@ func (e *Engineer) recheckMRStillMergeable(mr *MRInfo, target string) ProcessRes
 		}
 		if closeReason := strings.TrimSpace(fields.CloseReason); closeReason != "" {
 			if strings.EqualFold(closeReason, string(CloseReasonMerged)) {
-				if err := e.closeMRWithReason(mr, string(CloseReasonMerged)); err != nil {
+				if err := e.closeMRWithReason(mr, string(CloseReasonMerged), ""); err != nil {
 					return ProcessResult{Success: false, Error: fmt.Sprintf("failed to close already-merged MR %s: %v", mrID, err)}
 				}
 				return mergeIneligibleResult("MR close_reason is %s", closeReason)
@@ -1359,32 +1359,9 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Released merge slot\n")
 	}
 
-	// Update and close the MR bead
-	if mr.ID != "" {
-		// Fetch the MR bead to update its fields
-		mrBead, err := e.beads.Show(mr.ID)
-		if err != nil {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to fetch MR bead %s: %v\n", mr.ID, err)
-		} else {
-			// Update MR with merge_commit SHA and close_reason
-			mrFields := beads.ParseMRFields(mrBead)
-			if mrFields == nil {
-				mrFields = &beads.MRFields{}
-			}
-			mrFields.MergeCommit = result.MergeCommit
-			mrFields.CloseReason = "merged"
-			newDesc := beads.SetMRFields(mrBead, mrFields)
-			if err := e.beads.Update(mr.ID, beads.UpdateOptions{Description: &newDesc}); err != nil {
-				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to update MR %s with merge commit: %v\n", mr.ID, err)
-			}
-		}
-
-		// Close MR bead with reason 'merged'
-		if err := e.beads.CloseWithReason("merged", mr.ID); err != nil {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to close MR %s: %v\n", mr.ID, err)
-		} else {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Closed MR bead: %s\n", mr.ID)
-		}
+	// Update and close the MR bead.
+	if err := e.closeMRWithReason(mr, string(CloseReasonMerged), result.MergeCommit); err != nil {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to close merged MR %s: %v\n", mr.ID, err)
 	}
 
 	// 1. Close source issue with reference to MR.
@@ -1412,13 +1389,6 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 	// Conflict beads otherwise outlive the successful re-land of their content
 	// and rot as open issues (re-dlcs/re-4i3b/re-gcii pattern).
 	e.closeSupersededConflictArtifacts(mr)
-
-	// 1.5. Clear agent bead's active_mr reference (traceability cleanup)
-	if mr.AgentBead != "" {
-		if err := e.clearAgentActiveMR(mr.AgentBead); err != nil {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to clear agent bead %s active_mr: %v\n", mr.AgentBead, err)
-		}
-	}
 
 	// 2. Delete source branch (local and remote).
 	// Polecat branches (polecat/*) are always cleaned up — they are ephemeral
@@ -1467,10 +1437,6 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 
 	// 5. Log success
 	_, _ = fmt.Fprintf(e.output, "[Engineer] ✓ Merged: %s (commit: %s)\n", mr.ID, result.MergeCommit)
-}
-
-func (e *Engineer) clearAgentActiveMR(agentBeadID string) error {
-	return e.beads.ForAgentBead().UpdateAgentActiveMR(agentBeadID, "")
 }
 
 // HandleMRInfoFailure handles a failed merge from MRInfo.
@@ -1597,10 +1563,10 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 }
 
 func (e *Engineer) closeIneligibleMR(mr *MRInfo, reason string) error {
-	return e.closeMRWithReason(mr, "rejected: "+reason)
+	return e.closeMRWithReason(mr, "rejected: "+reason, "")
 }
 
-func (e *Engineer) closeMRWithReason(mr *MRInfo, closeReason string) error {
+func (e *Engineer) closeMRWithReason(mr *MRInfo, closeReason string, mergeCommit string) error {
 	if mr == nil || strings.TrimSpace(mr.ID) == "" {
 		return nil
 	}
@@ -1611,13 +1577,20 @@ func (e *Engineer) closeMRWithReason(mr *MRInfo, closeReason string) error {
 		}
 		return nil
 	}
-	if issue == nil || beads.IssueStatus(issue.Status) != beads.StatusOpen {
+	if issue == nil || beads.IssueStatus(issue.Status).IsTerminal() {
 		return nil
 	}
 
 	fields := beads.ParseMRFields(issue)
 	if fields == nil {
 		fields = &beads.MRFields{}
+	}
+	agentBeadID := strings.TrimSpace(mr.AgentBead)
+	if agentBeadID == "" {
+		agentBeadID = strings.TrimSpace(fields.AgentBead)
+	}
+	if mergeCommit = strings.TrimSpace(mergeCommit); mergeCommit != "" {
+		fields.MergeCommit = mergeCommit
 	}
 	fields.CloseReason = normalizedMRCloseReason(closeReason)
 	newDesc := beads.SetMRFields(issue, fields)
@@ -1629,13 +1602,27 @@ func (e *Engineer) closeMRWithReason(mr *MRInfo, closeReason string) error {
 		return fmt.Errorf("close MR: %w", err)
 	}
 	_, _ = fmt.Fprintf(e.output, "[Engineer] Closed MR bead: %s (%s)\n", mr.ID, closeReason)
+	if agentBeadID != "" {
+		cleared, err := e.beads.ForAgentBead().ClearAgentActiveMRIfMatches(agentBeadID, mr.ID)
+		if err != nil {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to clear agent bead %s active_mr for MR %s: %v\n", agentBeadID, mr.ID, err)
+		} else if !cleared {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Agent bead %s active_mr no longer points at MR %s; leaving it intact\n", agentBeadID, mr.ID)
+		}
+	}
 	return nil
 }
 
 func normalizedMRCloseReason(closeReason string) string {
 	closeReason = strings.TrimSpace(closeReason)
-	if strings.HasPrefix(strings.ToLower(closeReason), "rejected:") {
+	lower := strings.ToLower(closeReason)
+	switch {
+	case strings.HasPrefix(lower, "rejected:"):
 		return string(CloseReasonRejected)
+	case strings.HasPrefix(lower, "superseded"):
+		return string(CloseReasonSuperseded)
+	case strings.HasPrefix(lower, "conflict"):
+		return string(CloseReasonConflict)
 	}
 	return closeReason
 }
@@ -1817,7 +1804,7 @@ func (e *Engineer) closeSupersededConflictArtifacts(merged *MRInfo) {
 			continue
 		}
 		reason := fmt.Sprintf("superseded by %s", merged.ID)
-		if err := e.beads.CloseWithReason(reason, other.ID); err != nil {
+		if err := e.closeMRWithReason(other, reason, ""); err != nil {
 			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to close superseded MR %s: %v\n", other.ID, err)
 		} else {
 			_, _ = fmt.Fprintf(e.output, "[Engineer] Closed superseded MR %s: %s\n", other.ID, reason)

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -13,9 +13,151 @@ import (
 	"testing"
 	"time"
 
+	beadsdk "github.com/steveyegge/beads"
+
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/rig"
 )
+
+type refineryTestStore struct {
+	beadsdk.Storage
+	issues       map[string]*beadsdk.Issue
+	closeReasons map[string]string
+}
+
+func newRefineryTestStore() *refineryTestStore {
+	return &refineryTestStore{
+		issues:       make(map[string]*beadsdk.Issue),
+		closeReasons: make(map[string]string),
+	}
+}
+
+func (s *refineryTestStore) GetIssue(_ context.Context, id string) (*beadsdk.Issue, error) {
+	issue, ok := s.issues[id]
+	if !ok {
+		return nil, fmt.Errorf("issue %s not found", id)
+	}
+	return issue, nil
+}
+
+func (s *refineryTestStore) GetIssuesByIDs(_ context.Context, ids []string) ([]*beadsdk.Issue, error) {
+	issues := make([]*beadsdk.Issue, 0, len(ids))
+	for _, id := range ids {
+		if issue, ok := s.issues[id]; ok {
+			issues = append(issues, issue)
+		}
+	}
+	return issues, nil
+}
+
+func (s *refineryTestStore) GetDependenciesWithMetadata(_ context.Context, _ string) ([]*beadsdk.IssueWithDependencyMetadata, error) {
+	return nil, nil
+}
+
+func (s *refineryTestStore) UpdateIssue(_ context.Context, id string, updates map[string]interface{}, _ string) error {
+	issue, ok := s.issues[id]
+	if !ok {
+		return fmt.Errorf("issue %s not found", id)
+	}
+	if v, ok := updates["description"]; ok {
+		issue.Description = v.(string)
+	}
+	if v, ok := updates["status"]; ok {
+		issue.Status = beadsdk.Status(v.(string))
+	}
+	issue.UpdatedAt = time.Now()
+	return nil
+}
+
+func (s *refineryTestStore) CloseIssue(_ context.Context, id, reason, _, _ string) error {
+	issue, ok := s.issues[id]
+	if !ok {
+		return fmt.Errorf("issue %s not found", id)
+	}
+	issue.Status = beadsdk.StatusClosed
+	now := time.Now()
+	issue.ClosedAt = &now
+	s.closeReasons[id] = reason
+	return nil
+}
+
+func (s *refineryTestStore) SearchIssues(_ context.Context, _ string, filter beadsdk.IssueFilter) ([]*beadsdk.Issue, error) {
+	var result []*beadsdk.Issue
+	for _, issue := range s.issues {
+		if filter.Status != nil && issue.Status != *filter.Status {
+			continue
+		}
+		if len(filter.Labels) > 0 && !refineryTestHasAllLabels(issue.Labels, filter.Labels) {
+			continue
+		}
+		result = append(result, issue)
+	}
+	return result, nil
+}
+
+func (s *refineryTestStore) GetLabels(_ context.Context, id string) ([]string, error) {
+	issue, ok := s.issues[id]
+	if !ok {
+		return nil, fmt.Errorf("issue %s not found", id)
+	}
+	return issue.Labels, nil
+}
+
+func (s *refineryTestStore) Close() error { return nil }
+
+func refineryTestHasLabel(labels []string, want string) bool {
+	for _, label := range labels {
+		if label == want {
+			return true
+		}
+	}
+	return false
+}
+
+func refineryTestHasAllLabels(labels []string, wants []string) bool {
+	for _, want := range wants {
+		if !refineryTestHasLabel(labels, want) {
+			return false
+		}
+	}
+	return true
+}
+
+func refineryTestIssue(id, title, desc string, labels ...string) *beadsdk.Issue {
+	now := time.Now()
+	return &beadsdk.Issue{
+		ID:          id,
+		Title:       title,
+		Description: desc,
+		Status:      beadsdk.StatusOpen,
+		IssueType:   beadsdk.TypeTask,
+		Priority:    2,
+		Labels:      labels,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+}
+
+func newRefineryTestEngineer(t *testing.T, store *refineryTestStore) *Engineer {
+	t.Helper()
+	workDir := t.TempDir()
+	stubDir := t.TempDir()
+	stubPath := filepath.Join(stubDir, "gt")
+	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("write gt stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return &Engineer{
+		rig:              &rig.Rig{Name: "gastown", Path: filepath.Join(workDir, "gastown")},
+		beads:            beads.NewWithStore(workDir, store),
+		git:              git.NewGit(workDir),
+		workDir:          workDir,
+		output:           io.Discard,
+		config:           DefaultMergeQueueConfig(),
+		mergeSlotRelease: func(_ string) error { return nil },
+	}
+}
 
 func TestDefaultMergeQueueConfig(t *testing.T) {
 	cfg := DefaultMergeQueueConfig()
@@ -117,7 +259,7 @@ func TestEngineerFirstOpenBlockerUsesDependencySemantics(t *testing.T) {
 	}
 }
 
-func TestEngineerClearAgentActiveMRUsesTownBeadsDir(t *testing.T) {
+func TestEngineerClearAgentActiveMRIfMatchesUsesTownBeadsDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses Unix shell script mock for bd")
 	}
@@ -188,8 +330,12 @@ esac
 		beads:  beads.NewWithBeadsDir(mayorRig, rigBeadsDir),
 		output: io.Discard,
 	}
-	if err := e.clearAgentActiveMR("gt-gastown-polecat-rust"); err != nil {
-		t.Fatalf("clearAgentActiveMR: %v", err)
+	cleared, err := e.beads.ForAgentBead().ClearAgentActiveMRIfMatches("gt-gastown-polecat-rust", "gt-mr")
+	if err != nil {
+		t.Fatalf("ClearAgentActiveMRIfMatches: %v", err)
+	}
+	if !cleared {
+		t.Fatal("ClearAgentActiveMRIfMatches did not clear matching active_mr")
 	}
 
 	logBytes, err := os.ReadFile(logPath)
@@ -202,6 +348,206 @@ esac
 	}
 	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, "args=show") || !strings.Contains(logOutput, "args=update") {
 		t.Fatalf("refinery active_mr cleanup did not use town BEADS_DIR; log:\n%s", logOutput)
+	}
+}
+
+func TestCloseMRWithReasonRejectsAndClearsMatchingActiveMR(t *testing.T) {
+	store := newRefineryTestStore()
+	store.issues["gt-mr"] = refineryTestIssue("gt-mr", "MR", `branch: feature/pr4381
+target: main
+source_issue: gt-src
+rig: gastown
+agent_bead: gt-agent`, "gt:merge-request")
+	store.issues["gt-src"] = refineryTestIssue("gt-src", "source", "")
+	store.issues["gt-agent"] = refineryTestIssue("gt-agent", "agent", `role_type: polecat
+rig: gastown
+agent_state: idle
+active_mr: gt-mr`, "gt:agent")
+	e := newRefineryTestEngineer(t, store)
+
+	if err := e.closeMRWithReason(&MRInfo{ID: "gt-mr", SourceIssue: "gt-src", AgentBead: "gt-agent"}, "rejected: source_issue gt-src has no_merge=true", ""); err != nil {
+		t.Fatalf("closeMRWithReason: %v", err)
+	}
+
+	mrIssue, err := e.beads.Show("gt-mr")
+	if err != nil {
+		t.Fatalf("show MR: %v", err)
+	}
+	mrFields := beads.ParseMRFields(mrIssue)
+	if mrFields.CloseReason != string(CloseReasonRejected) {
+		t.Fatalf("MR close_reason = %q, want %q", mrFields.CloseReason, CloseReasonRejected)
+	}
+	if mrFields.MergeCommit != "" {
+		t.Fatalf("MR merge_commit = %q, want empty", mrFields.MergeCommit)
+	}
+	if got := store.closeReasons["gt-mr"]; got != "rejected: source_issue gt-src has no_merge=true" {
+		t.Fatalf("MR close reason = %q", got)
+	}
+	if store.issues["gt-src"].Status != beadsdk.StatusOpen {
+		t.Fatalf("source issue status = %s, want open", store.issues["gt-src"].Status)
+	}
+	if got := beads.ParseAgentFields(store.issues["gt-agent"].Description).ActiveMR; got != "" {
+		t.Fatalf("agent active_mr = %q, want cleared", got)
+	}
+}
+
+func TestRecheckAlreadyMergedClosesMRWithoutClosingSource(t *testing.T) {
+	store := newRefineryTestStore()
+	store.issues["gt-mr"] = refineryTestIssue("gt-mr", "MR", `branch: feature/pr4381
+target: main
+source_issue: gt-src
+rig: gastown
+close_reason: merged
+agent_bead: gt-agent`, "gt:merge-request")
+	store.issues["gt-src"] = refineryTestIssue("gt-src", "source", "")
+	store.issues["gt-agent"] = refineryTestIssue("gt-agent", "agent", `role_type: polecat
+rig: gastown
+agent_state: idle
+active_mr: gt-mr`, "gt:agent")
+	e := newRefineryTestEngineer(t, store)
+
+	result := e.recheckMRStillMergeable(&MRInfo{ID: "gt-mr", SourceIssue: "gt-src", Target: "main", AgentBead: "gt-agent"}, "main")
+	if result.Success || !result.NoMerge {
+		t.Fatalf("recheck result = %+v, want no-merge", result)
+	}
+	if got := store.closeReasons["gt-mr"]; got != string(CloseReasonMerged) {
+		t.Fatalf("MR close reason = %q, want merged", got)
+	}
+	if store.issues["gt-src"].Status != beadsdk.StatusOpen {
+		t.Fatalf("source issue status = %s, want open", store.issues["gt-src"].Status)
+	}
+	if got := beads.ParseAgentFields(store.issues["gt-agent"].Description).ActiveMR; got != "" {
+		t.Fatalf("agent active_mr = %q, want cleared", got)
+	}
+}
+
+func TestHandleMRInfoSuccessUsesTerminalCloseHelper(t *testing.T) {
+	store := newRefineryTestStore()
+	store.issues["gt-mr"] = refineryTestIssue("gt-mr", "MR", `branch: contributor/pr4381
+target: main
+source_issue: gt-src
+rig: gastown
+agent_bead: gt-agent`, "gt:merge-request")
+	store.issues["gt-src"] = refineryTestIssue("gt-src", "source", "")
+	store.issues["gt-agent"] = refineryTestIssue("gt-agent", "agent", `role_type: polecat
+rig: gastown
+agent_state: idle
+active_mr: gt-mr`, "gt:agent")
+	e := newRefineryTestEngineer(t, store)
+
+	e.HandleMRInfoSuccess(&MRInfo{ID: "gt-mr", Branch: "contributor/pr4381", Target: "main", SourceIssue: "gt-src", AgentBead: "gt-agent"}, ProcessResult{Success: true, MergeCommit: "abc123"})
+
+	mrIssue, err := e.beads.Show("gt-mr")
+	if err != nil {
+		t.Fatalf("show MR: %v", err)
+	}
+	mrFields := beads.ParseMRFields(mrIssue)
+	if mrFields.CloseReason != string(CloseReasonMerged) {
+		t.Fatalf("MR close_reason = %q, want merged", mrFields.CloseReason)
+	}
+	if mrFields.MergeCommit != "abc123" {
+		t.Fatalf("MR merge_commit = %q, want abc123", mrFields.MergeCommit)
+	}
+	if got := store.closeReasons["gt-mr"]; got != string(CloseReasonMerged) {
+		t.Fatalf("MR close reason = %q, want merged", got)
+	}
+	if got := store.closeReasons["gt-src"]; !strings.Contains(got, "Merged in gt-mr") || !strings.Contains(got, "commit_sha: abc123") {
+		t.Fatalf("source close reason = %q", got)
+	}
+	if got := beads.ParseAgentFields(store.issues["gt-agent"].Description).ActiveMR; got != "" {
+		t.Fatalf("agent active_mr = %q, want cleared", got)
+	}
+}
+
+func TestCloseSupersededConflictArtifactsUsesTerminalCloseHelper(t *testing.T) {
+	store := newRefineryTestStore()
+	store.issues["gt-sibling"] = refineryTestIssue("gt-sibling", "sibling MR", `branch: contributor/pr4381-retry
+target: main
+source_issue: gt-src
+rig: gastown
+conflict_task_id: gt-conflict
+agent_bead: gt-agent`, "gt:merge-request")
+	store.issues["gt-src"] = refineryTestIssue("gt-src", "source", "")
+	store.issues["gt-agent"] = refineryTestIssue("gt-agent", "agent", `role_type: polecat
+rig: gastown
+agent_state: idle
+active_mr: gt-sibling`, "gt:agent")
+	store.issues["gt-conflict"] = refineryTestIssue("gt-conflict", "conflict", `Resolve merge conflicts
+
+## Metadata
+- Original MR: gt-sibling
+- Original issue: gt-src`)
+	e := newRefineryTestEngineer(t, store)
+
+	e.closeSupersededConflictArtifacts(&MRInfo{ID: "gt-landed", SourceIssue: "gt-src"})
+
+	mrIssue, err := e.beads.Show("gt-sibling")
+	if err != nil {
+		t.Fatalf("show sibling MR: %v", err)
+	}
+	mrFields := beads.ParseMRFields(mrIssue)
+	if mrFields.CloseReason != string(CloseReasonSuperseded) {
+		t.Fatalf("sibling close_reason = %q, want superseded", mrFields.CloseReason)
+	}
+	if mrFields.MergeCommit != "" {
+		t.Fatalf("sibling merge_commit = %q, want empty", mrFields.MergeCommit)
+	}
+	if got := store.closeReasons["gt-sibling"]; got != "superseded by gt-landed" {
+		t.Fatalf("sibling close reason = %q", got)
+	}
+	if got := store.closeReasons["gt-conflict"]; !strings.Contains(got, "conflict moot: gt-src landed") {
+		t.Fatalf("conflict close reason = %q", got)
+	}
+	if store.issues["gt-src"].Status != beadsdk.StatusOpen {
+		t.Fatalf("source issue status = %s, want open", store.issues["gt-src"].Status)
+	}
+	if got := beads.ParseAgentFields(store.issues["gt-agent"].Description).ActiveMR; got != "" {
+		t.Fatalf("agent active_mr = %q, want cleared", got)
+	}
+}
+
+func TestTerminalCloseDoesNotClearNewerActiveMR(t *testing.T) {
+	store := newRefineryTestStore()
+	store.issues["gt-old"] = refineryTestIssue("gt-old", "old MR", `branch: contributor/pr4381-old
+target: main
+source_issue: gt-src
+rig: gastown
+agent_bead: gt-agent`, "gt:merge-request")
+	store.issues["gt-agent"] = refineryTestIssue("gt-agent", "agent", `role_type: polecat
+rig: gastown
+agent_state: idle
+active_mr: gt-new`, "gt:agent")
+	e := newRefineryTestEngineer(t, store)
+
+	if err := e.closeMRWithReason(&MRInfo{ID: "gt-old", AgentBead: "gt-agent"}, string(CloseReasonMerged), ""); err != nil {
+		t.Fatalf("closeMRWithReason: %v", err)
+	}
+	if got := beads.ParseAgentFields(store.issues["gt-agent"].Description).ActiveMR; got != "gt-new" {
+		t.Fatalf("agent active_mr = %q, want gt-new", got)
+	}
+	if got := store.closeReasons["gt-old"]; got != string(CloseReasonMerged) {
+		t.Fatalf("old MR close reason = %q, want merged", got)
+	}
+}
+
+func TestTerminalCloseAgentClearFailureIsNonFatal(t *testing.T) {
+	store := newRefineryTestStore()
+	store.issues["gt-mr"] = refineryTestIssue("gt-mr", "MR", `branch: contributor/pr4381
+target: main
+source_issue: gt-src
+rig: gastown
+agent_bead: gt-not-agent`, "gt:merge-request")
+	store.issues["gt-not-agent"] = refineryTestIssue("gt-not-agent", "not agent", `active_mr: gt-mr`)
+	e := newRefineryTestEngineer(t, store)
+
+	if err := e.closeMRWithReason(&MRInfo{ID: "gt-mr", AgentBead: "gt-not-agent"}, string(CloseReasonMerged), ""); err != nil {
+		t.Fatalf("closeMRWithReason returned active_mr clear error: %v", err)
+	}
+	if got := store.closeReasons["gt-mr"]; got != string(CloseReasonMerged) {
+		t.Fatalf("MR close reason = %q, want merged", got)
+	}
+	if got := store.issues["gt-not-agent"].Description; got != `active_mr: gt-mr` {
+		t.Fatalf("non-agent description mutated to %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Cleanup-first maintainer replacement for #4381. This carries forward @hux's valid diagnosis while converging the terminal MR close paths instead of only adding cleanup to one path.

- Add `ClearAgentActiveMRIfMatches` so terminal MR cleanup clears an agent bead only when its current `active_mr` still equals the closing MR.
- Route Engineer terminal close paths through `closeMRWithReason`: rejected/ineligible, already-merged, success, and superseded conflict sibling close.
- Preserve success-only source issue closure and existing fail-closed `polecat.AssessActiveMR` read behavior.
- Record normalized MR `close_reason` while preserving detailed Beads close reasons.

## Attribution

This is a cleanup-first maintainer replacement for #4381, not a direct cherry-pick of 504cae65774aa74ebf008ce74b081d3a9e41e7d5. It carries forward @hux's terminal MR close-path convergence intent on current `main`.

Original PR: https://github.com/gastownhall/gastown/pull/4381
Original commit: https://github.com/gastownhall/gastown/commit/504cae65774aa74ebf008ce74b081d3a9e41e7d5
Contributor credit: @hux (`nitro <hux@j3di.net>`) via `Co-authored-by: nitro <hux@j3di.net>`.

## Verification

- `CGO_ENABLED=0 go build -o /tmp/opencode/gt-pr4381-verify ./cmd/gt`
- `CGO_ENABLED=0 go test ./internal/beads ./internal/refinery -run '^(TestClearAgentActiveMRIfMatches|TestClearAgentActiveMRIfMatchesNoopsWhenDifferentOrMissing|TestClearAgentActiveMRIfMatchesRejectsNonAgent|TestEngineerClearAgentActiveMRIfMatchesUsesTownBeadsDir|TestCloseMRWithReasonRejectsAndClearsMatchingActiveMR|TestRecheckAlreadyMergedClosesMRWithoutClosingSource|TestHandleMRInfoSuccessUsesTerminalCloseHelper|TestCloseSupersededConflictArtifactsUsesTerminalCloseHelper|TestTerminalCloseDoesNotClearNewerActiveMR|TestTerminalCloseAgentClearFailureIsNonFatal)$' -count=1`
- `CGO_ENABLED=0 go test ./internal/refinery ./internal/cmd ./internal/polecat ./internal/beads -run '^(TestEngineerClearAgentActiveMRIfMatchesUsesTownBeadsDir|TestCloseMRWithReasonRejectsAndClearsMatchingActiveMR|TestRecheckAlreadyMergedClosesMRWithoutClosingSource|TestHandleMRInfoSuccessUsesTerminalCloseHelper|TestCloseSupersededConflictArtifactsUsesTerminalCloseHelper|TestTerminalCloseDoesNotClearNewerActiveMR|TestTerminalCloseAgentClearFailureIsNonFatal|TestClearAgentActiveMRIfMatches|TestClearAgentActiveMRIfMatchesNoopsWhenDifferentOrMissing|TestClearAgentActiveMRIfMatchesRejectsNonAgent|TestActiveMRBlocker|TestRecoveryDispositionActiveWorkBlocksSafeToNuke|TestAssessActiveMR|TestAssessActiveMRLookupErrorsFailClosed|TestParseAgentFields_AllFields|TestAgentFieldsCompletionMetadataRoundTrip|TestMRFieldsRoundTrip|TestSetMRFields)$' -count=1`

## PR Sheriff

Evidence/checker artifacts are being materialized for `gt-7xgu` against head `3162a37adc1b711b1c88677480808ba9ec4cd9e2`.
