### PR TITLE
Fix redirected .beads identity cleanup

### DIFF
--- a/internal/beads/beads_redirect.go
+++ b/internal/beads/beads_redirect.go
@@ -2,9 +2,11 @@
 package beads
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -108,12 +110,26 @@ func resolveBeadsDirWithDepth(beadsDir string, maxDepth int) string {
 	return resolveBeadsDirWithDepth(resolved, maxDepth-1)
 }
 
-// cleanBeadsRuntimeFiles removes gitignored runtime files from a .beads directory
-// while preserving tracked files (formulas/, README.md, config.yaml, .gitignore).
+// cleanBeadsRuntimeFiles removes redirect-local runtime and identity files from a
+// .beads directory while preserving tracked docs/formula surfaces (formulas/,
+// README.md, .gitignore). Identity files next to a redirect can make bd bind to
+// the wrong database, so tracked identity files are hidden before removal.
 // This is safe to call even if the directory doesn't exist.
 func cleanBeadsRuntimeFiles(beadsDir string) error {
-	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
+	info, err := os.Lstat(beadsDir)
+	if os.IsNotExist(err) {
 		return nil // Nothing to clean
+	} else if err != nil {
+		return err
+	} else if !info.IsDir() {
+		return nil
+	}
+
+	worktreePath := filepath.Dir(beadsDir)
+	for _, name := range []string{"metadata.json", "config.yaml"} {
+		if err := removeWorktreeIdentityFile(worktreePath, filepath.Join(beadsDir, name)); err != nil {
+			return err
+		}
 	}
 
 	// Runtime files/patterns that are gitignored and safe to remove
@@ -147,6 +163,63 @@ func cleanBeadsRuntimeFiles(beadsDir string) error {
 	}
 
 	return firstErr
+}
+
+func removeWorktreeIdentityFile(worktreePath, path string) error {
+	if _, err := os.Lstat(path); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("checking %s: %w", path, err)
+	}
+
+	rel, err := filepath.Rel(worktreePath, path)
+	if err != nil {
+		return fmt.Errorf("computing git path for %s: %w", path, err)
+	}
+	if rel == "." || rel == "" || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("refusing to clean identity file outside worktree: %s", path)
+	}
+	rel = filepath.ToSlash(rel)
+
+	tracked, err := gitPathTracked(worktreePath, rel)
+	if err != nil {
+		return err
+	}
+	if tracked {
+		if err := markGitPathSkipWorktree(worktreePath, rel); err != nil {
+			return err
+		}
+	}
+
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing %s: %w", path, err)
+	}
+	return nil
+}
+
+func gitPathTracked(worktreePath, relPath string) (bool, error) {
+	cmd := exec.Command("git", "-C", worktreePath, "ls-files", "--stage", "--", relPath) //nolint:gosec // argv is fixed; relPath is passed after --.
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("git ls-files %s: %w%s", relPath, err, gitOutputSuffix(out))
+	}
+	return len(bytes.TrimSpace(out)) > 0, nil
+}
+
+func markGitPathSkipWorktree(worktreePath, relPath string) error {
+	cmd := exec.Command("git", "-C", worktreePath, "update-index", "--skip-worktree", "--", relPath) //nolint:gosec // argv is fixed; relPath is passed after --.
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git update-index --skip-worktree %s: %w%s", relPath, err, gitOutputSuffix(out))
+	}
+	return nil
+}
+
+func gitOutputSuffix(out []byte) string {
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return ""
+	}
+	return ": " + trimmed
 }
 
 // ComputeRedirectTarget computes the expected redirect target for a worktree.
@@ -349,13 +422,13 @@ func SetupRedirect(townRoot, worktreePath string) error {
 		}
 	}
 
-	// Clean up runtime files in .beads/ but preserve tracked files (formulas/, README.md, etc.)
+	// Clean up runtime/identity files in .beads/ but preserve tracked docs (formulas/, README.md, etc.)
 	worktreeBeadsDir := filepath.Join(worktreePath, ".beads")
 
-	// Handle edge case: if .beads exists as a file (not directory), remove it.
+	// Handle edge cases: if .beads exists as a file or symlink, remove that path.
 	// This can happen with stale state from previous failed operations or
 	// unusual clone state. MkdirAll would fail with "file exists" in this case.
-	if info, err := os.Stat(worktreeBeadsDir); err == nil && !info.IsDir() {
+	if info, err := os.Lstat(worktreeBeadsDir); err == nil && !info.IsDir() {
 		if err := os.Remove(worktreeBeadsDir); err != nil {
 			return fmt.Errorf("removing stale .beads file: %w", err)
 		}

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -3447,6 +3447,35 @@ func TestDelegationTerms(t *testing.T) {
 
 // TestSetupRedirect tests the beads redirect setup for worktrees.
 func TestSetupRedirect(t *testing.T) {
+	runGit := func(t *testing.T, dir string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		return string(out)
+	}
+	initGitRepo := func(t *testing.T, dir string) {
+		t.Helper()
+		runGit(t, dir, "init")
+		runGit(t, dir, "config", "user.email", "test@example.com")
+		runGit(t, dir, "config", "user.name", "Test User")
+	}
+	installFakeGit := func(t *testing.T, body string) {
+		t.Helper()
+		if runtime.GOOS == "windows" {
+			t.Skip("fake git shell script test is POSIX-only")
+		}
+		binDir := t.TempDir()
+		gitPath := filepath.Join(binDir, "git")
+		if err := os.WriteFile(gitPath, []byte(body), 0755); err != nil {
+			t.Fatalf("write fake git: %v", err)
+		}
+		t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	}
+
 	t.Run("rig with own DB redirects to rig-level beads", func(t *testing.T) {
 		// When rig has its own dolt_database in metadata.json, crew must
 		// redirect to rig-level .beads (not town-level) to see correct prefix.
@@ -3725,7 +3754,7 @@ func TestSetupRedirect(t *testing.T) {
 		}
 	})
 
-	t.Run("cleans runtime files but preserves config files", func(t *testing.T) {
+	t.Run("cleans runtime files and redirect identity files", func(t *testing.T) {
 		townRoot := t.TempDir()
 		rigRoot := filepath.Join(townRoot, "testrig")
 		rigBeads := filepath.Join(rigRoot, ".beads")
@@ -3739,18 +3768,19 @@ func TestSetupRedirect(t *testing.T) {
 		if err := os.MkdirAll(crewBeads, 0755); err != nil {
 			t.Fatalf("mkdir crew beads: %v", err)
 		}
+		initGitRepo(t, crewPath)
 		// Runtime files (should be removed)
 		if err := os.WriteFile(filepath.Join(crewBeads, "daemon.lock"), []byte("1234"), 0644); err != nil {
 			t.Fatalf("write daemon.lock: %v", err)
 		}
-		// Local beads metadata is per-machine configuration and must survive startup.
+		// Redirect-local identity files should be removed so bd follows the redirect.
 		if err := os.WriteFile(filepath.Join(crewBeads, "metadata.json"), []byte("{}"), 0644); err != nil {
 			t.Fatalf("write metadata.json: %v", err)
 		}
-		// Config files (should be preserved)
 		if err := os.WriteFile(filepath.Join(crewBeads, "config.yaml"), []byte("prefix: test"), 0644); err != nil {
 			t.Fatalf("write config: %v", err)
 		}
+		// Non-identity docs/config surfaces are preserved.
 		if err := os.WriteFile(filepath.Join(crewBeads, "README.md"), []byte("# Beads"), 0644); err != nil {
 			t.Fatalf("write README: %v", err)
 		}
@@ -3763,13 +3793,11 @@ func TestSetupRedirect(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(crewBeads, "daemon.lock")); !os.IsNotExist(err) {
 			t.Error("daemon.lock should have been removed")
 		}
-		if _, err := os.Stat(filepath.Join(crewBeads, "metadata.json")); err != nil {
-			t.Errorf("metadata.json should have been preserved: %v", err)
+		if _, err := os.Stat(filepath.Join(crewBeads, "metadata.json")); !os.IsNotExist(err) {
+			t.Errorf("metadata.json should have been removed, stat err=%v", err)
 		}
-
-		// Verify config files were preserved
-		if _, err := os.Stat(filepath.Join(crewBeads, "config.yaml")); err != nil {
-			t.Errorf("config.yaml should have been preserved: %v", err)
+		if _, err := os.Stat(filepath.Join(crewBeads, "config.yaml")); !os.IsNotExist(err) {
+			t.Errorf("config.yaml should have been removed, stat err=%v", err)
 		}
 		if _, err := os.Stat(filepath.Join(crewBeads, "README.md")); err != nil {
 			t.Errorf("README.md should have been preserved: %v", err)
@@ -3779,6 +3807,123 @@ func TestSetupRedirect(t *testing.T) {
 		redirectPath := filepath.Join(crewBeads, "redirect")
 		if _, err := os.Stat(redirectPath); err != nil {
 			t.Errorf("redirect file should exist: %v", err)
+		}
+	})
+
+	t.Run("tracked identity cleanup keeps git status clean", func(t *testing.T) {
+		townRoot := t.TempDir()
+		rigRoot := filepath.Join(townRoot, "testrig")
+		rigBeads := filepath.Join(rigRoot, ".beads")
+		crewPath := filepath.Join(rigRoot, "crew", "max")
+		crewBeads := filepath.Join(crewPath, ".beads")
+
+		if err := os.MkdirAll(rigBeads, 0755); err != nil {
+			t.Fatalf("mkdir rig beads: %v", err)
+		}
+		if err := os.MkdirAll(crewBeads, 0755); err != nil {
+			t.Fatalf("mkdir crew beads: %v", err)
+		}
+		initGitRepo(t, crewPath)
+
+		for _, file := range []string{"metadata.json", "config.yaml"} {
+			if err := os.WriteFile(filepath.Join(crewBeads, file), []byte("identity"), 0644); err != nil {
+				t.Fatalf("write %s: %v", file, err)
+			}
+		}
+		runGit(t, crewPath, "add", ".beads/metadata.json", ".beads/config.yaml")
+		runGit(t, crewPath, "commit", "-m", "track identity files")
+
+		if err := SetupRedirect(townRoot, crewPath); err != nil {
+			t.Fatalf("SetupRedirect failed: %v", err)
+		}
+
+		for _, file := range []string{"metadata.json", "config.yaml"} {
+			if _, err := os.Stat(filepath.Join(crewBeads, file)); !os.IsNotExist(err) {
+				t.Fatalf("%s should have been removed, stat err=%v", file, err)
+			}
+		}
+		if status := runGit(t, crewPath, "status", "--porcelain", "--", ".beads/metadata.json", ".beads/config.yaml"); status != "" {
+			t.Fatalf("tracked identity cleanup dirtied git status:\n%s", status)
+		}
+		flags := runGit(t, crewPath, "ls-files", "-v", "--", ".beads/metadata.json", ".beads/config.yaml")
+		for _, file := range []string{".beads/metadata.json", ".beads/config.yaml"} {
+			if !strings.Contains(flags, "S "+file) {
+				t.Fatalf("%s should be skip-worktree; flags:\n%s", file, flags)
+			}
+		}
+	})
+
+	t.Run("fails closed when git ls-files fails", func(t *testing.T) {
+		installFakeGit(t, `#!/bin/sh
+if [ "$3" = "ls-files" ]; then
+  echo "fatal: broken index" >&2
+  exit 128
+fi
+echo "unexpected git invocation: $*" >&2
+exit 2
+`)
+		townRoot := t.TempDir()
+		rigRoot := filepath.Join(townRoot, "testrig")
+		rigBeads := filepath.Join(rigRoot, ".beads")
+		crewPath := filepath.Join(rigRoot, "crew", "max")
+		crewBeads := filepath.Join(crewPath, ".beads")
+
+		if err := os.MkdirAll(rigBeads, 0755); err != nil {
+			t.Fatalf("mkdir rig beads: %v", err)
+		}
+		if err := os.MkdirAll(crewBeads, 0755); err != nil {
+			t.Fatalf("mkdir crew beads: %v", err)
+		}
+		metadataPath := filepath.Join(crewBeads, "metadata.json")
+		if err := os.WriteFile(metadataPath, []byte("identity"), 0644); err != nil {
+			t.Fatalf("write metadata: %v", err)
+		}
+
+		err := SetupRedirect(townRoot, crewPath)
+		if err == nil || !strings.Contains(err.Error(), "git ls-files") {
+			t.Fatalf("SetupRedirect should fail on ls-files error, got %v", err)
+		}
+		if _, statErr := os.Stat(metadataPath); statErr != nil {
+			t.Fatalf("metadata.json should remain after ls-files failure: %v", statErr)
+		}
+	})
+
+	t.Run("fails closed when git update-index fails", func(t *testing.T) {
+		installFakeGit(t, `#!/bin/sh
+if [ "$3" = "ls-files" ]; then
+  printf '100644 abcdef 0\t%s\n' "$6"
+  exit 0
+fi
+if [ "$3" = "update-index" ]; then
+  echo "update-index failed" >&2
+  exit 2
+fi
+echo "unexpected git invocation: $*" >&2
+exit 2
+`)
+		townRoot := t.TempDir()
+		rigRoot := filepath.Join(townRoot, "testrig")
+		rigBeads := filepath.Join(rigRoot, ".beads")
+		crewPath := filepath.Join(rigRoot, "crew", "max")
+		crewBeads := filepath.Join(crewPath, ".beads")
+
+		if err := os.MkdirAll(rigBeads, 0755); err != nil {
+			t.Fatalf("mkdir rig beads: %v", err)
+		}
+		if err := os.MkdirAll(crewBeads, 0755); err != nil {
+			t.Fatalf("mkdir crew beads: %v", err)
+		}
+		metadataPath := filepath.Join(crewBeads, "metadata.json")
+		if err := os.WriteFile(metadataPath, []byte("identity"), 0644); err != nil {
+			t.Fatalf("write metadata: %v", err)
+		}
+
+		err := SetupRedirect(townRoot, crewPath)
+		if err == nil || !strings.Contains(err.Error(), "git update-index") {
+			t.Fatalf("SetupRedirect should fail on update-index error, got %v", err)
+		}
+		if _, statErr := os.Stat(metadataPath); statErr != nil {
+			t.Fatalf("metadata.json should remain after update-index failure: %v", statErr)
 		}
 	})
 
@@ -4030,6 +4175,53 @@ func TestSetupRedirect(t *testing.T) {
 		want := "../../.beads\n"
 		if string(content) != want {
 			t.Errorf("redirect content = %q, want %q", string(content), want)
+		}
+	})
+
+	t.Run("replaces symlinked worktree beads without mutating target", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink test is POSIX-only")
+		}
+		townRoot := t.TempDir()
+		rigRoot := filepath.Join(townRoot, "testrig")
+		rigBeads := filepath.Join(rigRoot, ".beads")
+		crewPath := filepath.Join(rigRoot, "crew", "max")
+		crewBeads := filepath.Join(crewPath, ".beads")
+
+		if err := os.MkdirAll(rigBeads, 0755); err != nil {
+			t.Fatalf("mkdir rig beads: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(rigBeads, "metadata.json"), []byte("canonical metadata"), 0644); err != nil {
+			t.Fatalf("write target metadata: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(rigBeads, "config.yaml"), []byte("canonical config"), 0644); err != nil {
+			t.Fatalf("write target config: %v", err)
+		}
+		if err := os.MkdirAll(crewPath, 0755); err != nil {
+			t.Fatalf("mkdir crew: %v", err)
+		}
+		if err := os.Symlink(rigBeads, crewBeads); err != nil {
+			t.Fatalf("symlink crew beads: %v", err)
+		}
+
+		if err := SetupRedirect(townRoot, crewPath); err != nil {
+			t.Fatalf("SetupRedirect failed: %v", err)
+		}
+		info, err := os.Lstat(crewBeads)
+		if err != nil {
+			t.Fatalf("lstat crew beads: %v", err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Fatal("crew .beads should have been replaced with a directory, still symlink")
+		}
+		if !info.IsDir() {
+			t.Fatal("crew .beads should be a directory")
+		}
+		if got, err := os.ReadFile(filepath.Join(rigBeads, "metadata.json")); err != nil || string(got) != "canonical metadata" {
+			t.Fatalf("target metadata changed: got %q err=%v", got, err)
+		}
+		if got, err := os.ReadFile(filepath.Join(rigBeads, "config.yaml")); err != nil || string(got) != "canonical config" {
+			t.Fatalf("target config changed: got %q err=%v", got, err)
 		}
 	})
 }

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -1282,12 +1282,30 @@ func ensureBeadsRedirect(ctx RoleContext) {
 		if _, statErr := os.Stat(redirectPath); statErr == nil {
 			return
 		}
-	} else if data, readErr := os.ReadFile(redirectPath); readErr == nil && strings.TrimSpace(string(data)) == expected {
+	} else if data, readErr := os.ReadFile(redirectPath); readErr == nil && strings.TrimSpace(string(data)) == expected && !worktreeBeadsNeedsCleanup(ctx.WorkDir) {
 		return
 	}
 
 	// Use shared helper - silently ignore errors during prime
 	_ = beads.SetupRedirect(ctx.TownRoot, ctx.WorkDir)
+}
+
+func worktreeBeadsNeedsCleanup(workDir string) bool {
+	beadsDir := filepath.Join(workDir, ".beads")
+	if info, err := os.Lstat(beadsDir); err == nil {
+		if !info.IsDir() {
+			return true
+		}
+	} else {
+		return false
+	}
+
+	for _, name := range []string{"metadata.json", "config.yaml"} {
+		if _, err := os.Lstat(filepath.Join(beadsDir, name)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // injectWorkContext extracts the current work context (rig, bead, molecule) from the

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -1168,6 +1168,72 @@ func TestEnsureBeadsRedirect_RepairsExistingRedirectChain(t *testing.T) {
 	}
 }
 
+func TestEnsureBeadsRedirect_CleansIdentityFilesWhenRedirectAlreadyCorrect(t *testing.T) {
+	runGit := func(t *testing.T, dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	townRoot := t.TempDir()
+	rigRoot := filepath.Join(townRoot, "testrig")
+	rigBeadsDir := filepath.Join(rigRoot, ".beads")
+	mayorBeadsDir := filepath.Join(rigRoot, "mayor", "rig", ".beads")
+	workDir := filepath.Join(rigRoot, "polecats", "worker1", "gastown")
+	workBeadsDir := filepath.Join(workDir, ".beads")
+
+	if err := os.MkdirAll(mayorBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor beads dir: %v", err)
+	}
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir rig beads dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "redirect"), []byte("mayor/rig/.beads\n"), 0644); err != nil {
+		t.Fatalf("write rig redirect: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "metadata.json"), []byte(`{"dolt_database":"hq","backend":"dolt"}`), 0644); err != nil {
+		t.Fatalf("write rig metadata: %v", err)
+	}
+	if err := os.MkdirAll(workBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir work beads dir: %v", err)
+	}
+	runGit(t, workDir, "init")
+
+	redirectPath := filepath.Join(workBeadsDir, "redirect")
+	if err := os.WriteFile(redirectPath, []byte("../../../mayor/rig/.beads\n"), 0644); err != nil {
+		t.Fatalf("write redirect: %v", err)
+	}
+	for _, file := range []string{"metadata.json", "config.yaml"} {
+		if err := os.WriteFile(filepath.Join(workBeadsDir, file), []byte("stale identity"), 0644); err != nil {
+			t.Fatalf("write %s: %v", file, err)
+		}
+	}
+
+	ctx := RoleContext{
+		Role:     RolePolecat,
+		WorkDir:  workDir,
+		TownRoot: townRoot,
+	}
+
+	ensureBeadsRedirect(ctx)
+
+	content, err := os.ReadFile(redirectPath)
+	if err != nil {
+		t.Fatalf("read redirect: %v", err)
+	}
+	if got, want := string(content), "../../../mayor/rig/.beads\n"; got != want {
+		t.Fatalf("redirect content = %q, want %q", got, want)
+	}
+	for _, file := range []string{"metadata.json", "config.yaml"} {
+		if _, err := os.Stat(filepath.Join(workBeadsDir, file)); !os.IsNotExist(err) {
+			t.Fatalf("%s should have been cleaned, stat err=%v", file, err)
+		}
+	}
+}
+
 func TestOutputRalphLoopDirective_PluginInstalled(t *testing.T) {
 	attachment := &beads.AttachmentFields{
 		Mode:            "ralph",


### PR DESCRIPTION
Clean replacement for #4320 based on current `gastownhall/gastown:main`.

Supersedes #4320 and carries forward only its accepted bugfix intent: make redirected worktree `.beads` directories remove stale identity files so `bd` follows `.beads/redirect` instead of binding to local `metadata.json` or `config.yaml`.

Scope:
- Updates `SetupRedirect` cleanup to remove redirect-local `.beads/metadata.json` and `.beads/config.yaml`.
- Marks tracked identity files `skip-worktree` before deletion so worktrees stay clean.
- Fails closed on real `git ls-files` / `git update-index` errors.
- Uses `Lstat` so symlinked worktree `.beads` paths are replaced without mutating targets.
- Updates `gt prime` redirect repair so a correct redirect still triggers cleanup when stale identity files remain.

Out of scope:
- No doctor, routing, convoy, refinery/MQ, or broad tracked `.beads/backup` cleanup.
- No reuse of the rejected contaminated branch `polecat/brahmin/gt-y2g3@mrb3iukc`.

Verification:
- `git diff --check upstream/main...HEAD`
- `CGO_ENABLED=0 go test ./internal/beads ./internal/cmd -run 'TestSetupRedirect|TestEnsureBeadsRedirect'`
- `CGO_ENABLED=0 go test ./internal/beads ./internal/cmd -run 'Test.*Redirect|Test.*Prime|Test.*Beads'`

PR Sheriff:
- 15 independent research legs completed.
- 5 approving pre-implementation reviews completed before code changes.
- 5 approving post-implementation reviews completed for final head `5abcc425201f6d91f996cc2e36eda61cce132d37`.
- `gt-pr-sheriff-check --evidence /tmp/opencode/gt-1zei-pr-4320/evidence.json --merge-gate` passed: `merge_path_allowed=true`, `verdict=merge_replacement`, `gates: 12 pass, 2 not_applicable, 0 waived, 0 fail`.

Provenance:
- #4320 implementation commit: `72300e0` by `guzzle <thalia.geraghty@fiserv.com>`, with co-author trailers for Chris Sauer and Claude Opus 4.7.
- Original PR: #4130 by Chris Sauer.
- This replacement preserves contributor credit in commit trailers.
- Do not close #4320 or #4130 as superseded until this replacement lands.

Full PR Sheriff evidence JSON is posted as a follow-up PR comment.
