### PR TITLE
fix(deacon): start nudge-poller for deacon lifecycle

### DIFF
--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -16,6 +16,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/deacon"
+	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
@@ -580,8 +581,25 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 	deaconTownRoot, _ := workspace.FindFromCwdOrError()
 	runtimeCfg := config.ResolveRoleAgentConfig("deacon", deaconTownRoot, "")
 	_ = runtime.RunStartupFallback(t, sessionName, "deacon", runtimeCfg)
+	startDeaconNudgePoller(townRoot, sessionName)
 
 	return nil
+}
+
+func startDeaconNudgePoller(townRoot, sessionName string) {
+	if _, pollerErr := nudge.StartPoller(townRoot, sessionName); pollerErr != nil {
+		style.PrintWarning("could not start nudge poller for %s: %v", sessionName, pollerErr)
+	}
+}
+
+func stopDeaconNudgePoller(sessionName string) {
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return
+	}
+	if pollerErr := nudge.StopPoller(townRoot, sessionName); pollerErr != nil {
+		style.PrintWarning("could not stop nudge poller for %s: %v", sessionName, pollerErr)
+	}
 }
 
 func runDeaconStop(cmd *cobra.Command, args []string) error {
@@ -599,6 +617,7 @@ func runDeaconStop(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Stopping Deacon session...")
+	stopDeaconNudgePoller(sessionName)
 
 	// Try graceful shutdown first (best-effort interrupt)
 	_ = t.SendKeysRaw(sessionName, "C-c")
@@ -786,6 +805,8 @@ func runDeaconRestart(cmd *cobra.Command, args []string) error {
 	fmt.Println("Restarting Deacon...")
 
 	if running {
+		stopDeaconNudgePoller(sessionName)
+
 		// Kill existing session.
 		// Use KillSessionWithProcesses to ensure all descendant processes are killed.
 		if err := t.KillSessionWithProcesses(sessionName); err != nil {

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
@@ -42,15 +43,19 @@ type tmuxOps interface {
 
 // Manager handles deacon lifecycle operations.
 type Manager struct {
-	townRoot string
-	tmux     tmuxOps
+	townRoot    string
+	tmux        tmuxOps
+	startPoller func(townRoot, session string) (int, error)
+	stopPoller  func(townRoot, session string) error
 }
 
 // NewManager creates a new deacon manager for a town.
 func NewManager(townRoot string) *Manager {
 	return &Manager{
-		townRoot: townRoot,
-		tmux:     tmux.NewTmux(),
+		townRoot:    townRoot,
+		tmux:        tmux.NewTmux(),
+		startPoller: nudge.StartPoller,
+		stopPoller:  nudge.StopPoller,
 	}
 }
 
@@ -70,6 +75,24 @@ func (m *Manager) deaconDir() string {
 	return filepath.Join(m.townRoot, "deacon")
 }
 
+func (m *Manager) startNudgePoller(sessionID string) {
+	if m.startPoller == nil {
+		return
+	}
+	if _, pollerErr := m.startPoller(m.townRoot, sessionID); pollerErr != nil {
+		fmt.Printf("warning: could not start nudge poller for %s: %v\n", sessionID, pollerErr)
+	}
+}
+
+func (m *Manager) stopNudgePoller(sessionID string) {
+	if m.stopPoller == nil {
+		return
+	}
+	if pollerErr := m.stopPoller(m.townRoot, sessionID); pollerErr != nil {
+		fmt.Printf("warning: could not stop nudge poller for %s: %v\n", sessionID, pollerErr)
+	}
+}
+
 // Start starts the deacon session.
 // agentOverride allows specifying an alternate agent alias (e.g., for testing).
 // Restarts are handled by daemon via ensureDeaconRunning on each heartbeat.
@@ -82,6 +105,7 @@ func (m *Manager) Start(agentOverride string) error {
 	if running {
 		// Session exists - check if agent is actually running (healthy vs zombie)
 		if t.IsAgentAlive(sessionID) {
+			m.startNudgePoller(sessionID)
 			return ErrAlreadyRunning
 		}
 
@@ -89,6 +113,7 @@ func (m *Manager) Start(agentOverride string) error {
 		// The auto-respawn hook (SetAutoRespawnHook) handles clean exits at the
 		// tmux level — Go doesn't need to distinguish dead pane vs zombie shell.
 		// Use KillSessionWithProcesses to ensure all descendant processes are killed.
+		m.stopNudgePoller(sessionID)
 		if err := t.KillSessionWithProcesses(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)
 		}
@@ -178,6 +203,7 @@ func (m *Manager) Start(agentOverride string) error {
 
 	// Accept startup dialogs (workspace trust + bypass permissions) if they appear.
 	_ = t.AcceptStartupDialogs(sessionID)
+	m.startNudgePoller(sessionID)
 
 	time.Sleep(constants.ShutdownNotifyDelay)
 
@@ -197,6 +223,8 @@ func (m *Manager) Stop() error {
 	if !running {
 		return ErrNotRunning
 	}
+
+	m.stopNudgePoller(sessionID)
 
 	// Try graceful shutdown first (best-effort interrupt)
 	_ = t.SendKeysRaw(sessionID, "C-c")

--- a/internal/deacon/manager_test.go
+++ b/internal/deacon/manager_test.go
@@ -119,6 +119,34 @@ func TestStart_AlreadyRunning(t *testing.T) {
 	}
 }
 
+func TestStart_AlreadyRunningRepairsNudgePoller(t *testing.T) {
+	mock := &mockTmux{
+		hasSessionResult: true,
+		agentAlive:       true,
+	}
+	m := newTestManager(t.TempDir(), mock)
+
+	var calls int
+	m.startPoller = func(townRoot, session string) (int, error) {
+		calls++
+		if townRoot != m.townRoot {
+			t.Fatalf("townRoot = %q, want %q", townRoot, m.townRoot)
+		}
+		if session != m.SessionName() {
+			t.Fatalf("session = %q, want %q", session, m.SessionName())
+		}
+		return 123, nil
+	}
+
+	err := m.Start("")
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("Start() error = %v, want ErrAlreadyRunning", err)
+	}
+	if calls != 1 {
+		t.Errorf("startPoller calls = %d, want 1", calls)
+	}
+}
+
 func TestStart_ZombieDetected_KillFails(t *testing.T) {
 	killErr := errors.New("kill failed: session locked")
 	mock := &mockTmux{
@@ -176,6 +204,33 @@ func TestStart_NoExistingSession(t *testing.T) {
 	// Should NOT have tried to kill anything
 	if len(mock.killCalls) != 0 {
 		t.Errorf("expected 0 kill calls, got %d", len(mock.killCalls))
+	}
+}
+
+func TestStart_SuccessStartsNudgePoller(t *testing.T) {
+	mock := &mockTmux{
+		hasSessionResult: false,
+	}
+	m := newTestManager(t.TempDir(), mock)
+
+	var calls int
+	m.startPoller = func(townRoot, session string) (int, error) {
+		calls++
+		if townRoot != m.townRoot {
+			t.Fatalf("townRoot = %q, want %q", townRoot, m.townRoot)
+		}
+		if session != m.SessionName() {
+			t.Fatalf("session = %q, want %q", session, m.SessionName())
+		}
+		return 123, nil
+	}
+
+	err := m.Start("claude")
+	if err != nil {
+		t.Fatalf("Start() error = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Errorf("startPoller calls = %d, want 1", calls)
 	}
 }
 
@@ -293,6 +348,32 @@ func TestStop_Success(t *testing.T) {
 	}
 	if len(mock.killCalls) != 1 {
 		t.Errorf("expected 1 kill call, got %d", len(mock.killCalls))
+	}
+}
+
+func TestStop_StopsNudgePoller(t *testing.T) {
+	mock := &mockTmux{
+		hasSessionResult: true,
+	}
+	m := newTestManager(t.TempDir(), mock)
+
+	var calls int
+	m.stopPoller = func(townRoot, session string) error {
+		calls++
+		if townRoot != m.townRoot {
+			t.Fatalf("townRoot = %q, want %q", townRoot, m.townRoot)
+		}
+		if session != m.SessionName() {
+			t.Fatalf("session = %q, want %q", session, m.SessionName())
+		}
+		return nil
+	}
+
+	if err := m.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Errorf("stopPoller calls = %d, want 1", calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

Clean current-main replacement for #4099. This wires the Deacon into the existing nudge-poller lifecycle so queued nudges drain after the patrol-role `UserPromptSubmit` drain was disabled.

Changes:
- Starts or repairs the existing `nudge.StartPoller` from `internal/deacon.Manager` for new and already-running healthy Deacon sessions.
- Stops the existing poller before Deacon zombie replacement and explicit manager stop.
- Mirrors start/stop poller lifecycle in the legacy `gt deacon start` / `stop` / `restart` CLI path.
- Adds focused `internal/deacon` tests for manager poller repair/start/stop calls.

No `gt mail check --inject` resurrection, no new transport, no daemon/scheduler changes, and no content from the contaminated `polecat/chrome/gt-7n93@mrb25p9r` branch.

## Attribution

Supersedes original PR: https://github.com/gastownhall/gastown/pull/4099

Original PR author: @KayoticSully (Ryan Sullivan)

Original scoped fix commit: `363c47a213b1353df00be5bf5f44058ef28d5e88`

Replacement commit includes co-author trailers for Ryan Sullivan and Claude Opus 4.7.

## PR Sheriff Evidence

- Research legs: 15/15 complete
- Pre-implementation reviews: 5/5 approving amended plan
- Post-implementation reviews: 5/5 approving final head `1d01b315c505d0ec05d66d391403d38950f069f5`
- Cleanup-first: acceptable minimal, reuses existing `internal/nudge` lifecycle seams
- Superseded closure: keep #4099 open until this replacement lands, then close #4099 as superseded

## Verification

- `CGO_ENABLED=0 go test ./internal/deacon ./internal/nudge`
- `CGO_ENABLED=0 go test ./internal/cmd -run TestDeaconStatusJSON -count=1`
- `CGO_ENABLED=0 go test ./internal/cmd -run '^$'`
- `CGO_ENABLED=0 go build ./...`

A full `CGO_ENABLED=0 go test ./internal/cmd ./internal/deacon ./internal/nudge` package run exceeded the 120s local timeout after the focused package checks had passed.
