### PR TITLE
fix(tmux): harden process snapshot traversal tests

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -855,16 +855,22 @@ func getAllDescendants(pid string) []string {
 	if err != nil {
 		return nil
 	}
+	return descendantsFromPS(pid, out)
+}
 
+func descendantsFromPS(pid string, out []byte) []string {
 	childrenOf := make(map[string][]string)
 	for _, line := range strings.Split(string(out), "\n") {
 		f := strings.Fields(line)
-		if len(f) != 2 {
+		if len(f) < 2 {
 			continue
 		}
 		childrenOf[f[1]] = append(childrenOf[f[1]], f[0])
 	}
+	return walkDescendants(pid, childrenOf)
+}
 
+func walkDescendants(pid string, childrenOf map[string][]string) []string {
 	var result []string
 	seen := map[string]bool{pid: true}
 	var walk func(string)
@@ -2390,7 +2396,7 @@ func processMatchesNames(pid string, names []string) bool {
 }
 
 // hasDescendantWithNames checks if a process has any descendant (child, grandchild, etc.)
-// matching any of the given names. Recursively traverses the process tree up to maxDepth.
+// matching any of the given names.
 // Used when the pane command is a shell (bash, zsh, pwsh) that launched an agent.
 func hasDescendantWithNames(pid string, names []string, depth int) bool {
 	const maxDepth = 10 // Prevent infinite loops in case of circular references
@@ -2411,6 +2417,10 @@ func hasDescendantWithNamesPosix(pid string, names []string, _ int) bool {
 	if err != nil {
 		return false
 	}
+	return hasDescendantWithNamesFromPS(pid, names, out)
+}
+
+func hasDescendantWithNamesFromPS(pid string, names []string, out []byte) bool {
 	nameSet := make(map[string]bool, len(names))
 	for _, n := range names {
 		nameSet[n] = true
@@ -2423,7 +2433,7 @@ func hasDescendantWithNamesPosix(pid string, names []string, _ int) bool {
 			continue
 		}
 		childrenOf[f[1]] = append(childrenOf[f[1]], f[0])
-		nameOf[f[0]] = filepath.Base(f[2])
+		nameOf[f[0]] = filepath.Base(strings.Join(f[2:], " "))
 	}
 	queue := []string{pid}
 	seen := map[string]bool{pid: true}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -841,25 +841,44 @@ func collectReparentedGroupMembers(pgid string, knownPIDs map[string]bool) []str
 	return reparented
 }
 
-// getAllDescendants recursively finds all descendant PIDs of a process.
+// getAllDescendants finds all descendant PIDs of a process.
 // Returns PIDs in deepest-first order so killing them doesn't orphan grandchildren.
+//
+// Implemented as a single ps snapshot walked in memory, NOT recursive pgrep -P
+// calls: on macOS, pgrep -P <pid> returns EVERY process on the system when
+// <pid> no longer exists (exit 0), so a transient child exiting between the
+// parent listing and its own lookup made the old recursive walk explode into
+// an unbounded traversal of the whole process table (gt sling/down hangs) —
+// and the resulting kill list would have included every user process.
 func getAllDescendants(pid string) []string {
-	var result []string
-
-	// Get direct children using pgrep
-	out, err := exec.Command("pgrep", "-P", pid).Output()
+	out, err := exec.Command("ps", "-axo", "pid=,ppid=").Output()
 	if err != nil {
-		return result
+		return nil
 	}
 
-	children := strings.Fields(strings.TrimSpace(string(out)))
-	for _, child := range children {
-		// First add grandchildren (recursively) - deepest first
-		result = append(result, getAllDescendants(child)...)
-		// Then add this child
-		result = append(result, child)
+	childrenOf := make(map[string][]string)
+	for _, line := range strings.Split(string(out), "\n") {
+		f := strings.Fields(line)
+		if len(f) != 2 {
+			continue
+		}
+		childrenOf[f[1]] = append(childrenOf[f[1]], f[0])
 	}
 
+	var result []string
+	seen := map[string]bool{pid: true}
+	var walk func(string)
+	walk = func(p string) {
+		for _, child := range childrenOf[p] {
+			if seen[child] {
+				continue
+			}
+			seen[child] = true
+			walk(child) // grandchildren first - deepest first
+			result = append(result, child)
+		}
+	}
+	walk(pid)
 	return result
 }
 
@@ -2384,43 +2403,42 @@ func hasDescendantWithNames(pid string, names []string, depth int) bool {
 	return hasDescendantWithNamesPosix(pid, names, depth)
 }
 
-// hasDescendantWithNamesPosix uses pgrep to find child processes on Unix systems.
-func hasDescendantWithNamesPosix(pid string, names []string, depth int) bool {
-	const maxDepth = 10
-	if depth > maxDepth {
-		return false
-	}
-	// Use pgrep to find child processes
-	cmd := exec.Command("pgrep", "-P", pid, "-l")
-	out, err := cmd.Output()
+// hasDescendantWithNamesPosix walks the process tree from a single ps
+// snapshot. See getAllDescendants for why this must not use recursive
+// pgrep -P calls (macOS pgrep -P on a dead PID matches every process).
+func hasDescendantWithNamesPosix(pid string, names []string, _ int) bool {
+	out, err := exec.Command("ps", "-axo", "pid=,ppid=,comm=").Output()
 	if err != nil {
 		return false
 	}
-	// Build a set of names for fast lookup
 	nameSet := make(map[string]bool, len(names))
 	for _, n := range names {
 		nameSet[n] = true
 	}
-	// Check if any child matches, or recursively check grandchildren
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
+	childrenOf := make(map[string][]string)
+	nameOf := make(map[string]string)
+	for _, line := range strings.Split(string(out), "\n") {
+		f := strings.Fields(line)
+		if len(f) < 3 {
 			continue
 		}
-		// Format: "PID name" e.g., "29677 node"
-		parts := strings.Fields(line)
-		if len(parts) >= 2 {
-			childPid := parts[0]
-			childName := parts[1]
-			// Direct match
-			if nameSet[childName] {
+		childrenOf[f[1]] = append(childrenOf[f[1]], f[0])
+		nameOf[f[0]] = filepath.Base(f[2])
+	}
+	queue := []string{pid}
+	seen := map[string]bool{pid: true}
+	for len(queue) > 0 {
+		p := queue[0]
+		queue = queue[1:]
+		for _, child := range childrenOf[p] {
+			if seen[child] {
+				continue
+			}
+			seen[child] = true
+			if nameSet[nameOf[child]] {
 				return true
 			}
-			// Recursive check of descendants
-			if hasDescendantWithNames(childPid, names, depth+1) {
-				return true
-			}
+			queue = append(queue, child)
 		}
 	}
 	return false

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -700,6 +700,67 @@ func TestGetAllDescendants(t *testing.T) {
 	}
 }
 
+func TestDescendantsFromPS(t *testing.T) {
+	t.Parallel()
+
+	snapshot := []byte(`
+1 0
+2 1
+3 1
+4 2
+5 4
+2 1
+1 5
+6
+7 99
+`)
+
+	got := descendantsFromPS("1", snapshot)
+	if strings.Join(got, ",") != "5,4,2,3" {
+		t.Fatalf("descendantsFromPS returned %v, want deepest-first [5 4 2 3]", got)
+	}
+
+	got = descendantsFromPS("42", snapshot)
+	if len(got) != 0 {
+		t.Fatalf("descendantsFromPS for nonexistent root returned %v, want empty", got)
+	}
+}
+
+func TestHasDescendantWithNamesFromPS(t *testing.T) {
+	t.Parallel()
+
+	snapshot := []byte(`
+1 0 /usr/bin/bash
+2 1 tmux: client
+3 2 /usr/local/bin/node
+4 99 /usr/local/bin/node
+5 99 ruby
+bad row
+6
+`)
+
+	if !hasDescendantWithNamesFromPS("1", []string{"node"}, snapshot) {
+		t.Fatal("expected node descendant to match")
+	}
+	if !hasDescendantWithNamesFromPS("1", []string{"tmux: client"}, snapshot) {
+		t.Fatal("expected multi-word comm descendant to match")
+	}
+	if hasDescendantWithNamesFromPS("1", []string{"ruby"}, snapshot) {
+		t.Fatal("unrelated ruby process should not match")
+	}
+	if hasDescendantWithNamesFromPS("42", []string{"node"}, snapshot) {
+		t.Fatal("nonexistent root should not match ambient node process")
+	}
+	if hasDescendantWithNamesFromPS("1", nil, snapshot) {
+		t.Fatal("nil names should not match")
+	}
+
+	rootOnly := []byte("1 0 node\n")
+	if hasDescendantWithNamesFromPS("1", []string{"node"}, rootOnly) {
+		t.Fatal("root process name should not match as its own descendant")
+	}
+}
+
 func TestKillSessionWithProcesses(t *testing.T) {
 	tm := newTestTmux(t)
 	sessionName := "gt-test-killproc-" + t.Name()


### PR DESCRIPTION
Replacement/fixup for #4380.

This carries forward Peter Banka's accepted process-snapshot direction from #4380 and adds focused deterministic tests for the traversal/name-matching behavior identified by PR Sheriff.

Evidence from bead gt-5v0t:
- Original #4380 commit cherry-picked with Peter Banka as author.
- Follow-up commit adds private snapshot traversal helpers and deterministic tests.
- Focused verification passed locally: go test ./internal/tmux -run ^(TestDescendantsFromPS|TestHasDescendantWithNamesFromPS|TestGetAllDescendants|TestHasDescendantWithNames)$ -count=1 -short -timeout=2m.
- Race-focused internal/tmux verification was reported as passed by the polecat.
- PR Sheriff non-merge evidence was persisted; merge gate remained blocked pending macOS/CI and maintainer review.

No refinery/MQ path used. Original PR #4380 should remain open until this replacement/fixup merges and superseded closure evidence exists.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>