### PR TITLE
fix(polecat): trigger Stop safety on dirty work

### DIFF
--- a/internal/cmd/tap_polecat_stop.go
+++ b/internal/cmd/tap_polecat_stop.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/polecat"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
@@ -21,7 +22,7 @@ but forget to call gt done before the session ends.
 This command is designed to run from a Claude Code Stop hook. It checks:
 1. Whether this is a polecat session (GT_POLECAT env var)
 2. Whether gt done has already run (heartbeat state is "exiting" or "idle")
-3. Whether the polecat has commits on its branch
+3. Whether the polecat has commits, stashes, or non-runtime dirty work
 
 If the polecat has pending work that wasn't submitted, this command
 runs gt done to submit it. If gt done already ran or there's nothing
@@ -68,7 +69,7 @@ func runTapPolecatStop(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Check if the polecat is on a feature branch with commits
+	// Check if the polecat is on a feature branch with work to submit.
 	rigName := os.Getenv("GT_RIG")
 	if rigName == "" {
 		return nil
@@ -97,20 +98,14 @@ func runTapPolecatStop(cmd *cobra.Command, args []string) error {
 		return nil // On default branch — nothing to submit
 	}
 
-	// Check for commits ahead of origin/main
-	aheadCmd := exec.Command("git", "-C", cloneDir, "rev-list", "--count", "origin/main..HEAD")
-	aheadOut, err := aheadCmd.Output()
-	if err != nil {
-		return nil // Can't check — exit quietly (don't block session stop)
-	}
-	ahead := strings.TrimSpace(string(aheadOut))
-	if ahead == "0" {
-		return nil // No commits ahead — nothing to submit
+	pending, reason, err := polecatStopPendingWork(cloneDir, branch)
+	if err != nil || !pending {
+		return nil // Can't check, or no work to submit — don't block session stop
 	}
 
 	// Polecat has pending work! Run gt done as a safety net.
 	fmt.Fprintf(os.Stderr, "\n")
-	fmt.Fprintf(os.Stderr, "⚠️  Polecat %s has %s unpushed commit(s) on branch %s\n", polecatName, ahead, branch)
+	fmt.Fprintf(os.Stderr, "⚠️  Polecat %s has pending work on branch %s (%s)\n", polecatName, branch, reason)
 	fmt.Fprintf(os.Stderr, "   Auto-running gt done as safety net...\n")
 	fmt.Fprintf(os.Stderr, "\n")
 
@@ -136,4 +131,29 @@ func runTapPolecatStop(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func polecatStopPendingWork(cloneDir, branch string) (bool, string, error) {
+	g := git.NewGit(cloneDir)
+	workStatus, err := g.CheckUncommittedWork()
+	if err != nil {
+		return false, "", err
+	}
+
+	if workStatus.HasUncommittedChanges && !workStatus.CleanExcludingRuntime() {
+		return true, fmt.Sprintf("%d non-runtime dirty file(s)", len(workStatus.NonRuntimePaths())), nil
+	}
+	if workStatus.StashCount > 0 {
+		return true, fmt.Sprintf("%d branch stash(es)", workStatus.StashCount), nil
+	}
+
+	targetStatus, err := g.BranchTargetStatus(branch, "origin", nil)
+	if err != nil {
+		return false, "", err
+	}
+	if !targetStatus.Preserved && targetStatus.UnpreservedPatchCount > 0 {
+		return true, fmt.Sprintf("%d unsubmitted commit(s)", targetStatus.UnpreservedPatchCount), nil
+	}
+
+	return false, "", nil
 }

--- a/internal/cmd/tap_polecat_stop_test.go
+++ b/internal/cmd/tap_polecat_stop_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const polecatStopTestBranch = "polecat/test/gt-ksnv@abc123"
+
+func TestPolecatStopPendingWork(t *testing.T) {
+	t.Run("clean feature branch has no pending work", func(t *testing.T) {
+		repo := initPolecatStopTestRepo(t)
+
+		pending, reason, err := polecatStopPendingWork(repo, polecatStopTestBranch)
+		if err != nil {
+			t.Fatalf("polecatStopPendingWork: %v", err)
+		}
+		if pending {
+			t.Fatalf("pending = true (%s), want false", reason)
+		}
+	})
+
+	t.Run("non-runtime dirty work is pending", func(t *testing.T) {
+		repo := initPolecatStopTestRepo(t)
+		writePolecatStopTestFile(t, repo, "internal/cmd/work.go", "package cmd\n")
+
+		pending, reason, err := polecatStopPendingWork(repo, polecatStopTestBranch)
+		if err != nil {
+			t.Fatalf("polecatStopPendingWork: %v", err)
+		}
+		if !pending {
+			t.Fatal("pending = false, want true")
+		}
+		if !strings.Contains(reason, "non-runtime dirty") {
+			t.Fatalf("reason = %q, want non-runtime dirty work", reason)
+		}
+	})
+
+	t.Run("runtime-only dirty work is ignored", func(t *testing.T) {
+		repo := initPolecatStopTestRepo(t)
+		writePolecatStopTestFile(t, repo, ".opencode/state.json", "{}\n")
+
+		pending, reason, err := polecatStopPendingWork(repo, polecatStopTestBranch)
+		if err != nil {
+			t.Fatalf("polecatStopPendingWork: %v", err)
+		}
+		if pending {
+			t.Fatalf("pending = true (%s), want false", reason)
+		}
+	})
+
+	t.Run("branch stash is pending", func(t *testing.T) {
+		repo := initPolecatStopTestRepo(t)
+		writePolecatStopTestFile(t, repo, "stash-work.txt", "saved work\n")
+		runPolecatStopTestGit(t, repo, "stash", "push", "-u", "-m", "branch stash")
+
+		pending, reason, err := polecatStopPendingWork(repo, polecatStopTestBranch)
+		if err != nil {
+			t.Fatalf("polecatStopPendingWork: %v", err)
+		}
+		if !pending {
+			t.Fatal("pending = false, want true")
+		}
+		if !strings.Contains(reason, "branch stash") {
+			t.Fatalf("reason = %q, want branch stash", reason)
+		}
+	})
+
+	t.Run("pushed source branch still pending until target contains it", func(t *testing.T) {
+		repo := initPolecatStopTestRepo(t)
+		writePolecatStopTestFile(t, repo, "submitted.go", "package main\n")
+		runPolecatStopTestGit(t, repo, "add", "submitted.go")
+		runPolecatStopTestGit(t, repo, "commit", "-m", "add submitted work")
+		runPolecatStopTestGit(t, repo, "push", "origin", "HEAD:"+polecatStopTestBranch)
+
+		pending, reason, err := polecatStopPendingWork(repo, polecatStopTestBranch)
+		if err != nil {
+			t.Fatalf("polecatStopPendingWork: %v", err)
+		}
+		if !pending {
+			t.Fatal("pending = false, want true")
+		}
+		if !strings.Contains(reason, "unsubmitted commit") {
+			t.Fatalf("reason = %q, want unsubmitted commit", reason)
+		}
+	})
+
+	t.Run("target-contained commit has no pending work", func(t *testing.T) {
+		repo := initPolecatStopTestRepo(t)
+		writePolecatStopTestFile(t, repo, "merged.go", "package main\n")
+		runPolecatStopTestGit(t, repo, "add", "merged.go")
+		runPolecatStopTestGit(t, repo, "commit", "-m", "add merged work")
+		runPolecatStopTestGit(t, repo, "checkout", "main")
+		runPolecatStopTestGit(t, repo, "merge", "--ff-only", polecatStopTestBranch)
+		runPolecatStopTestGit(t, repo, "push", "origin", "main")
+		runPolecatStopTestGit(t, repo, "checkout", polecatStopTestBranch)
+
+		pending, reason, err := polecatStopPendingWork(repo, polecatStopTestBranch)
+		if err != nil {
+			t.Fatalf("polecatStopPendingWork: %v", err)
+		}
+		if pending {
+			t.Fatalf("pending = true (%s), want false", reason)
+		}
+	})
+
+	t.Run("invalid repo fails closed", func(t *testing.T) {
+		pending, reason, err := polecatStopPendingWork(t.TempDir(), polecatStopTestBranch)
+		if err == nil {
+			t.Fatal("polecatStopPendingWork error = nil, want error")
+		}
+		if pending {
+			t.Fatalf("pending = true (%s), want false", reason)
+		}
+	})
+}
+
+func initPolecatStopTestRepo(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "repo")
+	origin := filepath.Join(tmp, "origin.git")
+
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	runPolecatStopTestGit(t, repo, "init")
+	runPolecatStopTestGit(t, repo, "branch", "-M", "main")
+	runPolecatStopTestGit(t, repo, "config", "user.email", "test@test.com")
+	runPolecatStopTestGit(t, repo, "config", "user.name", "Test User")
+	writePolecatStopTestFile(t, repo, "README.md", "# Test\n")
+	runPolecatStopTestGit(t, repo, "add", "README.md")
+	runPolecatStopTestGit(t, repo, "commit", "-m", "initial")
+
+	runPolecatStopTestGit(t, tmp, "init", "--bare", origin)
+	runPolecatStopTestGit(t, repo, "remote", "add", "origin", origin)
+	runPolecatStopTestGit(t, repo, "push", "-u", "origin", "main")
+	runPolecatStopTestGit(t, repo, "checkout", "-b", polecatStopTestBranch)
+
+	return repo
+}
+
+func writePolecatStopTestFile(t *testing.T, repo, rel, contents string) {
+	t.Helper()
+	path := filepath.Join(repo, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func runPolecatStopTestGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	fullArgs := append([]string{"-c", "protocol.file.allow=always"}, args...)
+	cmd := exec.Command("git", fullArgs...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+}


### PR DESCRIPTION
## Summary

Clean current-main replacement for #4323.

This keeps the polecat Stop hook as a thin safety trigger, but expands its pending-work predicate so Stop invokes the existing `gt done` safety net when a polecat branch has:

- non-runtime dirty work detected by `CheckUncommittedWork` / `CleanExcludingRuntime`
- branch-local stashes
- commits not represented on target/custody refs via `BranchTargetStatus`

All autosave and submission behavior remains in `gt done`; this does not add a second autosave path.

## Attribution

Supersedes #4323 by @Ben-Williams-Founder.

Original head: `b9e00b316d05c855f3d45742814a0db0fd4a6201`

The commit includes `Original-PR`, `Original-Head`, and `Co-authored-by` trailers preserving contributor credit.

## Verification

Passed locally:

```bash
CGO_ENABLED=0 go test ./internal/cmd ./internal/git -run 'TestPolecatStopPendingWork|TestAutoCommitSafetyNet|TestSyncGuardWithUncommittedChanges|TestCleanExcludingRuntime|TestRuntimeArtifactPaths|TestRuntimeArtifactPathspecs|TestCheckUncommittedWorkCapturesPorcelainRenameAndUnmergedPaths'
```

Attempted broader local package gate:

```bash
CGO_ENABLED=0 go test ./internal/cmd ./internal/git
```

That exceeded the 120s local timeout with no output, so the focused regression gate above is the recorded local verification. GitHub CI should provide the full remote signal.

## PR Sheriff

PR Sheriff 15+5+5 workflow completed for final head `659f9a1ec1d03143659de5d0b99b9ae98066f11d`.

Durable evidence is recorded on bead `gt-ksnv`. This PR is GitHub-only and should not be submitted through the Gas Town merge queue.
