### PR TITLE
fix(formula): converge formula root resolution

### DIFF
--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -56,9 +56,9 @@ Commands:
   create  Create a new formula template
 
 Search paths (in order):
-  1. .beads/formulas/ (project)
-  2. ~/.beads/formulas/ (user)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator)
+  1. Route-resolved rig .beads/formulas/
+  2. Town .beads/formulas/
+  3. Embedded formulas
 
 Examples:
   gt formula list                    # List all formulas
@@ -73,9 +73,9 @@ var formulaListCmd = &cobra.Command{
 	Long: `List available formulas from all search paths.
 
 Searches for formula files (.formula.toml, .formula.json) in:
-  1. .beads/formulas/ (project)
-  2. ~/.beads/formulas/ (user)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator)
+  1. Route-resolved rig .beads/formulas/
+  2. Town .beads/formulas/
+  3. Embedded formulas
 
 Examples:
   gt formula list            # List all formulas
@@ -218,39 +218,38 @@ func runFormulaShow(cmd *cobra.Command, args []string) error {
 // For convoy-type formulas, it creates a convoy bead, creates leg beads,
 // and slings each leg to a separate polecat with leg-specific prompts.
 func runFormulaRun(cmd *cobra.Command, args []string) error {
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("finding town root: %w", err)
+	}
+
 	// Determine target rig first (needed for default formula lookup)
 	targetRig := formulaRunRig
 	var rigPath string
 	if targetRig == "" {
 		// Try to detect from current directory
-		townRoot, err := workspace.FindFromCwd()
-		if err == nil && townRoot != "" {
-			rigName, r, rigErr := findCurrentRig(townRoot)
-			if rigErr == nil && rigName != "" {
-				targetRig = rigName
-				if r != nil {
-					rigPath = r.Path
-				}
+		rigName, r, rigErr := findCurrentRig(townRoot)
+		if rigErr == nil && rigName != "" {
+			targetRig = rigName
+			if r != nil {
+				rigPath = r.Path
 			}
-			// Still no rig — auto-select when there is exactly one registered rig,
-			// otherwise surface a helpful error (e.g. Deacon at HQ level on
-			// non-default installs where "gastown" rig does not exist).
-			if targetRig == "" {
-				name, path, inferErr := autoInferRig(townRoot)
-				if inferErr != nil {
-					return inferErr
-				}
-				targetRig = name
-				rigPath = path
+		}
+		// Still no rig — auto-select when there is exactly one registered rig,
+		// otherwise surface a helpful error (e.g. Deacon at HQ level on
+		// non-default installs where "gastown" rig does not exist).
+		if targetRig == "" {
+			name, path, inferErr := autoInferRig(townRoot)
+			if inferErr != nil {
+				return inferErr
 			}
-		} else {
-			// No town root found, cannot determine target rig
-			return fmt.Errorf("cannot determine target rig: not in a Gas Town workspace; use --rig=NAME")
+			targetRig = name
+			rigPath = path
 		}
 	} else {
-		// If rig specified, construct path
-		townRoot, err := workspace.FindFromCwd()
-		if err == nil && townRoot != "" {
+		// If rig specified, use its route-resolved path for default config lookup.
+		rigPath = beads.GetRigDirForName(townRoot, targetRig)
+		if rigPath == "" {
 			rigPath = filepath.Join(townRoot, targetRig)
 		}
 	}
@@ -270,16 +269,10 @@ func runFormulaRun(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s Using default formula: %s\n", style.Dim.Render("Note:"), formulaName)
 	}
 
-	// Find the formula file
-	formulaPath, err := findFormulaFile(formulaName)
+	// Resolve and parse the named formula through the shared tiered resolver.
+	f, err := loadNamedFormula(formulaName, townRoot, targetRig)
 	if err != nil {
-		return fmt.Errorf("finding formula: %w", err)
-	}
-
-	// Parse the formula
-	f, err := parseFormulaFile(formulaPath)
-	if err != nil {
-		return fmt.Errorf("parsing formula: %w", err)
+		return fmt.Errorf("loading formula: %w", err)
 	}
 
 	// Handle dry-run mode
@@ -303,6 +296,26 @@ func runFormulaRun(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  4. Sling to rig:   gt sling <mol-id> %s\n", targetRig)
 		return nil
 	}
+}
+
+func loadNamedFormulaFromCwd(name, rigName string) (*formula.Formula, error) {
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return nil, fmt.Errorf("finding town root: %w", err)
+	}
+	return loadNamedFormula(name, townRoot, rigName)
+}
+
+func loadNamedFormula(name, townRoot, rigName string) (*formula.Formula, error) {
+	content, err := formula.ResolveFormulaContent(name, townRoot, rigName)
+	if err != nil {
+		return nil, err
+	}
+	f, err := formula.Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("parsing formula %q: %w", name, err)
+	}
+	return f, nil
 }
 
 // dryRunFormula shows what would happen without executing
@@ -431,7 +444,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		style.Bold.Render("🚚"), formulaName)
 
 	// Get town root and resolve rig-scoped bead prefix
-	townRoot, err := workspace.FindFromCwd()
+	townRoot, err := workspace.FindFromCwdOrError()
 	if err != nil {
 		return fmt.Errorf("finding town root: %w", err)
 	}
@@ -716,7 +729,7 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 	}
 
 	// Get town beads directory
-	townRoot, err := workspace.FindFromCwd()
+	townRoot, err := workspace.FindFromCwdOrError()
 	if err != nil {
 		return fmt.Errorf("finding town root: %w", err)
 	}
@@ -1034,45 +1047,6 @@ func substituteFormulaVars(text string, vars map[string]interface{}) string {
 		}
 		return fmt.Sprint(v)
 	})
-}
-
-// findFormulaFile searches for a formula file by name
-func findFormulaFile(name string) (string, error) {
-	// Search paths in order
-	searchPaths := []string{}
-
-	// 1. Project .beads/formulas/
-	if cwd, err := os.Getwd(); err == nil {
-		searchPaths = append(searchPaths, filepath.Join(cwd, ".beads", "formulas"))
-	}
-
-	// 2. Town .beads/formulas/
-	if townRoot, err := workspace.FindFromCwd(); err == nil {
-		searchPaths = append(searchPaths, filepath.Join(townRoot, ".beads", "formulas"))
-	}
-
-	// 3. User ~/.beads/formulas/
-	if home, err := os.UserHomeDir(); err == nil {
-		searchPaths = append(searchPaths, filepath.Join(home, ".beads", "formulas"))
-	}
-
-	// Try each path with common extensions
-	extensions := []string{".formula.toml", ".formula.json"}
-	for _, basePath := range searchPaths {
-		for _, ext := range extensions {
-			path := filepath.Join(basePath, name+ext)
-			if _, err := os.Stat(path); err == nil {
-				return path, nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("formula '%s' not found in search paths", name)
-}
-
-// parseFormulaFile parses a formula file using the formula package's TOML parser.
-func parseFormulaFile(path string) (*formula.Formula, error) {
-	return formula.ParseFile(path)
 }
 
 // renderTemplate renders a Go text/template with the given context map

--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -72,7 +72,7 @@ var formulaListCmd = &cobra.Command{
 	Short: "List available formulas",
 	Long: `List available formulas from all search paths.
 
-Searches for formula files (.formula.toml, .formula.json) in:
+Searches for formulas in:
   1. Route-resolved rig .beads/formulas/
   2. Town .beads/formulas/
   3. Embedded formulas
@@ -247,11 +247,9 @@ func runFormulaRun(cmd *cobra.Command, args []string) error {
 			rigPath = path
 		}
 	} else {
-		// If rig specified, use its route-resolved path for default config lookup.
-		rigPath = beads.GetRigDirForName(townRoot, targetRig)
-		if rigPath == "" {
-			rigPath = filepath.Join(townRoot, targetRig)
-		}
+		// Rig settings live at the rig container path; formula content resolution
+		// below handles any route-resolved .beads path for the same rig name.
+		rigPath = filepath.Join(townRoot, targetRig)
 	}
 
 	// Get formula name from args or default

--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -55,10 +55,8 @@ Commands:
   run     Execute a formula (pour and dispatch)
   create  Create a new formula template
 
-Search paths (in order):
-  1. Route-resolved rig .beads/formulas/
-  2. Town .beads/formulas/
-  3. Embedded formulas
+Named formula execution resolves formulas from the target rig, then town,
+then embedded formulas. List/show are delegated to bd.
 
 Examples:
   gt formula list                    # List all formulas
@@ -72,10 +70,7 @@ var formulaListCmd = &cobra.Command{
 	Short: "List available formulas",
 	Long: `List available formulas from all search paths.
 
-Searches for formulas in:
-  1. Route-resolved rig .beads/formulas/
-  2. Town .beads/formulas/
-  3. Embedded formulas
+Delegates to bd formula list, using bd's configured formula search paths.
 
 Examples:
   gt formula list            # List all formulas

--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -247,6 +247,9 @@ func runFormulaRun(cmd *cobra.Command, args []string) error {
 			rigPath = path
 		}
 	} else {
+		if err := validateFormulaRunRigName(targetRig); err != nil {
+			return err
+		}
 		// Rig settings live at the rig container path; formula content resolution
 		// below handles any route-resolved .beads path for the same rig name.
 		rigPath = filepath.Join(townRoot, targetRig)
@@ -314,6 +317,13 @@ func loadNamedFormula(name, townRoot, rigName string) (*formula.Formula, error) 
 		return nil, fmt.Errorf("parsing formula %q: %w", name, err)
 	}
 	return f, nil
+}
+
+func validateFormulaRunRigName(rigName string) error {
+	if rigName == "" || filepath.IsAbs(rigName) || strings.Contains(rigName, "..") || strings.Contains(rigName, "/") || strings.Contains(rigName, "\\") {
+		return fmt.Errorf("invalid rig name %q", rigName)
+	}
+	return nil
 }
 
 // dryRunFormula shows what would happen without executing

--- a/internal/cmd/formula_test.go
+++ b/internal/cmd/formula_test.go
@@ -131,6 +131,17 @@ func TestAutoInferRig(t *testing.T) {
 	})
 }
 
+func TestValidateFormulaRunRigNameRejectsPathLike(t *testing.T) {
+	for _, rigName := range []string{"", "../outside", "rig/other", `rig\other`, "/tmp/rig"} {
+		if err := validateFormulaRunRigName(rigName); err == nil {
+			t.Fatalf("validateFormulaRunRigName(%q) = nil, want error", rigName)
+		}
+	}
+	if err := validateFormulaRunRigName("gastown"); err != nil {
+		t.Fatalf("validateFormulaRunRigName(gastown) error: %v", err)
+	}
+}
+
 func TestBuildConvoyLegSlingArgs_AlwaysIncludesNoConvoy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/synthesis.go
+++ b/internal/cmd/synthesis.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -123,6 +124,7 @@ type ConvoyMeta struct {
 	Status      string   `json:"status"`
 	Formula     string   `json:"formula,omitempty"`      // Formula name
 	FormulaPath string   `json:"formula_path,omitempty"` // Path to formula file
+	Rig         string   `json:"rig,omitempty"`          // Rig used for formula resolution
 	ReviewID    string   `json:"review_id,omitempty"`    // Review ID for output paths
 	LegIssues   []string `json:"leg_issues,omitempty"`   // Tracked leg issue IDs
 }
@@ -138,23 +140,12 @@ func runSynthesisStart(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("%s Checking synthesis readiness for %s...\n", style.Bold.Render("🔬"), convoyID)
+	targetRig := resolveSynthesisTargetRig()
 
 	// Load formula if specified
-	var f *formula.Formula
-	if meta.FormulaPath != "" {
-		f, err = formula.ParseFile(meta.FormulaPath)
-		if err != nil {
-			return fmt.Errorf("loading formula: %w", err)
-		}
-	} else if meta.Formula != "" {
-		// Try to find formula by name
-		formulaPath, findErr := findFormula(meta.Formula)
-		if findErr == nil {
-			f, err = formula.ParseFile(formulaPath)
-			if err != nil {
-				return fmt.Errorf("loading formula: %w", err)
-			}
-		}
+	f, err := loadSynthesisFormula(meta, targetRig)
+	if err != nil {
+		return err
 	}
 
 	// Check leg completion status
@@ -192,21 +183,6 @@ func runSynthesisStart(cmd *cobra.Command, args []string) error {
 	if reviewID == "" {
 		// Extract from convoy ID
 		reviewID = strings.TrimPrefix(convoyID, "hq-cv-")
-	}
-
-	// Determine target rig
-	targetRig := synthesisRig
-	if targetRig == "" {
-		townRoot, err := workspace.FindFromCwdOrError()
-		if err == nil {
-			rigName, _, rigErr := findCurrentRig(townRoot)
-			if rigErr == nil && rigName != "" {
-				targetRig = rigName
-			}
-		}
-		if targetRig == "" {
-			targetRig = "gastown"
-		}
 	}
 
 	if synthesisDryRun {
@@ -250,14 +226,7 @@ func runSynthesisStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	// Load formula if available
-	var f *formula.Formula
-	if meta.FormulaPath != "" {
-		f, _ = formula.ParseFile(meta.FormulaPath)
-	} else if meta.Formula != "" {
-		if path, err := findFormula(meta.Formula); err == nil {
-			f, _ = formula.ParseFile(path)
-		}
-	}
+	f, _ := loadSynthesisFormula(meta, "")
 
 	// Collect leg outputs
 	legOutputs, allComplete, err := collectLegOutputs(meta, f)
@@ -411,22 +380,7 @@ func getConvoyMeta(convoyID string) (*ConvoyMeta, error) {
 		Status: convoy.Status,
 	}
 
-	// Look for structured fields in description
-	for _, line := range strings.Split(convoy.Description, "\n") {
-		line = strings.TrimSpace(line)
-		if colonIdx := strings.Index(line, ":"); colonIdx != -1 {
-			key := strings.ToLower(strings.TrimSpace(line[:colonIdx]))
-			value := strings.TrimSpace(line[colonIdx+1:])
-			switch key {
-			case "formula":
-				meta.Formula = value
-			case "formula_path", "formula-path":
-				meta.FormulaPath = value
-			case "review_id", "review-id":
-				meta.ReviewID = value
-			}
-		}
-	}
+	parseConvoyDescriptionMeta(meta, convoy.Description)
 
 	// Get tracked leg issues
 	tracked, err := getTrackedIssues(townBeads, convoyID)
@@ -640,39 +594,63 @@ func slingSynthesis(beadID, targetRig string) error {
 	return slingCmd.Run()
 }
 
-// findFormula searches for a formula file by name.
-func findFormula(name string) (string, error) {
-	// Search paths
-	searchPaths := []string{
-		".beads/formulas",
+func resolveSynthesisTargetRig() string {
+	if synthesisRig != "" {
+		return synthesisRig
 	}
-
-	// Add home directory formulas
-	if home, err := os.UserHomeDir(); err == nil {
-		searchPaths = append(searchPaths, filepath.Join(home, ".beads", "formulas"))
-	}
-
-	// Add GT_ROOT formulas if set
-	if gtRoot := os.Getenv("GT_ROOT"); gtRoot != "" {
-		searchPaths = append(searchPaths, filepath.Join(gtRoot, ".beads", "formulas"))
-	}
-
-	// Try each search path
-	for _, searchPath := range searchPaths {
-		// Try with .formula.toml extension
-		path := filepath.Join(searchPath, name+".formula.toml")
-		if _, err := os.Stat(path); err == nil {
-			return path, nil
-		}
-
-		// Try with .formula.json extension
-		path = filepath.Join(searchPath, name+".formula.json")
-		if _, err := os.Stat(path); err == nil {
-			return path, nil
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err == nil {
+		rigName, _, rigErr := findCurrentRig(townRoot)
+		if rigErr == nil && rigName != "" {
+			return rigName
 		}
 	}
+	return "gastown"
+}
 
-	return "", fmt.Errorf("formula '%s' not found", name)
+func loadSynthesisFormula(meta *ConvoyMeta, targetRig string) (*formula.Formula, error) {
+	if meta.FormulaPath != "" {
+		f, err := formula.ParseFile(meta.FormulaPath)
+		if err != nil {
+			return nil, fmt.Errorf("loading formula: %w", err)
+		}
+		return f, nil
+	}
+	if meta.Formula == "" {
+		return nil, nil
+	}
+	rigName := meta.Rig
+	if rigName == "" {
+		rigName = targetRig
+	}
+	f, err := loadNamedFormulaFromCwd(meta.Formula, rigName)
+	if errors.Is(err, formula.ErrFormulaNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("loading formula: %w", err)
+	}
+	return f, nil
+}
+
+func parseConvoyDescriptionMeta(meta *ConvoyMeta, description string) {
+	for _, line := range strings.Split(description, "\n") {
+		line = strings.TrimSpace(line)
+		if colonIdx := strings.Index(line, ":"); colonIdx != -1 {
+			key := strings.ToLower(strings.TrimSpace(line[:colonIdx]))
+			value := strings.TrimSpace(line[colonIdx+1:])
+			switch key {
+			case "formula", "formula convoy":
+				meta.Formula = value
+			case "formula_path", "formula-path":
+				meta.FormulaPath = value
+			case "review_id", "review-id":
+				meta.ReviewID = value
+			case "rig":
+				meta.Rig = value
+			}
+		}
+	}
 }
 
 // CheckSynthesisReady checks if a convoy is ready for synthesis.
@@ -708,14 +686,7 @@ func TriggerSynthesisIfReady(convoyID, targetRig string) error {
 	}
 
 	// Load formula if available
-	var f *formula.Formula
-	if meta.FormulaPath != "" {
-		f, _ = formula.ParseFile(meta.FormulaPath)
-	} else if meta.Formula != "" {
-		if path, err := findFormula(meta.Formula); err == nil {
-			f, _ = formula.ParseFile(path)
-		}
-	}
+	f, _ := loadSynthesisFormula(meta, targetRig)
 
 	legOutputs, _, _ := collectLegOutputs(meta, f)
 	reviewID := meta.ReviewID

--- a/internal/cmd/synthesis_test.go
+++ b/internal/cmd/synthesis_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -100,4 +101,81 @@ func TestConvoyMeta(t *testing.T) {
 	if len(meta.LegIssues) != 3 {
 		t.Errorf("len(LegIssues) = %d, want 3", len(meta.LegIssues))
 	}
+}
+
+func TestLoadSynthesisFormulaUsesGTTownRootAndExistingConvoyMetadata(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test-town"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	formulasDir := filepath.Join(townRoot, ".beads", "formulas")
+	if err := os.MkdirAll(formulasDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	formulaName := "gt-town-root-only"
+	if err := os.WriteFile(filepath.Join(formulasDir, formulaName+".formula.toml"), []byte(sprintfTestFormula(formulaName, "town tier sentinel")), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GT_ROOT", "")
+	t.Setenv("GT_TOWN_ROOT", townRoot)
+
+	meta := &ConvoyMeta{}
+	parseConvoyDescriptionMeta(meta, "Formula convoy: "+formulaName+"\n\nLegs: 1\nRig: gastown")
+	if meta.Formula != formulaName {
+		t.Fatalf("Formula = %q, want %q", meta.Formula, formulaName)
+	}
+	if meta.Rig != "gastown" {
+		t.Fatalf("Rig = %q, want gastown", meta.Rig)
+	}
+
+	f, err := loadSynthesisFormula(meta, "")
+	if err != nil {
+		t.Fatalf("loadSynthesisFormula() error: %v", err)
+	}
+	if f == nil || f.Name != formulaName {
+		t.Fatalf("loaded formula = %#v, want %q", f, formulaName)
+	}
+}
+
+func TestLoadSynthesisFormulaPreservesExplicitPathPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	explicitPath := filepath.Join(dir, "explicit.formula.toml")
+	if err := os.WriteFile(explicitPath, []byte(sprintfTestFormula("explicit-path", "explicit path wins")), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := &ConvoyMeta{
+		Formula:     "missing-named-formula",
+		FormulaPath: explicitPath,
+		Rig:         "gastown",
+	}
+	f, err := loadSynthesisFormula(meta, "gastown")
+	if err != nil {
+		t.Fatalf("loadSynthesisFormula() error: %v", err)
+	}
+	if f == nil || f.Name != "explicit-path" {
+		t.Fatalf("loaded formula = %#v, want explicit-path", f)
+	}
+}
+
+func sprintfTestFormula(name, description string) string {
+	return "formula = \"" + name + "\"\n" +
+		"version = 1\n" +
+		"description = \"" + description + "\"\n\n" +
+		"[[steps]]\n" +
+		"id = \"step-1\"\n" +
+		"title = \"Step 1\"\n" +
+		"description = \"Do it\"\n"
 }

--- a/internal/formula/embed.go
+++ b/internal/formula/embed.go
@@ -5,9 +5,13 @@ import (
 	"embed"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 // Formulas live in internal/formula/formulas/ (source of truth).
@@ -44,33 +48,56 @@ type HealthReport struct {
 	Error     int // file could not be read (e.g. permission denied)
 }
 
+// ErrFormulaNotFound marks a named formula lookup miss across disk and embedded tiers.
+var ErrFormulaNotFound = errors.New("formula not found")
+
 // ResolveFormulaContent resolves formula content using the three-tier precedence
 // defined in docs/design/formula-resolution.md: rig > town > embedded.
 //
-// Tier 1 (rig): townRoot/rigName/.beads/formulas/<name>.formula.toml
+// Tier 1 (rig): route-resolved rig .beads/formulas, then legacy direct rig path
 // Tier 2 (town): townRoot/.beads/formulas/<name>.formula.toml
 // Tier 3 (embedded): compiled into the binary
 //
 // Either townRoot or rigName may be empty; those tiers are skipped.
 func ResolveFormulaContent(name, townRoot, rigName string) ([]byte, error) {
-	filename := name
-	if !hasFormulaSuffix(filename) {
-		filename = filename + ".formula.toml"
+	filename, err := formulaFilename(name)
+	if err != nil {
+		return nil, err
+	}
+
+	paths := make([]string, 0, 3)
+	seen := make(map[string]struct{})
+	addPath := func(path string) {
+		if path == "" {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
 	}
 
 	// Tier 1: rig-level (most specific)
 	if townRoot != "" && rigName != "" {
-		path := filepath.Join(townRoot, rigName, ".beads", "formulas", filename)
-		if content, err := os.ReadFile(path); err == nil {
-			return content, nil
+		if rigDir := beads.GetRigDirForName(townRoot, rigName); rigDir != "" {
+			addPath(filepath.Join(beads.ResolveBeadsDir(rigDir), "formulas", filename))
 		}
+		addPath(filepath.Join(townRoot, rigName, ".beads", "formulas", filename))
 	}
 
 	// Tier 2: town-level
 	if townRoot != "" {
-		path := filepath.Join(townRoot, ".beads", "formulas", filename)
-		if content, err := os.ReadFile(path); err == nil {
+		addPath(filepath.Join(townRoot, ".beads", "formulas", filename))
+	}
+
+	for _, path := range paths {
+		content, err := os.ReadFile(path)
+		if err == nil {
 			return content, nil
+		}
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("reading formula %s: %w", path, err)
 		}
 	}
 
@@ -83,15 +110,25 @@ func ResolveFormulaContent(name, townRoot, rigName string) ([]byte, error) {
 // Returns the content bytes, or an error if the formula is not found.
 func GetEmbeddedFormulaContent(name string) ([]byte, error) {
 	// Normalize: ensure the filename has the correct suffix
-	filename := name
-	if !hasFormulaSuffix(filename) {
-		filename = filename + ".formula.toml"
+	filename, err := formulaFilename(name)
+	if err != nil {
+		return nil, err
 	}
 	content, err := formulasFS.ReadFile("formulas/" + filename)
 	if err != nil {
-		return nil, fmt.Errorf("embedded formula %q not found: %w", name, err)
+		return nil, fmt.Errorf("%w: embedded formula %q: %v", ErrFormulaNotFound, name, err)
 	}
 	return content, nil
+}
+
+func formulaFilename(name string) (string, error) {
+	if name == "" || filepath.IsAbs(name) || strings.Contains(name, "..") || strings.Contains(name, "/") || strings.Contains(name, "\\") {
+		return "", fmt.Errorf("invalid formula name %q", name)
+	}
+	if hasFormulaSuffix(name) {
+		return name, nil
+	}
+	return name + ".formula.toml", nil
 }
 
 // hasFormulaSuffix checks if a name already has a formula file suffix.

--- a/internal/formula/embed.go
+++ b/internal/formula/embed.go
@@ -80,6 +80,9 @@ func ResolveFormulaContent(name, townRoot, rigName string) ([]byte, error) {
 
 	// Tier 1: rig-level (most specific)
 	if townRoot != "" && rigName != "" {
+		if err := validateFormulaPathComponent("rig", rigName); err != nil {
+			return nil, err
+		}
 		if rigDir := beads.GetRigDirForName(townRoot, rigName); rigDir != "" {
 			addPath(filepath.Join(beads.ResolveBeadsDir(rigDir), "formulas", filename))
 		}
@@ -122,13 +125,20 @@ func GetEmbeddedFormulaContent(name string) ([]byte, error) {
 }
 
 func formulaFilename(name string) (string, error) {
-	if name == "" || filepath.IsAbs(name) || strings.Contains(name, "..") || strings.Contains(name, "/") || strings.Contains(name, "\\") {
-		return "", fmt.Errorf("invalid formula name %q", name)
+	if err := validateFormulaPathComponent("formula", name); err != nil {
+		return "", err
 	}
 	if hasFormulaSuffix(name) {
 		return name, nil
 	}
 	return name + ".formula.toml", nil
+}
+
+func validateFormulaPathComponent(kind, value string) error {
+	if value == "" || filepath.IsAbs(value) || strings.Contains(value, "..") || strings.Contains(value, "/") || strings.Contains(value, "\\") {
+		return fmt.Errorf("invalid %s name %q", kind, value)
+	}
+	return nil
 }
 
 // hasFormulaSuffix checks if a name already has a formula file suffix.

--- a/internal/formula/embed_test.go
+++ b/internal/formula/embed_test.go
@@ -1015,6 +1015,13 @@ func TestResolveFormulaContent(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects path-like rig names", func(t *testing.T) {
+		_, err := ResolveFormulaContent("mol-polecat-work", t.TempDir(), "../outside")
+		if err == nil {
+			t.Fatal("expected error for path-like rig name")
+		}
+	})
+
 	t.Run("returns error when not found anywhere", func(t *testing.T) {
 		_, err := ResolveFormulaContent("mol-does-not-exist", "", "")
 		if err == nil {

--- a/internal/formula/embed_test.go
+++ b/internal/formula/embed_test.go
@@ -1,6 +1,7 @@
 package formula
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -928,6 +929,48 @@ func TestResolveFormulaContent(t *testing.T) {
 		}
 	})
 
+	t.Run("route-resolved rig formula shadows direct rig and town", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(`{"prefix":"rt-","path":"routed/mayor/rig"}`+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		formulaName := "mol-routed-test"
+		routedFormulasDir := filepath.Join(tmpDir, "routed", "mayor", "rig", ".beads", "formulas")
+		directFormulasDir := filepath.Join(tmpDir, "routed", ".beads", "formulas")
+		townFormulasDir := filepath.Join(tmpDir, ".beads", "formulas")
+		for _, dir := range []string{routedFormulasDir, directFormulasDir, townFormulasDir} {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		routedContent := []byte("formula = \"mol-routed-test\"\nversion = 3\n")
+		directContent := []byte("formula = \"mol-routed-test\"\nversion = 2\n")
+		townContent := []byte("formula = \"mol-routed-test\"\nversion = 1\n")
+		for path, content := range map[string][]byte{
+			filepath.Join(routedFormulasDir, formulaName+".formula.toml"): routedContent,
+			filepath.Join(directFormulasDir, formulaName+".formula.toml"): directContent,
+			filepath.Join(townFormulasDir, formulaName+".formula.toml"):   townContent,
+		} {
+			if err := os.WriteFile(path, content, 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		content, err := ResolveFormulaContent(formulaName, tmpDir, "routed")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(content, routedContent) {
+			t.Fatalf("expected route-resolved rig content, got %q", string(content))
+		}
+	})
+
 	t.Run("falls back to town when rig has no override", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		townFormulasDir := filepath.Join(tmpDir, ".beads", "formulas")
@@ -945,6 +988,30 @@ func TestResolveFormulaContent(t *testing.T) {
 		}
 		if string(content) != string(townContent) {
 			t.Error("expected town-level content when rig has no override")
+		}
+	})
+
+	t.Run("falls back to embedded when disk tiers miss", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		for _, dir := range []string{
+			filepath.Join(tmpDir, ".beads", "formulas"),
+			filepath.Join(tmpDir, "myrig", ".beads", "formulas"),
+		} {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		content, err := ResolveFormulaContent("mol-polecat-work", tmpDir, "myrig")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		embedded, err := GetEmbeddedFormulaContent("mol-polecat-work")
+		if err != nil {
+			t.Fatalf("unexpected embedded error: %v", err)
+		}
+		if !bytes.Equal(content, embedded) {
+			t.Fatal("expected embedded content after disk tiers miss")
 		}
 	})
 


### PR DESCRIPTION
## Summary
- replace duplicated formula lookup paths with shared rig/town/embedded named resolution
- make formula resolution route-aware for rig-level formulas while preserving explicit formula_path behavior
- route synthesis and formula-run named loads through the shared resolver and cover GT_TOWN_ROOT-only lookup

## Attribution
Carries forward the accepted bug-fix intent from #4334 by Anthony Wong / antiwong.

Original PR #4334 should remain open until this replacement lands.

## Verification
- CGO_ENABLED=0 go test ./internal/formula -run 'TestResolveFormulaContent|TestGetEmbeddedFormulaContent' -count=1\n- CGO_ENABLED=0 go test ./internal/cmd -run 'TestLoadSynthesisFormula|TestValidateFormulaRunRigName|TestConvoyMeta|TestExpandOutputPath|TestLegOutput' -count=1\n- CGO_ENABLED=0 go build ./cmd/gt\n\n## PR Sheriff\n- Evidence target: gt-6uao / replacement for #4334\n- Research: 15/15 complete\n- Pre-implementation reviews: 5/5 approving\n- Post-implementation reviews: 5/5 approving, tied to b0467e95fa21b020bf6dfcde2ae2eb9b72905944\n- Checker: gt-pr-sheriff-check --evidence pr-sheriff-evidence/gt-6uao-pr4334-replacement/evidence.json --format json\n- Checker result: PASS, verdict=defer_human_review, merge_path_allowed=false\n- Defer reason: original #4334 is status/review-failed and this replacement is status/reviewing, not merge-ready yet.