### PR TITLE
fix(refinery): converge terminal MR active_mr cleanup

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -565,6 +565,49 @@ func (b *Beads) UpdateAgentActiveMR(id string, activeMR string) error {
 	return b.UpdateAgentDescriptionFields(id, AgentFieldUpdates{ActiveMR: &activeMR})
 }
 
+// ClearAgentActiveMRIfMatches clears active_mr only when it still references
+// expectedMR. It returns true when a clear was written.
+func (b *Beads) ClearAgentActiveMRIfMatches(id string, expectedMR string) (bool, error) {
+	if target := b.agentBeadTarget(); target != b {
+		return target.ClearAgentActiveMRIfMatches(id, expectedMR)
+	}
+
+	id = strings.TrimSpace(id)
+	expectedMR = strings.TrimSpace(expectedMR)
+	if id == "" || expectedMR == "" {
+		return false, nil
+	}
+
+	fl, lockErr := b.lockAgentBead(id)
+	if lockErr != nil {
+		return false, fmt.Errorf("locking agent bead %s: %w", id, lockErr)
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	issue, err := b.Show(id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !IsAgentBead(issue) {
+		return false, fmt.Errorf("%s is not an agent bead", id)
+	}
+
+	fields := ParseAgentFields(issue.Description)
+	if strings.TrimSpace(fields.ActiveMR) != expectedMR {
+		return false, nil
+	}
+
+	fields.ActiveMR = ""
+	description := FormatAgentDescription(issue.Title, fields)
+	if err := b.Update(id, UpdateOptions{Description: &description}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // UpdateAgentNotificationLevel updates the notification_level field in an agent bead.
 // Valid levels: verbose, normal, muted (DND mode).
 // Pass empty string to reset to default (normal).

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -236,6 +236,84 @@ func TestUpdateAgentState_UsesUpdateDescriptionPath(t *testing.T) {
 	}
 }
 
+func TestClearAgentActiveMRIfMatchesClearsExactMatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for bd")
+	}
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	logPath := installMockBDShowRecorder(t, `[{"id":"gt-gastown-polecat-nux","title":"Polecat nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: working\nactive_mr: gt-wisp-old\ncleanup_status: clean"}]`)
+	bd := NewIsolated(tmpDir)
+
+	cleared, err := bd.ClearAgentActiveMRIfMatches("gt-gastown-polecat-nux", "gt-wisp-old")
+	if err != nil {
+		t.Fatalf("ClearAgentActiveMRIfMatches: %v", err)
+	}
+	if !cleared {
+		t.Fatal("ClearAgentActiveMRIfMatches cleared = false, want true")
+	}
+
+	logOutput := readMockBDLog(t, logPath)
+	if !strings.Contains(logOutput, "show gt-gastown-polecat-nux --json") || !strings.Contains(logOutput, "update gt-gastown-polecat-nux") {
+		t.Fatalf("mock bd log %q missing show/update", logOutput)
+	}
+}
+
+func TestClearAgentActiveMRIfMatchesNoopsWhenDifferent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for bd")
+	}
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	logPath := installMockBDShowRecorder(t, `[{"id":"gt-gastown-polecat-nux","title":"Polecat nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: working\nactive_mr: gt-wisp-new"}]`)
+	bd := NewIsolated(tmpDir)
+
+	cleared, err := bd.ClearAgentActiveMRIfMatches("gt-gastown-polecat-nux", "gt-wisp-old")
+	if err != nil {
+		t.Fatalf("ClearAgentActiveMRIfMatches: %v", err)
+	}
+	if cleared {
+		t.Fatal("ClearAgentActiveMRIfMatches cleared = true, want false")
+	}
+
+	logOutput := readMockBDLog(t, logPath)
+	if strings.Contains(logOutput, "update gt-gastown-polecat-nux") {
+		t.Fatalf("mock bd log %q unexpectedly updated mismatched active_mr", logOutput)
+	}
+}
+
+func TestClearAgentActiveMRIfMatchesRejectsNonAgent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for bd")
+	}
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	logPath := installMockBDShowRecorder(t, `[{"id":"gt-task","title":"Task","issue_type":"task","labels":["gt:task"],"description":"active_mr: gt-wisp-old"}]`)
+	bd := NewIsolated(tmpDir)
+
+	cleared, err := bd.ClearAgentActiveMRIfMatches("gt-task", "gt-wisp-old")
+	if err == nil {
+		t.Fatal("ClearAgentActiveMRIfMatches expected non-agent error")
+	}
+	if cleared {
+		t.Fatal("ClearAgentActiveMRIfMatches cleared = true, want false")
+	}
+
+	logOutput := readMockBDLog(t, logPath)
+	if strings.Contains(logOutput, "update gt-task") {
+		t.Fatalf("mock bd log %q unexpectedly updated non-agent", logOutput)
+	}
+}
+
 func TestUpdateAgentState_UsesExplicitBeadsDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses Unix shell script mocks for bd")

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1361,29 +1361,8 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 
 	// Update and close the MR bead
 	if mr.ID != "" {
-		// Fetch the MR bead to update its fields
-		mrBead, err := e.beads.Show(mr.ID)
-		if err != nil {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to fetch MR bead %s: %v\n", mr.ID, err)
-		} else {
-			// Update MR with merge_commit SHA and close_reason
-			mrFields := beads.ParseMRFields(mrBead)
-			if mrFields == nil {
-				mrFields = &beads.MRFields{}
-			}
-			mrFields.MergeCommit = result.MergeCommit
-			mrFields.CloseReason = "merged"
-			newDesc := beads.SetMRFields(mrBead, mrFields)
-			if err := e.beads.Update(mr.ID, beads.UpdateOptions{Description: &newDesc}); err != nil {
-				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to update MR %s with merge commit: %v\n", mr.ID, err)
-			}
-		}
-
-		// Close MR bead with reason 'merged'
-		if err := e.beads.CloseWithReason("merged", mr.ID); err != nil {
+		if err := e.closeMRWithReason(mr, string(CloseReasonMerged), result.MergeCommit); err != nil {
 			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to close MR %s: %v\n", mr.ID, err)
-		} else {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Closed MR bead: %s\n", mr.ID)
 		}
 	}
 
@@ -1412,13 +1391,6 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 	// Conflict beads otherwise outlive the successful re-land of their content
 	// and rot as open issues (re-dlcs/re-4i3b/re-gcii pattern).
 	e.closeSupersededConflictArtifacts(mr)
-
-	// 1.5. Clear agent bead's active_mr reference (traceability cleanup)
-	if mr.AgentBead != "" {
-		if err := e.clearAgentActiveMR(mr.AgentBead); err != nil {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to clear agent bead %s active_mr: %v\n", mr.AgentBead, err)
-		}
-	}
 
 	// 2. Delete source branch (local and remote).
 	// Polecat branches (polecat/*) are always cleaned up — they are ephemeral
@@ -1467,10 +1439,6 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 
 	// 5. Log success
 	_, _ = fmt.Fprintf(e.output, "[Engineer] ✓ Merged: %s (commit: %s)\n", mr.ID, result.MergeCommit)
-}
-
-func (e *Engineer) clearAgentActiveMR(agentBeadID string) error {
-	return e.beads.ForAgentBead().UpdateAgentActiveMR(agentBeadID, "")
 }
 
 // HandleMRInfoFailure handles a failed merge from MRInfo.
@@ -1600,42 +1568,43 @@ func (e *Engineer) closeIneligibleMR(mr *MRInfo, reason string) error {
 	return e.closeMRWithReason(mr, "rejected: "+reason)
 }
 
-func (e *Engineer) closeMRWithReason(mr *MRInfo, closeReason string) error {
+func (e *Engineer) closeMRWithReason(mr *MRInfo, closeReason string, mergeCommit ...string) error {
 	if mr == nil || strings.TrimSpace(mr.ID) == "" {
 		return nil
 	}
-	issue, err := e.beads.Show(mr.ID)
+	var commit string
+	if len(mergeCommit) > 0 {
+		commit = mergeCommit[0]
+	}
+	result, err := closeTerminalMR(e.beads, mr.ID, terminalMRCloseOptions{
+		Reason:        closeReason,
+		MergeCommit:   commit,
+		AgentBeadHint: mr.AgentBead,
+		MissingOK:     true,
+	})
 	if err != nil {
-		if !errors.Is(err, beads.ErrNotFound) {
-			return fmt.Errorf("fetch MR for close: %w", err)
-		}
-		return nil
+		return err
 	}
-	if issue == nil || beads.IssueStatus(issue.Status) != beads.StatusOpen {
-		return nil
+	if result.Closed {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] Closed MR bead: %s (%s)\n", mr.ID, closeReason)
 	}
-
-	fields := beads.ParseMRFields(issue)
-	if fields == nil {
-		fields = &beads.MRFields{}
+	if result.AgentActiveMRClearErr != nil {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to clear agent bead %s active_mr: %v\n", result.AgentBead, result.AgentActiveMRClearErr)
 	}
-	fields.CloseReason = normalizedMRCloseReason(closeReason)
-	newDesc := beads.SetMRFields(issue, fields)
-	if err := e.beads.Update(mr.ID, beads.UpdateOptions{Description: &newDesc}); err != nil {
-		return fmt.Errorf("record MR close reason: %w", err)
-	}
-
-	if err := e.beads.CloseWithReason(closeReason, mr.ID); err != nil {
-		return fmt.Errorf("close MR: %w", err)
-	}
-	_, _ = fmt.Fprintf(e.output, "[Engineer] Closed MR bead: %s (%s)\n", mr.ID, closeReason)
 	return nil
 }
 
 func normalizedMRCloseReason(closeReason string) string {
 	closeReason = strings.TrimSpace(closeReason)
-	if strings.HasPrefix(strings.ToLower(closeReason), "rejected:") {
+	lower := strings.ToLower(closeReason)
+	if strings.HasPrefix(lower, "rejected:") {
 		return string(CloseReasonRejected)
+	}
+	if strings.HasPrefix(lower, "superseded") {
+		return string(CloseReasonSuperseded)
+	}
+	if strings.HasPrefix(lower, "conflict") {
+		return string(CloseReasonConflict)
 	}
 	return closeReason
 }
@@ -1817,7 +1786,7 @@ func (e *Engineer) closeSupersededConflictArtifacts(merged *MRInfo) {
 			continue
 		}
 		reason := fmt.Sprintf("superseded by %s", merged.ID)
-		if err := e.beads.CloseWithReason(reason, other.ID); err != nil {
+		if err := e.closeMRWithReason(other, reason); err != nil {
 			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to close superseded MR %s: %v\n", other.ID, err)
 		} else {
 			_, _ = fmt.Fprintf(e.output, "[Engineer] Closed superseded MR %s: %s\n", other.ID, reason)

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -9,12 +9,14 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/rig"
+	"github.com/steveyegge/gastown/internal/testutil"
 )
 
 func TestDefaultMergeQueueConfig(t *testing.T) {
@@ -117,7 +119,7 @@ func TestEngineerFirstOpenBlockerUsesDependencySemantics(t *testing.T) {
 	}
 }
 
-func TestEngineerClearAgentActiveMRUsesTownBeadsDir(t *testing.T) {
+func TestEngineerTerminalCloseClearsAgentActiveMRUsesTownBeadsDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses Unix shell script mock for bd")
 	}
@@ -152,7 +154,6 @@ func TestEngineerClearAgentActiveMRUsesTownBeadsDir(t *testing.T) {
 	logPath := filepath.Join(binDir, "bd.log")
 	script := fmt.Sprintf(`#!/bin/sh
 LOG=%q
-EXPECTED=%q
 printf 'env=%%s args=%%s\n' "${BEADS_DIR:-<unset>}" "$*" >> "$LOG"
 cmd=""
 for arg in "$@"; do
@@ -161,23 +162,26 @@ for arg in "$@"; do
     *) cmd="$arg"; break ;;
   esac
 done
-if [ "$cmd" != "version" ] && [ "${BEADS_DIR:-}" != "$EXPECTED" ]; then
-  echo "wrong BEADS_DIR ${BEADS_DIR:-<unset>}" >&2
-  exit 9
-fi
 case "$cmd" in
-  version|update)
-    exit 0
-    ;;
-  show)
-    printf '%%s\n' '[{"id":"gt-gastown-polecat-rust","title":"gt-gastown-polecat-rust","issue_type":"task","labels":["gt:agent"],"status":"open","description":"role_type: polecat\nrig: gastown\nagent_state: idle\nactive_mr: gt-mr"}]'
-    exit 0
-    ;;
-  *)
+	version|update|close)
+		exit 0
+		;;
+	show)
+		case "$*" in
+			*gt-wisp-mr*)
+				printf '%%s\n' '[{"id":"gt-wisp-mr","title":"MR","issue_type":"task","labels":["gt:merge-request"],"status":"open","description":"branch: polecat/rust/gt-test\nsource_issue: gt-test\nagent_bead: gt-gastown-polecat-rust"}]'
+				;;
+			*)
+				printf '%%s\n' '[{"id":"gt-gastown-polecat-rust","title":"gt-gastown-polecat-rust","issue_type":"task","labels":["gt:agent"],"status":"open","description":"role_type: polecat\nrig: gastown\nagent_state: idle\nactive_mr: gt-wisp-mr"}]'
+				;;
+		esac
+		exit 0
+		;;
+	*)
     exit 0
     ;;
 esac
-`, logPath, townBeadsDir)
+`, logPath)
 	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
 		t.Fatalf("write mock bd: %v", err)
 	}
@@ -188,8 +192,8 @@ esac
 		beads:  beads.NewWithBeadsDir(mayorRig, rigBeadsDir),
 		output: io.Discard,
 	}
-	if err := e.clearAgentActiveMR("gt-gastown-polecat-rust"); err != nil {
-		t.Fatalf("clearAgentActiveMR: %v", err)
+	if err := e.closeMRWithReason(&MRInfo{ID: "gt-wisp-mr", AgentBead: "gt-gastown-polecat-rust"}, "rejected: test"); err != nil {
+		t.Fatalf("closeMRWithReason: %v", err)
 	}
 
 	logBytes, err := os.ReadFile(logPath)
@@ -197,12 +201,135 @@ esac
 		t.Fatalf("read mock log: %v", err)
 	}
 	logOutput := string(logBytes)
-	if strings.Contains(logOutput, "env="+rigBeadsDir) {
-		t.Fatalf("refinery active_mr cleanup used rig BEADS_DIR; log:\n%s", logOutput)
+	for _, line := range strings.Split(strings.TrimSpace(logOutput), "\n") {
+		if strings.Contains(line, "gt-gastown-polecat-rust") && strings.Contains(line, "env="+rigBeadsDir) {
+			t.Fatalf("refinery active_mr cleanup used rig BEADS_DIR; log:\n%s", logOutput)
+		}
 	}
-	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, "args=show") || !strings.Contains(logOutput, "args=update") {
+	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=show gt-gastown-polecat-rust") || !strings.Contains(logOutput, "env="+townBeadsDir+" args=update gt-gastown-polecat-rust") {
 		t.Fatalf("refinery active_mr cleanup did not use town BEADS_DIR; log:\n%s", logOutput)
 	}
+}
+
+func TestEngineerCloseMRWithReasonRecordsMergeCommitAndClearsActiveMR(t *testing.T) {
+	e, b, mrIssue, agentIssue, _ := setupEngineerTerminalCloseTest(t, "gt-wisp-old")
+
+	if err := e.closeMRWithReason(&MRInfo{ID: mrIssue.ID, AgentBead: agentIssue.ID}, string(CloseReasonMerged), "abc123"); err != nil {
+		t.Fatalf("closeMRWithReason: %v", err)
+	}
+
+	assertIssueStatus(t, b, mrIssue.ID, string(beads.StatusClosed))
+	assertAgentActiveMR(t, b, agentIssue.ID, "")
+	assertMRCloseReason(t, b, mrIssue.ID, string(CloseReasonMerged))
+	issue, err := b.Show(mrIssue.ID)
+	if err != nil {
+		t.Fatalf("show MR %s: %v", mrIssue.ID, err)
+	}
+	fields := beads.ParseMRFields(issue)
+	if fields.MergeCommit != "abc123" {
+		t.Fatalf("MR merge_commit = %q, want abc123", fields.MergeCommit)
+	}
+}
+
+func TestEngineerCloseMRWithReasonRejectsAndClearsMatchingActiveMR(t *testing.T) {
+	e, b, mrIssue, agentIssue, srcIssue := setupEngineerTerminalCloseTest(t, "gt-wisp-old")
+
+	if err := e.closeMRWithReason(&MRInfo{ID: mrIssue.ID, AgentBead: agentIssue.ID}, "rejected: policy failed"); err != nil {
+		t.Fatalf("closeMRWithReason: %v", err)
+	}
+
+	assertIssueStatus(t, b, mrIssue.ID, string(beads.StatusClosed))
+	assertIssueStatus(t, b, srcIssue.ID, string(beads.StatusOpen))
+	assertAgentActiveMR(t, b, agentIssue.ID, "")
+	assertMRCloseReason(t, b, mrIssue.ID, string(CloseReasonRejected))
+}
+
+func TestEngineerCloseMRWithReasonAlreadyTerminalRetriesActiveMRCleanup(t *testing.T) {
+	e, b, mrIssue, agentIssue, _ := setupEngineerTerminalCloseTest(t, "gt-wisp-old")
+	issue, err := b.Show(mrIssue.ID)
+	if err != nil {
+		t.Fatalf("show MR %s: %v", mrIssue.ID, err)
+	}
+	fields := beads.ParseMRFields(issue)
+	fields.CloseReason = string(CloseReasonRejected)
+	desc := beads.SetMRFields(issue, fields)
+	if err := b.Update(mrIssue.ID, beads.UpdateOptions{Description: &desc}); err != nil {
+		t.Fatalf("record close_reason: %v", err)
+	}
+	if err := b.CloseWithReason("rejected: policy failed", mrIssue.ID); err != nil {
+		t.Fatalf("close MR issue: %v", err)
+	}
+
+	if err := e.closeMRWithReason(&MRInfo{ID: mrIssue.ID, AgentBead: agentIssue.ID}, "rejected: policy failed"); err != nil {
+		t.Fatalf("closeMRWithReason retry: %v", err)
+	}
+
+	assertAgentActiveMR(t, b, agentIssue.ID, "")
+}
+
+func TestEngineerCloseMRWithReasonDoesNotClearNewerActiveMR(t *testing.T) {
+	e, b, mrIssue, agentIssue, _ := setupEngineerTerminalCloseTest(t, "gt-wisp-newer")
+
+	if err := e.closeMRWithReason(&MRInfo{ID: mrIssue.ID, AgentBead: agentIssue.ID}, "rejected: policy failed"); err != nil {
+		t.Fatalf("closeMRWithReason: %v", err)
+	}
+
+	assertAgentActiveMR(t, b, agentIssue.ID, "gt-wisp-newer")
+}
+
+func TestEngineerCloseMRWithReasonNormalizesSuperseded(t *testing.T) {
+	e, b, mrIssue, agentIssue, _ := setupEngineerTerminalCloseTest(t, "gt-wisp-old")
+
+	if err := e.closeMRWithReason(&MRInfo{ID: mrIssue.ID, AgentBead: agentIssue.ID}, "superseded by gt-wisp-new"); err != nil {
+		t.Fatalf("closeMRWithReason: %v", err)
+	}
+
+	assertAgentActiveMR(t, b, agentIssue.ID, "")
+	assertMRCloseReason(t, b, mrIssue.ID, string(CloseReasonSuperseded))
+}
+
+func setupEngineerTerminalCloseTest(t *testing.T, activeMR string) (*Engineer, *beads.Beads, *beads.Issue, *beads.Issue, *beads.Issue) {
+	t.Helper()
+	testutil.RequireDoltContainer(t)
+	port, _ := strconv.Atoi(testutil.DoltContainerPort())
+	rigPath := t.TempDir()
+	b := beads.NewIsolatedWithPort(rigPath, port)
+	if err := b.Init("gt"); err != nil {
+		t.Skipf("bd init unavailable: %v", err)
+	}
+
+	srcIssue, err := b.Create(beads.CreateOptions{Title: "Implement feature X", Labels: []string{"gt:task"}})
+	if err != nil {
+		t.Fatalf("create source issue: %v", err)
+	}
+	agentIssue, err := b.Create(beads.CreateOptions{
+		Title:       "Polecat nux",
+		Labels:      []string{"gt:agent"},
+		Description: "role_type: polecat\nrig: testrig\nagent_state: working\nactive_mr: " + activeMR,
+	})
+	if err != nil {
+		t.Fatalf("create agent issue: %v", err)
+	}
+	mrIssue, err := b.Create(beads.CreateOptions{
+		Title:       "MR for feature X",
+		Labels:      []string{"gt:merge-request"},
+		Description: "branch: polecat/test/gt-xyz\nsource_issue: " + srcIssue.ID + "\nworker: test\ntarget: main\nagent_bead: " + agentIssue.ID,
+	})
+	if err != nil {
+		t.Fatalf("create MR issue: %v", err)
+	}
+	if activeMR == "gt-wisp-old" {
+		if err := b.UpdateAgentActiveMR(agentIssue.ID, mrIssue.ID); err != nil {
+			t.Fatalf("set active_mr: %v", err)
+		}
+	}
+
+	e := &Engineer{
+		rig:    &rig.Rig{Name: "testrig", Path: rigPath},
+		beads:  b,
+		output: io.Discard,
+	}
+	return e, b, mrIssue, agentIssue, srcIssue
 }
 
 func TestEngineer_LoadConfig_NoFile(t *testing.T) {

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -606,31 +606,41 @@ func (m *Manager) RegisterMR(_ *MergeRequest) error {
 // It closes the MR with rejected status and optionally notifies the worker.
 // Returns the rejected MR for display purposes.
 func (m *Manager) RejectMR(idOrBranch string, reason string, notify bool) (*MergeRequest, error) {
-	mr, err := m.FindMR(idOrBranch)
+	b := beads.New(m.rig.BeadsPath())
+	mr, err := m.findMRForTerminalCleanup(idOrBranch, b)
 	if err != nil {
 		return nil, err
 	}
 
-	// Verify MR is open or in_progress (can't reject already closed)
-	if mr.IsClosed() {
-		return nil, fmt.Errorf("%w: MR is already closed with reason: %s", ErrClosedImmutable, mr.CloseReason)
-	}
-
-	// Close the bead in storage with the rejection reason
-	b := beads.New(m.rig.BeadsPath())
-	if err := b.CloseWithReason("rejected: "+reason, mr.ID); err != nil {
+	closeResult, err := closeTerminalMR(b, mr.ID, terminalMRCloseOptions{
+		Reason:        "rejected: " + reason,
+		AgentBeadHint: mr.AgentBead,
+	})
+	if err != nil {
 		return nil, fmt.Errorf("failed to close MR bead: %w", err)
+	}
+	if closeResult.AgentBead != "" {
+		mr.AgentBead = closeResult.AgentBead
+	}
+	if closeResult.AgentActiveMRClearErr != nil {
+		_, _ = fmt.Fprintf(m.output, "Warning: failed to clear agent bead %s active_mr: %v\n", closeResult.AgentBead, closeResult.AgentActiveMRClearErr)
 	}
 
 	// Update in-memory state for return value
-	if err := mr.Close(CloseReasonRejected); err != nil {
-		// Non-fatal: bead is already closed, just log
-		_, _ = fmt.Fprintf(m.output, "Warning: failed to update MR state: %v\n", err)
+	if closeResult.Closed {
+		if err := mr.Close(CloseReasonRejected); err != nil {
+			// Non-fatal: bead is already closed, just log
+			_, _ = fmt.Fprintf(m.output, "Warning: failed to update MR state: %v\n", err)
+		}
+	} else if closeResult.AlreadyTerminal {
+		mr.Status = MRClosed
+	} else {
+		return nil, fmt.Errorf("failed to close MR bead: MR %s status is not open or terminal", mr.ID)
 	}
 	mr.Error = reason
 
 	// Optionally notify worker
-	if notify {
+	if notify && !closeResult.AlreadyTerminal {
 		m.notifyWorkerRejected(mr, reason)
 	}
 
@@ -650,7 +660,8 @@ type PostMergeResult struct {
 // It closes the MR bead and its source issue. Branch deletion is handled
 // by the caller since the Manager doesn't have git access.
 func (m *Manager) PostMerge(idOrBranch string) (*PostMergeResult, error) {
-	mr, err := m.FindMR(idOrBranch)
+	b := beads.New(m.rig.BeadsPath())
+	mr, err := m.findMRForTerminalCleanup(idOrBranch, b)
 	if err != nil {
 		return nil, err
 	}
@@ -660,20 +671,37 @@ func (m *Manager) PostMerge(idOrBranch string) (*PostMergeResult, error) {
 		SourceIssueID: mr.IssueID,
 	}
 
-	b := beads.New(m.rig.BeadsPath())
-
 	// Close the MR bead
-	if mr.IsClosed() {
+	closeResult, err := closeTerminalMR(b, mr.ID, terminalMRCloseOptions{
+		Reason:        string(CloseReasonMerged),
+		MergeCommit:   mr.MergeCommit,
+		AgentBeadHint: mr.AgentBead,
+	})
+	if err != nil {
+		return result, fmt.Errorf("closing MR bead: %w", err)
+	}
+	if closeResult.AgentBead != "" {
+		mr.AgentBead = closeResult.AgentBead
+	}
+	if closeResult.AgentActiveMRClearErr != nil {
+		_, _ = fmt.Fprintf(m.output, "Warning: failed to clear agent bead %s active_mr: %v\n", closeResult.AgentBead, closeResult.AgentActiveMRClearErr)
+	}
+	if closeResult.AlreadyTerminal {
 		_, _ = fmt.Fprintf(m.output, "  %s MR already closed\n", style.Dim.Render("—"))
 		result.MRClosed = true
-	} else {
-		if err := b.CloseWithReason("merged", mr.ID); err != nil {
-			return result, fmt.Errorf("closing MR bead: %w", err)
+		if mr.CloseReason != CloseReasonMerged {
+			if mr.CloseReason == "" {
+				return result, fmt.Errorf("post-merge retry for already-closed MR %s requires close_reason=%s", mr.ID, CloseReasonMerged)
+			}
+			return result, fmt.Errorf("post-merge retry for already-closed MR %s has close_reason=%s", mr.ID, mr.CloseReason)
 		}
+	} else if closeResult.Closed {
 		if closeErr := mr.Close(CloseReasonMerged); closeErr != nil {
 			_, _ = fmt.Fprintf(m.output, "Warning: failed to update MR state: %v\n", closeErr)
 		}
 		result.MRClosed = true
+	} else {
+		return result, fmt.Errorf("closing MR bead: MR %s status is not open or terminal", mr.ID)
 	}
 
 	// Close the source issue with reason and --force to bypass dependency checks.

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -460,7 +460,7 @@ func (m *Manager) issueToMR(issue *beads.Issue) *MergeRequest {
 		return &MergeRequest{
 			ID:           issue.ID,
 			IssueID:      issue.ID,
-			Status:       MROpen,
+			Status:       mrStatusFromIssue(issue),
 			CreatedAt:    parseTime(issue.CreatedAt),
 			TargetBranch: defaultBranch,
 		}
@@ -476,12 +476,28 @@ func (m *Manager) issueToMR(issue *beads.Issue) *MergeRequest {
 		ID:           issue.ID,
 		Branch:       fields.Branch,
 		Worker:       fields.Worker,
+		AgentBead:    fields.AgentBead,
 		IssueID:      fields.SourceIssue,
 		TargetBranch: target,
 		MergeCommit:  fields.MergeCommit,
-		Status:       MROpen,
+		Status:       mrStatusFromIssue(issue),
+		CloseReason:  CloseReason(fields.CloseReason),
 		CreatedAt:    parseTime(issue.CreatedAt),
 	}
+}
+
+func mrStatusFromIssue(issue *beads.Issue) MRStatus {
+	if issue == nil {
+		return MROpen
+	}
+	status := beads.IssueStatus(strings.TrimSpace(issue.Status))
+	if status.IsTerminal() {
+		return MRClosed
+	}
+	if status == "in_progress" {
+		return MRInProgress
+	}
+	return MROpen
 }
 
 // parseTime parses a time string, returning zero time on error.
@@ -550,6 +566,25 @@ func (m *Manager) FindMR(idOrBranch string) (*MergeRequest, error) {
 	}
 
 	return nil, ErrMRNotFound
+}
+
+func (m *Manager) findMRForTerminalCleanup(idOrBranch string, b *beads.Beads) (*MergeRequest, error) {
+	mr, err := m.FindMR(idOrBranch)
+	if err == nil {
+		return mr, nil
+	}
+	if !errors.Is(err, ErrMRNotFound) {
+		return nil, err
+	}
+
+	issue, showErr := b.Show(idOrBranch)
+	if showErr != nil {
+		return nil, err
+	}
+	if issue == nil || !beads.HasLabel(issue, "gt:merge-request") {
+		return nil, err
+	}
+	return m.issueToMR(issue), nil
 }
 
 // Retry is deprecated - the Refinery agent handles retry logic autonomously.

--- a/internal/refinery/manager_test.go
+++ b/internal/refinery/manager_test.go
@@ -507,6 +507,184 @@ func TestManager_PostMerge_ClosesMRAndSourceIssue(t *testing.T) {
 	}
 }
 
+func TestManager_RejectMR_ClearsMatchingActiveMR(t *testing.T) {
+	mgr, rigPath := setupTestManager(t)
+	testutil.RequireDoltContainer(t)
+	port, _ := strconv.Atoi(testutil.DoltContainerPort())
+	b := beads.NewIsolatedWithPort(rigPath, port)
+	if err := b.Init("gt"); err != nil {
+		t.Skipf("bd init unavailable: %v", err)
+	}
+
+	srcIssue, err := b.Create(beads.CreateOptions{Title: "Implement feature X", Labels: []string{"gt:task"}})
+	if err != nil {
+		t.Fatalf("create source issue: %v", err)
+	}
+	agentIssue, err := b.Create(beads.CreateOptions{
+		Title:       "Polecat nux",
+		Labels:      []string{"gt:agent"},
+		Description: "role_type: polecat\nrig: testrig\nagent_state: working\nactive_mr: null",
+	})
+	if err != nil {
+		t.Fatalf("create agent issue: %v", err)
+	}
+	mrIssue, err := b.Create(beads.CreateOptions{
+		Title:       "MR for feature X",
+		Labels:      []string{"gt:merge-request"},
+		Description: "branch: polecat/test/gt-xyz\nsource_issue: " + srcIssue.ID + "\nworker: test\ntarget: main\nagent_bead: " + agentIssue.ID,
+	})
+	if err != nil {
+		t.Fatalf("create MR issue: %v", err)
+	}
+	if err := b.UpdateAgentActiveMR(agentIssue.ID, mrIssue.ID); err != nil {
+		t.Fatalf("set active_mr: %v", err)
+	}
+
+	result, err := mgr.RejectMR(mrIssue.ID, "policy failed", false)
+	if err != nil {
+		t.Fatalf("RejectMR() error: %v", err)
+	}
+	if result.Status != MRClosed {
+		t.Fatalf("RejectMR() status = %s, want closed", result.Status)
+	}
+
+	assertAgentActiveMR(t, b, agentIssue.ID, "")
+	assertIssueStatus(t, b, srcIssue.ID, string(beads.StatusOpen))
+	assertMRCloseReason(t, b, mrIssue.ID, string(CloseReasonRejected))
+}
+
+func TestManager_PostMerge_ClearsMatchingActiveMRAndClosesSource(t *testing.T) {
+	mgr, rigPath := setupTestManager(t)
+	testutil.RequireDoltContainer(t)
+	port, _ := strconv.Atoi(testutil.DoltContainerPort())
+	b := beads.NewIsolatedWithPort(rigPath, port)
+	if err := b.Init("gt"); err != nil {
+		t.Skipf("bd init unavailable: %v", err)
+	}
+
+	srcIssue, err := b.Create(beads.CreateOptions{Title: "Implement feature X", Labels: []string{"gt:task"}})
+	if err != nil {
+		t.Fatalf("create source issue: %v", err)
+	}
+	agentIssue, err := b.Create(beads.CreateOptions{
+		Title:       "Polecat nux",
+		Labels:      []string{"gt:agent"},
+		Description: "role_type: polecat\nrig: testrig\nagent_state: working\nactive_mr: null",
+	})
+	if err != nil {
+		t.Fatalf("create agent issue: %v", err)
+	}
+	mrIssue, err := b.Create(beads.CreateOptions{
+		Title:       "MR for feature X",
+		Labels:      []string{"gt:merge-request"},
+		Description: "branch: polecat/test/gt-xyz\nsource_issue: " + srcIssue.ID + "\nworker: test\ntarget: main\nagent_bead: " + agentIssue.ID + "\nmerge_commit: abc123",
+	})
+	if err != nil {
+		t.Fatalf("create MR issue: %v", err)
+	}
+	if err := b.UpdateAgentActiveMR(agentIssue.ID, mrIssue.ID); err != nil {
+		t.Fatalf("set active_mr: %v", err)
+	}
+
+	result, err := mgr.PostMerge(mrIssue.ID)
+	if err != nil {
+		t.Fatalf("PostMerge() error: %v", err)
+	}
+	if !result.MRClosed || !result.SourceIssueClosed {
+		t.Fatalf("PostMerge() result = %+v, want MR/source closed", result)
+	}
+
+	assertAgentActiveMR(t, b, agentIssue.ID, "")
+	assertIssueStatus(t, b, srcIssue.ID, string(beads.StatusClosed))
+	assertMRCloseReason(t, b, mrIssue.ID, string(CloseReasonMerged))
+}
+
+func TestManager_PostMerge_AlreadyClosedMRRetriesActiveMRCleanup(t *testing.T) {
+	mgr, rigPath := setupTestManager(t)
+	testutil.RequireDoltContainer(t)
+	port, _ := strconv.Atoi(testutil.DoltContainerPort())
+	b := beads.NewIsolatedWithPort(rigPath, port)
+	if err := b.Init("gt"); err != nil {
+		t.Skipf("bd init unavailable: %v", err)
+	}
+
+	srcIssue, err := b.Create(beads.CreateOptions{Title: "Implement feature X", Labels: []string{"gt:task"}})
+	if err != nil {
+		t.Fatalf("create source issue: %v", err)
+	}
+	agentIssue, err := b.Create(beads.CreateOptions{
+		Title:       "Polecat nux",
+		Labels:      []string{"gt:agent"},
+		Description: "role_type: polecat\nrig: testrig\nagent_state: working\nactive_mr: null",
+	})
+	if err != nil {
+		t.Fatalf("create agent issue: %v", err)
+	}
+	mrIssue, err := b.Create(beads.CreateOptions{
+		Title:       "Already merged MR",
+		Labels:      []string{"gt:merge-request"},
+		Description: "branch: polecat/test/gt-xyz\nsource_issue: " + srcIssue.ID + "\nworker: test\ntarget: main\nagent_bead: " + agentIssue.ID + "\nclose_reason: merged",
+	})
+	if err != nil {
+		t.Fatalf("create MR issue: %v", err)
+	}
+	if err := b.UpdateAgentActiveMR(agentIssue.ID, mrIssue.ID); err != nil {
+		t.Fatalf("set active_mr: %v", err)
+	}
+	if err := b.CloseWithReason("merged", mrIssue.ID); err != nil {
+		t.Fatalf("close MR issue: %v", err)
+	}
+
+	result, err := mgr.PostMerge(mrIssue.ID)
+	if err != nil {
+		t.Fatalf("PostMerge() error: %v", err)
+	}
+	if !result.MRClosed || !result.SourceIssueClosed {
+		t.Fatalf("PostMerge() result = %+v, want MR/source closed", result)
+	}
+
+	assertAgentActiveMR(t, b, agentIssue.ID, "")
+	assertIssueStatus(t, b, srcIssue.ID, string(beads.StatusClosed))
+}
+
+func TestManager_TerminalCloseDoesNotClearNewerActiveMR(t *testing.T) {
+	mgr, rigPath := setupTestManager(t)
+	testutil.RequireDoltContainer(t)
+	port, _ := strconv.Atoi(testutil.DoltContainerPort())
+	b := beads.NewIsolatedWithPort(rigPath, port)
+	if err := b.Init("gt"); err != nil {
+		t.Skipf("bd init unavailable: %v", err)
+	}
+
+	srcIssue, err := b.Create(beads.CreateOptions{Title: "Implement feature X", Labels: []string{"gt:task"}})
+	if err != nil {
+		t.Fatalf("create source issue: %v", err)
+	}
+	agentIssue, err := b.Create(beads.CreateOptions{
+		Title:       "Polecat nux",
+		Labels:      []string{"gt:agent"},
+		Description: "role_type: polecat\nrig: testrig\nagent_state: working\nactive_mr: gt-wisp-newer",
+	})
+	if err != nil {
+		t.Fatalf("create agent issue: %v", err)
+	}
+	mrIssue, err := b.Create(beads.CreateOptions{
+		Title:       "MR for feature X",
+		Labels:      []string{"gt:merge-request"},
+		Description: "branch: polecat/test/gt-xyz\nsource_issue: " + srcIssue.ID + "\nworker: test\ntarget: main\nagent_bead: " + agentIssue.ID,
+	})
+	if err != nil {
+		t.Fatalf("create MR issue: %v", err)
+	}
+
+	if _, err := mgr.RejectMR(mrIssue.ID, "policy failed", false); err != nil {
+		t.Fatalf("RejectMR() error: %v", err)
+	}
+
+	assertAgentActiveMR(t, b, agentIssue.ID, "gt-wisp-newer")
+	assertIssueStatus(t, b, srcIssue.ID, string(beads.StatusOpen))
+}
+
 func TestManager_PostMerge_AlreadyClosedMR(t *testing.T) {
 	mgr, rigPath := setupTestManager(t)
 	testutil.RequireDoltContainer(t)
@@ -529,10 +707,10 @@ func TestManager_PostMerge_AlreadyClosedMR(t *testing.T) {
 		t.Fatalf("close MR issue: %v", err)
 	}
 
-	// PostMerge should fail since MR is already closed and won't be in queue
+	// Already-closed MRs without a merged close_reason are not safe to post-merge.
 	_, err = mgr.PostMerge(mrIssue.ID)
 	if err == nil {
-		t.Error("PostMerge() expected error for already-closed MR")
+		t.Error("PostMerge() expected error for already-closed MR without merged close_reason")
 	}
 }
 
@@ -542,5 +720,43 @@ func TestManager_PostMerge_NotFound(t *testing.T) {
 	_, err := mgr.PostMerge("nonexistent-mr-id")
 	if err == nil {
 		t.Error("PostMerge() expected error for nonexistent MR")
+	}
+}
+
+func assertAgentActiveMR(t *testing.T, b *beads.Beads, agentID string, want string) {
+	t.Helper()
+	issue, err := b.Show(agentID)
+	if err != nil {
+		t.Fatalf("show agent %s: %v", agentID, err)
+	}
+	fields := beads.ParseAgentFields(issue.Description)
+	if fields.ActiveMR != want {
+		t.Fatalf("agent active_mr = %q, want %q", fields.ActiveMR, want)
+	}
+}
+
+func assertIssueStatus(t *testing.T, b *beads.Beads, issueID string, want string) {
+	t.Helper()
+	issue, err := b.Show(issueID)
+	if err != nil {
+		t.Fatalf("show issue %s: %v", issueID, err)
+	}
+	if issue.Status != want {
+		t.Fatalf("issue %s status = %q, want %q", issueID, issue.Status, want)
+	}
+}
+
+func assertMRCloseReason(t *testing.T, b *beads.Beads, mrID string, want string) {
+	t.Helper()
+	issue, err := b.Show(mrID)
+	if err != nil {
+		t.Fatalf("show MR %s: %v", mrID, err)
+	}
+	fields := beads.ParseMRFields(issue)
+	if fields == nil {
+		t.Fatalf("MR %s missing fields", mrID)
+	}
+	if fields.CloseReason != want {
+		t.Fatalf("MR close_reason = %q, want %q", fields.CloseReason, want)
 	}
 }

--- a/internal/refinery/terminal_mr.go
+++ b/internal/refinery/terminal_mr.go
@@ -1,0 +1,95 @@
+package refinery
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+type terminalMRCloseOptions struct {
+	Reason        string
+	MergeCommit   string
+	AgentBeadHint string
+	MissingOK     bool
+}
+
+type terminalMRCloseResult struct {
+	MRID                  string
+	SourceIssue           string
+	AgentBead             string
+	Closed                bool
+	AlreadyTerminal       bool
+	AgentActiveMRCleared  bool
+	AgentActiveMRClearErr error
+}
+
+func closeTerminalMR(b *beads.Beads, mrID string, opts terminalMRCloseOptions) (*terminalMRCloseResult, error) {
+	mrID = strings.TrimSpace(mrID)
+	result := &terminalMRCloseResult{MRID: mrID}
+	if b == nil || mrID == "" {
+		return result, nil
+	}
+
+	issue, err := b.Show(mrID)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) && opts.MissingOK {
+			return result, nil
+		}
+		return result, fmt.Errorf("fetch MR for close: %w", err)
+	}
+	if issue == nil {
+		return result, nil
+	}
+
+	fields := beads.ParseMRFields(issue)
+	if fields == nil {
+		fields = &beads.MRFields{}
+	}
+	result.SourceIssue = strings.TrimSpace(fields.SourceIssue)
+	result.AgentBead = firstNonEmpty(opts.AgentBeadHint, fields.AgentBead)
+
+	status := beads.IssueStatus(strings.TrimSpace(issue.Status))
+	switch {
+	case status == beads.StatusOpen:
+		if opts.MergeCommit != "" {
+			fields.MergeCommit = opts.MergeCommit
+		}
+		if closeReason := normalizedMRCloseReason(opts.Reason); closeReason != "" {
+			fields.CloseReason = closeReason
+		}
+		if result.AgentBead != "" && strings.TrimSpace(fields.AgentBead) == "" {
+			fields.AgentBead = result.AgentBead
+		}
+
+		newDesc := beads.SetMRFields(issue, fields)
+		if err := b.Update(mrID, beads.UpdateOptions{Description: &newDesc}); err != nil {
+			return result, fmt.Errorf("record MR close metadata: %w", err)
+		}
+		if err := b.CloseWithReason(opts.Reason, mrID); err != nil {
+			return result, fmt.Errorf("close MR: %w", err)
+		}
+		result.Closed = true
+	case status.IsTerminal():
+		result.AlreadyTerminal = true
+	default:
+		return result, nil
+	}
+
+	if result.AgentBead != "" {
+		cleared, clearErr := b.ForAgentBead().ClearAgentActiveMRIfMatches(result.AgentBead, mrID)
+		result.AgentActiveMRCleared = cleared
+		result.AgentActiveMRClearErr = clearErr
+	}
+	return result, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/refinery/types.go
+++ b/internal/refinery/types.go
@@ -21,6 +21,9 @@ type MergeRequest struct {
 	// Worker is the polecat that created this branch.
 	Worker string `json:"worker"`
 
+	// AgentBead is the town-level agent bead that owns active_mr for this MR.
+	AgentBead string `json:"agent_bead,omitempty"`
+
 	// IssueID is the beads issue being worked on.
 	IssueID string `json:"issue_id"`
 


### PR DESCRIPTION
Replacement/fixup for PR #4396.

This refreshes the terminal MR active_mr cleanup work from current upstream/main and keeps the original PR #4396 intent visible for attribution. Original PR head: 3162a37adc1b711b1c88677480808ba9ec4cd9e2.

Summary:
- Add locked exact-match active_mr clearing so old terminal MR cleanup cannot clear a newer active_mr.
- Route Engineer and Manager terminal MR close paths through one retryable close helper.
- Retry matching active_mr cleanup for already-terminal MRs without mutating closed MR metadata.
- Preserve source issue closure only for merged/post-merge paths.

Verification:
- CGO_ENABLED=0 go test ./internal/beads ./internal/refinery -count=1
- git diff --check upstream/main...HEAD

PR Sheriff evidence for bead gt-u1ze: 15 research legs, 5 pre-implementation reviews, 5 post-implementation reviews, checker PASS with merge_path_allowed=true.