### PR TITLE
Fix recovery cleanup preservation for squash-merged work

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1503,14 +1503,14 @@ func recoveryTargetRefs(bd *beads.Beads, issueID, activeMR, branch string, extra
 		if activeMR != "" {
 			if issue, err := bd.Show(activeMR); err == nil {
 				appendMRTarget(issue)
-			} else {
+			} else if !errors.Is(err, beads.ErrNotFound) {
 				lookupFailed = true
 			}
 		}
 		if branch != "" {
 			if issue, err := bd.FindMRForBranchAny(branch); err == nil {
 				appendMRTarget(issue)
-			} else {
+			} else if !errors.Is(err, beads.ErrNotFound) {
 				lookupFailed = true
 			}
 		}

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1099,12 +1099,12 @@ func runPolecatCheckRecovery(cmd *cobra.Command, args []string) error {
 		// Use cleanup_status from agent bead, then overlay direct git and MQ facts.
 		input.CleanupStatus = polecat.CleanupStatus(fields.CleanupStatus)
 		status.ActiveMR = fields.ActiveMR
-		targetRefs = recoveryTargetRefs(bd, status.Issue, status.ActiveMR, status.Branch)
 		input.ActiveMR = fields.ActiveMR
 		hookBead := agentHookBead(agentIssue, fields)
 		hookSafe, hookTerminal, hookBlocker := hookBeadSafeForCleanup(bd, hookBead)
 		workTerminal = beadTerminal || hookTerminal
 		sourceHint := agentSourceIssueHint(status.Issue, fields)
+		targetRefs = recoveryTargetRefs(bd, status.Issue, status.ActiveMR, status.Branch, sourceHint)
 		if status.Issue == "" && sourceHint != "" {
 			status.Issue = sourceHint
 		}
@@ -1488,7 +1488,7 @@ func isRecoveryBaseBranch(branch string) bool {
 	return branch == "main" || branch == "master" || strings.HasPrefix(branch, "integration/")
 }
 
-func recoveryTargetRefs(bd *beads.Beads, issueID, activeMR, branch string) []string {
+func recoveryTargetRefs(bd *beads.Beads, issueID, activeMR, branch string, extraIssueIDs ...string) []string {
 	var refs []string
 	appendMRTarget := func(issue *beads.Issue) {
 		if fields := beads.ParseMRFields(issue); fields != nil && fields.Target != "" {
@@ -1506,8 +1506,11 @@ func recoveryTargetRefs(bd *beads.Beads, issueID, activeMR, branch string) []str
 				appendMRTarget(issue)
 			}
 		}
-		if issueID != "" {
-			if issue, err := bd.Show(issueID); err == nil {
+		for _, candidateIssueID := range append([]string{issueID}, extraIssueIDs...) {
+			if candidateIssueID == "" {
+				continue
+			}
+			if issue, err := bd.Show(candidateIssueID); err == nil {
 				appendAttachmentTargets(&refs, bd, issue)
 			}
 		}

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1062,7 +1062,7 @@ func runPolecatCheckRecovery(cmd *cobra.Command, args []string) error {
 	}
 	beadTerminal := isAssignedBeadTerminal(bd, status.Issue)
 	workTerminal := beadTerminal
-	targetRefs := recoveryTargetRefs(bd, status.Issue, status.ActiveMR, status.Branch)
+	targetRefs, targetRefLookupFailed := recoveryTargetRefs(bd, status.Issue, status.ActiveMR, status.Branch)
 	input := polecat.WorkstateInput{State: p.State, CleanupStatus: polecat.CleanupUnknown, Branch: p.Branch}
 	var gitState *GitState
 	var gitErr error
@@ -1104,7 +1104,7 @@ func runPolecatCheckRecovery(cmd *cobra.Command, args []string) error {
 		hookSafe, hookTerminal, hookBlocker := hookBeadSafeForCleanup(bd, hookBead)
 		workTerminal = beadTerminal || hookTerminal
 		sourceHint := agentSourceIssueHint(status.Issue, fields)
-		targetRefs = recoveryTargetRefs(bd, status.Issue, status.ActiveMR, status.Branch, sourceHint)
+		targetRefs, targetRefLookupFailed = recoveryTargetRefs(bd, status.Issue, status.ActiveMR, status.Branch, sourceHint)
 		if status.Issue == "" && sourceHint != "" {
 			status.Issue = sourceHint
 		}
@@ -1160,7 +1160,7 @@ func runPolecatCheckRecovery(cmd *cobra.Command, args []string) error {
 	}
 
 	status.CleanupStatus = input.CleanupStatus
-	applyMQFactsToWorkstateInput(&input, &status, bd, workTerminal, p.ClonePath, targetRefs, gitState, gitErr)
+	applyMQFactsToWorkstateInput(&input, &status, bd, workTerminal, p.ClonePath, targetRefs, targetRefLookupFailed, gitState, gitErr)
 	disposition := polecat.DecideWorkstate(input)
 	applyWorkstateDispositionToRecoveryStatus(&status, disposition)
 
@@ -1255,7 +1255,7 @@ func applyGitStateToWorkstateInput(input *polecat.WorkstateInput, worktreePath s
 	}
 }
 
-func applyMQFactsToWorkstateInput(input *polecat.WorkstateInput, status *RecoveryStatus, bd *beads.Beads, beadTerminal bool, worktreePath string, targetRefs []string, gitState *GitState, gitErr error) {
+func applyMQFactsToWorkstateInput(input *polecat.WorkstateInput, status *RecoveryStatus, bd *beads.Beads, beadTerminal bool, worktreePath string, targetRefs []string, targetRefLookupFailed bool, gitState *GitState, gitErr error) {
 	if status.Branch == "" {
 		return
 	}
@@ -1263,6 +1263,9 @@ func applyMQFactsToWorkstateInput(input *polecat.WorkstateInput, status *Recover
 	input.AssignedBeadTerminal = beadTerminal
 	input.HasSubmittableWork = hasSubmittableWorkForRecovery(worktreePath, targetRefs, gitState, gitErr)
 	input.MQNotRequired = isMQNotRequiredSource(bd, status.Issue)
+	if targetRefLookupFailed {
+		input.MQLookupFailed = true
+	}
 	if !input.HasSubmittableWork || input.MQNotRequired || input.AssignedBeadTerminal {
 		return
 	}
@@ -1488,8 +1491,9 @@ func isRecoveryBaseBranch(branch string) bool {
 	return branch == "main" || branch == "master" || strings.HasPrefix(branch, "integration/")
 }
 
-func recoveryTargetRefs(bd *beads.Beads, issueID, activeMR, branch string, extraIssueIDs ...string) []string {
+func recoveryTargetRefs(bd *beads.Beads, issueID, activeMR, branch string, extraIssueIDs ...string) ([]string, bool) {
 	var refs []string
+	lookupFailed := false
 	appendMRTarget := func(issue *beads.Issue) {
 		if fields := beads.ParseMRFields(issue); fields != nil && fields.Target != "" {
 			refs = append(refs, fields.Target)
@@ -1499,11 +1503,15 @@ func recoveryTargetRefs(bd *beads.Beads, issueID, activeMR, branch string, extra
 		if activeMR != "" {
 			if issue, err := bd.Show(activeMR); err == nil {
 				appendMRTarget(issue)
+			} else {
+				lookupFailed = true
 			}
 		}
 		if branch != "" {
 			if issue, err := bd.FindMRForBranchAny(branch); err == nil {
 				appendMRTarget(issue)
+			} else {
+				lookupFailed = true
 			}
 		}
 		for _, candidateIssueID := range append([]string{issueID}, extraIssueIDs...) {
@@ -1512,10 +1520,12 @@ func recoveryTargetRefs(bd *beads.Beads, issueID, activeMR, branch string, extra
 			}
 			if issue, err := bd.Show(candidateIssueID); err == nil {
 				appendAttachmentTargets(&refs, bd, issue)
+			} else {
+				lookupFailed = true
 			}
 		}
 	}
-	return uniqueStrings(refs)
+	return uniqueStrings(refs), lookupFailed
 }
 
 func appendAttachmentTargets(refs *[]string, bd *beads.Beads, issue *beads.Issue) {

--- a/internal/cmd/polecat_check_recovery_test.go
+++ b/internal/cmd/polecat_check_recovery_test.go
@@ -729,6 +729,33 @@ func TestHasSubmittableWorkForRecoveryUsesExplicitTargetCherry(t *testing.T) {
 	}
 }
 
+func TestHasSubmittableWorkForRecoveryUsesExplicitTargetSquashNoop(t *testing.T) {
+	repo := setupRecoveryGitRepo(t)
+	if err := exec.Command("git", "-C", repo, "merge-tree", "--write-tree", "HEAD", "HEAD").Run(); err != nil {
+		t.Skipf("git merge-tree --write-tree unsupported: %v", err)
+	}
+	runGit(t, repo, "switch", "-c", "polecat/squash")
+	writeRecoveryFile(t, filepath.Join(repo, "squash.txt"), "one\n")
+	runGit(t, repo, "add", "squash.txt")
+	runGit(t, repo, "commit", "-m", "checkpoint one")
+	writeRecoveryFile(t, filepath.Join(repo, "squash.txt"), "one\ntwo\n")
+	runGit(t, repo, "add", "squash.txt")
+	runGit(t, repo, "commit", "-m", "checkpoint two")
+
+	runGit(t, repo, "switch", "integration/test")
+	runGit(t, repo, "merge", "--squash", "polecat/squash")
+	runGit(t, repo, "commit", "-m", "squash polecat work")
+	writeRecoveryFile(t, filepath.Join(repo, "target.txt"), "target advanced\n")
+	runGit(t, repo, "add", "target.txt")
+	runGit(t, repo, "commit", "-m", "advance target")
+	runGit(t, repo, "push", "origin", "integration/test")
+	runGit(t, repo, "switch", "polecat/squash")
+
+	if got := hasSubmittableWorkForRecovery(repo, []string{"integration/test"}, &GitState{UnpushedCommits: 99}, nil); got {
+		t.Fatal("squash-preserved branch on advanced explicit target should not require MQ submission")
+	}
+}
+
 func TestHasSubmittableWorkForRecoveryKeepsExplicitTargetUniquePatch(t *testing.T) {
 	repo := setupRecoveryGitRepo(t)
 	runGit(t, repo, "switch", "-c", "polecat/unique")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2802,8 +2802,7 @@ func comparisonRefCandidates(ref, remote string) []string {
 	if strings.HasPrefix(ref, "refs/") || strings.HasPrefix(ref, remote+"/") {
 		return []string{ref}
 	}
-	branch := strings.TrimPrefix(ref, "origin/")
-	return []string{ref, remote + "/" + branch}
+	return []string{remote + "/" + ref, ref}
 }
 
 func (g *Git) preservationAgainstRef(ref string) (BranchPreservationStatus, error) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2802,6 +2802,12 @@ func comparisonRefCandidates(ref, remote string) []string {
 	if strings.HasPrefix(ref, "refs/") || strings.HasPrefix(ref, remote+"/") {
 		return []string{ref}
 	}
+	if strings.HasPrefix(ref, "upstream/") {
+		return []string{ref}
+	}
+	if !strings.Contains(ref, "/") && remote != "upstream" {
+		return []string{"upstream/" + ref, remote + "/" + ref, ref}
+	}
 	return []string{remote + "/" + ref, ref}
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2751,7 +2751,9 @@ func (g *Git) branchPreservationStatus(localBranch, remote string, targets []str
 			lastErr = err
 			continue
 		}
-		candidate.Evidence = "comparison_ref"
+		if candidate.Evidence == "" {
+			candidate.Evidence = "comparison_ref"
+		}
 		if candidate.Preserved {
 			return candidate, nil
 		}
@@ -2808,6 +2810,12 @@ func (g *Git) preservationAgainstRef(ref string) (BranchPreservationStatus, erro
 	status := BranchPreservationStatus{ComparisonBase: ref}
 	if contains, err := g.refContainsHead(ref); err == nil && contains {
 		status.Preserved = true
+		status.Evidence = "ancestor"
+		return status, nil
+	}
+	if preserved, err := g.mergeTreeNoopAgainstRef(ref); err == nil && preserved {
+		status.Preserved = true
+		status.Evidence = "merge_tree_noop"
 		return status, nil
 	}
 	out, err := g.Cherry(ref, "HEAD")
@@ -2817,6 +2825,18 @@ func (g *Git) preservationAgainstRef(ref string) (BranchPreservationStatus, erro
 	status.UnpreservedPatchCount = CountCherryUnmergedCommits(out)
 	status.Preserved = status.UnpreservedPatchCount == 0
 	return status, nil
+}
+
+func (g *Git) mergeTreeNoopAgainstRef(ref string) (bool, error) {
+	refTree, err := g.run("rev-parse", ref+"^{tree}")
+	if err != nil {
+		return false, err
+	}
+	mergedTree, err := g.run("merge-tree", "--write-tree", ref, "HEAD")
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(mergedTree) == strings.TrimSpace(refTree), nil
 }
 
 // CountCherryUnmergedCommits counts `git cherry` lines whose patches are not

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3293,6 +3293,19 @@ func TestUnpushedCommitsPrefersExactRemoteBranchOverUpstream(t *testing.T) {
 	}
 }
 
+func TestComparisonRefCandidatesPreferRemoteTrackingRef(t *testing.T) {
+	got := comparisonRefCandidates("main", "origin")
+	want := []string{"origin/main", "main"}
+	if len(got) != len(want) {
+		t.Fatalf("comparisonRefCandidates length = %d, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("comparisonRefCandidates()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestBranchTargetStatusPreservesSquashMergedAdvancedTarget(t *testing.T) {
 	localDir, _, mainBranch := initTestRepoWithRemote(t)
 	if err := exec.Command("git", "-C", localDir, "merge-tree", "--write-tree", "HEAD", "HEAD").Run(); err != nil {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3295,7 +3295,7 @@ func TestUnpushedCommitsPrefersExactRemoteBranchOverUpstream(t *testing.T) {
 
 func TestComparisonRefCandidatesPreferRemoteTrackingRef(t *testing.T) {
 	got := comparisonRefCandidates("main", "origin")
-	want := []string{"origin/main", "main"}
+	want := []string{"upstream/main", "origin/main", "main"}
 	if len(got) != len(want) {
 		t.Fatalf("comparisonRefCandidates length = %d, want %d: %v", len(got), len(want), got)
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3293,6 +3293,87 @@ func TestUnpushedCommitsPrefersExactRemoteBranchOverUpstream(t *testing.T) {
 	}
 }
 
+func TestBranchTargetStatusPreservesSquashMergedAdvancedTarget(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	if err := exec.Command("git", "-C", localDir, "merge-tree", "--write-tree", "HEAD", "HEAD").Run(); err != nil {
+		t.Skipf("git merge-tree --write-tree unsupported: %v", err)
+	}
+	g := NewGit(localDir)
+	branch := "polecat/squash-preserved"
+
+	if err := g.CreateBranch(branch); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if err := g.Checkout(branch); err != nil {
+		t.Fatalf("Checkout: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "feature.txt"), []byte("one\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := g.Add("feature.txt"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := g.Commit("checkpoint one"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "feature.txt"), []byte("one\ntwo\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := g.Add("feature.txt"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := g.Commit("checkpoint two"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	if err := g.Checkout(mainBranch); err != nil {
+		t.Fatalf("Checkout main: %v", err)
+	}
+	runGit(t, localDir, "merge", "--squash", branch)
+	runGit(t, localDir, "commit", "-m", "squash polecat work")
+	if err := os.WriteFile(filepath.Join(localDir, "advance.txt"), []byte("target advanced\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := g.Add("advance.txt"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := g.Commit("advance target"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	runGit(t, localDir, "push", "origin", mainBranch)
+
+	if err := g.Checkout(branch); err != nil {
+		t.Fatalf("Checkout branch: %v", err)
+	}
+	status, err := g.BranchTargetStatus(branch, "origin", []string{"origin/" + mainBranch})
+	if err != nil {
+		t.Fatalf("BranchTargetStatus: %v", err)
+	}
+	if !status.Preserved || status.UnpreservedPatchCount != 0 {
+		t.Fatalf("BranchTargetStatus = %+v, want squash-preserved target", status)
+	}
+	if status.Evidence != "merge_tree_noop" {
+		t.Fatalf("Evidence = %q, want merge_tree_noop", status.Evidence)
+	}
+
+	if err := os.WriteFile(filepath.Join(localDir, "feature.txt"), []byte("one\ntwo\nthree\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := g.Add("feature.txt"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := g.Commit("extra local work"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	status, err = g.BranchTargetStatus(branch, "origin", []string{"origin/" + mainBranch})
+	if err != nil {
+		t.Fatalf("BranchTargetStatus after extra work: %v", err)
+	}
+	if status.Preserved || status.UnpreservedPatchCount == 0 {
+		t.Fatalf("BranchTargetStatus after extra work = %+v, want unpreserved work", status)
+	}
+}
+
 // TestBranchPushedToRemote_NoPushURL verifies baseline behavior: when fetch and
 // push URLs are the same, BranchPushedToRemote works normally.
 func TestBranchPushedToRemote_NoPushURL(t *testing.T) {

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2323,7 +2323,7 @@ func (m *Manager) reuseTargetRefs(fields *beads.AgentFields, branch string) ([]s
 			if mrFields := beads.ParseMRFields(issue); mrFields != nil && mrFields.Target != "" {
 				refs = append(refs, mrFields.Target)
 			}
-		} else {
+		} else if !errors.Is(err, beads.ErrNotFound) {
 			lookupFailed = true
 		}
 	}
@@ -2332,7 +2332,7 @@ func (m *Manager) reuseTargetRefs(fields *beads.AgentFields, branch string) ([]s
 			if mrFields := beads.ParseMRFields(issue); mrFields != nil && mrFields.Target != "" {
 				refs = append(refs, mrFields.Target)
 			}
-		} else {
+		} else if !errors.Is(err, beads.ErrNotFound) {
 			lookupFailed = true
 		}
 	}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2204,8 +2204,6 @@ func (m *Manager) workstateInputForPolecat(name string, state State, issue strin
 			input.CleanupStatus = CleanupStatus(fields.CleanupStatus)
 		}
 	}
-	targetRefs := m.reuseTargetRefs(fields)
-
 	clonePath := m.clonePath(name)
 	g := git.NewGit(clonePath)
 	branch, branchErr := g.CurrentBranch()
@@ -2214,6 +2212,7 @@ func (m *Manager) workstateInputForPolecat(name string, state State, issue strin
 	} else {
 		input.Branch = branch
 	}
+	targetRefs := m.reuseTargetRefs(fields, branch)
 	if status, err := g.CheckUncommittedWork(); err == nil {
 		input.GitDirty = !status.CleanExcludingRuntime()
 		input.StashCount = status.StashCount
@@ -2310,7 +2309,7 @@ func hasSubmittableWorkForWorkstate(worktreePath string, targetRefs []string) bo
 	return err == nil && status.UnpreservedPatchCount > 0
 }
 
-func (m *Manager) reuseTargetRefs(fields *beads.AgentFields) []string {
+func (m *Manager) reuseTargetRefs(fields *beads.AgentFields, branch string) []string {
 	if fields == nil {
 		return nil
 	}
@@ -2320,6 +2319,18 @@ func (m *Manager) reuseTargetRefs(fields *beads.AgentFields) []string {
 			if mrFields := beads.ParseMRFields(issue); mrFields != nil && mrFields.Target != "" {
 				refs = append(refs, mrFields.Target)
 			}
+		}
+	}
+	if branch != "" {
+		if issue, err := m.beads.FindMRForBranchAny(branch); err == nil {
+			if mrFields := beads.ParseMRFields(issue); mrFields != nil && mrFields.Target != "" {
+				refs = append(refs, mrFields.Target)
+			}
+		}
+	}
+	if fields.LastSourceIssue != "" && fields.LastSourceIssue != fields.HookBead {
+		if issue, err := m.beads.Show(fields.LastSourceIssue); err == nil {
+			refs = append(refs, attachmentTargetRefs(m.beads, issue)...)
 		}
 	}
 	if fields.HookBead != "" {

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2249,14 +2249,18 @@ func (m *Manager) workstateInputForPolecat(name string, state State, issue strin
 			sourceTerminal = true
 		}
 	}
+	workIssue := issue
+	if workIssue == "" {
+		workIssue = sourceHint
+	}
 	input.MQCheckRequired = input.Branch != ""
 	input.HasSubmittableWork = hasSubmittableWorkForWorkstate(clonePath, targetRefs)
-	input.AssignedBeadTerminal = m.assignedBeadTerminal(issue)
+	input.AssignedBeadTerminal = m.assignedBeadTerminal(workIssue)
 	workTerminal := input.AssignedBeadTerminal || sourceTerminal || hookTerminal
 	if CanIgnoreStaleCleanupStatus(input.CleanupStatus, workTerminal, hookSafe, activeMRSafe, gitSafe) {
 		input.IgnoreCleanupStatus = true
 	}
-	input.MQNotRequired = m.mqNotRequiredSource(issue)
+	input.MQNotRequired = m.mqNotRequiredSource(workIssue)
 	if input.MQCheckRequired && input.HasSubmittableWork && !input.AssignedBeadTerminal && !input.MQNotRequired {
 		mr, err := m.beads.FindMRForBranchAny(input.Branch)
 		if err != nil {

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2248,7 +2248,7 @@ func (m *Manager) workstateInputForPolecat(name string, state State, issue strin
 		}
 	}
 	input.MQCheckRequired = input.Branch != ""
-	input.HasSubmittableWork = hasSubmittableWorkForWorkstate(clonePath)
+	input.HasSubmittableWork = hasSubmittableWorkForWorkstate(clonePath, targetRefs)
 	input.AssignedBeadTerminal = m.assignedBeadTerminal(issue)
 	workTerminal := input.AssignedBeadTerminal || sourceTerminal || hookTerminal
 	if CanIgnoreStaleCleanupStatus(input.CleanupStatus, workTerminal, hookSafe, activeMRSafe, gitSafe) {
@@ -2303,53 +2303,11 @@ func (m *Manager) mqNotRequiredSource(issueID string) bool {
 	return attachment.NoMerge || attachment.ReviewOnly || strings.EqualFold(strings.TrimSpace(attachment.MergeStrategy), "local")
 }
 
-func hasSubmittableWorkForWorkstate(worktreePath string) bool {
-	ref, err := workstateComparisonRef(worktreePath)
-	if err != nil {
-		return false
-	}
-	count, err := countPatchUniqueCommitsForWorkstate(worktreePath, ref)
-	return err == nil && count > 0
-}
-
-func workstateComparisonRef(worktreePath string) (string, error) {
-	upstreamCmd := exec.Command("git", "rev-parse", "--abbrev-ref", "@{u}")
-	upstreamCmd.Dir = worktreePath
-	if output, err := upstreamCmd.Output(); err == nil {
-		upstream := strings.TrimSpace(string(output))
-		upstreamBranch := strings.TrimPrefix(upstream, "origin/")
-		if upstream != "" && isWorkstateRecoveryBaseBranch(upstreamBranch) {
-			return upstream, nil
-		}
-	}
-	for _, ref := range []string{"origin/main", "origin/master"} {
-		verifyCmd := exec.Command("git", "rev-parse", "--verify", "--quiet", ref)
-		verifyCmd.Dir = worktreePath
-		if err := verifyCmd.Run(); err == nil {
-			return ref, nil
-		}
-	}
-	return "", fmt.Errorf("no recovery base ref")
-}
-
-func isWorkstateRecoveryBaseBranch(branch string) bool {
-	return branch == "main" || branch == "master" || strings.HasPrefix(branch, "integration/")
-}
-
-func countPatchUniqueCommitsForWorkstate(worktreePath, baseRef string) (int, error) {
-	cherryCmd := exec.Command("git", "cherry", baseRef, "HEAD")
-	cherryCmd.Dir = worktreePath
-	output, err := cherryCmd.Output()
-	if err != nil {
-		return 0, err
-	}
-	count := 0
-	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "+") {
-			count++
-		}
-	}
-	return count, nil
+func hasSubmittableWorkForWorkstate(worktreePath string, targetRefs []string) bool {
+	g := git.NewGit(worktreePath)
+	branch, _ := g.CurrentBranch()
+	status, err := g.BranchTargetStatus(branch, "origin", targetRefs)
+	return err == nil && status.UnpreservedPatchCount > 0
 }
 
 func (m *Manager) reuseTargetRefs(fields *beads.AgentFields) []string {

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2212,7 +2212,10 @@ func (m *Manager) workstateInputForPolecat(name string, state State, issue strin
 	} else {
 		input.Branch = branch
 	}
-	targetRefs := m.reuseTargetRefs(fields, branch)
+	targetRefs, targetRefLookupFailed := m.reuseTargetRefs(fields, branch)
+	if targetRefLookupFailed {
+		input.MQLookupFailed = true
+	}
 	if status, err := g.CheckUncommittedWork(); err == nil {
 		input.GitDirty = !status.CleanExcludingRuntime()
 		input.StashCount = status.StashCount
@@ -2309,16 +2312,19 @@ func hasSubmittableWorkForWorkstate(worktreePath string, targetRefs []string) bo
 	return err == nil && status.UnpreservedPatchCount > 0
 }
 
-func (m *Manager) reuseTargetRefs(fields *beads.AgentFields, branch string) []string {
+func (m *Manager) reuseTargetRefs(fields *beads.AgentFields, branch string) ([]string, bool) {
 	if fields == nil {
-		return nil
+		return nil, false
 	}
 	var refs []string
+	lookupFailed := false
 	if fields.ActiveMR != "" {
 		if issue, err := m.beads.Show(fields.ActiveMR); err == nil {
 			if mrFields := beads.ParseMRFields(issue); mrFields != nil && mrFields.Target != "" {
 				refs = append(refs, mrFields.Target)
 			}
+		} else {
+			lookupFailed = true
 		}
 	}
 	if branch != "" {
@@ -2326,19 +2332,25 @@ func (m *Manager) reuseTargetRefs(fields *beads.AgentFields, branch string) []st
 			if mrFields := beads.ParseMRFields(issue); mrFields != nil && mrFields.Target != "" {
 				refs = append(refs, mrFields.Target)
 			}
+		} else {
+			lookupFailed = true
 		}
 	}
 	if fields.LastSourceIssue != "" && fields.LastSourceIssue != fields.HookBead {
 		if issue, err := m.beads.Show(fields.LastSourceIssue); err == nil {
 			refs = append(refs, attachmentTargetRefs(m.beads, issue)...)
+		} else {
+			lookupFailed = true
 		}
 	}
 	if fields.HookBead != "" {
 		if issue, err := m.beads.Show(fields.HookBead); err == nil {
 			refs = append(refs, attachmentTargetRefs(m.beads, issue)...)
+		} else {
+			lookupFailed = true
 		}
 	}
-	return uniqueRefs(refs)
+	return uniqueRefs(refs), lookupFailed
 }
 
 func attachmentTargetRefs(bd *beads.Beads, issue *beads.Issue) []string {

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -23,6 +23,78 @@ import (
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
+func TestHasSubmittableWorkForWorkstateUsesBranchTargetStatus(t *testing.T) {
+	repo := setupManagerSquashPreservedRepo(t)
+	if got := hasSubmittableWorkForWorkstate(repo, []string{"integration/test"}); got {
+		t.Fatal("squash-preserved branch should not require MQ submission through manager workstate helper")
+	}
+
+	managerWriteFile(t, filepath.Join(repo, "feature.txt"), "one\ntwo\nthree\n")
+	runManagerGit(t, repo, "add", "feature.txt")
+	runManagerGit(t, repo, "commit", "-m", "extra local work")
+	if got := hasSubmittableWorkForWorkstate(repo, []string{"integration/test"}); !got {
+		t.Fatal("new local work after squash preservation should still require MQ submission")
+	}
+}
+
+func setupManagerSquashPreservedRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	repo := filepath.Join(root, "repo")
+	runManagerGit(t, root, "init", "--bare", remote)
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runManagerGit(t, repo, "init")
+	runManagerGit(t, repo, "config", "user.email", "test@example.com")
+	runManagerGit(t, repo, "config", "user.name", "Test User")
+	managerWriteFile(t, filepath.Join(repo, "README.md"), "base\n")
+	runManagerGit(t, repo, "add", "README.md")
+	runManagerGit(t, repo, "commit", "-m", "base")
+	runManagerGit(t, repo, "branch", "-M", "main")
+	runManagerGit(t, repo, "remote", "add", "origin", remote)
+	runManagerGit(t, repo, "push", "-u", "origin", "main")
+	runManagerGit(t, repo, "switch", "-c", "integration/test")
+	runManagerGit(t, repo, "push", "-u", "origin", "integration/test")
+	if err := exec.Command("git", "-C", repo, "merge-tree", "--write-tree", "HEAD", "HEAD").Run(); err != nil {
+		t.Skipf("git merge-tree --write-tree unsupported: %v", err)
+	}
+
+	runManagerGit(t, repo, "switch", "-c", "polecat/squash")
+	managerWriteFile(t, filepath.Join(repo, "feature.txt"), "one\n")
+	runManagerGit(t, repo, "add", "feature.txt")
+	runManagerGit(t, repo, "commit", "-m", "checkpoint one")
+	managerWriteFile(t, filepath.Join(repo, "feature.txt"), "one\ntwo\n")
+	runManagerGit(t, repo, "add", "feature.txt")
+	runManagerGit(t, repo, "commit", "-m", "checkpoint two")
+	runManagerGit(t, repo, "switch", "integration/test")
+	runManagerGit(t, repo, "merge", "--squash", "polecat/squash")
+	runManagerGit(t, repo, "commit", "-m", "squash polecat work")
+	managerWriteFile(t, filepath.Join(repo, "target.txt"), "target advanced\n")
+	runManagerGit(t, repo, "add", "target.txt")
+	runManagerGit(t, repo, "commit", "-m", "advance target")
+	runManagerGit(t, repo, "push", "origin", "integration/test")
+	runManagerGit(t, repo, "switch", "polecat/squash")
+	return repo
+}
+
+func managerWriteFile(t *testing.T, path, data string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runManagerGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+}
+
 // installMockBd places a fake bd binary in PATH that handles the commands
 // needed by AddWithOptions (init, create, show, config, update, slot, etc.).
 // This allows polecat tests to run without a real bd installation.

--- a/internal/polecat/workstate.go
+++ b/internal/polecat/workstate.go
@@ -161,7 +161,7 @@ func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
 			return d
 		} else if !in.HasSubmittableWork || in.MQNotRequired {
 			d.MQStatus = "not_required"
-		} else if in.AssignedBeadTerminal || in.MRSubmitted {
+		} else if in.MRSubmitted {
 			d.MQStatus = "submitted"
 		} else {
 			d.Verdict = WorkstateVerdictNeedsMQSubmit

--- a/internal/polecat/workstate.go
+++ b/internal/polecat/workstate.go
@@ -150,12 +150,19 @@ func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
 	}
 
 	if in.MQCheckRequired {
-		if !in.HasSubmittableWork || in.MQNotRequired {
+		if in.MQLookupFailed {
+			d.Verdict = WorkstateVerdictNeedsRecovery
+			d.Reason = "mq-lookup-failed"
+			d.NeedsRecovery = true
+			d.MQStatus = "unknown"
+			d.CountsTowardCapacity = true
+			d.ReuseStatus = "idle-recovery-needed"
+			d.Blockers = append(d.Blockers, "mq_status=unknown")
+			return d
+		} else if !in.HasSubmittableWork || in.MQNotRequired {
 			d.MQStatus = "not_required"
 		} else if in.AssignedBeadTerminal || in.MRSubmitted {
 			d.MQStatus = "submitted"
-		} else if in.MQLookupFailed {
-			d.MQStatus = "unknown"
 		} else {
 			d.Verdict = WorkstateVerdictNeedsMQSubmit
 			d.Reason = "mq-not-submitted"

--- a/internal/polecat/workstate_test.go
+++ b/internal/polecat/workstate_test.go
@@ -34,9 +34,24 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsMQSubmit, Reason: "mq-not-submitted", NeedsRecovery: true, NeedsMQSubmit: true, MQStatus: "not_submitted", CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed"},
 		},
 		{
+			name: "open work with unpushed commits needs recovery",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", UnpushedCommits: 1},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "git-unpushed", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed", Blockers: []string{"git_state=has_unpushed unpushed_commits=1"}},
+		},
+		{
 			name: "terminal source makes mq submitted",
 			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", MQCheckRequired: true, HasSubmittableWork: true, AssignedBeadTerminal: true},
 			want: WorkstateDisposition{Verdict: WorkstateVerdictSafeToNuke, Reason: "reusable", Reusable: true, SafeToNuke: true, MQStatus: "submitted", ReuseStatus: "idle-preserved"},
+		},
+		{
+			name: "dirty worktree blocks terminal source",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", GitDirty: true, GitDirtyReason: "git_state=has_uncommitted uncommitted_files=1", MQCheckRequired: true, HasSubmittableWork: true, AssignedBeadTerminal: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "git-dirty", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed", Blockers: []string{"git_state=has_uncommitted uncommitted_files=1"}},
+		},
+		{
+			name: "stash blocks terminal source",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", StashCount: 1, MQCheckRequired: true, HasSubmittableWork: true, AssignedBeadTerminal: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "git-stash", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed", Blockers: []string{"git_state=has_stash stash_count=1"}},
 		},
 		{
 			name: "terminal source does not suppress unpreserved commits",

--- a/internal/polecat/workstate_test.go
+++ b/internal/polecat/workstate_test.go
@@ -39,6 +39,26 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 			want: WorkstateDisposition{Verdict: WorkstateVerdictSafeToNuke, Reason: "reusable", Reusable: true, SafeToNuke: true, MQStatus: "submitted", ReuseStatus: "idle-preserved"},
 		},
 		{
+			name: "terminal source does not suppress unpreserved commits",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", UnpushedCommits: 1, MQCheckRequired: true, HasSubmittableWork: true, AssignedBeadTerminal: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "git-unpushed", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed", Blockers: []string{"git_state=has_unpushed unpushed_commits=1"}},
+		},
+		{
+			name: "push failure blocks terminal source",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", PushFailed: true, MQCheckRequired: true, HasSubmittableWork: true, AssignedBeadTerminal: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "push-failed", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed", Blockers: []string{"push_failed=true"}},
+		},
+		{
+			name: "mr failure blocks terminal source",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", MRFailed: true, MQCheckRequired: true, HasSubmittableWork: true, AssignedBeadTerminal: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "mr-failed", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed", Blockers: []string{"mr_failed=true"}},
+		},
+		{
+			name: "open active mr blocks terminal source",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", ActiveMR: "gt-mr-open", ActiveMRBlocker: "active_mr=gt-mr-open status=open", MQCheckRequired: true, HasSubmittableWork: true, AssignedBeadTerminal: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictPendingMR, Reason: "active-mr-open", ReuseStatus: "idle-pr-open", Blockers: []string{"active_mr=gt-mr-open status=open"}},
+		},
+		{
 			name: "terminal active mr does not block when gatherer omits blocker",
 			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, ActiveMR: "gt-mr-closed"},
 			want: WorkstateDisposition{Verdict: WorkstateVerdictSafeToNuke, Reason: "reusable", Reusable: true, SafeToNuke: true, ReuseStatus: "idle-clean"},

--- a/internal/polecat/workstate_test.go
+++ b/internal/polecat/workstate_test.go
@@ -44,9 +44,14 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "git-unpushed", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed", Blockers: []string{"git_state=has_unpushed unpushed_commits=1"}},
 		},
 		{
-			name: "terminal source makes mq submitted",
-			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", MQCheckRequired: true, HasSubmittableWork: true, AssignedBeadTerminal: true},
+			name: "mr submission makes mq submitted",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", MQCheckRequired: true, HasSubmittableWork: true, MRSubmitted: true},
 			want: WorkstateDisposition{Verdict: WorkstateVerdictSafeToNuke, Reason: "reusable", Reusable: true, SafeToNuke: true, MQStatus: "submitted", ReuseStatus: "idle-preserved"},
+		},
+		{
+			name: "terminal source alone does not prove mq submitted",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", MQCheckRequired: true, HasSubmittableWork: true, AssignedBeadTerminal: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsMQSubmit, Reason: "mq-not-submitted", NeedsRecovery: true, NeedsMQSubmit: true, MQStatus: "not_submitted", CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed"},
 		},
 		{
 			name: "dirty worktree blocks terminal source",

--- a/internal/polecat/workstate_test.go
+++ b/internal/polecat/workstate_test.go
@@ -34,6 +34,11 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsMQSubmit, Reason: "mq-not-submitted", NeedsRecovery: true, NeedsMQSubmit: true, MQStatus: "not_submitted", CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed"},
 		},
 		{
+			name: "mq lookup uncertainty blocks cleanup",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", MQCheckRequired: true, MQLookupFailed: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "mq-lookup-failed", NeedsRecovery: true, MQStatus: "unknown", CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed", Blockers: []string{"mq_status=unknown"}},
+		},
+		{
 			name: "open work with unpushed commits needs recovery",
 			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/test", UnpushedCommits: 1},
 			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "git-unpushed", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed", Blockers: []string{"git_state=has_unpushed unpushed_commits=1"}},

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1100,7 +1100,7 @@ func witnessRecoveryTargetRefs(bd *beads.Beads, fields *beads.AgentFields, branc
 			if mrFields := beads.ParseMRFields(issue); mrFields != nil && mrFields.Target != "" {
 				refs = append(refs, mrFields.Target)
 			}
-		} else {
+		} else if !errors.Is(err, beads.ErrNotFound) {
 			lookupFailed = true
 		}
 	}
@@ -1109,7 +1109,7 @@ func witnessRecoveryTargetRefs(bd *beads.Beads, fields *beads.AgentFields, branc
 			if mrFields := beads.ParseMRFields(issue); mrFields != nil && mrFields.Target != "" {
 				refs = append(refs, mrFields.Target)
 			}
-		} else {
+		} else if !errors.Is(err, beads.ErrNotFound) {
 			lookupFailed = true
 		}
 	}
@@ -1468,11 +1468,9 @@ func _verifyCommitOnMain(workDir, rigName, polecatName string) (bool, error) {
 // Flow (aa-apw):
 //  1. Fast path: ancestor check via verifyCommitOnMain (catches fast-forward /
 //     regular merges).
-//  2. Patch-id path: `git cherry <remote>/<default> <HEAD>` lines starting with
-//     "-" mean the patch-id is already applied upstream. If every commit the
-//     polecat branch adds on top of origin/main is marked "-", the work is
-//     equivalent to something already merged (e.g., squash-merged). Empty
-//     output is also equivalent — branch has no commits beyond base.
+//  2. Target-preservation path: reuse git.BranchTargetStatus so squash-merged
+//     checkpoint work, patch-equivalent work, and advanced default branches are
+//     classified the same way as check-recovery and reuse.
 //
 // Returns:
 //   - true, nil: work on this branch is already on default branch (skip restart,
@@ -1511,38 +1509,22 @@ func _verifyBranchAlreadyMerged(workDir, rigName, polecatName string) (bool, err
 		remotes = []string{"origin"}
 	}
 
-	// git cherry marks each commit that HEAD introduces on top of <upstream>:
-	//   "+ <sha>" — patch-id not present upstream
-	//   "- <sha>" — patch-id already upstream (e.g., squash-merged)
-	// If no "+" lines remain, the work is fully landed.
+	branch, err := g.CurrentBranch()
+	if err != nil {
+		return false, err
+	}
 	for _, remote := range remotes {
 		upstream := remote + "/" + defaultBranch
-		out, err := g.Cherry(upstream, "HEAD")
+		status, err := g.BranchTargetStatus(branch, remote, []string{upstream})
 		if err != nil {
 			continue // try next remote
 		}
-		if !cherryHasUnmergedCommits(out) {
+		if status.Preserved {
 			return true, nil
 		}
 	}
 
 	return false, nil
-}
-
-// cherryHasUnmergedCommits returns true if `git cherry` output contains at least
-// one commit marked with "+" (not yet upstream). Empty output means no commits
-// beyond base — already merged.
-func cherryHasUnmergedCommits(out string) bool {
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		if strings.HasPrefix(line, "+") {
-			return true
-		}
-	}
-	return false
 }
 
 // ZombieClassification categorizes why a polecat was classified as a zombie.

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1030,9 +1030,11 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 	}
 	clonePath := filepath.Join(townRoot, rigName, "polecats", polecatName, rigName)
 	g := git.NewGit(clonePath)
-	targetRefs := witnessRecoveryTargetRefs(beads.New(beads.ResolveBeadsDir(workDir)), fields)
+	bd := beads.New(beads.ResolveBeadsDir(workDir))
+	var targetRefs []string
 	if branch, err := g.CurrentBranch(); err == nil {
 		input.Branch = branch
+		targetRefs = witnessRecoveryTargetRefs(bd, fields, branch)
 		if status, err := g.CheckUncommittedWork(); err == nil {
 			input.GitDirty = !status.CleanExcludingRuntime()
 			input.StashCount = status.StashCount
@@ -1056,7 +1058,7 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 		if sourceHint == "" {
 			sourceHint = fields.HookBead
 		}
-		assessment := polecat.AssessActiveMR(beads.New(beads.ResolveBeadsDir(workDir)), polecat.ActiveMRInput{ActiveMR: fields.ActiveMR, SourceIssueHint: sourceHint, RequireGitSafe: true, GitSafe: gitSafe})
+		assessment := polecat.AssessActiveMR(bd, polecat.ActiveMRInput{ActiveMR: fields.ActiveMR, SourceIssueHint: sourceHint, RequireGitSafe: true, GitSafe: gitSafe})
 		if assessment.Pending {
 			input.ActiveMRBlocker = assessment.Reason
 		}
@@ -1083,7 +1085,7 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 	return polecat.DecideSlotReuse(input)
 }
 
-func witnessRecoveryTargetRefs(bd *beads.Beads, fields *beads.AgentFields) []string {
+func witnessRecoveryTargetRefs(bd *beads.Beads, fields *beads.AgentFields, branch string) []string {
 	if fields == nil || bd == nil {
 		return nil
 	}
@@ -1093,6 +1095,18 @@ func witnessRecoveryTargetRefs(bd *beads.Beads, fields *beads.AgentFields) []str
 			if mrFields := beads.ParseMRFields(issue); mrFields != nil && mrFields.Target != "" {
 				refs = append(refs, mrFields.Target)
 			}
+		}
+	}
+	if branch != "" {
+		if issue, err := bd.FindMRForBranchAny(branch); err == nil {
+			if mrFields := beads.ParseMRFields(issue); mrFields != nil && mrFields.Target != "" {
+				refs = append(refs, mrFields.Target)
+			}
+		}
+	}
+	if fields.LastSourceIssue != "" && fields.LastSourceIssue != fields.HookBead {
+		if issue, err := bd.Show(fields.LastSourceIssue); err == nil {
+			refs = append(refs, witnessAttachmentTargetRefs(bd, issue)...)
 		}
 	}
 	if fields.HookBead != "" {

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1066,7 +1066,7 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 		}
 	}
 	input.MQCheckRequired = input.Branch != ""
-	input.HasSubmittableWork = witnessHasSubmittableWork(clonePath)
+	input.HasSubmittableWork = witnessHasSubmittableWork(clonePath, targetRefs)
 	input.AssignedBeadTerminal = witnessIssueTerminal(rigBeads, issueID)
 	if polecat.CanIgnoreStaleCleanupStatus(input.CleanupStatus, input.AssignedBeadTerminal || sourceTerminal || hookTerminal, hookSafe, activeMRSafe, gitSafe) {
 		input.IgnoreCleanupStatus = true
@@ -1192,53 +1192,11 @@ func witnessMQNotRequiredSource(bd *beads.Beads, issueID string) bool {
 	return attachment.NoMerge || attachment.ReviewOnly || strings.EqualFold(strings.TrimSpace(attachment.MergeStrategy), "local")
 }
 
-func witnessHasSubmittableWork(worktreePath string) bool {
-	ref, err := witnessWorkstateComparisonRef(worktreePath)
-	if err != nil {
-		return false
-	}
-	count, err := witnessCountPatchUniqueCommits(worktreePath, ref)
-	return err == nil && count > 0
-}
-
-func witnessWorkstateComparisonRef(worktreePath string) (string, error) {
-	upstreamCmd := exec.Command("git", "rev-parse", "--abbrev-ref", "@{u}")
-	upstreamCmd.Dir = worktreePath
-	if output, err := upstreamCmd.Output(); err == nil {
-		upstream := strings.TrimSpace(string(output))
-		upstreamBranch := strings.TrimPrefix(upstream, "origin/")
-		if upstream != "" && witnessIsWorkstateRecoveryBaseBranch(upstreamBranch) {
-			return upstream, nil
-		}
-	}
-	for _, ref := range []string{"origin/main", "origin/master"} {
-		verifyCmd := exec.Command("git", "rev-parse", "--verify", "--quiet", ref)
-		verifyCmd.Dir = worktreePath
-		if err := verifyCmd.Run(); err == nil {
-			return ref, nil
-		}
-	}
-	return "", fmt.Errorf("no recovery base ref")
-}
-
-func witnessIsWorkstateRecoveryBaseBranch(branch string) bool {
-	return branch == "main" || branch == "master" || strings.HasPrefix(branch, "integration/")
-}
-
-func witnessCountPatchUniqueCommits(worktreePath, baseRef string) (int, error) {
-	cherryCmd := exec.Command("git", "cherry", baseRef, "HEAD")
-	cherryCmd.Dir = worktreePath
-	output, err := cherryCmd.Output()
-	if err != nil {
-		return 0, err
-	}
-	count := 0
-	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "+") {
-			count++
-		}
-	}
-	return count, nil
+func witnessHasSubmittableWork(worktreePath string, targetRefs []string) bool {
+	g := git.NewGit(worktreePath)
+	branch, _ := g.CurrentBranch()
+	status, err := g.BranchTargetStatus(branch, "origin", targetRefs)
+	return err == nil && status.UnpreservedPatchCount > 0
 }
 
 // RecoveryPayload contains data for RECOVERY_NEEDED escalation.

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1034,7 +1034,11 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 	var targetRefs []string
 	if branch, err := g.CurrentBranch(); err == nil {
 		input.Branch = branch
-		targetRefs = witnessRecoveryTargetRefs(bd, fields, branch)
+		var targetRefLookupFailed bool
+		targetRefs, targetRefLookupFailed = witnessRecoveryTargetRefs(bd, fields, branch)
+		if targetRefLookupFailed {
+			input.MQLookupFailed = true
+		}
 		if status, err := g.CheckUncommittedWork(); err == nil {
 			input.GitDirty = !status.CleanExcludingRuntime()
 			input.StashCount = status.StashCount
@@ -1085,16 +1089,19 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 	return polecat.DecideSlotReuse(input)
 }
 
-func witnessRecoveryTargetRefs(bd *beads.Beads, fields *beads.AgentFields, branch string) []string {
+func witnessRecoveryTargetRefs(bd *beads.Beads, fields *beads.AgentFields, branch string) ([]string, bool) {
 	if fields == nil || bd == nil {
-		return nil
+		return nil, false
 	}
 	var refs []string
+	lookupFailed := false
 	if fields.ActiveMR != "" {
 		if issue, err := bd.Show(fields.ActiveMR); err == nil {
 			if mrFields := beads.ParseMRFields(issue); mrFields != nil && mrFields.Target != "" {
 				refs = append(refs, mrFields.Target)
 			}
+		} else {
+			lookupFailed = true
 		}
 	}
 	if branch != "" {
@@ -1102,19 +1109,25 @@ func witnessRecoveryTargetRefs(bd *beads.Beads, fields *beads.AgentFields, branc
 			if mrFields := beads.ParseMRFields(issue); mrFields != nil && mrFields.Target != "" {
 				refs = append(refs, mrFields.Target)
 			}
+		} else {
+			lookupFailed = true
 		}
 	}
 	if fields.LastSourceIssue != "" && fields.LastSourceIssue != fields.HookBead {
 		if issue, err := bd.Show(fields.LastSourceIssue); err == nil {
 			refs = append(refs, witnessAttachmentTargetRefs(bd, issue)...)
+		} else {
+			lookupFailed = true
 		}
 	}
 	if fields.HookBead != "" {
 		if issue, err := bd.Show(fields.HookBead); err == nil {
 			refs = append(refs, witnessAttachmentTargetRefs(bd, issue)...)
+		} else {
+			lookupFailed = true
 		}
 	}
-	return witnessUniqueRefs(refs)
+	return witnessUniqueRefs(refs), lookupFailed
 }
 
 func witnessAttachmentTargetRefs(bd *beads.Beads, issue *beads.Issue) []string {

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -32,12 +32,44 @@ func TestWitnessHasSubmittableWorkUsesBranchTargetStatus(t *testing.T) {
 	}
 }
 
+func TestVerifyBranchAlreadyMergedUsesBranchTargetStatus(t *testing.T) {
+	townRoot, workDir := setupSlotOpenTestTown(t)
+	repo := filepath.Join(townRoot, "gastown", "polecats", "institute", "gastown")
+	setupWitnessSquashPreservedRepoAt(t, repo, filepath.Join(t.TempDir(), "remote.git"))
+	runWitnessGit(t, repo, "push", "origin", "integration/test:main")
+
+	merged, err := _verifyBranchAlreadyMerged(workDir, "gastown", "institute")
+	if err != nil {
+		t.Fatalf("_verifyBranchAlreadyMerged: %v", err)
+	}
+	if !merged {
+		t.Fatal("squash-preserved branch on advanced default target should be treated as already merged")
+	}
+
+	witnessWriteFile(t, filepath.Join(repo, "feature.txt"), "one\ntwo\nthree\n")
+	runWitnessGit(t, repo, "add", "feature.txt")
+	runWitnessGit(t, repo, "commit", "-m", "extra local work")
+	merged, err = _verifyBranchAlreadyMerged(workDir, "gastown", "institute")
+	if err != nil {
+		t.Fatalf("_verifyBranchAlreadyMerged after extra work: %v", err)
+	}
+	if merged {
+		t.Fatal("new local work after squash preservation should not be treated as already merged")
+	}
+}
+
 func setupWitnessSquashPreservedRepo(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
 	remote := filepath.Join(root, "remote.git")
 	repo := filepath.Join(root, "repo")
-	runWitnessGit(t, root, "init", "--bare", remote)
+	setupWitnessSquashPreservedRepoAt(t, repo, remote)
+	return repo
+}
+
+func setupWitnessSquashPreservedRepoAt(t *testing.T, repo, remote string) {
+	t.Helper()
+	runWitnessGit(t, filepath.Dir(remote), "init", "--bare", remote)
 	if err := os.MkdirAll(repo, 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +103,6 @@ func setupWitnessSquashPreservedRepo(t *testing.T) string {
 	runWitnessGit(t, repo, "commit", "-m", "advance target")
 	runWitnessGit(t, repo, "push", "origin", "integration/test")
 	runWitnessGit(t, repo, "switch", "polecat/squash")
-	return repo
 }
 
 func witnessWriteFile(t *testing.T, path, data string) {
@@ -2728,33 +2759,6 @@ func TestNotifyRefineryMergeReady_EmitsChannelEvent(t *testing.T) {
 	}
 	if payload["rig"] != "dashboard" {
 		t.Errorf("payload.rig = %v, want dashboard", payload["rig"])
-	}
-}
-
-// TestCherryHasUnmergedCommits covers the git-cherry output parser used by
-// verifyBranchAlreadyMerged (aa-apw).
-func TestCherryHasUnmergedCommits(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name string
-		in   string
-		want bool
-	}{
-		{"empty output — branch has no commits beyond base", "", false},
-		{"whitespace only", "  \n\n", false},
-		{"all squash-applied (-)", "- abc123\n- def456\n", false},
-		{"one unmerged (+)", "+ abc123\n", true},
-		{"mixed", "- abc123\n+ def456\n", true},
-		{"unmerged only", "+ a\n+ b\n+ c\n", true},
-	}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if got := cherryHasUnmergedCommits(tc.in); got != tc.want {
-				t.Errorf("cherryHasUnmergedCommits(%q) = %v, want %v", tc.in, got, tc.want)
-			}
-		})
 	}
 }
 

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -18,6 +18,78 @@ import (
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
+func TestWitnessHasSubmittableWorkUsesBranchTargetStatus(t *testing.T) {
+	repo := setupWitnessSquashPreservedRepo(t)
+	if got := witnessHasSubmittableWork(repo, []string{"integration/test"}); got {
+		t.Fatal("squash-preserved branch should not require MQ submission through witness helper")
+	}
+
+	witnessWriteFile(t, filepath.Join(repo, "feature.txt"), "one\ntwo\nthree\n")
+	runWitnessGit(t, repo, "add", "feature.txt")
+	runWitnessGit(t, repo, "commit", "-m", "extra local work")
+	if got := witnessHasSubmittableWork(repo, []string{"integration/test"}); !got {
+		t.Fatal("new local work after squash preservation should still require MQ submission")
+	}
+}
+
+func setupWitnessSquashPreservedRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	repo := filepath.Join(root, "repo")
+	runWitnessGit(t, root, "init", "--bare", remote)
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		t.Fatal(err)
+	}
+	runWitnessGit(t, repo, "init")
+	runWitnessGit(t, repo, "config", "user.email", "test@example.com")
+	runWitnessGit(t, repo, "config", "user.name", "Test User")
+	witnessWriteFile(t, filepath.Join(repo, "README.md"), "base\n")
+	runWitnessGit(t, repo, "add", "README.md")
+	runWitnessGit(t, repo, "commit", "-m", "base")
+	runWitnessGit(t, repo, "branch", "-M", "main")
+	runWitnessGit(t, repo, "remote", "add", "origin", remote)
+	runWitnessGit(t, repo, "push", "-u", "origin", "main")
+	runWitnessGit(t, repo, "switch", "-c", "integration/test")
+	runWitnessGit(t, repo, "push", "-u", "origin", "integration/test")
+	if err := exec.Command("git", "-C", repo, "merge-tree", "--write-tree", "HEAD", "HEAD").Run(); err != nil {
+		t.Skipf("git merge-tree --write-tree unsupported: %v", err)
+	}
+
+	runWitnessGit(t, repo, "switch", "-c", "polecat/squash")
+	witnessWriteFile(t, filepath.Join(repo, "feature.txt"), "one\n")
+	runWitnessGit(t, repo, "add", "feature.txt")
+	runWitnessGit(t, repo, "commit", "-m", "checkpoint one")
+	witnessWriteFile(t, filepath.Join(repo, "feature.txt"), "one\ntwo\n")
+	runWitnessGit(t, repo, "add", "feature.txt")
+	runWitnessGit(t, repo, "commit", "-m", "checkpoint two")
+	runWitnessGit(t, repo, "switch", "integration/test")
+	runWitnessGit(t, repo, "merge", "--squash", "polecat/squash")
+	runWitnessGit(t, repo, "commit", "-m", "squash polecat work")
+	witnessWriteFile(t, filepath.Join(repo, "target.txt"), "target advanced\n")
+	runWitnessGit(t, repo, "add", "target.txt")
+	runWitnessGit(t, repo, "commit", "-m", "advance target")
+	runWitnessGit(t, repo, "push", "origin", "integration/test")
+	runWitnessGit(t, repo, "switch", "polecat/squash")
+	return repo
+}
+
+func witnessWriteFile(t *testing.T, path, data string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runWitnessGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+}
+
 type testMayorEvent struct {
 	Type    string            `json:"type"`
 	Payload map[string]string `json:"payload"`


### PR DESCRIPTION
Replacement for PR #4324. Do not merge #4324 as-is.

Problem evidence: https://github.com/gastownhall/gastown/pull/4324 at head dc2b629146c5aa753f3d7fd00c5ee909376e2ece.

Summary:
- Add a shared squash-aware preservation proof using `git merge-tree --write-tree <target> HEAD`, with existing `git cherry` as the fail-closed fallback.
- Keep cleanup safety strict: terminal/closed source state alone no longer proves unpushed commits are safe or MQ-submitted.
- Converge check-recovery, manager/reuse, witness slot-open, and witness branch-already-merged paths on shared git preservation APIs.
- Prefer clean upstream target refs for plain default branch targets, while preserving explicit origin/upstream refs.
- Fail closed on MQ/target lookup uncertainty; treat missing MR beads as stale metadata only when active-MR safety can prove the source is terminal and git is safe.

Attribution:
- This uses PR #4324 as problem evidence and requirement context. No non-trivial code or test body was copied from PR #4324.

Verification:
- `CGO_ENABLED=0 go test ./internal/git ./internal/polecat ./internal/witness -count=1`
- `CGO_ENABLED=0 go test ./internal/cmd -run 'Test(HasSubmittableWorkForRecovery|RecoveryGitStateBlocker|CleanupStatusBlocker|StaleCleanupStatusCanBeIgnoredForRecovery|ReconcileCleanupStatusIfSafe|CleanupStatusReconcileCandidateRequiresStrictPredicates|HookBeadSafeForCleanup|PartialSpawnWithoutDurableHook|DryRunNukeSummary)' -count=1`\n- Focused smoke after final rebase: `CGO_ENABLED=0 go test ./internal/git`, `./internal/polecat`, `./internal/cmd`, and `./internal/witness` targeted recovery tests.\n\nPR Sheriff evidence:\n- Bead: gt-pkh1\n- Final head: 7d03ecb8b9cafd27aec447e8131545a068d23763\n- Research: 15/15 complete\n- Pre-implementation reviews: 5/5 after remediation\n- Post-implementation validations: 5/5 approve at final head\n