### PR TITLE
fix(tmux): guard NewSession socket creation

### DIFF
--- a/internal/tmux/socket_guard_unix.go
+++ b/internal/tmux/socket_guard_unix.go
@@ -1,0 +1,117 @@
+//go:build !windows
+
+package tmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+const (
+	newSessionSocketDialTimeout  = 200 * time.Millisecond
+	newSessionSocketProbeTimeout = time.Second
+)
+
+func (t *Tmux) ensureNewSessionSocketSafe() error {
+	if t.socketName == "" {
+		return nil
+	}
+
+	socketPath := filepath.Join(SocketDir(), t.socketName)
+	info, err := os.Lstat(socketPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("lstat tmux socket %s: %w", socketPath, err)
+	}
+	mode := info.Mode()
+	if mode&os.ModeSymlink != 0 {
+		return fmt.Errorf("tmux socket %s is a symlink; refusing to start a new session because tmux could unlink or rebind the target (see gt-h9z)", socketPath)
+	}
+	if mode&os.ModeSocket == 0 {
+		return fmt.Errorf("tmux socket %s is %s, not a Unix socket; refusing to start a new session because tmux could replace it (see gt-h9z)", socketPath, mode.Type())
+	}
+
+	return t.ensureLiveSocketSafe(socketPath)
+}
+
+func (t *Tmux) ensureLiveSocketSafe(socketPath string) error {
+	if stale, err := unixSocketStale(socketPath); err != nil || stale {
+		if stale {
+			return nil
+		}
+		return fmt.Errorf("tmux socket %s exists but cannot be safely contacted: %w", socketPath, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), newSessionSocketProbeTimeout)
+	defer cancel()
+	if err := t.runListSessionsProbe(ctx); err == nil {
+		return nil
+	} else if errors.Is(err, ErrNoServer) {
+		stale, recheckErr := unixSocketStale(socketPath)
+		if recheckErr == nil && stale {
+			return nil
+		}
+		if recheckErr != nil {
+			err = fmt.Errorf("%w; socket recheck failed: %v", err, recheckErr)
+		}
+		return fmt.Errorf("tmux socket %s has a live listener but tmux reported no server; refusing to start a new session because tmux could unlink and rebind it (see gt-h9z): %w", socketPath, err)
+	} else {
+		return fmt.Errorf("tmux socket %s has a live listener but list-sessions failed; refusing to start a new session because tmux could unlink and rebind it (see gt-h9z): %w", socketPath, err)
+	}
+}
+
+func unixSocketStale(socketPath string) (bool, error) {
+	conn, err := net.DialTimeout("unix", socketPath, newSessionSocketDialTimeout)
+	if err != nil {
+		if os.IsNotExist(err) || errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.ECONNREFUSED) {
+			return true, nil
+		}
+		return false, err
+	}
+	_ = conn.Close()
+	return false, nil
+}
+
+func (t *Tmux) runListSessionsProbe(ctx context.Context) error {
+	stdout, err := os.CreateTemp("", "gt-tmux-probe-stdout-*")
+	if err != nil {
+		return err
+	}
+	stdoutPath := stdout.Name()
+	defer func() { _ = os.Remove(stdoutPath) }()
+	defer func() { _ = stdout.Close() }()
+
+	stderr, err := os.CreateTemp("", "gt-tmux-probe-stderr-*")
+	if err != nil {
+		return err
+	}
+	stderrPath := stderr.Name()
+	defer func() { _ = os.Remove(stderrPath) }()
+	defer func() { _ = stderr.Close() }()
+
+	args := []string{"list-sessions", "-F", ""}
+	cmd := t.commandContext(ctx, args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.WaitDelay = 100 * time.Millisecond
+
+	if err := cmd.Run(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("tmux list-sessions timed out after %s: %w", newSessionSocketProbeTimeout, ctxErr)
+		}
+		stderrBytes, readErr := os.ReadFile(stderrPath)
+		if readErr != nil {
+			return fmt.Errorf("tmux list-sessions: %w", err)
+		}
+		return t.wrapError(err, string(stderrBytes), args)
+	}
+	return nil
+}

--- a/internal/tmux/socket_guard_unix_test.go
+++ b/internal/tmux/socket_guard_unix_test.go
@@ -1,0 +1,303 @@
+//go:build !windows
+
+package tmux
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func uniqueSocketName(t *testing.T, prefix string) string {
+	t.Helper()
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
+func socketPathForTest(t *testing.T, socket string) string {
+	t.Helper()
+	dir := SocketDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", dir, err)
+	}
+	return filepath.Join(dir, socket)
+}
+
+func createStaleUnixSocket(t *testing.T, socket string) string {
+	t.Helper()
+	socketPath := socketPathForTest(t, socket)
+	_ = os.Remove(socketPath)
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		t.Fatalf("ListenUnix(%s): %v", socketPath, err)
+	}
+	listener.SetUnlinkOnClose(false)
+	if err := listener.Close(); err != nil {
+		t.Fatalf("Close stale listener: %v", err)
+	}
+	info, err := os.Lstat(socketPath)
+	if err != nil {
+		t.Fatalf("Lstat(%s): %v", socketPath, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("%s mode = %s, want Unix socket", socketPath, info.Mode())
+	}
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+	return socketPath
+}
+
+func listenOnSocketPath(t *testing.T, socket string) (*net.UnixListener, string) {
+	t.Helper()
+	socketPath := socketPathForTest(t, socket)
+	_ = os.Remove(socketPath)
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		t.Fatalf("ListenUnix(%s): %v", socketPath, err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+	})
+	return listener, socketPath
+}
+
+func assertSameSocketPath(t *testing.T, socketPath string, before os.FileInfo) {
+	t.Helper()
+	after, err := os.Lstat(socketPath)
+	if err != nil {
+		t.Fatalf("Lstat(%s) after refusal: %v", socketPath, err)
+	}
+	if after.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("%s after refusal mode = %s, want Unix socket", socketPath, after.Mode())
+	}
+	if !os.SameFile(before, after) {
+		t.Fatalf("%s was replaced after refusal", socketPath)
+	}
+}
+
+func TestEnsureNewSessionSocketSafe(t *testing.T) {
+	t.Run("default_socket", func(t *testing.T) {
+		if err := (&Tmux{}).ensureNewSessionSocketSafe(); err != nil {
+			t.Fatalf("ensureNewSessionSocketSafe(default) = %v", err)
+		}
+	})
+
+	t.Run("absent_socket", func(t *testing.T) {
+		socket := uniqueSocketName(t, "gt-h9z-absent")
+		if err := NewTmuxWithSocket(socket).ensureNewSessionSocketSafe(); err != nil {
+			t.Fatalf("ensureNewSessionSocketSafe(absent) = %v", err)
+		}
+	})
+
+	t.Run("stale_unix_socket", func(t *testing.T) {
+		socket := uniqueSocketName(t, "gt-h9z-stale")
+		createStaleUnixSocket(t, socket)
+		if err := NewTmuxWithSocket(socket).ensureNewSessionSocketSafe(); err != nil {
+			t.Fatalf("ensureNewSessionSocketSafe(stale) = %v", err)
+		}
+	})
+
+	t.Run("regular_file", func(t *testing.T) {
+		socket := uniqueSocketName(t, "gt-h9z-file")
+		socketPath := socketPathForTest(t, socket)
+		if err := os.WriteFile(socketPath, []byte("not a socket"), 0o600); err != nil {
+			t.Fatalf("WriteFile(%s): %v", socketPath, err)
+		}
+		t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+		err := NewTmuxWithSocket(socket).ensureNewSessionSocketSafe()
+		if err == nil {
+			t.Fatal("ensureNewSessionSocketSafe(regular file) = nil, want error")
+		}
+		if !strings.Contains(err.Error(), socketPath) {
+			t.Fatalf("error %q does not mention %s", err, socketPath)
+		}
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		socket := uniqueSocketName(t, "gt-h9z-dir")
+		socketPath := socketPathForTest(t, socket)
+		if err := os.Mkdir(socketPath, 0o700); err != nil {
+			t.Fatalf("Mkdir(%s): %v", socketPath, err)
+		}
+		t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+		if err := NewTmuxWithSocket(socket).ensureNewSessionSocketSafe(); err == nil {
+			t.Fatal("ensureNewSessionSocketSafe(directory) = nil, want error")
+		}
+	})
+
+	t.Run("symlink", func(t *testing.T) {
+		socket := uniqueSocketName(t, "gt-h9z-link")
+		socketPath := socketPathForTest(t, socket)
+		target := socketPath + "-target"
+		if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+			t.Fatalf("WriteFile(%s): %v", target, err)
+		}
+		t.Cleanup(func() { _ = os.Remove(target) })
+		if err := os.Symlink(target, socketPath); err != nil {
+			t.Skipf("Symlink not supported: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+		err := NewTmuxWithSocket(socket).ensureNewSessionSocketSafe()
+		if err == nil {
+			t.Fatal("ensureNewSessionSocketSafe(symlink) = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "symlink") {
+			t.Fatalf("error %q should mention symlink", err)
+		}
+	})
+
+	t.Run("live_tmux_server", func(t *testing.T) {
+		if !hasTmux() {
+			t.Skip("tmux not installed")
+		}
+		socket := uniqueSocketName(t, "gt-h9z-live")
+		tm := NewTmuxWithSocket(socket)
+		t.Cleanup(func() { _ = tm.KillServer() })
+		if _, err := tm.run("new-session", "-d", "-s", "gt-h9z-live"); err != nil {
+			t.Fatalf("new-session setup: %v", err)
+		}
+		if err := tm.ensureNewSessionSocketSafe(); err != nil {
+			t.Fatalf("ensureNewSessionSocketSafe(live tmux) = %v", err)
+		}
+	})
+}
+
+func TestNewSessionAllowsStaleUnixSocket(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+	socket := uniqueSocketName(t, "gt-h9z-newsession-stale")
+	createStaleUnixSocket(t, socket)
+	tm := NewTmuxWithSocket(socket)
+	t.Cleanup(func() { _ = tm.KillServer() })
+
+	if err := tm.NewSession("gt-h9z-stale-ok", ""); err != nil {
+		t.Fatalf("NewSession against stale Unix socket = %v, want success", err)
+	}
+}
+
+func TestNewSessionRefusesUnresponsiveSocket(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+	socket := uniqueSocketName(t, "gt-h9z-unresponsive")
+	listener, socketPath := listenOnSocketPath(t, socket)
+	var heldMu sync.Mutex
+	var held []*net.UnixConn
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := listener.AcceptUnix()
+			if err != nil {
+				return
+			}
+			heldMu.Lock()
+			held = append(held, conn)
+			heldMu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		<-done
+		heldMu.Lock()
+		defer heldMu.Unlock()
+		for _, conn := range held {
+			_ = conn.Close()
+		}
+	})
+
+	before, err := os.Lstat(socketPath)
+	if err != nil {
+		t.Fatalf("Lstat(%s): %v", socketPath, err)
+	}
+	errCh := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		errCh <- NewTmuxWithSocket(socket).NewSession("gt-h9z-unresponsive", "")
+	}()
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("NewSession against unresponsive listener = nil, want error")
+		}
+		if elapsed := time.Since(start); elapsed > 3*time.Second {
+			t.Fatalf("NewSession took %s, want bounded refusal", elapsed)
+		}
+	case <-time.After(4 * time.Second):
+		_ = listener.Close()
+		t.Fatal("NewSession against unresponsive listener hung")
+	}
+	assertSameSocketPath(t, socketPath, before)
+}
+
+func TestNewSessionRefusesClosingListener(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+	socket := uniqueSocketName(t, "gt-h9z-closing")
+	listener, socketPath := listenOnSocketPath(t, socket)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := listener.AcceptUnix()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		<-done
+	})
+
+	before, err := os.Lstat(socketPath)
+	if err != nil {
+		t.Fatalf("Lstat(%s): %v", socketPath, err)
+	}
+	if err := NewTmuxWithSocket(socket).NewSession("gt-h9z-closing", ""); err == nil {
+		t.Fatal("NewSession against closing listener = nil, want error")
+	}
+	assertSameSocketPath(t, socketPath, before)
+}
+
+func TestNewSessionVariantsUseSocketGuard(t *testing.T) {
+	socket := uniqueSocketName(t, "gt-h9z-variants")
+	socketPath := socketPathForTest(t, socket)
+	if err := os.WriteFile(socketPath, []byte("not a socket"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%s): %v", socketPath, err)
+	}
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
+	tm := NewTmuxWithSocket(socket)
+
+	tests := []struct {
+		name string
+		run  func(string) error
+	}{
+		{name: "NewSession", run: func(name string) error { return tm.NewSession(name, "") }},
+		{name: "NewSessionWithCommand", run: func(name string) error { return tm.NewSessionWithCommand(name, "", "sleep 5") }},
+		{name: "NewSessionWithCommandAndEnv", run: func(name string) error {
+			return tm.NewSessionWithCommandAndEnv(name, "", "sleep 5", map[string]string{"GT_TEST": "1"})
+		}},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run(fmt.Sprintf("gt-h9z-variant-%d", i))
+			if err == nil {
+				t.Fatal("creation variant returned nil, want socket guard error")
+			}
+			if !strings.Contains(err.Error(), socketPath) {
+				t.Fatalf("error %q does not mention %s", err, socketPath)
+			}
+		})
+	}
+}

--- a/internal/tmux/socket_guard_windows.go
+++ b/internal/tmux/socket_guard_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package tmux
+
+func (t *Tmux) ensureNewSessionSocketSafe() error {
+	return nil
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -221,15 +221,25 @@ func NewTmuxWithSocket(socket string) *Tmux {
 // All commands include -u flag for UTF-8 support regardless of locale settings.
 // See: https://github.com/steveyegge/gastown/issues/1219
 func (t *Tmux) run(args ...string) (string, error) {
-	// Prepend global flags: -u (UTF-8 mode, PATCH-004) and optionally -L (socket).
-	// The -L flag must come before the subcommand, so it goes in the prefix.
+	return t.runContext(context.Background(), args...)
+}
+
+func (t *Tmux) commandContext(ctx context.Context, args ...string) *exec.Cmd {
 	allArgs := []string{"-u"}
 	if t.socketName != "" {
 		allArgs = append(allArgs, "-L", t.socketName)
 	}
 	allArgs = append(allArgs, args...)
-	cmd := exec.Command("tmux", allArgs...)
+	cmd := exec.CommandContext(ctx, "tmux", allArgs...)
 	hideConsoleWindow(cmd)
+	return cmd
+}
+
+func (t *Tmux) runContext(ctx context.Context, args ...string) (string, error) {
+	cmd := t.commandContext(ctx, args...)
+	if _, ok := ctx.Deadline(); ok {
+		cmd.WaitDelay = 100 * time.Millisecond
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -267,14 +277,22 @@ func (t *Tmux) wrapError(err error, stderr string, args []string) error {
 	return fmt.Errorf("tmux %s: %w", args[0], err)
 }
 
-// NewSession creates a new detached tmux session.
-func (t *Tmux) NewSession(name, workDir string) error {
-	if err := validateSessionName(name); err != nil {
+func (t *Tmux) createNewSession(name, workDir string, env map[string]string) error {
+	if err := t.ensureNewSessionSocketSafe(); err != nil {
 		return err
 	}
+
 	args := []string{"new-session", "-d", "-s", name}
 	if workDir != "" {
 		args = append(args, "-c", workDir)
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		args = append(args, "-e", fmt.Sprintf("%s=%s", k, env[k]))
 	}
 	if _, err := t.run(args...); err != nil {
 		return err
@@ -284,6 +302,14 @@ func (t *Tmux) NewSession(name, workDir string) error {
 	// "latest" so the window auto-resizes to the attaching client's terminal size.
 	_, _ = t.run("set-option", "-wt", name, "window-size", "latest")
 	return nil
+}
+
+// NewSession creates a new detached tmux session.
+func (t *Tmux) NewSession(name, workDir string) error {
+	if err := validateSessionName(name); err != nil {
+		return err
+	}
+	return t.createNewSession(name, workDir, nil)
 }
 
 // NewSessionWithCommand creates a new detached tmux session that immediately runs a command.
@@ -311,6 +337,9 @@ func (t *Tmux) NewSessionWithCommand(name, workDir, command string) error {
 	if err := validateCommandBinary(command); err != nil {
 		return err
 	}
+	if err := t.ensureNewSessionSocketSafe(); err != nil {
+		return err
+	}
 
 	// Defense-in-depth: remove CLAUDECODE and agent-identity vars from the
 	// tmux server's global environment so new sessions don't inherit them.
@@ -330,17 +359,9 @@ func (t *Tmux) NewSessionWithCommand(name, workDir, command string) error {
 	// Two-step creation: create session with default shell first, configure
 	// remain-on-exit, then replace the shell with the actual command. This
 	// eliminates the race between command exit and health check setup.
-	args := []string{"new-session", "-d", "-s", name}
-	if workDir != "" {
-		args = append(args, "-c", workDir)
-	}
-	if _, err := t.run(args...); err != nil {
+	if err := t.createNewSession(name, workDir, nil); err != nil {
 		return err
 	}
-	// tmux 3.3+ sets window-size=manual on detached sessions (no client present),
-	// which locks the window at 80x24 even after a client attaches. Override to
-	// "latest" so the window auto-resizes to the attaching client's terminal size.
-	_, _ = t.run("set-option", "-wt", name, "window-size", "latest")
 
 	// Enable remain-on-exit BEFORE command runs so we can inspect exit status
 	_, _ = t.run("set-option", "-t", name, "remain-on-exit", "on")
@@ -402,27 +423,9 @@ func (t *Tmux) NewSessionWithCommandAndEnv(name, workDir, command string, env ma
 
 	// Two-step creation: create session with env vars and default shell, then
 	// replace the shell with the actual command after configuring remain-on-exit.
-	args := []string{"new-session", "-d", "-s", name}
-	if workDir != "" {
-		args = append(args, "-c", workDir)
-	}
-	// Add -e flags to set environment variables in the session before the shell starts.
-	// Keys are sorted for deterministic behavior.
-	keys := make([]string, 0, len(env))
-	for k := range env {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		args = append(args, "-e", fmt.Sprintf("%s=%s", k, env[k]))
-	}
-	if _, err := t.run(args...); err != nil {
+	if err := t.createNewSession(name, workDir, env); err != nil {
 		return err
 	}
-	// tmux 3.3+ sets window-size=manual on detached sessions (no client present),
-	// which locks the window at 80x24 even after a client attaches. Override to
-	// "latest" so the window auto-resizes to the attaching client's terminal size.
-	_, _ = t.run("set-option", "-wt", name, "window-size", "latest")
 
 	// Enable remain-on-exit BEFORE command runs so we can inspect exit status
 	_, _ = t.run("set-option", "-t", name, "remain-on-exit", "on")


### PR DESCRIPTION
Replacement/fixup for #4150, based on current upstream/main.\n\nPreserves Rome-1 provenance from #4150 / f6676bdf72d9f546f20acb0d8f1829a8c69b99f0 via commit trailers.\n\nWhat changed:\n- Centralizes all tmux NewSession variants through one guarded creation helper.\n- Uses strict Unix socket Lstat/ModeSocket validation and rejects symlinks/non-sockets before dialing.\n- Allows absent/stale Unix sockets while rejecting unresponsive or live-closing/protocol-incompatible listeners with a bounded list-sessions probe.\n- Adds deterministic coverage for stale socket allowance, non-socket/symlink refusal, unresponsive listener refusal, live-closing listener refusal, and all NewSession variants.\n\nVerification:\n- go test ./internal/tmux -run 'TestEnsureNewSessionSocketSafe|TestNewSessionAllowsStaleUnixSocket|TestNewSessionRefusesUnresponsiveSocket|TestNewSessionRefusesClosingListener|TestNewSessionVariantsUseSocketGuard' -count=3 -timeout 120s\n- go test ./internal/tmux -run '^(TestNewSessionWithCommandAndEnv|TestNewSessionWithCommandAndEnvEmpty|TestSessionLifecycle|TestDuplicateSession)$' -count=1 -timeout 120s\n- go test -race -short ./internal/tmux -run '^(TestEnsureNewSessionSocketSafe|TestNewSessionAllowsStaleUnixSocket|TestNewSessionRefusesUnresponsiveSocket|TestNewSessionRefusesClosingListener|TestNewSessionVariantsUseSocketGuard|TestSessionLifecycle|TestDuplicateSession|TestNewSession_RejectsInvalidName|TestEnsureSessionFresh_RejectsInvalidName)$' -count=1 -timeout 120s\n- go test ./internal/tmux -run '^$' -count=1 -timeout 120s\n- go vet ./internal/tmux\n- go build ./internal/tmux\n- GOOS=windows go test -c -o /tmp/opencode/tmux-windows.test.exe ./internal/tmux\n\nNotes:\n- Full go build ./... and go vet ./... are blocked in this environment by missing ICU headers for github.com/dolthub/go-icu-regex/internal/icu.\n- The broader internal/tmux NewSession regex still hits known baseline TestNewSessionWithCommand_ExecEnvSuccess where sleep reports as coreutils in this environment.\n