### PR TITLE
fix(beads): keep rig identity beads durable

### DIFF
--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -582,7 +582,7 @@ func TestCreateOrReopenAgentBeadExistingUsesTownBeadsDir(t *testing.T) {
 	if err := WriteRoutes(townBeadsDir, []Route{{Prefix: "hq-", Path: "."}, {Prefix: "gt-", Path: "gastown/mayor/rig"}}); err != nil {
 		t.Fatalf("write routes: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(townBeadsDir, ".gt-types-configured"), []byte("v1\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(townBeadsDir, ".gt-types-configured"), []byte(TypeConfigSentinelValue()+"\n"), 0644); err != nil {
 		t.Fatalf("write types sentinel: %v", err)
 	}
 

--- a/internal/beads/beads_rig.go
+++ b/internal/beads/beads_rig.go
@@ -144,10 +144,12 @@ func (b *Beads) CreateRigBead(name string, fields *RigFields) (*Issue, error) {
 	id := RigBeadIDWithPrefix(prefix, name)
 	description := FormatRigDescription(name, fields)
 
-	// Ensure target database has custom types configured (including "rig").
-	// This matches what CreateAgentBead does — without it, bd rejects
-	// --type=rig on databases that haven't registered custom types yet.
-	_ = EnsureCustomTypes(b.getResolvedBeadsDir())
+	// Ensure target database keeps rig as a durable custom type, not an
+	// infra/wisp type. Failing closed avoids silently creating ephemeral rig
+	// identity beads when type config cannot be persisted.
+	if err := EnsureCustomTypes(b.getResolvedBeadsDir()); err != nil {
+		return nil, fmt.Errorf("ensuring rig bead types: %w", err)
+	}
 
 	args := []string{"create", "--json",
 		"--id=" + id,

--- a/internal/beads/beads_rig_test.go
+++ b/internal/beads/beads_rig_test.go
@@ -1,16 +1,19 @@
 package beads
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
 
 func TestFormatRigDescription(t *testing.T) {
 	tests := []struct {
-		name   string
+		name    string
 		rigName string
-		fields *RigFields
-		want   []string
+		fields  *RigFields
+		want    []string
 	}{
 		{
 			name:    "nil fields",
@@ -217,5 +220,118 @@ func TestValidRigState(t *testing.T) {
 				t.Errorf("ValidRigState(%q) = %v, want %v", tt.state, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCreateRigBeadUsesDurableRigType(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses POSIX shell fake bd")
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_LOG"
+case "$1:$2:$3" in
+  config:get:types.custom)
+    printf '%s\n' 'agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request'
+    exit 0
+    ;;
+  config:get:types.infra)
+    printf '%s\n' 'agent,role,message'
+    exit 0
+    ;;
+esac
+if [ "$1" = "config" ]; then
+  exit 0
+fi
+if [ "$1" = "create" ]; then
+  printf '%s\n' '{"id":"gt-rig-gastown","title":"gastown","issue_type":"rig","status":"open","priority":2,"created_at":"2026-07-07T00:00:00Z","updated_at":"2026-07-07T00:00:00Z","labels":["gt:rig"]}'
+  exit 0
+fi
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_LOG", logPath)
+
+	workDir := t.TempDir()
+	beadsDir := filepath.Join(workDir, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "dolt"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	ResetEnsuredDirs()
+
+	issue, err := NewIsolated(workDir).CreateRigBead("gastown", &RigFields{Prefix: "gt", State: RigStateActive})
+	if err != nil {
+		t.Fatalf("CreateRigBead: %v", err)
+	}
+	if issue.Type != "rig" || issue.Ephemeral {
+		t.Fatalf("created issue type/ephemeral = %q/%v, want rig/false", issue.Type, issue.Ephemeral)
+	}
+
+	log := string(mustReadFile(t, logPath))
+	for _, want := range []string{"config set types.custom", "config set types.infra agent,role,message", "create --json", "--labels=gt:rig", "--type=rig"} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("bd log missing %q in:\n%s", want, log)
+		}
+	}
+	if strings.Contains(log, "--type=task") {
+		t.Fatalf("rig bead creation used task type:\n%s", log)
+	}
+}
+
+func TestCreateRigBeadFailsClosedWhenTypeConfigFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses POSIX shell fake bd")
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_LOG"
+if [ "$1" = "config" ]; then
+  case "$2:$3" in
+    get:types.custom)
+      printf '%s\n' 'agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request'
+      exit 0
+      ;;
+    get:types.infra)
+      printf '%s\n' 'agent,rig,role,message'
+      exit 0
+      ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "create" ]; then
+  printf '%s\n' '{"id":"should-not-create"}'
+  exit 0
+fi
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_LOG", logPath)
+
+	workDir := t.TempDir()
+	beadsDir := filepath.Join(workDir, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "dolt"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	ResetEnsuredDirs()
+
+	_, err := NewIsolated(workDir).CreateRigBead("gastown", &RigFields{Prefix: "gt"})
+	if err == nil {
+		t.Fatal("expected CreateRigBead to fail when types.infra verification fails")
+	}
+	if !strings.Contains(err.Error(), "types.infra not persisted") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if log := string(mustReadFile(t, logPath)); strings.Contains(log, "create --json") {
+		t.Fatalf("CreateRigBead called bd create after config failure:\n%s", log)
 	}
 }

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -232,8 +232,6 @@ func EnsureCustomTypesConfigYAML(beadsDir string) error {
 	if err := EnsureConfigYAMLValue(beadsDir, "types.infra", infraTypes); err != nil {
 		return err
 	}
-	_ = os.WriteFile(filepath.Join(beadsDir, typesSentinel), []byte(TypeConfigSentinelValue()+"\n"), 0644)
-	ensuredDirs[beadsDir] = true
 	return nil
 }
 

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -92,9 +92,9 @@ func ResolveRoutingTarget(townRoot, beadID, fallbackDir string) string {
 //   - In-memory cache for multiple creates in the same CLI invocation
 //   - Sentinel file on disk for persistence across CLI invocations
 //
-// The sentinel file stores the configured types list. When the types list changes
-// (e.g., new types added in a gastown upgrade), the sentinel is detected as stale
-// and types are re-configured automatically (gt-zmy, gt-26f).
+// The sentinel file stores the configured custom and infra type lists. When
+// either list changes, the sentinel is detected as stale and types are
+// re-configured automatically (gt-zmy, gt-26f).
 //
 // This function is thread-safe and idempotent.
 //
@@ -105,7 +105,9 @@ func EnsureCustomTypes(beadsDir string) error {
 		return fmt.Errorf("empty beads directory")
 	}
 
-	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
+	customTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
+	infraTypes := strings.Join(constants.BeadsInfraTypesList(), ",")
+	sentinelValue := TypeConfigSentinelValue()
 
 	ensuredMu.Lock()
 	defer ensuredMu.Unlock()
@@ -116,12 +118,12 @@ func EnsureCustomTypes(beadsDir string) error {
 	}
 
 	// Fast path: sentinel file matches current types list (previous CLI invocation).
-	// The sentinel stores the types that were configured. If types have changed
-	// (e.g., "queue" and "event" added), the sentinel won't match and we'll
-	// re-configure. Legacy "v1\n" sentinels also won't match.
+	// The sentinel stores the type configuration that was applied. If types have
+	// changed, the sentinel won't match and we'll re-configure. Legacy "v1\n" and
+	// custom-types-only sentinels also won't match.
 	sentinelPath := filepath.Join(beadsDir, typesSentinel)
 	if data, err := os.ReadFile(sentinelPath); err == nil {
-		if strings.TrimSpace(string(data)) == typesList {
+		if strings.TrimSpace(string(data)) == sentinelValue {
 			ensuredDirs[beadsDir] = true
 			return nil
 		}
@@ -138,18 +140,14 @@ func EnsureCustomTypes(beadsDir string) error {
 		return fmt.Errorf("ensure database initialized: %w", err)
 	}
 
-	// Configure custom types via bd CLI
+	// Configure custom and infra types via bd CLI. Rig is a durable custom type,
+	// not an infra/wisp type.
 	bdEnv := BuildMutationPinnedBDEnv(os.Environ(), beadsDir)
-	cmd := exec.Command("bd", "config", "set", "types.custom", typesList)
-	cmd.Dir = beadsDir
-	util.SetDetachedProcessGroup(cmd)
-	// Set BEADS_DIR and BEADS_DOLT_SERVER_DATABASE explicitly to ensure bd
-	// operates on the correct database. Strip inherited values first —
-	// getenv() returns the first match (gt-uygpe).
-	cmd.Env = bdEnv
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("configure custom types in %s: %s: %w",
-			beadsDir, strings.TrimSpace(string(output)), err)
+	if err := setBDConfig(beadsDir, bdEnv, "types.custom", customTypes); err != nil {
+		return err
+	}
+	if err := setBDConfig(beadsDir, bdEnv, "types.infra", infraTypes); err != nil {
+		return err
 	}
 
 	// Verify the config was actually persisted in the database (GH#2637).
@@ -157,21 +155,54 @@ func EnsureCustomTypes(beadsDir string) error {
 	// database (redirect mismatch, stale metadata, server not running).
 	// Without this check, the sentinel file below would cache a lie,
 	// causing all future EnsureCustomTypes calls to skip re-configuration.
-	verifyCmd := exec.Command("bd", "config", "get", "types.custom")
-	verifyCmd.Dir = beadsDir
-	verifyCmd.Env = bdEnv
-	util.SetDetachedProcessGroup(verifyCmd)
-	if verifyOutput, err := verifyCmd.Output(); err != nil || !strings.Contains(string(verifyOutput), "agent") {
-		return fmt.Errorf("types.custom not persisted in %s after bd config set (verify returned %q): db may be misconfigured",
-			beadsDir, strings.TrimSpace(string(verifyOutput)))
+	if err := verifyBDConfig(beadsDir, bdEnv, "types.custom", customTypes); err != nil {
+		return err
+	}
+	if err := verifyBDConfig(beadsDir, bdEnv, "types.infra", infraTypes); err != nil {
+		return err
 	}
 
-	// Write sentinel file with the types list for staleness detection.
-	// On next invocation, if types have changed, the sentinel won't match
-	// and we'll re-configure automatically.
-	_ = os.WriteFile(sentinelPath, []byte(typesList+"\n"), 0644)
+	// Write sentinel file with the type config for staleness detection. On next
+	// invocation, if types have changed, the sentinel won't match and we'll
+	// re-configure automatically.
+	_ = os.WriteFile(sentinelPath, []byte(sentinelValue+"\n"), 0644)
 
 	ensuredDirs[beadsDir] = true
+	return nil
+}
+
+// TypeConfigSentinelValue returns the current type configuration fingerprint.
+// Tests in other packages use this to avoid duplicating the sentinel format.
+func TypeConfigSentinelValue() string {
+	return fmt.Sprintf("types.custom=%s\ntypes.infra=%s",
+		strings.Join(constants.BeadsCustomTypesList(), ","),
+		strings.Join(constants.BeadsInfraTypesList(), ","))
+}
+
+func setBDConfig(beadsDir string, env []string, key, value string) error {
+	cmd := exec.Command("bd", "config", "set", key, value)
+	cmd.Dir = beadsDir
+	util.SetDetachedProcessGroup(cmd)
+	// Set BEADS_DIR and BEADS_DOLT_SERVER_DATABASE explicitly to ensure bd
+	// operates on the correct database. Strip inherited values first — getenv()
+	// returns the first match (gt-uygpe).
+	cmd.Env = env
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("configure %s in %s: %s: %w", key, beadsDir, strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+func verifyBDConfig(beadsDir string, env []string, key, want string) error {
+	cmd := exec.Command("bd", "config", "get", key)
+	cmd.Dir = beadsDir
+	cmd.Env = env
+	util.SetDetachedProcessGroup(cmd)
+	output, err := cmd.Output()
+	got := ParseConfigOutput(output)
+	if err != nil || got != want {
+		return fmt.Errorf("%s not persisted in %s after bd config set (verify returned %q): db may be misconfigured", key, beadsDir, got)
+	}
 	return nil
 }
 
@@ -186,7 +217,8 @@ func EnsureCustomTypesConfigYAML(beadsDir string) error {
 		return fmt.Errorf("beads directory does not exist: %s", beadsDir)
 	}
 
-	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
+	customTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
+	infraTypes := strings.Join(constants.BeadsInfraTypesList(), ",")
 
 	ensuredMu.Lock()
 	defer ensuredMu.Unlock()
@@ -194,10 +226,13 @@ func EnsureCustomTypesConfigYAML(beadsDir string) error {
 	if ensuredDirs[beadsDir] {
 		return nil
 	}
-	if err := EnsureConfigYAMLValue(beadsDir, "types.custom", typesList); err != nil {
+	if err := EnsureConfigYAMLValue(beadsDir, "types.custom", customTypes); err != nil {
 		return err
 	}
-	_ = os.WriteFile(filepath.Join(beadsDir, typesSentinel), []byte(typesList+"\n"), 0644)
+	if err := EnsureConfigYAMLValue(beadsDir, "types.infra", infraTypes); err != nil {
+		return err
+	}
+	_ = os.WriteFile(filepath.Join(beadsDir, typesSentinel), []byte(TypeConfigSentinelValue()+"\n"), 0644)
 	ensuredDirs[beadsDir] = true
 	return nil
 }

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -220,12 +220,6 @@ func EnsureCustomTypesConfigYAML(beadsDir string) error {
 	customTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
 	infraTypes := strings.Join(constants.BeadsInfraTypesList(), ",")
 
-	ensuredMu.Lock()
-	defer ensuredMu.Unlock()
-
-	if ensuredDirs[beadsDir] {
-		return nil
-	}
 	if err := EnsureConfigYAMLValue(beadsDir, "types.custom", customTypes); err != nil {
 		return err
 	}

--- a/internal/beads/beads_types_test.go
+++ b/internal/beads/beads_types_test.go
@@ -53,11 +53,14 @@ switch ($cmd) {
     if ($args.Length -ge 3 -and $args[1] -eq 'get' -and $args[2] -eq 'status.custom') {
       Write-Output ''
     }
-    if ($args.Length -ge 3 -and $args[1] -eq 'get' -and $args[2] -eq 'types.custom') {
-      Write-Output 'agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request'
-    }
-    exit 0
-  }
+			if ($args.Length -ge 3 -and $args[1] -eq 'get' -and $args[2] -eq 'types.custom') {
+			  Write-Output 'agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request'
+			}
+			if ($args.Length -ge 3 -and $args[1] -eq 'get' -and $args[2] -eq 'types.infra') {
+			  Write-Output 'agent,role,message'
+			}
+			exit 0
+		  }
   'migrate' { exit 0 }
   default { exit 0 }
 }
@@ -95,12 +98,14 @@ case "$cmd" in
     printf 'prefix: %s\nissue-prefix: %s-\n' "$prefix" "$prefix" > "$target/config.yaml"
     exit 0
     ;;
-  config)
-    # Return types list for "config get types.custom" verification
-    if echo "$*" | grep -q "get types.custom"; then
-      echo "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request"
-    fi
-    exit 0
+	  config)
+	    # Return types list for "config get types.custom" verification
+	    if echo "$*" | grep -q "get types.custom"; then
+	      echo "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request"
+	    elif echo "$*" | grep -q "get types.infra"; then
+	      echo "agent,role,message"
+	    fi
+	    exit 0
     ;;
   migrate)
     exit 0
@@ -312,10 +317,9 @@ func TestEnsureCustomTypes(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Create sentinel file with current types list
-		currentTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
+		// Create sentinel file with current type config.
 		sentinelPath := filepath.Join(beadsDir, typesSentinel)
-		if err := os.WriteFile(sentinelPath, []byte(currentTypes+"\n"), 0644); err != nil {
+		if err := os.WriteFile(sentinelPath, []byte(TypeConfigSentinelValue()+"\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -350,12 +354,46 @@ func TestEnsureCustomTypes(t *testing.T) {
 			t.Fatalf("EnsureCustomTypes: %v", err)
 		}
 
-		if got := strings.TrimSpace(string(mustReadFile(t, sentinelPath))); got != strings.Join(constants.BeadsCustomTypesList(), ",") {
-			t.Fatalf("types sentinel = %q, want current configured types", got)
+		if got := strings.TrimSpace(string(mustReadFile(t, sentinelPath))); got != TypeConfigSentinelValue() {
+			t.Fatalf("types sentinel = %q, want current type config", got)
 		}
 
 		logOutput := readMockBDLog(t, logPath)
-		for _, want := range []string{"init", "config set types.custom"} {
+		for _, want := range []string{"init", "config set types.custom", "config set types.infra"} {
+			if !strings.Contains(logOutput, want) {
+				t.Fatalf("mock bd log %q missing %q", logOutput, want)
+			}
+		}
+	})
+
+	t.Run("custom-types-only sentinel triggers infra re-configuration", func(t *testing.T) {
+		logPath := installMockBDRecorder(t)
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// This was the real pre-fix sentinel format. It must be stale so existing
+		// databases receive the durable-rig infra config.
+		sentinelPath := filepath.Join(beadsDir, typesSentinel)
+		legacyValue := strings.Join(constants.BeadsCustomTypesList(), ",")
+		if err := os.WriteFile(sentinelPath, []byte(legacyValue+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ResetEnsuredDirs()
+
+		if err := EnsureCustomTypes(beadsDir); err != nil {
+			t.Fatalf("EnsureCustomTypes: %v", err)
+		}
+
+		if got := strings.TrimSpace(string(mustReadFile(t, sentinelPath))); got != TypeConfigSentinelValue() {
+			t.Fatalf("types sentinel = %q, want current type config", got)
+		}
+
+		logOutput := readMockBDLog(t, logPath)
+		for _, want := range []string{"config set types.custom", "config set types.infra"} {
 			if !strings.Contains(logOutput, want) {
 				t.Fatalf("mock bd log %q missing %q", logOutput, want)
 			}
@@ -369,10 +407,9 @@ func TestEnsureCustomTypes(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Create sentinel with current types to avoid bd call
-		currentTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
+		// Create sentinel with current type config to avoid bd call.
 		sentinelPath := filepath.Join(beadsDir, typesSentinel)
-		if err := os.WriteFile(sentinelPath, []byte(currentTypes+"\n"), 0644); err != nil {
+		if err := os.WriteFile(sentinelPath, []byte(TypeConfigSentinelValue()+"\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -390,6 +427,37 @@ func TestEnsureCustomTypes(t *testing.T) {
 			t.Errorf("expected cache hit, got: %v", err)
 		}
 	})
+}
+
+func TestEnsureCustomTypesConfigYAML(t *testing.T) {
+	ResetEnsuredDirs()
+
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureCustomTypesConfigYAML(beadsDir); err != nil {
+		t.Fatalf("EnsureCustomTypesConfigYAML: %v", err)
+	}
+
+	config := string(mustReadFile(t, filepath.Join(beadsDir, "config.yaml")))
+	for _, want := range []string{
+		"types.custom: " + strings.Join(constants.BeadsCustomTypesList(), ","),
+		"types.infra: " + strings.Join(constants.BeadsInfraTypesList(), ","),
+	} {
+		if !strings.Contains(config, want) {
+			t.Fatalf("config.yaml missing %q in:\n%s", want, config)
+		}
+	}
+	if strings.Contains(config, "types.infra: agent,role,rig,message") {
+		t.Fatalf("config.yaml kept rig in infra types:\n%s", config)
+	}
+
+	sentinel := strings.TrimSpace(string(mustReadFile(t, filepath.Join(beadsDir, typesSentinel))))
+	if sentinel != TypeConfigSentinelValue() {
+		t.Fatalf("types sentinel = %q, want %q", sentinel, TypeConfigSentinelValue())
+	}
 }
 
 func TestEnsureCustomTypes_VerifyPersistence(t *testing.T) {

--- a/internal/beads/beads_types_test.go
+++ b/internal/beads/beads_types_test.go
@@ -454,9 +454,8 @@ func TestEnsureCustomTypesConfigYAML(t *testing.T) {
 		t.Fatalf("config.yaml kept rig in infra types:\n%s", config)
 	}
 
-	sentinel := strings.TrimSpace(string(mustReadFile(t, filepath.Join(beadsDir, typesSentinel))))
-	if sentinel != TypeConfigSentinelValue() {
-		t.Fatalf("types sentinel = %q, want %q", sentinel, TypeConfigSentinelValue())
+	if _, err := os.Stat(filepath.Join(beadsDir, typesSentinel)); !os.IsNotExist(err) {
+		t.Fatalf("YAML-only type config must not write DB-verified sentinel, stat err: %v", err)
 	}
 }
 

--- a/internal/beads/beads_types_test.go
+++ b/internal/beads/beads_types_test.go
@@ -459,6 +459,36 @@ func TestEnsureCustomTypesConfigYAML(t *testing.T) {
 	}
 }
 
+func TestEnsureCustomTypesConfigYAMLIgnoresDBCache(t *testing.T) {
+	ResetEnsuredDirs()
+
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	ensuredMu.Lock()
+	ensuredDirs[beadsDir] = true
+	ensuredMu.Unlock()
+	t.Cleanup(ResetEnsuredDirs)
+
+	if err := EnsureCustomTypesConfigYAML(beadsDir); err != nil {
+		t.Fatalf("EnsureCustomTypesConfigYAML: %v", err)
+	}
+
+	config := string(mustReadFile(t, filepath.Join(beadsDir, "config.yaml")))
+	for _, want := range []string{
+		"types.custom: " + strings.Join(constants.BeadsCustomTypesList(), ","),
+		"types.infra: " + strings.Join(constants.BeadsInfraTypesList(), ","),
+	} {
+		if !strings.Contains(config, want) {
+			t.Fatalf("config.yaml missing %q in:\n%s", want, config)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(beadsDir, typesSentinel)); !os.IsNotExist(err) {
+		t.Fatalf("YAML-only type config must not write DB-verified sentinel, stat err: %v", err)
+	}
+}
+
 func TestEnsureCustomTypes_VerifyPersistence(t *testing.T) {
 	t.Run("sentinel not written when db verify fails", func(t *testing.T) {
 		if runtime.GOOS == "windows" {

--- a/internal/cmd/convoy_bd_routing_test.go
+++ b/internal/cmd/convoy_bd_routing_test.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 func captureConvoyStdoutErr(t *testing.T, fn func() error) (string, error) {
@@ -228,8 +230,7 @@ func TestConvoyCreate_UsesTrackingHelper(t *testing.T) {
 	// Write sentinel files to skip EnsureCustomTypes/Statuses (they call bd
 	// config set/get which isn't relevant to routing).
 	beadsDir := filepath.Join(townRoot, ".beads")
-	typesList := "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request"
-	_ = os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(typesList), 0644)
+	_ = os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(beads.TypeConfigSentinelValue()), 0644)
 	_ = os.WriteFile(filepath.Join(beadsDir, ".gt-statuses-configured"), []byte("staged_ready,staged_warnings"), 0644)
 
 	var helperTownRoot, helperConvoyID, helperIssueID string

--- a/internal/cmd/convoy_resolve_beadsdir_test.go
+++ b/internal/cmd/convoy_resolve_beadsdir_test.go
@@ -87,9 +87,8 @@ func TestConvoyResolveBeadsDir_RegressionEmptyConvoy(t *testing.T) {
 		}
 
 		// Put sentinel ONLY in .beads (the correct location).
-		currentTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
 		correctSentinel := filepath.Join(beadsDir, ".gt-types-configured")
-		if err := os.WriteFile(correctSentinel, []byte(currentTypes+"\n"), 0644); err != nil {
+		if err := os.WriteFile(correctSentinel, []byte(beads.TypeConfigSentinelValue()+"\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -131,8 +130,7 @@ func TestConvoyResolveBeadsDir_RegressionEmptyConvoy(t *testing.T) {
 		}
 
 		// Pre-populate sentinel in .beads so we don't need a real bd.
-		currentTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
-		if err := os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(currentTypes+"\n"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(beads.TypeConfigSentinelValue()+"\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -271,8 +269,7 @@ func TestConvoyCreate_SentinelPlacement(t *testing.T) {
 	}
 
 	// Pre-populate sentinels to avoid needing a real bd binary.
-	currentTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
-	if err := os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(currentTypes+"\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(beads.TypeConfigSentinelValue()+"\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	currentStatuses := strings.Join(constants.BeadsCustomStatusesList(), ",")

--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/constants"
 )
 
@@ -383,8 +384,7 @@ func (d *testDAG) Setup(t *testing.T) (townRoot, logPath string) {
 	}
 
 	// Write sentinel files so beads.EnsureCustomTypes/Statuses skip bd calls.
-	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
-	if err := os.WriteFile(filepath.Join(townRoot, ".beads", ".gt-types-configured"), []byte(typesList+"\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", ".gt-types-configured"), []byte(beads.TypeConfigSentinelValue()+"\n"), 0644); err != nil {
 		t.Fatalf("write types sentinel: %v", err)
 	}
 	statusesList := strings.Join(constants.BeadsCustomStatusesList(), ",")

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -172,18 +172,23 @@ func registerCustomTypes(workDir string) error {
 		return nil // no beads DB yet, skip silently
 	}
 
-	// Try to set custom types
-	cmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
-	cmd.Dir = workDir
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		// Check for common expected errors
-		outStr := string(output)
-		if strings.Contains(outStr, "not initialized") ||
-			strings.Contains(outStr, "no such file") {
-			return nil // DB not initialized, skip silently
+	// Try to set Gas Town type config.
+	for _, cfg := range []struct{ key, value string }{
+		{"types.custom", constants.BeadsCustomTypes},
+		{"types.infra", constants.BeadsInfraTypes},
+	} {
+		cmd := exec.Command("bd", "config", "set", cfg.key, cfg.value)
+		cmd.Dir = workDir
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			// Check for common expected errors
+			outStr := string(output)
+			if strings.Contains(outStr, "not initialized") ||
+				strings.Contains(outStr, "no such file") {
+				return nil // DB not initialized, skip silently
+			}
+			return fmt.Errorf("%s", strings.TrimSpace(outStr))
 		}
-		return fmt.Errorf("%s", strings.TrimSpace(outStr))
 	}
 	return nil
 }

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -807,16 +807,21 @@ func withBeadsDirEnv(beadsDir string) []string {
 	return beads.BuildMutationPinnedBDEnv(base, beadsDir)
 }
 
-// ensureCustomTypes registers Gas Town custom issue types with beads.
+// ensureCustomTypes registers Gas Town issue type configuration with beads.
 // Beads core only supports built-in types (bug, feature, task, etc.).
-// Gas Town needs custom types: agent, role, rig, convoy, slot.
+// Gas Town needs custom types and keeps rig out of infra/wisp storage.
 // This is idempotent - safe to call multiple times.
 func ensureCustomTypes(beadsPath string) error {
-	cmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
-	cmd.Dir = beadsPath
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("bd config set types.custom: %s", strings.TrimSpace(string(output)))
+	for _, cfg := range []struct{ key, value string }{
+		{"types.custom", constants.BeadsCustomTypes},
+		{"types.infra", constants.BeadsInfraTypes},
+	} {
+		cmd := exec.Command("bd", "config", "set", cfg.key, cfg.value)
+		cmd.Dir = beadsPath
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("bd config set %s: %s", cfg.key, strings.TrimSpace(string(output)))
+		}
 	}
 	return nil
 }
@@ -903,11 +908,16 @@ func ensureBeadsCustomTypes(workDir string, types []string) error {
 		return nil
 	}
 
-	cmd := exec.Command("bd", "config", "set", "types.custom", strings.Join(types, ","))
-	cmd.Dir = workDir
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("bd config set types.custom failed: %s", strings.TrimSpace(string(output)))
+	for _, cfg := range []struct{ key, value string }{
+		{"types.custom", strings.Join(types, ",")},
+		{"types.infra", constants.BeadsInfraTypes},
+	} {
+		cmd := exec.Command("bd", "config", "set", cfg.key, cfg.value)
+		cmd.Dir = workDir
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("bd config set %s failed: %s", cfg.key, strings.TrimSpace(string(output)))
+		}
 	}
 	return nil
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -183,11 +183,21 @@ const (
 	//   gate          - Async coordination (bd gate wait, park/resume)
 	//   merge-request - Refinery MR processing (gt done, refinery)
 	BeadsCustomTypes = "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request"
+
+	// BeadsInfraTypes is the comma-separated list of issue types that beads should
+	// store as ephemeral wisps. Rig identity beads intentionally stay custom but
+	// not infra so their durable state survives wisp cleanup.
+	BeadsInfraTypes = "agent,role,message"
 )
 
 // BeadsCustomTypesList returns the custom types as a slice.
 func BeadsCustomTypesList() []string {
 	return []string{"agent", "role", "rig", "convoy", "slot", "queue", "event", "message", "molecule", "gate", "merge-request"}
+}
+
+// BeadsInfraTypesList returns the infra types as a slice.
+func BeadsInfraTypesList() []string {
+	return []string{"agent", "role", "message"}
 }
 
 // Beads custom status configuration constants.
@@ -441,4 +451,3 @@ var DefaultNearLimitPatterns = []string{
 	`almost\s+(at|hit|reached)\s+(your\s+)?(rate\s+)?limit`,       // "almost reached your rate limit"
 	`\d+\s*(messages?|requests?)\s*(left|remaining)`,               // "10 messages remaining"
 }
-

--- a/internal/constants/constants_test.go
+++ b/internal/constants/constants_test.go
@@ -42,6 +42,23 @@ func TestBeadsCustomTypesList(t *testing.T) {
 	}
 }
 
+func TestBeadsInfraTypesList(t *testing.T) {
+	types := BeadsInfraTypesList()
+	expected := []string{"agent", "role", "message"}
+
+	if len(types) != len(expected) {
+		t.Fatalf("BeadsInfraTypesList() returned %d items, want %d", len(types), len(expected))
+	}
+	for i, typ := range types {
+		if typ != expected[i] {
+			t.Errorf("BeadsInfraTypesList()[%d] = %q, want %q", i, typ, expected[i])
+		}
+		if typ == "rig" {
+			t.Fatal("rig must stay durable and must not be an infra type")
+		}
+	}
+}
+
 func TestMayorRigsPath(t *testing.T) {
 	got := MayorRigsPath("/town")
 	expect := "/town/mayor/rigs.json"

--- a/internal/doctor/config_check.go
+++ b/internal/doctor/config_check.go
@@ -683,10 +683,35 @@ func (c *CustomTypesCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 
 	if len(missing) == 0 {
+		infraCmd := exec.Command("bd", "config", "get", "types.infra")
+		infraCmd.Dir = beadsDir
+		infraCmd.Env = doctorConfigEnv(beadsDir)
+		infraOutput, infraErr := infraCmd.Output()
+		configuredInfra := parseConfigOutput(infraOutput)
+		if infraErr != nil || configuredInfra != constants.BeadsInfraTypes {
+			c.targetBeadsDir = beadsDir
+			details := []string{
+				fmt.Sprintf("Configured infra types: %s", configuredInfra),
+				fmt.Sprintf("Required infra types: %s", constants.BeadsInfraTypes),
+			}
+			for _, typ := range strings.Split(configuredInfra, ",") {
+				if strings.TrimSpace(typ) == "rig" {
+					details = append(details, "rig must not be an infra type; rig identity beads are durable")
+					break
+				}
+			}
+			return &CheckResult{
+				Name:    c.Name(),
+				Status:  StatusWarning,
+				Message: "Infra types not configured for durable rig identity beads",
+				Details: details,
+				FixHint: "Run 'gt doctor --fix' to register infra types",
+			}
+		}
 		return &CheckResult{
 			Name:    c.Name(),
 			Status:  StatusOK,
-			Message: "All custom types registered",
+			Message: "All custom and infra types registered",
 		}
 	}
 
@@ -746,6 +771,13 @@ func (c *CustomTypesCheck) Fix(ctx *CheckContext) error {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("bd config set types.custom: %s", strings.TrimSpace(string(output)))
+	}
+	infraCmd := exec.Command("bd", "config", "set", "types.infra", constants.BeadsInfraTypes)
+	infraCmd.Dir = c.targetBeadsDir
+	infraCmd.Env = doctorConfigEnv(c.targetBeadsDir)
+	infraOutput, err := infraCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("bd config set types.infra: %s", strings.TrimSpace(string(infraOutput)))
 	}
 	return nil
 }

--- a/internal/doctor/config_check_test.go
+++ b/internal/doctor/config_check_test.go
@@ -34,9 +34,19 @@ case "$1:$2:$3" in
       exit 1
     fi
     ;;
-  config:set:types.custom)
-    printf '%s\n' "$4" > "$target/types.custom"
-    ;;
+	  config:set:types.custom)
+	    printf '%s\n' "$4" > "$target/types.custom"
+	    ;;
+	  config:get:types.infra)
+	    if [ -f "$target/types.infra" ]; then
+	      cat "$target/types.infra"
+	    else
+	      exit 1
+	    fi
+	    ;;
+	  config:set:types.infra)
+	    printf '%s\n' "$4" > "$target/types.infra"
+	    ;;
   config:get:status.custom)
     if [ -f "$target/status.custom" ]; then
       cat "$target/status.custom"
@@ -611,6 +621,9 @@ func TestCustomTypesCheck_UsesRigScopedBeadsDir(t *testing.T) {
 	if got := readConfigCheckFile(t, townBeadsDir, "types.custom"); got != constants.BeadsCustomTypes {
 		t.Fatalf("town types.custom changed unexpectedly: %q", got)
 	}
+	if got := readConfigCheckFile(t, rigBeadsDir, "types.infra"); got != constants.BeadsInfraTypes {
+		t.Fatalf("rig types.infra = %q, want %q", got, constants.BeadsInfraTypes)
+	}
 
 	result = check.Run(ctx)
 	if result.Status != StatusOK {
@@ -650,6 +663,66 @@ func TestCustomTypesCheck_FixPreservesExistingRigTypes(t *testing.T) {
 	}
 	if len(wantSet) != 0 {
 		t.Fatalf("rig types.custom missing expected entries after fix: %v (got %q)", wantSet, strings.Join(got, ","))
+	}
+	if got := readConfigCheckFile(t, rigBeadsDir, "types.infra"); got != constants.BeadsInfraTypes {
+		t.Fatalf("rig types.infra = %q, want %q", got, constants.BeadsInfraTypes)
+	}
+}
+
+func TestCustomTypesCheck_FixesStaleInfraTypes(t *testing.T) {
+	townRoot := t.TempDir()
+	rigDir := filepath.Join(townRoot, "gastown")
+	rigBeadsDir := filepath.Join(rigDir, ".beads")
+
+	writeConfigCheckFile(t, rigBeadsDir, "types.custom", constants.BeadsCustomTypes)
+	writeConfigCheckFile(t, rigBeadsDir, "types.infra", "agent,role,rig,message")
+	installFakeBdForConfigChecks(t, townRoot)
+
+	check := NewCustomTypesCheck()
+	ctx := &CheckContext{TownRoot: townRoot, RigName: "gastown"}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v (%v)", result.Status, result.Details)
+	}
+	if !strings.Contains(strings.Join(result.Details, "\n"), "rig must not be an infra type") {
+		t.Fatalf("expected rig infra warning, got %v", result.Details)
+	}
+
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+	if got := readConfigCheckFile(t, rigBeadsDir, "types.infra"); got != constants.BeadsInfraTypes {
+		t.Fatalf("rig types.infra = %q, want %q", got, constants.BeadsInfraTypes)
+	}
+
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Fatalf("expected StatusOK after fix, got %v (%v)", result.Status, result.Details)
+	}
+}
+
+func TestCustomTypesCheck_FixesMissingInfraTypes(t *testing.T) {
+	townRoot := t.TempDir()
+	rigDir := filepath.Join(townRoot, "gastown")
+	rigBeadsDir := filepath.Join(rigDir, ".beads")
+
+	writeConfigCheckFile(t, rigBeadsDir, "types.custom", constants.BeadsCustomTypes)
+	installFakeBdForConfigChecks(t, townRoot)
+
+	check := NewCustomTypesCheck()
+	ctx := &CheckContext{TownRoot: townRoot, RigName: "gastown"}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v (%v)", result.Status, result.Details)
+	}
+
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+	if got := readConfigCheckFile(t, rigBeadsDir, "types.infra"); got != constants.BeadsInfraTypes {
+		t.Fatalf("rig types.infra = %q, want %q", got, constants.BeadsInfraTypes)
 	}
 }
 

--- a/internal/doctor/rig_check.go
+++ b/internal/doctor/rig_check.go
@@ -1077,11 +1077,17 @@ func (c *BeadsRedirectCheck) Fix(ctx *CheckContext) error {
 			// Continue - minimal config created
 		} else {
 			_ = output // bd init succeeded
-			// Configure custom types for Gas Town (beads v0.46.0+)
-			configCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
-			configCmd.Dir = rigPath
-			configCmd.Env = bdEnv
-			_, _ = configCmd.CombinedOutput() // Ignore errors - older beads don't need this
+			// Configure Gas Town bead types (beads v0.46.0+). Rig remains durable,
+			// not infra/wisp-backed.
+			for _, cfg := range []struct{ key, value string }{
+				{"types.custom", constants.BeadsCustomTypes},
+				{"types.infra", constants.BeadsInfraTypes},
+			} {
+				configCmd := exec.Command("bd", "config", "set", cfg.key, cfg.value)
+				configCmd.Dir = rigPath
+				configCmd.Env = bdEnv
+				_, _ = configCmd.CombinedOutput() // Ignore errors - older beads don't need this
+			}
 		}
 		if err := doltserver.EnsureMetadataForBeadsDir(ctx.TownRoot, rigBeadsDir, ctx.RigName, ctx.RigName); err != nil {
 			return fmt.Errorf("ensuring metadata.json: %w", err)

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -51,6 +51,7 @@ import (
 	"github.com/steveyegge/gastown/internal/atomicfile"
 	"github.com/steveyegge/gastown/internal/beads"
 	configpkg "github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/style"
 )
 
@@ -2672,6 +2673,12 @@ func EnsureRigIssuePrefix(townRoot, rigName string, serverMode bool) error {
 	}
 	if err := beads.EnsureConfigYAML(beadsDir, prefix); err != nil {
 		return fmt.Errorf("ensuring config.yaml: %w", err)
+	}
+	if err := beads.EnsureConfigYAMLValue(beadsDir, "types.custom", constants.BeadsCustomTypes); err != nil {
+		return fmt.Errorf("ensuring types.custom in config.yaml: %w", err)
+	}
+	if err := beads.EnsureConfigYAMLValue(beadsDir, "types.infra", constants.BeadsInfraTypes); err != nil {
+		return fmt.Errorf("ensuring types.infra in config.yaml: %w", err)
 	}
 	if err := EnsureMetadataForBeadsDir(townRoot, beadsDir, rigName, rigName); err != nil {
 		return fmt.Errorf("ensuring metadata.json: %w", err)

--- a/internal/mail/mailbox_test.go
+++ b/internal/mail/mailbox_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 func TestNewMailbox(t *testing.T) {
@@ -445,7 +445,7 @@ func TestMailboxListFromDirConvergesWispQueryAndFiltersStatuses(t *testing.T) {
 	}
 
 	beadsDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(strings.Join(constants.BeadsCustomTypesList(), ",")+"\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(beads.TypeConfigSentinelValue()+"\n"), 0644); err != nil {
 		t.Fatalf("write types sentinel: %v", err)
 	}
 

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -385,8 +385,7 @@ func TestSendFromCrewWorkspace_AvoidsEphemeralPrefixMismatch(t *testing.T) {
 	}
 
 	// Write sentinel files so beads.EnsureCustomTypes skips bd config calls.
-	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
-	if err := os.WriteFile(filepath.Join(townBeadsDir, ".gt-types-configured"), []byte(typesList+"\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(townBeadsDir, ".gt-types-configured"), []byte(beads.TypeConfigSentinelValue()+"\n"), 0644); err != nil {
 		t.Fatalf("write types sentinel: %v", err)
 	}
 
@@ -1230,9 +1229,12 @@ func TestValidateRecipient(t *testing.T) {
 	beadsDB := filepath.Join(beadsDir, "beads.db")
 	t.Setenv("BEADS_DB", beadsDB)
 
-	// Register custom types required for agent beads.
-	if _, err := b.Run("config", "set", "types.custom", "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request"); err != nil {
+	// Register type config required for agent beads.
+	if _, err := b.Run("config", "set", "types.custom", constants.BeadsCustomTypes); err != nil {
 		t.Fatalf("config set types.custom: %v", err)
+	}
+	if _, err := b.Run("config", "set", "types.infra", constants.BeadsInfraTypes); err != nil {
+		t.Fatalf("config set types.infra: %v", err)
 	}
 
 	// Create test agent beads with gt:agent label.

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1257,8 +1257,8 @@ func TestAddWithOptions_NoPrimeMDCreatedLocally(t *testing.T) {
 		}
 	} else {
 		installMockBd(t)
-		// Write the custom-types sentinel so EnsureCustomTypes is a no-op.
-		_ = os.WriteFile(filepath.Join(mayorBeads, ".gt-types-configured"), []byte("v1\n"), 0644)
+		// Write the type-config sentinel so EnsureCustomTypes is a no-op.
+		_ = os.WriteFile(filepath.Join(mayorBeads, ".gt-types-configured"), []byte(beads.TypeConfigSentinelValue()+"\n"), 0644)
 	}
 
 	// Initialize git repo in mayor/rig WITHOUT any .beads/PRIME.md
@@ -1607,8 +1607,8 @@ func TestAddWithOptions_NoFilesAddedToRepo(t *testing.T) {
 		}
 	} else {
 		installMockBd(t)
-		// Write the custom-types sentinel so EnsureCustomTypes is a no-op.
-		_ = os.WriteFile(filepath.Join(mayorBeads, ".gt-types-configured"), []byte("v1\n"), 0644)
+		// Write the type-config sentinel so EnsureCustomTypes is a no-op.
+		_ = os.WriteFile(filepath.Join(mayorBeads, ".gt-types-configured"), []byte(beads.TypeConfigSentinelValue()+"\n"), 0644)
 	}
 
 	// Initialize a CLEAN git repo with known files only
@@ -1753,8 +1753,8 @@ func TestAddWithOptions_SettingsInstalledInPolecatsDir(t *testing.T) {
 		}
 	} else {
 		installMockBd(t)
-		// Write the custom-types sentinel so EnsureCustomTypes is a no-op.
-		_ = os.WriteFile(filepath.Join(mayorBeads, ".gt-types-configured"), []byte("v1\n"), 0644)
+		// Write the type-config sentinel so EnsureCustomTypes is a no-op.
+		_ = os.WriteFile(filepath.Join(mayorBeads, ".gt-types-configured"), []byte(beads.TypeConfigSentinelValue()+"\n"), 0644)
 	}
 
 	// Initialize a git repo
@@ -2155,8 +2155,8 @@ esac
 	if err := os.WriteFile(filepath.Join(rigBeads, "redirect"), []byte("mayor/rig/.beads\n"), 0644); err != nil {
 		t.Fatalf("write redirect: %v", err)
 	}
-	// Write custom-types sentinel so EnsureCustomTypes is a no-op
-	_ = os.WriteFile(filepath.Join(mayorBeads, ".gt-types-configured"), []byte("v1\n"), 0644)
+	// Write type-config sentinel so EnsureCustomTypes is a no-op
+	_ = os.WriteFile(filepath.Join(mayorBeads, ".gt-types-configured"), []byte(beads.TypeConfigSentinelValue()+"\n"), 0644)
 
 	r := &rig.Rig{
 		Name: "rig",
@@ -2240,7 +2240,7 @@ func TestManagerAgentLifecycleUsesTownBeadsDir(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("write routes: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(townBeadsDir, ".gt-types-configured"), []byte("v1\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(townBeadsDir, ".gt-types-configured"), []byte(beads.TypeConfigSentinelValue()+"\n"), 0644); err != nil {
 		t.Fatalf("write types sentinel: %v", err)
 	}
 

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -707,11 +707,13 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 				fmt.Printf("  Warning: Could not set issue-prefix in config.yaml: %v\n", err)
 			}
 			_ = beads.EnsureConfigYAMLValue(resolvedBeadsDir, "types.custom", constants.BeadsCustomTypes)
+			_ = beads.EnsureConfigYAMLValue(resolvedBeadsDir, "types.infra", constants.BeadsInfraTypes)
 		}
 		if err := beads.EnsureDoltConfigValue(resolvedBeadsDir, "issue_prefix", opts.BeadsPrefix); err != nil {
 			fmt.Printf("  Warning: Could not set issue_prefix in rig database: %v\n", err)
 		}
 		_ = beads.EnsureDoltConfigValue(resolvedBeadsDir, "types.custom", constants.BeadsCustomTypes)
+		_ = beads.EnsureDoltConfigValue(resolvedBeadsDir, "types.infra", constants.BeadsInfraTypes)
 	}
 
 	// Auto-create DoltHub remote for the rig's beads database.
@@ -1185,13 +1187,18 @@ func (m *Manager) InitBeads(rigPath, prefix, rigName string) error {
 	} else {
 		// bd init succeeded - configure the Dolt database
 
-		// Configure custom types for Gas Town (agent, role, rig, convoy).
-		// These were extracted from beads core in v0.46.0 and now require explicit config.
-		configCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
-		configCmd.Dir = rigPath
-		configCmd.Env = filteredEnv
-		// Ignore errors - older beads versions don't need this
-		_, _ = configCmd.CombinedOutput()
+		// Configure Gas Town bead types. Rig remains a custom durable type, not an
+		// infra/wisp type.
+		for _, cfg := range []struct{ key, value string }{
+			{"types.custom", constants.BeadsCustomTypes},
+			{"types.infra", constants.BeadsInfraTypes},
+		} {
+			configCmd := exec.Command("bd", "config", "set", cfg.key, cfg.value)
+			configCmd.Dir = rigPath
+			configCmd.Env = filteredEnv
+			// Ignore errors - older beads versions don't need this
+			_, _ = configCmd.CombinedOutput()
+		}
 
 		// Explicitly set issue_prefix config (bd init --prefix may not persist it in newer versions).
 		// Without this, bd create and gt sling fail with "issue_prefix config is missing".


### PR DESCRIPTION
Cleanup-first current-main replacement for PR #4251.

Summary:
- Keep rig identity beads as durable type=rig records with gt:rig.
- Exclude rig from types.infra so rig identity beads are not hidden as infrastructure work.
- Separate YAML type seeding from DB sentinel/cache state so config-only paths do not skip needed type setup.
- Update direct rig init/config setup paths and focused tests.

Attribution:
- Original PR: https://github.com/gastownhall/gastown/pull/4251
- Original contributor: silvanshade / quartz
- Original commit: c24a4b412af0a72f152c82bdf0944e6bd6d82324
- Replacement commits include Co-authored-by: quartz <silvanshade@users.noreply.github.com>

Verification from worker:
- gt-pr-sheriff-check --evidence /tmp/opencode/pr-sheriff-gt-0i00-evidence.json: PASS, merge_path_allowed=false, verdict=defer_human_review
- CGO_ENABLED=0 go test ./internal/constants
- CGO_ENABLED=0 go test ./internal/beads
- CGO_ENABLED=0 go test ./internal/doltserver targeted
- Focused internal/mail, internal/doctor TestCustomTypesCheck, and internal/cmd convoy tests

No refinery/MQ. Original PR #4251 remains open until this replacement lands with merge evidence.