### PR TITLE
Fix dependency relation type decoding

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -296,11 +296,58 @@ type IssueDep struct {
 	CloseReason    string `json:"close_reason,omitempty"`
 }
 
+// UnmarshalJSON accepts both bd dependency relation field names. Some lower-level
+// dependency output uses "type" for the relation, while issue details also have
+// an issue_type field that must remain distinct.
+func (d *IssueDep) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		ID             string `json:"id"`
+		Title          string `json:"title"`
+		Status         string `json:"status"`
+		Priority       int    `json:"priority"`
+		Type           string `json:"issue_type"`
+		DependencyType string `json:"dependency_type,omitempty"`
+		RelationType   string `json:"type"`
+		CloseReason    string `json:"close_reason,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	d.ID = raw.ID
+	d.Title = raw.Title
+	d.Status = raw.Status
+	d.Priority = raw.Priority
+	d.Type = raw.Type
+	d.DependencyType = raw.DependencyType
+	d.CloseReason = raw.CloseReason
+	if strings.TrimSpace(d.DependencyType) == "" {
+		d.DependencyType = knownDependencyRelation(raw.RelationType)
+	}
+	return nil
+}
+
 var blockingDependencyTypes = map[string]bool{
 	"blocks":             true,
 	"conditional-blocks": true,
 	"waits-for":          true,
 	"merge-blocks":       true,
+}
+
+var nonblockingDependencyTypes = map[string]bool{
+	"tracks":          true,
+	"parent-child":    true,
+	"related":         true,
+	"discovered-from": true,
+	"thread":          true,
+}
+
+func knownDependencyRelation(depType string) string {
+	depType = strings.ToLower(strings.TrimSpace(depType))
+	if blockingDependencyTypes[depType] || nonblockingDependencyTypes[depType] {
+		return depType
+	}
+	return ""
 }
 
 // HasUnresolvedBlockers reports whether an issue has any unresolved blocking

--- a/internal/beads/beads_mr_test.go
+++ b/internal/beads/beads_mr_test.go
@@ -1,6 +1,7 @@
 package beads
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -148,6 +149,127 @@ func TestUnresolvedBlockingDependencyIDs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIssueDepUnmarshalRelationTypeFallbackFeedsBlockerSemantics(t *testing.T) {
+	issue := unmarshalIssueForTest(t, `{
+		"id":"gt-target",
+		"status":"open",
+		"issue_type":"task",
+		"dependencies":[
+			{"id":"gt-blocks","status":"open","issue_type":"task","type":"blocks"},
+			{"id":"gt-conditional","status":"open","issue_type":"task","type":"conditional-blocks"},
+			{"id":"gt-waits","status":"open","issue_type":"task","type":"waits-for"},
+			{"id":"gt-merge","status":"open","issue_type":"task","type":"merge-blocks"},
+			{"id":"gt-task","status":"open","issue_type":"task","type":"task"}
+		]
+	}`)
+
+	got, _ := unresolvedBlockingDependencyIDs(issue)
+	want := []string{"gt-blocks", "gt-conditional", "gt-waits", "gt-merge"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("unresolvedBlockingDependencyIDs() = %#v, want %#v", got, want)
+	}
+	if dep := issue.Dependencies[4]; dep.DependencyType != "" {
+		t.Fatalf("unknown fallback type populated DependencyType = %q, want empty", dep.DependencyType)
+	}
+}
+
+func TestIssueDepUnmarshalDependencyTypeTakesPrecedenceOverType(t *testing.T) {
+	issue := unmarshalIssueForTest(t, `{
+		"id":"gt-target",
+		"status":"open",
+		"issue_type":"task",
+		"dependencies":[
+			{"id":"gt-canonical-blocks","status":"open","issue_type":"task","dependency_type":"blocks","type":"tracks"},
+			{"id":"gt-canonical-tracks","status":"open","issue_type":"task","dependency_type":"tracks","type":"blocks"}
+		]
+	}`)
+
+	if got := issue.Dependencies[0].DependencyType; got != "blocks" {
+		t.Fatalf("DependencyType with canonical blocks = %q, want blocks", got)
+	}
+	if got := issue.Dependencies[1].DependencyType; got != "tracks" {
+		t.Fatalf("DependencyType with canonical tracks = %q, want tracks", got)
+	}
+	if got := HasUnresolvedBlockers(issue); !got {
+		t.Fatal("canonical blocks dependency should still block")
+	}
+	if got := FirstUnresolvedBlockerID(issue); got != "gt-canonical-blocks" {
+		t.Fatalf("FirstUnresolvedBlockerID() = %q, want gt-canonical-blocks", got)
+	}
+}
+
+func TestIssueDepUnmarshalPreservesIssueTypeSeparatelyFromRelationType(t *testing.T) {
+	issue := unmarshalIssueForTest(t, `{
+		"id":"gt-target",
+		"status":"open",
+		"issue_type":"task",
+		"dependencies":[
+			{"id":"gt-blocker","status":"open","issue_type":"bug","type":"blocks"}
+		]
+	}`)
+
+	dep := issue.Dependencies[0]
+	if dep.Type != "bug" {
+		t.Fatalf("IssueDep.Type = %q, want issue_type bug", dep.Type)
+	}
+	if dep.DependencyType != "blocks" {
+		t.Fatalf("IssueDep.DependencyType = %q, want blocks", dep.DependencyType)
+	}
+}
+
+func TestIssueDepUnmarshalPreservesNonblockingRelationTypes(t *testing.T) {
+	issue := unmarshalIssueForTest(t, `{
+		"id":"gt-target",
+		"status":"open",
+		"issue_type":"task",
+		"dependencies":[
+			{"id":"gt-track","status":"open","issue_type":"task","type":"tracks"},
+			{"id":"gt-parent","status":"open","issue_type":"task","type":"parent-child"},
+			{"id":"gt-related","status":"open","issue_type":"task","type":"related"},
+			{"id":"gt-discovered","status":"open","issue_type":"task","type":"discovered-from"},
+			{"id":"gt-thread","status":"open","issue_type":"task","type":"thread"}
+		]
+	}`)
+
+	wantTypes := []string{"tracks", "parent-child", "related", "discovered-from", "thread"}
+	for i, want := range wantTypes {
+		if got := issue.Dependencies[i].DependencyType; got != want {
+			t.Fatalf("Dependencies[%d].DependencyType = %q, want %q", i, got, want)
+		}
+	}
+	if HasUnresolvedBlockers(issue) {
+		t.Fatalf("nonblocking fallback relations should not block: %#v", issue.Dependencies)
+	}
+}
+
+func TestIssueDepUnmarshalMergeBlocksRequireMergedCloseReason(t *testing.T) {
+	issue := unmarshalIssueForTest(t, `{
+		"id":"gt-target",
+		"status":"open",
+		"issue_type":"task",
+		"dependencies":[
+			{"id":"gt-open","status":"open","issue_type":"task","type":"merge-blocks"},
+			{"id":"gt-closed","status":"closed","issue_type":"task","type":"merge-blocks"},
+			{"id":"gt-merged","status":"closed","issue_type":"task","type":"merge-blocks","close_reason":"Merged in abc123"}
+		]
+	}`)
+
+	got, _ := unresolvedBlockingDependencyIDs(issue)
+	want := []string{"gt-open", "gt-closed"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("unresolvedBlockingDependencyIDs() = %#v, want %#v", got, want)
+	}
+}
+
+func unmarshalIssueForTest(t *testing.T, data string) *Issue {
+	t.Helper()
+	var issue Issue
+	if err := json.Unmarshal([]byte(data), &issue); err != nil {
+		t.Fatalf("json.Unmarshal(Issue): %v", err)
+	}
+	return &issue
 }
 
 func TestHasUnresolvedBlockersFallsBackToListFields(t *testing.T) {


### PR DESCRIPTION
Clean replacement for #4189 from current upstream/main. This PR carries forward the accepted bug intent without reusing the preserved contaminated branch.

Summary:
- Decode dependency relation `type` as a fallback for `dependency_type` in the shared `internal/beads.IssueDep` JSON boundary.
- Keep `dependency_type` authoritative when present.
- Preserve `issue_type` separately from dependency relation `type`.
- Preserve known nonblocking relation values while keeping blocker semantics centralized.
- Cover fallback blocking, precedence, nonblocking relation preservation, issue type separation, and `merge-blocks` close-reason behavior with focused tests.

Verification:
- `CGO_ENABLED=0 go test ./internal/beads -run 'TestIssueDepUnmarshal|TestUnresolvedBlockingDependencyIDs|TestHasUnresolvedBlockersFallsBackToListFields|TestListMergeRequestsHydratesWispMRBlockers' -count=1`\n- `CGO_ENABLED=0 go test ./internal/beads -count=1`\n- `CGO_ENABLED=0 go test ./internal/cmd -run 'TestIssueDetailsIsBlocked|TestFindStrandedConvoys_StuckConvoy|TestGetTrackedIssues_FallsBackToShowTrackedDependencies' -count=1`\n- `CGO_ENABLED=0 go test ./internal/refinery -run 'TestEngineerFirstOpenBlockerUsesDependencySemantics' -count=1`\n- `git diff --check`\n\nPR Sheriff evidence:\n- 15/15 independent research legs complete.\n- 5/5 pre-implementation reviews approved the exact plan.\n- 5/5 post-implementation reviews approved final head `6c7eab4ee3a8148d6d5d440912fb040b0821b111`.\n- Final checker evidence will be attached after PR creation so it can reference this PR URL.\n\nAttribution:\n- Replacement for #4189 by @fengning-starsend.\n- Original PR head/commit: `c3fe0623401558b68a4d2f55814ddee68a5d9d10`.\n- Original commit author: Antigravity Agent <antigravity@google.com> (@shimonenator).\n- Preserved reference head reviewed but not reused: `8d04064819e8eaf06ba6ca2420497d27a7eec6bc`.\n\nOriginal PR #4189 should remain open until this replacement lands.