### PR TITLE
fix(mail): skip reply reminders for synthetic senders

### DIFF
--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -1789,6 +1789,7 @@ func prioritySeverityLabel(priority Priority) string {
 // Skipped when:
 //   - No town root (can't use nudge queue)
 //   - Message type is TypeReply (recipient is already replying)
+//   - Sender is not a direct mail address that can receive a reply
 //   - Configured delay is zero or negative (feature disabled)
 func (r *Router) enqueueReplyReminder(msg *Message, sessionID string) {
 	if r.townRoot == "" {
@@ -1796,6 +1797,9 @@ func (r *Router) enqueueReplyReminder(msg *Message, sessionID string) {
 	}
 	if msg.Type == TypeReply {
 		return // Already a reply — reminder would be redundant
+	}
+	if !senderCanReceiveReply(msg.From) {
+		return
 	}
 	delay := config.LoadOperationalConfig(r.townRoot).GetMailConfig().ReplyReminderDelayD()
 	if delay <= 0 {
@@ -1812,6 +1816,46 @@ func (r *Router) enqueueReplyReminder(msg *Message, sessionID string) {
 	if err := nudge.Enqueue(r.townRoot, sessionID, reminder); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to enqueue reply reminder for %s: %v\n", sessionID, err)
 	}
+}
+
+func senderCanReceiveReply(from string) bool {
+	if from == "" || strings.TrimSpace(from) != from || strings.ContainsAny(from, " \t\r\n") {
+		return false
+	}
+
+	identity := AddressToIdentity(from)
+	switch identity {
+	case "overseer", "mayor/", "deacon/":
+		return true
+	}
+	if identity == "" || strings.HasPrefix(identity, "@") || strings.ContainsAny(identity, ":@") {
+		return false
+	}
+
+	parts := strings.Split(identity, "/")
+	switch len(parts) {
+	case 2:
+		if !validReplyAddressPart(parts[0]) || !validReplyAddressPart(parts[1]) {
+			return false
+		}
+		if parts[0] == constants.RoleMayor || parts[0] == constants.RoleDeacon {
+			return false
+		}
+		switch parts[1] {
+		case constants.RoleCrew, "polecat", "polecats", "dogs":
+			return false
+		default:
+			return true
+		}
+	case 3:
+		return parts[0] == constants.RoleDeacon && parts[1] == "dogs" && validReplyAddressPart(parts[2])
+	default:
+		return false
+	}
+}
+
+func validReplyAddressPart(part string) bool {
+	return part != "" && strings.TrimSpace(part) == part && !strings.ContainsAny(part, " \t\r\n:@")
 }
 
 // ClearReplyReminders removes any queued reply-reminder nudges for the given

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -1968,6 +1968,113 @@ func TestEnqueueReplyReminder_Basic(t *testing.T) {
 	}
 }
 
+func TestEnqueueReplyReminder_SkipsUnreplyableSender(t *testing.T) {
+	for _, from := range []string{"gt-sling", "sling", "gt-done", "system", "daemon", "unknown"} {
+		t.Run(from, func(t *testing.T) {
+			townRoot := t.TempDir()
+			r := &Router{workDir: t.TempDir(), townRoot: townRoot}
+			msg := &Message{
+				From:    from,
+				To:      "gastown/witness",
+				Subject: "LIFECYCLE:Shutdown guzzle",
+				Type:    TypeTask,
+			}
+			sessionID := session.WitnessSessionName(session.PrefixFor("gastown"))
+
+			r.enqueueReplyReminder(msg, sessionID)
+
+			pending, err := nudge.Pending(townRoot, sessionID)
+			if err != nil {
+				t.Fatalf("Pending: %v", err)
+			}
+			if pending != 0 {
+				t.Fatalf("expected no queued reminders for %q, got %d", from, pending)
+			}
+		})
+	}
+}
+
+func TestEnqueueReplyReminder_RoutableSenderStillQueues(t *testing.T) {
+	for _, from := range []string{"overseer", "mayor/", "deacon/", "gastown/witness", "gastown/refinery", "gastown/crew/alice", "gastown/polecat/rust", "gastown/polecats/rust", "gastown/rust", "deacon/dogs/alpha"} {
+		t.Run(from, func(t *testing.T) {
+			townRoot := t.TempDir()
+			r := &Router{workDir: t.TempDir(), townRoot: townRoot}
+			msg := &Message{
+				From:    from,
+				To:      "gastown/crew/bob",
+				Subject: "status check",
+				Type:    TypeNotification,
+			}
+			sessionID := session.CrewSessionName(session.PrefixFor("gastown"), "bob")
+
+			r.enqueueReplyReminder(msg, sessionID)
+
+			pending, err := nudge.Pending(townRoot, sessionID)
+			if err != nil {
+				t.Fatalf("Pending: %v", err)
+			}
+			if pending != 1 {
+				t.Fatalf("expected one queued reminder for %q, got %d", from, pending)
+			}
+		})
+	}
+}
+
+func TestSenderCanReceiveReply(t *testing.T) {
+	tests := []struct {
+		from string
+		want bool
+	}{
+		{from: "", want: false},
+		{from: " mayor/", want: false},
+		{from: "gt-sling", want: false},
+		{from: "sling", want: false},
+		{from: "sling/", want: false},
+		{from: "gt-done", want: false},
+		{from: "system", want: false},
+		{from: "daemon", want: false},
+		{from: "unknown", want: false},
+		{from: "human", want: false},
+		{from: "alice@example.com", want: false},
+		{from: "@crew", want: false},
+		{from: "queue:reviews", want: false},
+		{from: "mayorx", want: false},
+		{from: "deaconess", want: false},
+		{from: "mayor/extra", want: false},
+		{from: "deacon/extra", want: false},
+		{from: "gastown/crew/", want: false},
+		{from: "gastown/polecat/", want: false},
+		{from: "gastown/polecats/", want: false},
+		{from: "gastown/crew/alice/extra", want: false},
+		{from: "deacon/dogs/", want: false},
+		{from: "deacon/dogs/alpha/extra", want: false},
+		{from: "overseer", want: true},
+		{from: "mayor", want: true},
+		{from: "mayor/", want: true},
+		{from: "deacon", want: true},
+		{from: "deacon/", want: true},
+		{from: "gastown/mayor", want: true},
+		{from: "gastown/deacon", want: true},
+		{from: "gastown/witness", want: true},
+		{from: "gastown/refinery", want: true},
+		{from: "gastown/crew/alice", want: true},
+		{from: "gastown/polecat/rust", want: true},
+		{from: "gastown/polecats/rust", want: true},
+		{from: "gastown/rust", want: true},
+		{from: "gastown/crew/gt-sling", want: true},
+		{from: "gastown/system-bot", want: true},
+		{from: "deacon/dogs/alpha", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.from, func(t *testing.T) {
+			if got := senderCanReceiveReply(tt.from); got != tt.want {
+				t.Fatalf("senderCanReceiveReply(%q) = %v, want %v", tt.from, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClearReplyReminders(t *testing.T) {
 	townRoot := t.TempDir()
 	r := &Router{workDir: t.TempDir(), townRoot: townRoot}


### PR DESCRIPTION
## Summary

Clean current-main replacement for PR #4153. The replacement carries only the accepted hq-bj5 behavior: deferred mail reply reminders are skipped when Message.From is not a replyable direct mail address, including synthetic senders such as gt-sling, sling, gt-done, system, daemon, and unknown. Ordinary routable human/agent senders still enqueue reminders.

## Attribution

- Supersedes original PR: https://github.com/gastownhall/gastown/pull/4153
- Original PR author: @reppam
- Original scoped fix commit: 7906f0da20f20066a6a6991ef0ebc44cfba404bb
- Replacement commit credits the original work in the commit body and includes co-author trailers for mayor <reppa48@gmail.com> and Claude Opus 4.8.
- Original PR #4153 should remain open until this replacement lands, then be closed as superseded.

## Verification

- PASS: CGO_ENABLED=0 go test ./internal/mail -count=1 -run 'TestEnqueueReplyReminder|TestClearReplyReminders|TestSenderCanReceiveReply'\n- PASS: CGO_ENABLED=0 go test ./internal/mail -count=1\n- PASS: CGO_ENABLED=0 go build -o /tmp/opencode/gt-build-check-cgo0 ./cmd/gt\n- BLOCKED locally: go build -o /tmp/opencode/gt-build-check ./cmd/gt, because this sandbox lacks required ICU header unicode/uregex.h. Repo docs require libicu-dev for raw source builds; CI should provide it.\n\n## PR Sheriff Evidence\n\n- Bead: gt-8ek2\n- Research: 15 independent legs completed\n- Pre-implementation reviews: 5 completed; test adequacy block resolved before implementation\n- Post-implementation reviews: 5 approved final implementation head b48fcee0c942dfd14ee7870350205ac03378b01f\n- PR Sheriff checker will be rerun after GitHub CI evidence is available.\n