### PR TITLE
fix: route compact wisp promotion through SDK

### DIFF
--- a/internal/beads/promote_wisp_test.go
+++ b/internal/beads/promote_wisp_test.go
@@ -1,0 +1,120 @@
+package beads
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	beadsdk "github.com/steveyegge/beads"
+)
+
+func TestPromoteWispUsesSDKPromotion(t *testing.T) {
+	data, err := os.ReadFile("store.go")
+	if err != nil {
+		t.Fatalf("read store.go: %v", err)
+	}
+	body := sourceBetween(t, string(data), "func (b *Beads) PromoteWisp(", "// storeAddLabel")
+
+	for _, want := range []string{
+		"OpenStore(ctx)",
+		"PromoteFromEphemeral(context.Context, string, string) error",
+		"promoter.PromoteFromEphemeral(ctx, id, actor)",
+		"store.RunInTransaction(ctx",
+		"tx.ImportIssueComment(ctx, id, actor, comment",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("PromoteWisp missing %q:\n%s", want, body)
+		}
+	}
+
+	for _, forbidden := range []string{
+		`Run("update"`,
+		`Run("promote"`,
+		`Run("comments"`,
+		`--persistent`,
+		`depends_on_id`,
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("PromoteWisp should not use %q:\n%s", forbidden, body)
+		}
+	}
+}
+
+func TestPromoteWispCallsSDKPromotionAndComments(t *testing.T) {
+	store := &promoteWispStore{tx: &promoteWispTx{}}
+	bd := NewWithStore(t.TempDir(), store)
+	t.Setenv("BD_ACTOR", "tester")
+
+	if err := bd.PromoteWisp("gt-wisp-alpha", "has comments"); err != nil {
+		t.Fatalf("PromoteWisp: %v", err)
+	}
+
+	if store.promotedID != "gt-wisp-alpha" {
+		t.Fatalf("promoted ID = %q, want gt-wisp-alpha", store.promotedID)
+	}
+	if store.promotedActor != "tester" {
+		t.Fatalf("promoted actor = %q, want tester", store.promotedActor)
+	}
+	if store.txMessage != "bd: comment on promoted wisp gt-wisp-alpha" {
+		t.Fatalf("transaction message = %q", store.txMessage)
+	}
+	if store.tx.issueID != "gt-wisp-alpha" || store.tx.author != "tester" {
+		t.Fatalf("comment target = %q/%q, want gt-wisp-alpha/tester", store.tx.issueID, store.tx.author)
+	}
+	if store.tx.text != "Promoted from Level 0: has comments" {
+		t.Fatalf("comment text = %q", store.tx.text)
+	}
+	if store.tx.createdAt.IsZero() {
+		t.Fatalf("comment timestamp was not set")
+	}
+}
+
+type promoteWispStore struct {
+	beadsdk.Storage
+	promotedID    string
+	promotedActor string
+	txMessage     string
+	tx            *promoteWispTx
+}
+
+func (s *promoteWispStore) PromoteFromEphemeral(_ context.Context, id, actor string) error {
+	s.promotedID = id
+	s.promotedActor = actor
+	return nil
+}
+
+func (s *promoteWispStore) RunInTransaction(_ context.Context, msg string, fn func(beadsdk.Transaction) error) error {
+	s.txMessage = msg
+	return fn(s.tx)
+}
+
+type promoteWispTx struct {
+	beadsdk.Transaction
+	issueID   string
+	author    string
+	text      string
+	createdAt time.Time
+}
+
+func (tx *promoteWispTx) ImportIssueComment(_ context.Context, issueID, author, text string, createdAt time.Time) (*beadsdk.Comment, error) {
+	tx.issueID = issueID
+	tx.author = author
+	tx.text = text
+	tx.createdAt = createdAt
+	return &beadsdk.Comment{}, nil
+}
+
+func sourceBetween(t *testing.T, source, startMarker, endMarker string) string {
+	t.Helper()
+	start := strings.Index(source, startMarker)
+	if start == -1 {
+		t.Fatalf("could not find %q", startMarker)
+	}
+	end := strings.Index(source[start:], endMarker)
+	if end == -1 {
+		t.Fatalf("could not find %q after %q", endMarker, startMarker)
+	}
+	return source[start : start+end]
+}

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -573,6 +574,54 @@ func (b *Beads) storeRemoveDependency(issue, dependsOn string) error {
 	defer cancel()
 
 	return b.store.RemoveDependency(ctx, issue, dependsOn, b.getActor())
+}
+
+// PromoteWisp promotes an ephemeral wisp through the in-process Beads storage
+// path. This keeps gt compact on the SDK's typed dependency promotion logic
+// instead of shelling out to whichever bd binary is on PATH.
+func (b *Beads) PromoteWisp(id, reason string) error {
+	ctx, cancel := storeCtx()
+	defer cancel()
+
+	store := b.store
+	cleanup := func() {}
+	if store == nil {
+		var err error
+		store, cleanup, err = b.OpenStore(ctx)
+		if err != nil {
+			return fmt.Errorf("open store for wisp promotion: %w", err)
+		}
+	}
+	defer cleanup()
+
+	promoter, ok := store.(interface {
+		PromoteFromEphemeral(context.Context, string, string) error
+	})
+	if !ok {
+		return fmt.Errorf("beads store does not support wisp promotion")
+	}
+
+	actor := b.getActor()
+	if actor == "" {
+		actor = "unknown"
+	}
+
+	if err := promoter.PromoteFromEphemeral(ctx, id, actor); err != nil {
+		return fmt.Errorf("promote wisp %s: %w", id, err)
+	}
+
+	comment := "Promoted from Level 0"
+	if reason != "" {
+		comment += ": " + reason
+	}
+	if err := store.RunInTransaction(ctx, fmt.Sprintf("bd: comment on promoted wisp %s", id), func(tx beadsdk.Transaction) error {
+		_, err := tx.ImportIssueComment(ctx, id, actor, comment, time.Now().UTC())
+		return err
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to add promotion comment to %s: %v\n", id, err)
+	}
+
+	return nil
 }
 
 // storeAddLabel implements AddLabel using the in-process store.

--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -345,7 +345,7 @@ func extractJSONArray(data []byte) []byte {
 	return data[idx:]
 }
 
-// promoteWisp makes a wisp permanent by setting --persistent and adding a comment.
+// promoteWisp makes a wisp permanent through Beads' canonical promotion path.
 func promoteWisp(bd *beads.Beads, w *compactIssue, reason string, result *compactResult) {
 	action := compactAction{ID: w.ID, Title: w.Title, Reason: reason, WispType: w.WispType}
 
@@ -358,15 +358,10 @@ func promoteWisp(bd *beads.Beads, w *compactIssue, reason string, result *compac
 		return
 	}
 
-	// bd update --persistent sets ephemeral=false
-	_, err := bd.Run("update", w.ID, "--persistent")
-	if err != nil {
+	if err := bd.PromoteWisp(w.ID, reason); err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("promote %s: %v", w.ID, err))
 		return
 	}
-
-	// Add comment noting the promotion
-	_, _ = bd.Run("comments", "add", w.ID, fmt.Sprintf("Promoted from Level 0: %s", reason))
 
 	result.Promoted = append(result.Promoted, action)
 

--- a/internal/cmd/compact_test.go
+++ b/internal/cmd/compact_test.go
@@ -290,6 +290,30 @@ func TestCleanOrphanedWispDepsUsesTypedTargets(t *testing.T) {
 	}
 }
 
+func TestPromoteWispUsesCanonicalSDKPromotion(t *testing.T) {
+	data, err := os.ReadFile("compact.go")
+	if err != nil {
+		t.Fatalf("read compact.go: %v", err)
+	}
+	body := compactSourceBetween(t, string(data), "func promoteWisp(", "// deleteWisp")
+
+	for _, forbidden := range []string{
+		`bd.Run("update"`,
+		`bd.Run("promote"`,
+		`bd.Run("comments"`,
+		`--persistent`,
+		`depends_on_id`,
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("promoteWisp should not use %q:\n%s", forbidden, body)
+		}
+	}
+
+	if !strings.Contains(body, `bd.PromoteWisp(w.ID, reason)`) {
+		t.Fatalf("promoteWisp should delegate to Beads SDK promotion:\n%s", body)
+	}
+}
+
 func compactSourceBetween(t *testing.T, source, startMarker, endMarker string) string {
 	t.Helper()
 	start := strings.Index(source, startMarker)


### PR DESCRIPTION
Clean current-main replacement for internal MR `gt-wisp-c05a` / source issue `gt-ih8i`.

The dirty internal branch is not merged as-is. This PR rebuilds the accepted compact promotion fix on current `upstream/main` with only the scoped radrat payload.

## What Changed
- Route `gt compact` wisp promotion through the repo-pinned Beads SDK `PromoteFromEphemeral` path.
- Preserve the promotion comment through in-process `RunInTransaction` / `ImportIssueComment`.
- Add source guards preventing regression to `bd update --persistent`, `bd promote`, `bd comments`, raw legacy dependency identifiers, or raw SQL promotion paths.
- Add a behavioral unit test covering SDK promotion, actor propagation, and promotion comment import through an injected store.

## Provenance / Attribution
- Internal MR: `gt-wisp-c05a`
- Source issue: `gt-ih8i`
- Dirty source branch not merged as-is: `polecat/radrat/gt-ih8i@mran8w40`
- Original relevant commits: `62b324edc`, `bedd2a0518894c958376a66f78d3959d4f8b4581`
- Original worker/author preserved in git history: `radrat <thalia.geraghty@fiserv.com>`
- Internal MR evidence: `pre_verified=true`, `pre_verified_at=2026-07-07T13:40:26Z`, `pre_verified_base=1d84e05c9d244fcdd82f8d5c2089161cbda92753`

## PR Sheriff Evidence
- 15 independent research legs completed for recovery bead `gt-2wc9` before code changes.
- 5 independent pre-implementation reviews approved the recovery plan before code changes.
- 5 independent final post-implementation reviews passed for head `f0f35ea1110add58964fdd2d9106622225847436`.
- Cleanup-first verdict: `convergent`. The change removes the failing external `bd update --persistent` promotion surface instead of adding compatibility SQL, patrol shims, or workaround layers.

## Verification
- `git diff --check upstream/main...HEAD`
- `CGO_ENABLED=0 go test ./internal/cmd ./internal/beads -run 'Test(PromoteWispUsesCanonicalSDKPromotion|CleanOrphanedWispDepsUsesTypedTargets|PromoteWispUsesSDKPromotion|PromoteWispCallsSDKPromotionAndComments)$' -count=1 -v`
- `CGO_ENABLED=0 go test ./internal/cmd ./internal/beads`

Default local CGO tests are blocked on this host by missing ICU headers (`unicode/uregex.h`); CI installs `libicu-dev`.
