### PR TITLE
fix(done): verify pushed commits against target branch ancestry

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -904,7 +904,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 						if g.ForkBackedRemote("origin") {
 							return fmt.Errorf("cannot close no-MR code bead in fork/upstream mode: %s has no commits ahead of %s; use the fork PR flow instead", branch, baseRef)
 						}
-						if verifyErr := g.VerifyPushedCommit("origin", defaultBranch, noMRCommitSHA); verifyErr != nil {
+						if verifyErr := g.VerifyPushedCommitReachableFromPushTarget("origin", defaultBranch, noMRCommitSHA); verifyErr != nil {
 							noteVerifiedPushFailure(cwd, issueID, defaultBranch, noMRCommitSHA, verifyErr)
 							return fmt.Errorf("cannot close no-MR code bead: %w", verifyErr)
 						}
@@ -1041,7 +1041,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			directCommitSHA, _ := g.Rev("HEAD")
 			if doneSkipVerify {
 				noteVerifiedPushSkipped(cwd, issueID, defaultBranch, directCommitSHA, "--skip-verify on direct merge")
-			} else if verifyErr := g.VerifyPushedCommit("origin", defaultBranch, directCommitSHA); verifyErr != nil {
+			} else if verifyErr := g.VerifyPushedCommitReachableFromPushTarget("origin", defaultBranch, directCommitSHA); verifyErr != nil {
 				pushFailed = true
 				errMsg := verifyErr.Error()
 				doneErrors = append(doneErrors, errMsg)
@@ -1367,7 +1367,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				lateDirectCommitSHA, _ := g.Rev("HEAD")
 				if doneSkipVerify {
 					noteVerifiedPushSkipped(cwd, issueID, defaultBranch, lateDirectCommitSHA, "--skip-verify on late direct merge")
-				} else if verifyErr := g.VerifyPushedCommit("origin", defaultBranch, lateDirectCommitSHA); verifyErr != nil {
+				} else if verifyErr := g.VerifyPushedCommitReachableFromPushTarget("origin", defaultBranch, lateDirectCommitSHA); verifyErr != nil {
 					pushFailed = true
 					errMsg := verifyErr.Error()
 					doneErrors = append(doneErrors, errMsg)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2057,6 +2057,44 @@ func (g *Git) VerifyPushedCommit(remote, branch, commit string) error {
 	return nil
 }
 
+// VerifyPushedCommitReachableFromPushTarget verifies that commit is reachable
+// from the push target branch. Use this only for shared target branches where a
+// later fast-forward push by another actor may legitimately advance the tip.
+func (g *Git) VerifyPushedCommitReachableFromPushTarget(remote, branch, commit string) error {
+	commit = strings.TrimSpace(commit)
+	if commit == "" {
+		return fmt.Errorf("verified_push_failed: empty commit for %s/%s", remote, branch)
+	}
+	tip, err := g.PushRemoteBranchTip(remote, branch)
+	if err != nil {
+		return fmt.Errorf("verified_push_failed: unable to read %s/%s: %w", remote, branch, err)
+	}
+	if tip == "" {
+		return fmt.Errorf("verified_push_failed: branch %s/%s missing after push (expected %s)", remote, branch, shortSHA(commit))
+	}
+	if tip == commit {
+		return nil
+	}
+
+	fetchTarget := remote
+	fetchURL, fetchErr := g.RemoteURL(remote)
+	pushURL, pushErr := g.GetPushURL(remote)
+	if fetchErr == nil && pushErr == nil && pushURL != fetchURL {
+		fetchTarget = pushURL
+	}
+	if _, err := g.run("fetch", "--no-tags", fetchTarget, "refs/heads/"+branch); err != nil {
+		return fmt.Errorf("verified_push_failed: unable to fetch %s/%s for ancestry check: %w", remote, branch, err)
+	}
+	reachable, err := g.IsAncestor(commit, "FETCH_HEAD")
+	if err != nil {
+		return fmt.Errorf("verified_push_failed: unable to verify commit %s on %s/%s: %w", shortSHA(commit), remote, branch, err)
+	}
+	if !reachable {
+		return fmt.Errorf("verified_push_failed: commit %s not on %s/%s (remote tip %s)", shortSHA(commit), remote, branch, shortSHA(tip))
+	}
+	return nil
+}
+
 func parseLSRemoteTip(out, branch string) string {
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		line = strings.TrimSpace(line)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3316,8 +3316,16 @@ func TestVerifyPushedCommitSplitURL(t *testing.T) {
 }
 
 func TestVerifyPushedCommitReachableFromPushTargetSplitURL(t *testing.T) {
-	localDir, _, forkDir, mainBranch := initTestRepoWithSplitRemote(t)
+	localDir, _, forkDir, _ := initTestRepoWithSplitRemote(t)
 	g := NewGit(localDir)
+	branch := "integration/verified-split"
+
+	if err := g.CreateBranch(branch); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if err := g.Checkout(branch); err != nil {
+		t.Fatalf("Checkout: %v", err)
+	}
 
 	if err := os.WriteFile(filepath.Join(localDir, "split-shared.txt"), []byte("v1\n"), 0644); err != nil {
 		t.Fatalf("write v1: %v", err)
@@ -3332,7 +3340,7 @@ func TestVerifyPushedCommitReachableFromPushTargetSplitURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Rev v1: %v", err)
 	}
-	if err := g.Push("origin", mainBranch, false); err != nil {
+	if err := g.Push("origin", branch, false); err != nil {
 		t.Fatalf("Push v1: %v", err)
 	}
 
@@ -3350,13 +3358,18 @@ func TestVerifyPushedCommitReachableFromPushTargetSplitURL(t *testing.T) {
 			t.Fatalf("%s: %v\n%s", args, err, out)
 		}
 	}
+	cmd := exec.Command("git", "checkout", branch)
+	cmd.Dir = cloneDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("checkout fork branch: %v\n%s", err, out)
+	}
 	if err := os.WriteFile(filepath.Join(cloneDir, "split-shared.txt"), []byte("v2\n"), 0644); err != nil {
 		t.Fatalf("write fork v2: %v", err)
 	}
 	for _, args := range [][]string{
 		{"git", "add", "split-shared.txt"},
 		{"git", "commit", "-m", "split shared v2"},
-		{"git", "push", "origin", mainBranch},
+		{"git", "push", "origin", branch},
 	} {
 		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Dir = cloneDir
@@ -3365,18 +3378,18 @@ func TestVerifyPushedCommitReachableFromPushTargetSplitURL(t *testing.T) {
 		}
 	}
 
-	fetchTip, err := g.RemoteBranchTip("origin", mainBranch)
+	fetchTip, err := g.RemoteBranchTip("origin", branch)
 	if err != nil {
 		t.Fatalf("RemoteBranchTip: %v", err)
 	}
-	pushTip, err := g.PushRemoteBranchTip("origin", mainBranch)
+	pushTip, err := g.PushRemoteBranchTip("origin", branch)
 	if err != nil {
 		t.Fatalf("PushRemoteBranchTip: %v", err)
 	}
 	if fetchTip == pushTip {
 		t.Fatalf("test setup expected split fetch/push tips to differ, got %s", fetchTip)
 	}
-	if err := g.VerifyPushedCommitReachableFromPushTarget("origin", mainBranch, v1); err != nil {
+	if err := g.VerifyPushedCommitReachableFromPushTarget("origin", branch, v1); err != nil {
 		t.Fatalf("Verify should query push URL and accept ancestor: %v", err)
 	}
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3170,6 +3170,112 @@ func TestVerifyPushedCommit(t *testing.T) {
 	}
 }
 
+func TestVerifyPushedCommitReachableFromPushTarget(t *testing.T) {
+	localDir, remoteDir, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+
+	if err := os.WriteFile(filepath.Join(localDir, "shared.txt"), []byte("v1\n"), 0644); err != nil {
+		t.Fatalf("write v1: %v", err)
+	}
+	if err := g.Add("shared.txt"); err != nil {
+		t.Fatalf("Add v1: %v", err)
+	}
+	if err := g.Commit("shared target v1"); err != nil {
+		t.Fatalf("Commit v1: %v", err)
+	}
+	v1, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev v1: %v", err)
+	}
+	if err := g.Push("origin", mainBranch, false); err != nil {
+		t.Fatalf("Push v1: %v", err)
+	}
+	if err := g.VerifyPushedCommitReachableFromPushTarget("origin", mainBranch, v1); err != nil {
+		t.Fatalf("Verify exact tip: %v", err)
+	}
+
+	cloneDir := filepath.Join(t.TempDir(), "advancer")
+	if out, err := exec.Command("git", "clone", remoteDir, cloneDir).CombinedOutput(); err != nil {
+		t.Fatalf("clone advancer: %v\n%s", err, out)
+	}
+	for _, args := range [][]string{
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test User"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = cloneDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(cloneDir, "shared.txt"), []byte("v2\n"), 0644); err != nil {
+		t.Fatalf("write advancer v2: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "add", "shared.txt"},
+		{"git", "commit", "-m", "shared target v2"},
+		{"git", "push", "origin", mainBranch},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = cloneDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s: %v\n%s", args, err, out)
+		}
+	}
+	if err := g.VerifyPushedCommitReachableFromPushTarget("origin", mainBranch, v1); err != nil {
+		t.Fatalf("Verify ancestor after concurrent push: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(localDir, "shared.txt"), []byte("local-only\n"), 0644); err != nil {
+		t.Fatalf("write local-only: %v", err)
+	}
+	if err := g.Add("shared.txt"); err != nil {
+		t.Fatalf("Add local-only: %v", err)
+	}
+	if err := g.Commit("local only"); err != nil {
+		t.Fatalf("Commit local-only: %v", err)
+	}
+	localOnly, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev local-only: %v", err)
+	}
+	if err := g.VerifyPushedCommitReachableFromPushTarget("origin", mainBranch, localOnly); err == nil {
+		t.Fatal("Verify should fail for commit not reachable from push target")
+	}
+	if err := g.VerifyPushedCommitReachableFromPushTarget("origin", "missing-branch", v1); err == nil {
+		t.Fatal("Verify should fail for missing branch")
+	}
+
+	for _, args := range [][]string{
+		{"git", "checkout", "--orphan", "replacement"},
+		{"git", "rm", "-rf", "."},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = cloneDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(cloneDir, "replacement.txt"), []byte("replacement\n"), 0644); err != nil {
+		t.Fatalf("write replacement: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "add", "replacement.txt"},
+		{"git", "commit", "-m", "replace remote history"},
+		{"git", "branch", "-M", mainBranch},
+		{"git", "push", "--force", "origin", mainBranch},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = cloneDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s: %v\n%s", args, err, out)
+		}
+	}
+	if err := g.VerifyPushedCommitReachableFromPushTarget("origin", mainBranch, v1); err == nil {
+		t.Fatal("Verify should fail when stale origin/main still has commit but push target does not")
+	}
+}
+
 func TestVerifyPushedCommitSplitURL(t *testing.T) {
 	localDir, _, _, _ := initTestRepoWithSplitRemote(t)
 	g := NewGit(localDir)
@@ -3206,6 +3312,72 @@ func TestVerifyPushedCommitSplitURL(t *testing.T) {
 	}
 	if err := g.VerifyPushedCommit("origin", "polecat/verified-split", sha); err != nil {
 		t.Fatalf("VerifyPushedCommit should query push URL: %v", err)
+	}
+}
+
+func TestVerifyPushedCommitReachableFromPushTargetSplitURL(t *testing.T) {
+	localDir, _, forkDir, mainBranch := initTestRepoWithSplitRemote(t)
+	g := NewGit(localDir)
+
+	if err := os.WriteFile(filepath.Join(localDir, "split-shared.txt"), []byte("v1\n"), 0644); err != nil {
+		t.Fatalf("write v1: %v", err)
+	}
+	if err := g.Add("split-shared.txt"); err != nil {
+		t.Fatalf("Add v1: %v", err)
+	}
+	if err := g.Commit("split shared v1"); err != nil {
+		t.Fatalf("Commit v1: %v", err)
+	}
+	v1, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev v1: %v", err)
+	}
+	if err := g.Push("origin", mainBranch, false); err != nil {
+		t.Fatalf("Push v1: %v", err)
+	}
+
+	cloneDir := filepath.Join(t.TempDir(), "fork-advancer")
+	if out, err := exec.Command("git", "clone", forkDir, cloneDir).CombinedOutput(); err != nil {
+		t.Fatalf("clone fork advancer: %v\n%s", err, out)
+	}
+	for _, args := range [][]string{
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test User"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = cloneDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(cloneDir, "split-shared.txt"), []byte("v2\n"), 0644); err != nil {
+		t.Fatalf("write fork v2: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "add", "split-shared.txt"},
+		{"git", "commit", "-m", "split shared v2"},
+		{"git", "push", "origin", mainBranch},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = cloneDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s: %v\n%s", args, err, out)
+		}
+	}
+
+	fetchTip, err := g.RemoteBranchTip("origin", mainBranch)
+	if err != nil {
+		t.Fatalf("RemoteBranchTip: %v", err)
+	}
+	pushTip, err := g.PushRemoteBranchTip("origin", mainBranch)
+	if err != nil {
+		t.Fatalf("PushRemoteBranchTip: %v", err)
+	}
+	if fetchTip == pushTip {
+		t.Fatalf("test setup expected split fetch/push tips to differ, got %s", fetchTip)
+	}
+	if err := g.VerifyPushedCommitReachableFromPushTarget("origin", mainBranch, v1); err != nil {
+		t.Fatalf("Verify should query push URL and accept ancestor: %v", err)
 	}
 }
 


### PR DESCRIPTION
Focused current-main replacement for PR #4067.

Summary:
- Add push-target ancestry verification for no-MR/direct gt done paths.
- Verify the commit is reachable from the actual push target branch, rather than requiring exact target tip equality.
- Preserve exact-tip verification for owned branch paths.
- Keep scope limited to the ancestry verification bug; no broad gt done rewrite.

Attribution:
- Original PR: https://github.com/gastownhall/gastown/pull/4067
- Original author: KayoticSully / Ryan Sullivan
- Replacement evidence in bead gt-q88c records PR Sheriff 15 research legs, 5 pre-implementation reviews, 5 post-implementation reviews, focused verification, and checker PASS.

Verification from worker:
- gt-pr-sheriff-check --evidence /tmp/opencode/gt-q88c/evidence.json --merge-gate: PASS, merge_path_allowed=true, verdict=merge_replacement
- CGO_ENABLED=0 go test ./internal/git -count=1
- CGO_ENABLED=0 go test ./internal/cmd -run '^$' -count=1
- CGO_ENABLED=0 go build -o /tmp/opencode/gt-q88c/gt ./cmd/gt

No refinery/MQ. Original PR #4067 should remain open until this replacement lands.