### PR TITLE
fix(mail): route dog mail to dog panes

### DIFF
--- a/internal/cmd/dnd_test.go
+++ b/internal/cmd/dnd_test.go
@@ -24,7 +24,11 @@ func TestAddressToAgentBeadID(t *testing.T) {
 	}{
 		// Mayor and deacon use hq- prefix (town-level)
 		{"mayor", "hq-mayor"},
+		{"mayor/", "hq-mayor"},
 		{"deacon", "hq-deacon"},
+		{"deacon/", "hq-deacon"},
+		{"deacon/dogs/alpha", "hq-dog-alpha"},
+		{"deacon/dogs/my-dog", "hq-dog-my-dog"},
 		{"gastown/witness", "gt-witness"},
 		{"gastown/refinery", "gt-refinery"},
 		{"gastown/alpha", "gt-alpha"},
@@ -34,6 +38,13 @@ func TestAddressToAgentBeadID(t *testing.T) {
 		{"beads/witness", "bd-witness"},
 		{"beads/beta", "bd-beta"},
 		// Invalid addresses should return empty string
+		{"deacon/dogs", ""},
+		{"deacon/dogs/", ""},
+		{"deacon/dogs/alpha/extra", ""},
+		{"deacon/foo", ""},
+		{"deaconer", ""},
+		{"mayor/foo", ""},
+		{"mayorer", ""},
 		{"invalid", ""},
 		{"", ""},
 	}

--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/events"
+	"github.com/steveyegge/gastown/internal/mail"
 	"github.com/steveyegge/gastown/internal/mayor"
 	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/session"
@@ -849,6 +850,8 @@ func sessionNameToAddress(sessionName string) string {
 		return constants.RoleMayor
 	case session.RoleDeacon:
 		return constants.RoleDeacon
+	case session.RoleDog:
+		return mail.DogAddress(identity.Name)
 	case session.RoleWitness:
 		return fmt.Sprintf("%s/witness", identity.Rig)
 	case session.RoleRefinery:
@@ -871,12 +874,18 @@ func sessionNameToAddress(sessionName string) string {
 //
 // Returns empty string if the address cannot be converted.
 func addressToAgentBeadID(address string) string {
+	if dogName, ok := mail.DogAddressName(address); ok {
+		return session.DogSessionName(dogName)
+	}
 	// Handle special cases
 	switch address {
-	case constants.RoleMayor:
+	case constants.RoleMayor, constants.RoleMayor + "/":
 		return session.MayorSessionName()
-	case constants.RoleDeacon:
+	case constants.RoleDeacon, constants.RoleDeacon + "/":
 		return session.DeaconSessionName()
+	}
+	if strings.HasPrefix(address, constants.RoleMayor+"/") || strings.HasPrefix(address, constants.RoleDeacon+"/") {
+		return ""
 	}
 
 	// Parse rig/role format

--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -520,6 +520,32 @@ func runNudge(cmd *cobra.Command, args []string) (retErr error) {
 		_ = events.LogFeed(events.TypeNudge, sender, events.NudgePayload("", constants.RoleDeacon, message))
 		return nil
 	}
+	if dogName, ok := mail.DogAddressName(target); ok {
+		sessionName := session.DogSessionName(dogName)
+		if nudgeModeFlag != NudgeModeImmediate && !hasACPSessionByName(townRoot, sessionName) {
+			exists, err := t.HasSession(sessionName)
+			if err != nil {
+				return fmt.Errorf("checking dog session: %w", err)
+			}
+			if !exists {
+				return fmt.Errorf("session %q not found (cannot queue nudge for nonexistent session)", sessionName)
+			}
+		}
+
+		if err := deliverNudge(t, sessionName, message, sender); err != nil {
+			return fmt.Errorf("nudging dog: %w", err)
+		}
+
+		fmt.Printf("%s Nudged %s (%s)\n", style.Bold.Render("✓"), target, nudgeModeFlag)
+		if townRoot, err := workspace.FindFromCwd(); err == nil && townRoot != "" {
+			_ = LogNudge(townRoot, target, message)
+		}
+		_ = events.LogFeed(events.TypeNudge, sender, events.NudgePayload("", target, message))
+		return nil
+	}
+	if strings.HasPrefix(target, constants.RoleMayor+"/") || strings.HasPrefix(target, constants.RoleDeacon+"/") {
+		return fmt.Errorf("invalid town target %q", target)
+	}
 
 	// Check if target is rig/polecat format or raw session name
 	if strings.Contains(target, "/") {

--- a/internal/cmd/nudge_test.go
+++ b/internal/cmd/nudge_test.go
@@ -188,6 +188,16 @@ func TestSessionNameToAddress(t *testing.T) {
 			expected:    "gastown/alpha",
 		},
 		{
+			name:        "dog",
+			sessionName: "hq-dog-alpha",
+			expected:    "deacon/dogs/alpha",
+		},
+		{
+			name:        "hyphenated dog",
+			sessionName: "hq-dog-my-dog",
+			expected:    "deacon/dogs/my-dog",
+		},
+		{
 			name:        "unrecognized format",
 			sessionName: "plaintext",
 			expected:    "",
@@ -226,9 +236,9 @@ func TestNudgeInvalidMode(t *testing.T) {
 	nudgeMessageFlag = "test"
 
 	tests := []struct {
-		name     string
-		mode     string
-		wantErr  string
+		name    string
+		mode    string
+		wantErr string
 	}{
 		{"bogus mode", "bogus", `invalid --mode "bogus"`},
 		{"empty mode", "", `invalid --mode ""`},

--- a/internal/cmd/nudge_test.go
+++ b/internal/cmd/nudge_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -495,6 +496,42 @@ func TestNudgeTrailingSlashNormalization(t *testing.T) {
 				t.Errorf("trailing-slash target %q was rejected as invalid address: %v", target, err)
 			}
 		})
+	}
+}
+
+func TestNudgeDogTargetRoutesToDogSession(t *testing.T) {
+	origMode := nudgeModeFlag
+	origPriority := nudgePriorityFlag
+	origMessage := nudgeMessageFlag
+	origStdin := nudgeStdinFlag
+	origForce := nudgeForceFlag
+	defer func() {
+		nudgeModeFlag = origMode
+		nudgePriorityFlag = origPriority
+		nudgeMessageFlag = origMessage
+		nudgeStdinFlag = origStdin
+		nudgeForceFlag = origForce
+	}()
+
+	logPath := filepath.Join(t.TempDir(), "nudge.log")
+	t.Setenv("GT_TEST_NUDGE_LOG", logPath)
+
+	nudgeModeFlag = NudgeModeImmediate
+	nudgePriorityFlag = nudge.PriorityNormal
+	nudgeMessageFlag = "hello dog"
+	nudgeStdinFlag = false
+	nudgeForceFlag = true
+
+	if err := runNudge(nudgeCmd, []string{"deacon/dogs/fido"}); err != nil {
+		t.Fatalf("runNudge dog target returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading nudge log: %v", err)
+	}
+	if got, want := string(data), "nudge:hq-dog-fido:"; !strings.Contains(got, want) {
+		t.Fatalf("nudge log = %q, want containing %q", got, want)
 	}
 }
 

--- a/internal/mail/dog_address.go
+++ b/internal/mail/dog_address.go
@@ -1,0 +1,63 @@
+package mail
+
+import (
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/session"
+)
+
+const dogAddressPrefix = constants.RoleDeacon + "/dogs/"
+
+// DogAddress returns the canonical mail address for a named dog.
+func DogAddress(name string) string {
+	if !isSafeDogName(name) {
+		return ""
+	}
+	return dogAddressPrefix + name
+}
+
+// DogAddressName extracts the dog name from a canonical deacon/dogs/<name> address.
+func DogAddressName(address string) (string, bool) {
+	if !strings.HasPrefix(address, dogAddressPrefix) {
+		return "", false
+	}
+	name := strings.TrimPrefix(address, dogAddressPrefix)
+	if !isSafeDogName(name) {
+		return "", false
+	}
+	return name, true
+}
+
+func dogAddressFromAgentBeadID(id string) string {
+	for _, prefix := range []string{session.HQPrefix + "dog-", "gt-dog-"} {
+		if strings.HasPrefix(id, prefix) {
+			return DogAddress(strings.TrimPrefix(id, prefix))
+		}
+	}
+	return ""
+}
+
+func isDogAgentBeadIDWithoutName(id string) bool {
+	return id == session.HQPrefix+"dog" || id == "gt-dog"
+}
+
+func dogAddressFromParts(parts []string, dogIndex int) string {
+	if dogIndex+1 >= len(parts) {
+		return ""
+	}
+	return DogAddress(strings.Join(parts[dogIndex+1:], "-"))
+}
+
+func isSafeDogName(name string) bool {
+	return name != "" &&
+		name != "." &&
+		name != ".." &&
+		!strings.ContainsAny(name, `/\\`) &&
+		!strings.Contains(name, "..")
+}
+
+func isReservedTownSubpath(address string) bool {
+	return strings.HasPrefix(address, constants.RoleMayor+"/") ||
+		strings.HasPrefix(address, constants.RoleDeacon+"/")
+}

--- a/internal/mail/resolve.go
+++ b/internal/mail/resolve.go
@@ -144,6 +144,12 @@ func (r *Resolver) validateAgentAddress(address string) error {
 	case constants.RoleMayor + "/", constants.RoleMayor, constants.RoleDeacon + "/", constants.RoleDeacon, "overseer":
 		return nil
 	}
+	validDogAddress := false
+	if _, ok := DogAddressName(normalized); ok {
+		validDogAddress = true
+	} else if isReservedTownSubpath(normalized) {
+		return fmt.Errorf("%w: %s", ErrUnknownRecipient, address)
+	}
 
 	parts := strings.SplitN(normalized, "/", 3)
 	if len(parts) < 2 || parts[1] == "" {
@@ -188,7 +194,11 @@ func (r *Resolver) validateAgentAddress(address string) error {
 			}
 		case 3:
 			// Explicit: rig/crew/name or rig/polecats/name
-			if dirExistsAt(filepath.Join(r.townRoot, parts[0], parts[1], parts[2])) {
+			if (parts[1] == constants.RoleCrew || parts[1] == "polecats") &&
+				dirExistsAt(filepath.Join(r.townRoot, parts[0], parts[1], parts[2])) {
+				return nil
+			}
+			if validDogAddress && dirExistsAt(filepath.Join(r.townRoot, parts[0], parts[1], parts[2])) {
 				return nil
 			}
 		}
@@ -464,6 +474,13 @@ func (r *Resolver) resolveChannel(name string) ([]Recipient, error) {
 //   - hq-deacon → deacon/
 //   - gt-gastown-crew-max → gastown/crew/max
 func AgentBeadIDToAddress(id string) string {
+	if addr := dogAddressFromAgentBeadID(id); addr != "" {
+		return addr
+	}
+	if isDogAgentBeadIDWithoutName(id) {
+		return ""
+	}
+
 	var rest string
 
 	// Handle both gt- (rig agents) and hq- (town agents) prefixes
@@ -509,11 +526,7 @@ func AgentBeadIDToAddress(id string) string {
 			return rig + "/" + role
 		case "dog":
 			// Town-level named: gt-dog-alpha
-			if i+1 < len(parts) {
-				name := strings.Join(parts[i+1:], "-")
-				return "dog/" + name
-			}
-			return "dog/"
+			return dogAddressFromParts(parts, i)
 		}
 	}
 

--- a/internal/mail/resolve_test.go
+++ b/internal/mail/resolve_test.go
@@ -1,6 +1,8 @@
 package mail
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
@@ -57,6 +59,9 @@ func TestAgentBeadIDToAddress(t *testing.T) {
 		// Town-level agents (hq- prefix)
 		{"hq-mayor", "mayor/"},
 		{"hq-deacon", "deacon/"},
+		{"hq-dog-alpha", "deacon/dogs/alpha"},
+		{"hq-dog-my-dog", "deacon/dogs/my-dog"},
+		{"gt-dog-alpha", "deacon/dogs/alpha"},
 
 		// Rig singletons
 		{"gt-gastown-witness", "gastown/witness"},
@@ -75,6 +80,7 @@ func TestAgentBeadIDToAddress(t *testing.T) {
 		// Invalid
 		{"invalid", ""},
 		{"not-gt-prefix", ""},
+		{"hq-dog", ""},
 		{"", ""},
 	}
 
@@ -83,6 +89,41 @@ func TestAgentBeadIDToAddress(t *testing.T) {
 			got := AgentBeadIDToAddress(tt.id)
 			if got != tt.want {
 				t.Errorf("AgentBeadIDToAddress(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolverValidateAgentAddressDogGuards(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "deacon", "dogs", "fido"), 0755); err != nil {
+		t.Fatalf("creating dog dir: %v", err)
+	}
+
+	resolver := NewResolver(nil, townRoot)
+	tests := []struct {
+		name    string
+		address string
+		wantErr bool
+	}{
+		{"valid dog", "deacon/dogs/fido", false},
+		{"dog pool", "deacon/dogs", true},
+		{"empty dog name", "deacon/dogs/", true},
+		{"nested dog path", "deacon/dogs/fido/extra", true},
+		{"dot dog name", "deacon/dogs/.", true},
+		{"dotdot dog name", "deacon/dogs/..", true},
+		{"unknown deacon subpath", "deacon/foo", true},
+		{"unknown mayor subpath", "mayor/foo", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := resolver.validateAgentAddress(tt.address)
+			if tt.wantErr && err == nil {
+				t.Fatalf("validateAgentAddress(%q) expected error", tt.address)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateAgentAddress(%q) unexpected error: %v", tt.address, err)
 			}
 		})
 	}

--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -363,6 +363,12 @@ func agentBeadToAddress(bead *agentBead) string {
 	}
 
 	id := bead.ID
+	if addr := dogAddressFromAgentBeadID(id); addr != "" {
+		return addr
+	}
+	if isDogAgentBeadIDWithoutName(id) {
+		return ""
+	}
 
 	// Handle hq- prefixed IDs (town-level format)
 	if strings.HasPrefix(id, "hq-") {
@@ -414,11 +420,7 @@ func agentBeadToAddress(bead *agentBead) string {
 			return rig + "/"
 		case "dog":
 			// Town-level named: gt-dog-alpha
-			if i+1 < len(parts) {
-				name := strings.Join(parts[i+1:], "-")
-				return "dog/" + name
-			}
-			return "dog/"
+			return dogAddressFromParts(parts, i)
 		}
 	}
 
@@ -938,6 +940,9 @@ func (r *Router) validateRecipient(identity string) error {
 	case "mayor", "mayor/", "deacon", "deacon/":
 		return nil
 	}
+	if _, ok := DogAddressName(identity); !ok && isReservedTownSubpath(identity) {
+		return fmt.Errorf("no agent found")
+	}
 
 	// Well-known rig-level singletons (rig/witness, rig/refinery) always
 	// valid — these agents are ephemeral and may not have an active session,
@@ -1005,6 +1010,10 @@ func (r *Router) validateRecipient(identity string) error {
 // validateAgentWorkspace checks if an agent's workspace directory exists on disk.
 // Used as a fallback when the agent isn't found in the bead registry.
 func (r *Router) validateAgentWorkspace(identity string) bool {
+	if _, ok := DogAddressName(identity); !ok && isReservedTownSubpath(identity) {
+		return false
+	}
+
 	parts := strings.Split(identity, "/")
 
 	switch len(parts) {
@@ -1030,7 +1039,7 @@ func (r *Router) validateAgentWorkspace(identity string) bool {
 			return dirExists(filepath.Join(r.townRoot, parts[0], parts[1], parts[2]))
 		}
 		// Dog addresses: deacon/dogs/<name>
-		if dirExists(filepath.Join(r.townRoot, parts[0], parts[1], parts[2])) {
+		if _, ok := DogAddressName(identity); ok && dirExists(filepath.Join(r.townRoot, parts[0], parts[1], parts[2])) {
 			return true
 		}
 	}
@@ -1862,13 +1871,20 @@ func (r *Router) isRecipientMuted(address string) bool {
 // addressToAgentBeadID converts a mail address to an agent bead ID for DND lookup.
 // Returns empty string if the address cannot be converted.
 func addressToAgentBeadID(address string) string {
-	switch {
-	case address == "overseer":
+	if address == "overseer" {
 		return "" // Overseer is a human, no agent bead
-	case strings.HasPrefix(address, constants.RoleMayor):
+	}
+	if dogName, ok := DogAddressName(address); ok {
+		return session.DogSessionName(dogName)
+	}
+	switch address {
+	case constants.RoleMayor, constants.RoleMayor + "/":
 		return session.MayorSessionName()
-	case strings.HasPrefix(address, constants.RoleDeacon):
+	case constants.RoleDeacon, constants.RoleDeacon + "/":
 		return session.DeaconSessionName()
+	}
+	if isReservedTownSubpath(address) {
+		return ""
 	}
 
 	parts := strings.SplitN(address, "/", 2)
@@ -1912,15 +1928,21 @@ func AddressToSessionIDs(address string) []string {
 	if address == "overseer" {
 		return []string{session.OverseerSessionName()}
 	}
+	if dogName, ok := DogAddressName(address); ok {
+		return []string{session.DogSessionName(dogName)}
+	}
 
 	// Mayor address: "mayor/" or "mayor"
-	if strings.HasPrefix(address, constants.RoleMayor) {
+	if address == constants.RoleMayor || address == constants.RoleMayor+"/" {
 		return []string{session.MayorSessionName()}
 	}
 
 	// Deacon address: "deacon/" or "deacon"
-	if strings.HasPrefix(address, constants.RoleDeacon) {
+	if address == constants.RoleDeacon || address == constants.RoleDeacon+"/" {
 		return []string{session.DeaconSessionName()}
+	}
+	if isReservedTownSubpath(address) {
+		return nil
 	}
 
 	// Rig-based address: "rig/target" or "rig/crew/name" or "rig/polecats/name"

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -183,6 +183,9 @@ func TestAddressToSessionIDs(t *testing.T) {
 		{"mayor", []string{"hq-mayor"}},
 		{"mayor/", []string{"hq-mayor"}},
 		{"deacon", []string{"hq-deacon"}},
+		{"deacon/", []string{"hq-deacon"}},
+		{"deacon/dogs/alpha", []string{"hq-dog-alpha"}},
+		{"deacon/dogs/my-dog", []string{"hq-dog-my-dog"}},
 
 		// Rig singletons - single session (no crew/polecat ambiguity)
 		{"gastown/refinery", []string{"gt-refinery"}},
@@ -201,6 +204,14 @@ func TestAddressToSessionIDs(t *testing.T) {
 		{"gastown/", nil}, // Empty target
 		{"gastown", nil},  // No slash
 		{"", nil},         // Empty address
+		{"deacon/dogs", nil},
+		{"deacon/dogs/", nil},
+		{"deacon/dogs/alpha/extra", nil},
+		{"deacon/dogs/..", nil},
+		{"deacon/foo", nil},
+		{"deaconer", nil},
+		{"mayor/foo", nil},
+		{"mayorer", nil},
 	}
 
 	for _, tt := range tests {
@@ -1010,6 +1021,13 @@ func TestAgentBeadToAddress(t *testing.T) {
 			bead: &agentBead{
 				ID: "hq-dog-bravo",
 			},
+			want: "deacon/dogs/bravo",
+		},
+		{
+			name: "malformed hq-dog returns empty",
+			bead: &agentBead{
+				ID: "hq-dog",
+			},
 			want: "",
 		},
 		{
@@ -1306,6 +1324,11 @@ func TestValidateAgentWorkspaceDog(t *testing.T) {
 	}{
 		{"dog exists", "deacon/dogs/fido", true},
 		{"dog not exists", "deacon/dogs/ghost", false},
+		{"dog pool is not mailbox", "deacon/dogs", false},
+		{"empty dog name", "deacon/dogs/", false},
+		{"nested dog path", "deacon/dogs/fido/extra", false},
+		{"dot dog name", "deacon/dogs/.", false},
+		{"dotdot dog name", "deacon/dogs/..", false},
 		{"not a dog path", "deacon/cats/fido", false},
 	}
 
@@ -1358,6 +1381,21 @@ func TestAddressToAgentBeadID(t *testing.T) {
 			expected: "hq-deacon",
 		},
 		{
+			name:     "deacon without slash",
+			address:  "deacon",
+			expected: "hq-deacon",
+		},
+		{
+			name:     "dog",
+			address:  "deacon/dogs/alpha",
+			expected: "hq-dog-alpha",
+		},
+		{
+			name:     "hyphenated dog",
+			address:  "deacon/dogs/my-dog",
+			expected: "hq-dog-my-dog",
+		},
+		{
 			name:     "witness",
 			address:  "gastown/witness",
 			expected: "gt-witness",
@@ -1395,6 +1433,41 @@ func TestAddressToAgentBeadID(t *testing.T) {
 		{
 			name:     "rig with empty target",
 			address:  "gastown/",
+			expected: "",
+		},
+		{
+			name:     "dog pool is not agent bead",
+			address:  "deacon/dogs",
+			expected: "",
+		},
+		{
+			name:     "empty dog name is not agent bead",
+			address:  "deacon/dogs/",
+			expected: "",
+		},
+		{
+			name:     "nested dog path is not agent bead",
+			address:  "deacon/dogs/alpha/extra",
+			expected: "",
+		},
+		{
+			name:     "unknown deacon subpath is not deacon",
+			address:  "deacon/foo",
+			expected: "",
+		},
+		{
+			name:     "deacon prefix is not deacon",
+			address:  "deaconer",
+			expected: "",
+		},
+		{
+			name:     "unknown mayor subpath is not mayor",
+			address:  "mayor/foo",
+			expected: "",
+		},
+		{
+			name:     "mayor prefix is not mayor",
+			address:  "mayorer",
 			expected: "",
 		},
 	}

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -1878,6 +1878,45 @@ func TestNotifyRecipient_CanonicalAliasQueuesAllHeadlessCandidates(t *testing.T)
 	}
 }
 
+func TestNotifyRecipient_DogQueuesDogSessionNotDeacon(t *testing.T) {
+	townRoot := t.TempDir()
+	r := &Router{
+		workDir:  t.TempDir(),
+		townRoot: townRoot,
+		tmux:     tmux.NewTmuxWithSocket("gt-test-missing-socket"),
+	}
+
+	msg := &Message{
+		From:     "mayor/",
+		To:       "deacon/dogs/fido",
+		Subject:  "dog delivery",
+		ThreadID: "thread-dog-delivery",
+	}
+
+	if err := r.notifyRecipient(msg); err != nil {
+		t.Fatalf("notifyRecipient returned error: %v", err)
+	}
+
+	dogNudges, err := nudge.Drain(townRoot, "hq-dog-fido")
+	if err != nil {
+		t.Fatalf("Drain(hq-dog-fido): %v", err)
+	}
+	if len(dogNudges) != 1 {
+		t.Fatalf("Drain(hq-dog-fido) returned %d nudges, want 1", len(dogNudges))
+	}
+	if dogNudges[0].ThreadID != msg.ThreadID {
+		t.Fatalf("dog nudge ThreadID = %q, want %q", dogNudges[0].ThreadID, msg.ThreadID)
+	}
+
+	deaconNudges, err := nudge.Drain(townRoot, "hq-deacon")
+	if err != nil {
+		t.Fatalf("Drain(hq-deacon): %v", err)
+	}
+	if len(deaconNudges) != 0 {
+		t.Fatalf("Drain(hq-deacon) returned %d nudges, want 0", len(deaconNudges))
+	}
+}
+
 func TestNotifyRecipient_BusyAgentEscalationUsesUrgentQueuedNudge(t *testing.T) {
 	socket := requireNotifyTestSocket(t)
 	sessionName := "gt-crew-busy-escalation"

--- a/pr-sheriff-evidence/gt-yzhl-pr4056-replacement/evidence.json
+++ b/pr-sheriff-evidence/gt-yzhl-pr4056-replacement/evidence.json
@@ -1,0 +1,235 @@
+{
+  "schema_version": "pr-sheriff-evidence/v1",
+  "policy_version": "pr-sheriff-policy/v1.1",
+  "generated_at": "2026-07-07T19:53:06Z",
+  "run_id": "gt-yzhl-pr4056-replacement",
+  "subject": {
+    "forge": "github",
+    "repo_id": "Bella-Giraffety/gastown",
+    "default_branch": "main",
+    "change_type": "pull_request",
+    "change_id": "gt-yzhl-replacement-for-4056",
+    "url": "https://github.com/Bella-Giraffety/gastown/compare/main...polecat/pipboy/gt-yzhl@8e9ea7",
+    "title": "Fix dog mail routing from PR #4056 with focused current-main replacement",
+    "author": "adensur/Maksim",
+    "author_tier": "known",
+    "draft": false,
+    "base_ref": "main",
+    "base_sha": "cb098cb41fad86817ecf6bd0c6ce287ca5f59553",
+    "head_ref": "polecat/pipboy/gt-yzhl@8e9ea7",
+    "head_sha": "1851d44300650595606b1be42b15a8ad27c5be7d",
+    "diff_summary": {
+      "additions": 367,
+      "deletions": 23,
+      "changed_files": 8,
+      "paths": [
+        "internal/cmd/dnd_test.go",
+        "internal/cmd/nudge.go",
+        "internal/cmd/nudge_test.go",
+        "internal/mail/dog_address.go",
+        "internal/mail/resolve.go",
+        "internal/mail/resolve_test.go",
+        "internal/mail/router.go",
+        "internal/mail/router_test.go"
+      ]
+    }
+  },
+  "repo_policy": {
+    "label_aliases": [],
+    "feature_kind_values": ["feature", "enhancement"],
+    "merge_ready_status_values": ["review-approved", "merge-ready"],
+    "approver_roles": ["maintainer", "owner", "mayor"],
+    "evidence_locations": ["local_report", "beads_notes", "artifact_store"],
+    "baseline_checks": [],
+    "no_verification_reasons": []
+  },
+  "action_plan": {
+    "id": "action-plan-gt-yzhl",
+    "mode": "replacement_pr",
+    "proposed_action_ref": "action-plan-gt-yzhl",
+    "summary": "Focused current-main replacement for stale/conflicting PR #4056: route deacon/dogs/<name> mail notifications and DND/resolver paths to dog sessions, guard malformed reserved paths, and preserve PR #4056 attribution without carrying the broad stale stack.",
+    "created_at": "2026-07-07T19:15:00Z"
+  },
+  "labels": {
+    "observed": [
+      {"name": "status/merge-ready", "family": "status", "semantic_value": "merge-ready"},
+      {"name": "priority/p2", "family": "priority", "semantic_value": "p2"},
+      {"name": "kind/bug", "family": "kind", "semantic_value": "bug"}
+    ],
+    "status": "merge-ready",
+    "priority": "p2",
+    "kind": "bug",
+    "snapshot_artifact_ref": "label-snapshot-replacement"
+  },
+  "artifacts": [
+    {"id": "label-snapshot-replacement", "kind": "label_snapshot", "uri": "file:pr-sheriff-evidence/gt-yzhl-pr4056-replacement/evidence.json#labels", "actor": "gastown/polecats/pipboy", "created_at": "2026-07-07T19:53:06Z", "digest": null, "summary": "Replacement target semantics: status=merge-ready, priority=p2, kind=bug. Original PR #4056 remains status/review-failed and is not merge target."},
+    {"id": "original-pr-4056", "kind": "pull_request_snapshot", "uri": "https://github.com/gastownhall/gastown/pull/4056", "actor": "github", "created_at": "2026-07-07T19:53:06Z", "digest": null, "summary": "Original PR #4056 by adensur/Maksim is open, conflicting/DIRTY, labels kind/bug priority/p2 status/review-failed, head 6010f264."},
+    {"id": "verification-focused", "kind": "verification_log", "uri": "file:pr-sheriff-evidence/gt-yzhl-pr4056-replacement/evidence.json#verification", "actor": "gastown/polecats/pipboy", "created_at": "2026-07-07T19:50:00Z", "digest": null, "summary": "CGO_ENABLED=0 build and focused mail/cmd tests passed on rebased head 1851d4430; default CGO tests blocked locally by missing unicode/uregex.h ICU header."},
+    {"id": "checker-merge-gate", "kind": "checker_output", "uri": "file:pr-sheriff-evidence/gt-yzhl-pr4056-replacement/merge-gate-check.txt", "actor": "gt-pr-sheriff-check", "created_at": "2026-07-07T19:54:00Z", "digest": null, "summary": "Checker passed merge gate: merge_path_allowed=true, verdict=merge_replacement, 12 pass, 2 not_applicable, 0 fail."},
+    {"id": "research-R01", "kind": "research_report", "uri": "beads:gt-yzhl#R01-pr4056-facts", "actor": "R01-pr4056-facts", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "PR #4056 facts: stale/conflicting, author adensur/Maksim, relevant commit 6010f264, broad unrelated stack to avoid."},
+    {"id": "research-R02", "kind": "research_report", "uri": "beads:gt-yzhl#R02-mail-routing-code", "actor": "R02-mail-routing-code", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "Mail Send persists dog assignee correctly but notifyRecipient misroutes via AddressToSessionIDs deacon prefix."},
+    {"id": "research-R03", "kind": "research_report", "uri": "beads:gt-yzhl#R03-dog-pane-resolver", "actor": "R03-dog-pane-resolver", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "Dog identity deacon/dogs/<name> should map to tmux session hq-dog-<name> at mail notification boundary."},
+    {"id": "research-R04", "kind": "research_report", "uri": "beads:gt-yzhl#R04-malformed-path-guards", "actor": "R04-malformed-path-guards", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "Malformed deacon/dogs, nested dog paths, and deacon/* must not fall through to Deacon."},
+    {"id": "research-R05", "kind": "research_report", "uri": "beads:gt-yzhl#R05-dnd-resolver-alignment", "actor": "R05-dnd-resolver-alignment", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "DND lookup and directory/bead resolver should align dog addresses with hq-dog-* rather than hq-deacon."},
+    {"id": "research-R06", "kind": "research_report", "uri": "beads:gt-yzhl#R06-existing-tests", "actor": "R06-existing-tests", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "Identified router, resolver, DND, and nudge tests needed for dog routing and malformed guards."},
+    {"id": "research-R07", "kind": "research_report", "uri": "beads:gt-yzhl#R07-frontend-pane-routing", "actor": "R07-frontend-pane-routing", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "Frontend only sends mail requests; dog pane routing is backend/CLI and no UI change is required."},
+    {"id": "research-R08", "kind": "research_report", "uri": "beads:gt-yzhl#R08-cli-recipient-parser", "actor": "R08-cli-recipient-parser", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "gt mail and gt nudge parsing surfaces identified; direct nudge dog alignment is adjacent but small."},
+    {"id": "research-R09", "kind": "research_report", "uri": "beads:gt-yzhl#R09-deacon-dog-architecture", "actor": "R09-deacon-dog-architecture", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "Architecture maps dog address deacon/dogs/<name> to hq-dog-<name>; canonical address should remain deacon/dogs/<name>."},
+    {"id": "research-R10", "kind": "research_report", "uri": "beads:gt-yzhl#R10-pr-commit-6010f264", "actor": "R10-pr-commit-6010f264", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "Commit 6010f264 has focused dog prefix fix pattern reusable with attribution; rest of PR stack is stale/broad."},
+    {"id": "research-R11", "kind": "research_report", "uri": "beads:gt-yzhl#R11-edge-risk-security", "actor": "R11-edge-risk-security", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "Risk review recommended exact dog parser, safe names, and reserved town-subpath fail-closed behavior."},
+    {"id": "research-R12", "kind": "research_report", "uri": "beads:gt-yzhl#R12-repo-conventions-gates", "actor": "R12-repo-conventions-gates", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "Repo uses Go/gofmt; targeted CGO_ENABLED=0 tests are appropriate locally due ICU constraint."},
+    {"id": "research-R13", "kind": "research_report", "uri": "beads:gt-yzhl#R13-sheriff-evidence-context", "actor": "R13-sheriff-evidence-context", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "Evidence should be persisted locally and in Beads with final PR-SHERIFF-EVIDENCE comment tied to head SHA."},
+    {"id": "research-R14", "kind": "research_report", "uri": "beads:gt-yzhl#R14-address-docs-examples", "actor": "R14-address-docs-examples", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "Docs confirm general mail/nudge address formats and reveal dog address documentation gaps; no doc change required for this fix."},
+    {"id": "research-R15", "kind": "research_report", "uri": "beads:gt-yzhl#R15-current-main-repro", "actor": "R15-current-main-repro", "created_at": "2026-07-07T19:05:00Z", "digest": null, "summary": "Current main repro/static behavior: deacon/dogs/fido would resolve to hq-deacon in mail notification; direct nudge failed as rig deacon."},
+    {"id": "pre-P01", "kind": "pre_implementation_review", "uri": "beads:gt-yzhl#P01-minimality-cleanup", "actor": "P01-minimality-cleanup", "created_at": "2026-07-07T19:20:00Z", "digest": null, "summary": "Approved minimal cleanup plan with mandatory tightening for duplicate bead address rendering and safe-name semantics."},
+    {"id": "pre-P02", "kind": "pre_implementation_review", "uri": "beads:gt-yzhl#P02-correctness-edgecases", "actor": "P02-correctness-edgecases", "created_at": "2026-07-07T19:20:00Z", "digest": null, "summary": "Approved with mandatory adjustments for exact town roles, reserved-path rejection, hq-dog-* fixed-prefix mapping, and cmd DND."},
+    {"id": "pre-P03", "kind": "pre_implementation_review", "uri": "beads:gt-yzhl#P03-scope-pr4056-attribution", "actor": "P03-scope-pr4056-attribution", "created_at": "2026-07-07T19:20:00Z", "digest": null, "summary": "Approved focused current-main replacement scope and attribution constraints for PR #4056/6010f264."},
+    {"id": "pre-P04", "kind": "pre_implementation_review", "uri": "beads:gt-yzhl#P04-testability-gates", "actor": "P04-testability-gates", "created_at": "2026-07-07T19:20:00Z", "digest": null, "summary": "Initial block resolved before code by adding all mandatory false-positive, malformed dog, deacon slash, and hq-dog tests to the implemented plan."},
+    {"id": "pre-P05", "kind": "pre_implementation_review", "uri": "beads:gt-yzhl#P05-design-convergence", "actor": "P05-design-convergence", "created_at": "2026-07-07T19:20:00Z", "digest": null, "summary": "Approved mail-local resolver convergence; central session.ParseAddress cleanup deferred as broader follow-up."},
+    {"id": "post-FINAL01", "kind": "post_implementation_review", "uri": "beads:gt-yzhl#POST-FINAL01-cleanup", "actor": "POST-FINAL01-cleanup", "created_at": "2026-07-07T19:51:00Z", "digest": null, "summary": "Approved final head 1851d4430 for cleanup-first scope, dog routing, malformed guards, DND/resolver, and direct nudge alignment."},
+    {"id": "post-FINAL02", "kind": "post_implementation_review", "uri": "beads:gt-yzhl#POST-FINAL02-correctness", "actor": "POST-FINAL02-correctness", "created_at": "2026-07-07T19:51:00Z", "digest": null, "summary": "Approved final head edge cases including hyphen dogs, malformed reserved paths, hq-dog reverse mapping, and DND behavior."},
+    {"id": "post-FINAL03", "kind": "post_implementation_review", "uri": "beads:gt-yzhl#POST-FINAL03-tests", "actor": "POST-FINAL03-tests", "created_at": "2026-07-07T19:51:00Z", "digest": null, "summary": "Approved final test coverage including prior blockers: notifyRecipient dog-not-deacon and runNudge dog target."},
+    {"id": "post-FINAL04", "kind": "post_implementation_review", "uri": "beads:gt-yzhl#POST-FINAL04-integration", "actor": "POST-FINAL04-integration", "created_at": "2026-07-07T19:51:00Z", "digest": null, "summary": "Approved integration surfaces and no import cycle; go list and focused tests passed."},
+    {"id": "post-FINAL05", "kind": "post_implementation_review", "uri": "beads:gt-yzhl#POST-FINAL05-policy", "actor": "POST-FINAL05-policy", "created_at": "2026-07-07T19:51:00Z", "digest": null, "summary": "Approved PR Sheriff policy readiness for final code; durable evidence/checker artifacts still required before completion."}
+  ],
+  "implementation": {
+    "code_changed_by_sheriff": true,
+    "mode": "replacement_pr",
+    "first_code_change_at": "2026-07-07T19:25:00Z",
+    "modified_paths": [
+      "internal/cmd/dnd_test.go",
+      "internal/cmd/nudge.go",
+      "internal/cmd/nudge_test.go",
+      "internal/mail/dog_address.go",
+      "internal/mail/resolve.go",
+      "internal/mail/resolve_test.go",
+      "internal/mail/router.go",
+      "internal/mail/router_test.go"
+    ],
+    "commits": ["4e59dc31f", "1851d4430"]
+  },
+  "evidence": {
+    "research_legs": [
+      {"id": "R01", "independence_key": "R01-pr4056-facts", "artifact_ref": "research-R01", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R01", "lens": "PR facts and stale scope", "summary": "Original PR #4056 is stale/conflicting; focused 6010f264 intent is valid."},
+      {"id": "R02", "independence_key": "R02-mail-routing-code", "artifact_ref": "research-R02", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R02", "lens": "mail routing code", "summary": "notifyRecipient uses AddressToSessionIDs where deacon prefix misroutes dog addresses."},
+      {"id": "R03", "independence_key": "R03-dog-pane-resolver", "artifact_ref": "research-R03", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R03", "lens": "dog pane resolver", "summary": "Dog mail address should map to hq-dog session at notification boundary."},
+      {"id": "R04", "independence_key": "R04-malformed-path-guards", "artifact_ref": "research-R04", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R04", "lens": "malformed guards", "summary": "Reserved malformed town paths must fail closed."},
+      {"id": "R05", "independence_key": "R05-dnd-resolver-alignment", "artifact_ref": "research-R05", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R05", "lens": "DND and resolver alignment", "summary": "DND and resolver drift confirmed for dogs."},
+      {"id": "R06", "independence_key": "R06-existing-tests", "artifact_ref": "research-R06", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R06", "lens": "tests", "summary": "Focused router, resolver, DND, and nudge tests identified."},
+      {"id": "R07", "independence_key": "R07-frontend-pane-routing", "artifact_ref": "research-R07", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R07", "lens": "frontend scope", "summary": "No frontend changes needed."},
+      {"id": "R08", "independence_key": "R08-cli-recipient-parser", "artifact_ref": "research-R08", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R08", "lens": "CLI parser", "summary": "Direct nudge dog target needed alignment after post-review."},
+      {"id": "R09", "independence_key": "R09-deacon-dog-architecture", "artifact_ref": "research-R09", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R09", "lens": "architecture", "summary": "Canonical dog address/session mapping established."},
+      {"id": "R10", "independence_key": "R10-pr-commit-6010f264", "artifact_ref": "research-R10", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R10", "lens": "original commit compare", "summary": "Focused dog-prefix code reusable; stale broad stack avoided."},
+      {"id": "R11", "independence_key": "R11-edge-risk-security", "artifact_ref": "research-R11", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R11", "lens": "edge and security risks", "summary": "Safe dog names and fail-closed reserved paths are required."},
+      {"id": "R12", "independence_key": "R12-repo-conventions-gates", "artifact_ref": "research-R12", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R12", "lens": "repo conventions", "summary": "Go/gofmt and targeted tests are appropriate."},
+      {"id": "R13", "independence_key": "R13-sheriff-evidence-context", "artifact_ref": "research-R13", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R13", "lens": "evidence context", "summary": "Local evidence and Beads final comment needed."},
+      {"id": "R14", "independence_key": "R14-address-docs-examples", "artifact_ref": "research-R14", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R14", "lens": "docs", "summary": "Docs do not require frontend/doc changes for this fix."},
+      {"id": "R15", "independence_key": "R15-current-main-repro", "artifact_ref": "research-R15", "completed_at": "2026-07-07T19:05:00Z", "actor": "researcher-R15", "lens": "current-main repro", "summary": "Current main bug behavior confirmed without sending real mail."}
+    ],
+    "pre_implementation_reviews": [
+      {"id": "P01", "independence_key": "P01-minimality-cleanup", "artifact_ref": "pre-P01", "reviewed_action_ref": "action-plan-gt-yzhl", "completed_at": "2026-07-07T19:20:00Z", "actor": "pre-reviewer-P01", "verdict": "approve", "summary": "Approved minimal cleanup plan with required dog bead/address tightening."},
+      {"id": "P02", "independence_key": "P02-correctness-edgecases", "artifact_ref": "pre-P02", "reviewed_action_ref": "action-plan-gt-yzhl", "completed_at": "2026-07-07T19:20:00Z", "actor": "pre-reviewer-P02", "verdict": "approve", "summary": "Approved with exact town aliases, reserved-path guards, fixed hq-dog mapping, and DND alignment."},
+      {"id": "P03", "independence_key": "P03-scope-pr4056-attribution", "artifact_ref": "pre-P03", "reviewed_action_ref": "action-plan-gt-yzhl", "completed_at": "2026-07-07T19:20:00Z", "actor": "pre-reviewer-P03", "verdict": "approve", "summary": "Approved PR #4056 replacement scope and attribution requirements."},
+      {"id": "P04", "independence_key": "P04-testability-gates", "artifact_ref": "pre-P04", "reviewed_action_ref": "action-plan-gt-yzhl", "completed_at": "2026-07-07T19:20:00Z", "actor": "pre-reviewer-P04", "verdict": "approve", "summary": "Mandatory test additions were incorporated before code; reviewed plan became testable and complete."},
+      {"id": "P05", "independence_key": "P05-design-convergence", "artifact_ref": "pre-P05", "reviewed_action_ref": "action-plan-gt-yzhl", "completed_at": "2026-07-07T19:20:00Z", "actor": "pre-reviewer-P05", "verdict": "approve", "summary": "Approved mail-local convergence and deferred broader central parser cleanup."}
+    ],
+    "post_implementation_reviews": [
+      {"id": "POST-FINAL01", "independence_key": "POST-FINAL01-cleanup", "artifact_ref": "post-FINAL01", "reviewed_action_ref": "action-plan-gt-yzhl", "reviewed_head_sha": "1851d44300650595606b1be42b15a8ad27c5be7d", "completed_at": "2026-07-07T19:51:00Z", "actor": "post-reviewer-FINAL01", "verdict": "approve", "summary": "Approved cleanup-first final implementation."},
+      {"id": "POST-FINAL02", "independence_key": "POST-FINAL02-correctness", "artifact_ref": "post-FINAL02", "reviewed_action_ref": "action-plan-gt-yzhl", "reviewed_head_sha": "1851d44300650595606b1be42b15a8ad27c5be7d", "completed_at": "2026-07-07T19:51:00Z", "actor": "post-reviewer-FINAL02", "verdict": "approve", "summary": "Approved final correctness and edge cases."},
+      {"id": "POST-FINAL03", "independence_key": "POST-FINAL03-tests", "artifact_ref": "post-FINAL03", "reviewed_action_ref": "action-plan-gt-yzhl", "reviewed_head_sha": "1851d44300650595606b1be42b15a8ad27c5be7d", "completed_at": "2026-07-07T19:51:00Z", "actor": "post-reviewer-FINAL03", "verdict": "approve", "summary": "Approved final test coverage."},
+      {"id": "POST-FINAL04", "independence_key": "POST-FINAL04-integration", "artifact_ref": "post-FINAL04", "reviewed_action_ref": "action-plan-gt-yzhl", "reviewed_head_sha": "1851d44300650595606b1be42b15a8ad27c5be7d", "completed_at": "2026-07-07T19:51:00Z", "actor": "post-reviewer-FINAL04", "verdict": "approve", "summary": "Approved integration and import-cycle risk."},
+      {"id": "POST-FINAL05", "independence_key": "POST-FINAL05-policy", "artifact_ref": "post-FINAL05", "reviewed_action_ref": "action-plan-gt-yzhl", "reviewed_head_sha": "1851d44300650595606b1be42b15a8ad27c5be7d", "completed_at": "2026-07-07T19:51:00Z", "actor": "post-reviewer-FINAL05", "verdict": "approve", "summary": "Approved policy readiness subject to this durable evidence and checker pass."}
+    ]
+  },
+  "cleanup_first": {
+    "assessment": "acceptable_minimal",
+    "rationale": "Focused current-main replacement collapses dog address parsing into one mail helper, removes loose mayor/deacon prefix routing, and avoids PR #4056's broad stale stack.",
+    "prohibited_patterns": [
+      {"kind": "bandaid", "present": false, "exception_reason": "none", "evidence_ref": "post-FINAL01"},
+      {"kind": "workaround_layer", "present": false, "exception_reason": "none", "evidence_ref": "post-FINAL01"},
+      {"kind": "compatibility_shim", "present": false, "exception_reason": "none", "evidence_ref": "post-FINAL01"},
+      {"kind": "patch_on_patch", "present": false, "exception_reason": "none", "evidence_ref": "post-FINAL01"},
+      {"kind": "scope_creep", "present": false, "exception_reason": "none", "evidence_ref": "post-FINAL01"}
+    ]
+  },
+  "enhancement_approval": {
+    "required": false,
+    "required_reason": null,
+    "approved": false,
+    "approver": null,
+    "approver_role": null,
+    "approval_ref": null,
+    "approved_at": null
+  },
+  "verification": {
+    "focused_checks": [
+      {"name": "gofmt", "command_or_check": "gofmt -w internal/cmd/nudge.go internal/cmd/nudge_test.go internal/mail/router_test.go", "outcome": "pass", "artifact_ref": "verification-focused", "reason": "Formatting completed for touched files."},
+      {"name": "diff-check", "command_or_check": "git diff --check upstream/main...HEAD", "outcome": "pass", "artifact_ref": "verification-focused", "reason": "No whitespace or conflict-marker issues in final diff."},
+      {"name": "build", "command_or_check": "CGO_ENABLED=0 go build -v ./cmd/gt", "outcome": "pass", "artifact_ref": "verification-focused", "reason": "CLI builds with CGO disabled in the local environment."},
+      {"name": "mail-focused-tests", "command_or_check": "CGO_ENABLED=0 go test ./internal/mail -run '^(TestAddressToSessionIDs|TestAddressToAgentBeadID|TestAgentBeadToAddress|TestAgentBeadIDToAddress|TestValidateAgentWorkspaceDog|TestResolverValidateAgentAddressDogGuards|TestNotifyRecipient_DogQueuesDogSessionNotDeacon)$' -count=1", "outcome": "pass", "artifact_ref": "verification-focused", "reason": "Focused mail routing, resolver, DND, and dog-not-deacon notification tests passed."},
+      {"name": "cmd-focused-tests", "command_or_check": "CGO_ENABLED=0 go test ./internal/cmd -run '^(TestAddressToAgentBeadID|TestSessionNameToAddress|TestNudgeDogTargetRoutesToDogSession)$' -count=1", "outcome": "pass", "artifact_ref": "verification-focused", "reason": "Focused command DND, session reverse mapping, and dog nudge routing tests passed."}
+    ],
+    "ci_checks": []
+  },
+  "baseline_red_waiver": {
+    "requested": false,
+    "approved": false,
+    "approved_by": null,
+    "approver_role": null,
+    "approved_at": null,
+    "approval_ref": null,
+    "failing_checks": [],
+    "unrelated_rationale": "",
+    "evidence_refs": []
+  },
+  "replacement_flow": {
+    "required": true,
+    "mode": "replacement_pr",
+    "state": "ready",
+    "original_change_url": "https://github.com/gastownhall/gastown/pull/4056",
+    "replacement_change_url": "https://github.com/Bella-Giraffety/gastown/compare/main...polecat/pipboy/gt-yzhl@8e9ea7",
+    "replacement_branch": "polecat/pipboy/gt-yzhl@8e9ea7",
+    "replacement_commit_refs": ["4e59dc31f3dfe5fac9abb88591001d804747e182", "1851d44300650595606b1be42b15a8ad27c5be7d"],
+    "original_author": "adensur/Maksim",
+    "evidence_reuse": {
+      "reused_artifact_refs": ["original-pr-4056", "research-R10"],
+      "fresh_artifact_refs": ["verification-focused", "post-FINAL01", "post-FINAL02", "post-FINAL03", "post-FINAL04", "post-FINAL05"],
+      "rationale": "Only the focused dog-prefix routing intent from 6010f264 was reused; final implementation and tests are fresh on current main."
+    },
+    "attribution": {
+      "required": true,
+      "required_reason": "Replacement preserves valid bug intent from PR #4056 and commit 6010f264 by adensur/Maksim.",
+      "preserved": true,
+      "method": "comment_credit",
+      "artifact_refs": ["original-pr-4056", "research-R10"]
+    },
+    "superseded_closure": {
+      "required": true,
+      "state": "deferred_until_replacement_merge",
+      "closure_intent_ref": "original-pr-4056",
+      "replacement_merge_ref": null,
+      "closure_ref": null
+    }
+  },
+  "blocker_scan": {
+    "scanned_sources": ["labels", "pr_comments", "review_comments", "beads_notes", "local_reviews", "verification"],
+    "unresolved_blockers_found": false,
+    "blocker_refs": [],
+    "resolution_refs": ["post-FINAL01", "post-FINAL02", "post-FINAL03", "post-FINAL04", "post-FINAL05", "verification-focused"],
+    "scanned_at": "2026-07-07T19:53:06Z",
+    "summary": "Original PR #4056 remains review-failed/conflicting and is not the merge target. Replacement branch blockers from post-review were resolved before final head 1851d4430; no unresolved blockers remain for the replacement target."
+  },
+  "gates": [],
+  "final": {
+    "verdict": "merge_replacement",
+    "decision_valid": true,
+    "merge_path_allowed": true,
+    "blocking_gates": [],
+    "target_change_url": "https://github.com/Bella-Giraffety/gastown/compare/main...polecat/pipboy/gt-yzhl@8e9ea7",
+    "target_head_sha": "1851d44300650595606b1be42b15a8ad27c5be7d",
+    "decided_by": "gastown/polecats/pipboy",
+    "decided_at": "2026-07-07T19:53:06Z",
+    "reason": "All PR Sheriff research, pre-review, post-review, cleanup-first, replacement attribution, blocker scan, and focused verification gates pass for the checked replacement head.",
+    "required_actions": ["Do not close PR #4056 as superseded until this replacement lands with evidence."]
+  }
+}

--- a/pr-sheriff-evidence/gt-yzhl-pr4056-replacement/merge-gate-check.txt
+++ b/pr-sheriff-evidence/gt-yzhl-pr4056-replacement/merge-gate-check.txt
@@ -1,0 +1,10 @@
+command: gt-pr-sheriff-check --evidence pr-sheriff-evidence/gt-yzhl-pr4056-replacement/evidence.json --merge-gate
+exit_code: 0
+
+stdout:
+PR Sheriff: PASS
+merge_path_allowed: true
+verdict: merge_replacement
+gates: 12 pass, 2 not_applicable, 0 waived, 0 fail
+
+stderr:


### PR DESCRIPTION
Focused current-main replacement for PR #4056 by adensur/Maksim. Preserves the valid dog-prefix routing intent from commit 6010f264 without carrying the stale broad PR stack.\n\nWhat changed:\n- Route deacon/dogs/<name> mail notifications to hq-dog-<name> before Deacon matching.\n- Guard malformed reserved paths like deacon/dogs, deacon/dogs/, nested dog paths, deacon/foo, mayor/foo, deaconer, and mayorer.\n- Align mail/cmd DND lookup, dog bead address rendering, and direct gt nudge deacon/dogs/<name>.\n- Add focused PR Sheriff evidence in pr-sheriff-evidence/gt-yzhl-pr4056-replacement/.\n\nVerification:\n- gt-pr-sheriff-check --evidence pr-sheriff-evidence/gt-yzhl-pr4056-replacement/evidence.json --merge-gate\n- CGO_ENABLED=0 go build -v ./cmd/gt\n- CGO_ENABLED=0 go test ./internal/mail -run '^(TestAddressToSessionIDs|TestAddressToAgentBeadID|TestAgentBeadToAddress|TestAgentBeadIDToAddress|TestValidateAgentWorkspaceDog|TestResolverValidateAgentAddressDogGuards|TestNotifyRecipient_DogQueuesDogSessionNotDeacon)$' -count=1\n- CGO_ENABLED=0 go test ./internal/cmd -run '^(TestAddressToAgentBeadID|TestSessionNameToAddress|TestNudgeDogTargetRoutesToDogSession)$' -count=1\n\nNote: local default CGO package tests are blocked by missing unicode/uregex.h ICU headers. PR #4056 should not be closed as superseded until this replacement lands with evidence.