### PR TITLE
fix: resolve rig-local agent tracking from cwd

### DIFF
--- a/internal/cmd/agent_state.go
+++ b/internal/cmd/agent_state.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -218,9 +218,10 @@ func modifyAgentState(agentBead, beadsDir string, hasIncr bool) error {
 		args = append(args, "--set-labels=")
 	}
 
-	// Execute bd update
-	cmd := exec.Command("bd", args...)
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
+	defer cancel()
+
+	cmd := beads.CommandContext(ctx, filepath.Dir(beadsDir), beadsDir, beads.MutationPinned, args...)
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -272,8 +273,7 @@ func getAllAgentLabels(agentBead, beadsDir string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	cmd := beads.CommandContext(ctx, filepath.Dir(beadsDir), beadsDir, beads.ReadOnlyPinned, args...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/cmd/agent_state.go
+++ b/internal/cmd/agent_state.go
@@ -94,15 +94,9 @@ type agentStateResult struct {
 func runAgentState(cmd *cobra.Command, args []string) error {
 	agentBead := args[0]
 
-	// Find beads directory
-	cwd, err := os.Getwd()
+	beadsDir, err := resolveAgentTrackingBeadsDir()
 	if err != nil {
-		return fmt.Errorf("getting working directory: %w", err)
-	}
-
-	beadsDir := beads.ResolveBeadsDir(cwd)
-	if beadsDir == "" {
-		return fmt.Errorf("not in a beads workspace")
+		return fmt.Errorf("not in a beads workspace: %w", err)
 	}
 
 	// Determine operation mode

--- a/internal/cmd/agent_tracking_beads.go
+++ b/internal/cmd/agent_tracking_beads.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+// findCwdBeadsWorkDir finds the nearest .beads directory by walking up from CWD.
+// It intentionally ignores BEADS_DIR for callers whose target is implied by
+// the current rig worktree rather than inherited session environment.
+func findCwdBeadsWorkDir() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	path := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(path, ".beads")); err == nil {
+			return path, nil
+		}
+
+		parent := filepath.Dir(path)
+		if parent == path {
+			break
+		}
+		path = parent
+	}
+
+	return "", fmt.Errorf("no .beads directory found")
+}
+
+// resolveAgentTrackingBeadsDir resolves the bead database used for agent state.
+// Agent tracking follows the agent's current rig, so cwd-local redirects must
+// win over an inherited town-level BEADS_DIR. The env-first resolver remains a
+// fallback for contexts that do not have a cwd-local .beads directory.
+func resolveAgentTrackingBeadsDir() (string, error) {
+	workDir, err := findCwdBeadsWorkDir()
+	if err != nil {
+		workDir, err = findLocalBeadsDir()
+	}
+	if err != nil {
+		return "", err
+	}
+
+	beadsDir := beads.ResolveBeadsDir(workDir)
+	if beadsDir == "" {
+		return "", fmt.Errorf("not in a beads workspace")
+	}
+	return beadsDir, nil
+}

--- a/internal/cmd/agent_tracking_beads_test.go
+++ b/internal/cmd/agent_tracking_beads_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveAgentTrackingBeadsDirPrefersCwdRigRedirectOverBeadsDir(t *testing.T) {
+	tmp := t.TempDir()
+	townRoot := filepath.Join(tmp, "gt")
+	townBeads := filepath.Join(townRoot, ".beads")
+	rigWorkDir := filepath.Join(townRoot, "gastown", "refinery", "rig")
+	rigRedirect := filepath.Join(rigWorkDir, ".beads")
+	rigBeads := filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
+
+	for _, dir := range []string{townBeads, rigRedirect, rigBeads} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(rigRedirect, "redirect"), []byte("../../mayor/rig/.beads"), 0o644); err != nil {
+		t.Fatalf("write rig redirect: %v", err)
+	}
+	t.Setenv("BEADS_DIR", townBeads)
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(rigWorkDir); err != nil {
+		t.Fatalf("chdir rig work dir: %v", err)
+	}
+
+	gotWorkDir, err := findCwdBeadsWorkDir()
+	if err != nil {
+		t.Fatalf("findCwdBeadsWorkDir() error = %v", err)
+	}
+	if gotWorkDir != rigWorkDir {
+		t.Fatalf("findCwdBeadsWorkDir() = %q, want %q", gotWorkDir, rigWorkDir)
+	}
+
+	gotBeadsDir, err := resolveAgentTrackingBeadsDir()
+	if err != nil {
+		t.Fatalf("resolveAgentTrackingBeadsDir() error = %v", err)
+	}
+	if gotBeadsDir != rigBeads {
+		t.Fatalf("resolveAgentTrackingBeadsDir() = %q, want %q", gotBeadsDir, rigBeads)
+	}
+
+	gotLocalWorkDir, err := findLocalBeadsDir()
+	if err != nil {
+		t.Fatalf("findLocalBeadsDir() error = %v", err)
+	}
+	if gotLocalWorkDir != townRoot {
+		t.Fatalf("findLocalBeadsDir() = %q, want env parent %q", gotLocalWorkDir, townRoot)
+	}
+}

--- a/internal/cmd/agent_tracking_beads_test.go
+++ b/internal/cmd/agent_tracking_beads_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -55,5 +57,120 @@ func TestResolveAgentTrackingBeadsDirPrefersCwdRigRedirectOverBeadsDir(t *testin
 	}
 	if gotLocalWorkDir != townRoot {
 		t.Fatalf("findLocalBeadsDir() = %q, want env parent %q", gotLocalWorkDir, townRoot)
+	}
+}
+
+func TestRunAgentStateUsesCwdRigBeadsDirWhenBeadsDirPointsTown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell fake bd")
+	}
+
+	tmp := t.TempDir()
+	townRoot := filepath.Join(tmp, "gt")
+	townBeads := filepath.Join(townRoot, ".beads")
+	rigWorkDir := filepath.Join(townRoot, "gastown", "refinery", "rig")
+	rigRedirect := filepath.Join(rigWorkDir, ".beads")
+	rigBeads := filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
+
+	for _, dir := range []string{townBeads, rigRedirect, rigBeads} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(rigRedirect, "redirect"), []byte("../../mayor/rig/.beads"), 0o644); err != nil {
+		t.Fatalf("write rig redirect: %v", err)
+	}
+	metadata := []byte(`{"dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`)
+	if err := os.WriteFile(filepath.Join(rigBeads, "metadata.json"), metadata, 0o644); err != nil {
+		t.Fatalf("write rig metadata: %v", err)
+	}
+
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	logPath := filepath.Join(tmp, "bd.log")
+	bdScript := `#!/bin/sh
+printf 'cmd=%s BEADS_DIR=%s DB=%s READONLY=%s AUTO=%s\n' "$1" "${BEADS_DIR-}" "${BEADS_DOLT_SERVER_DATABASE-}" "${BD_READONLY-}" "${BD_DOLT_AUTO_COMMIT-}" >> "$BD_LOG"
+case "$1" in
+  show)
+    printf '[{"labels":["gt:agent","idle:2"]}]\n'
+    ;;
+  update)
+    ;;
+  *)
+    printf 'unexpected bd command: %s\n' "$1" >&2
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("BEADS_DIR", townBeads)
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "town")
+	t.Setenv("BD_READONLY", "true")
+	t.Setenv("BD_DOLT_AUTO_COMMIT", "off")
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(rigWorkDir); err != nil {
+		t.Fatalf("chdir rig work dir: %v", err)
+	}
+
+	oldSet := agentStateSet
+	oldIncr := agentStateIncr
+	oldDel := agentStateDel
+	oldJSON := agentStateJSON
+	t.Cleanup(func() {
+		agentStateSet = oldSet
+		agentStateIncr = oldIncr
+		agentStateDel = oldDel
+		agentStateJSON = oldJSON
+	})
+	agentStateSet = []string{"idle=0"}
+	agentStateIncr = ""
+	agentStateDel = nil
+	agentStateJSON = false
+
+	if err := runAgentState(nil, []string{"gt-gastown-refinery"}); err != nil {
+		t.Fatalf("runAgentState() error = %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	log := strings.TrimSpace(string(data))
+	if log == "" {
+		t.Fatal("fake bd was not invoked")
+	}
+
+	for _, line := range strings.Split(log, "\n") {
+		if !strings.Contains(line, "BEADS_DIR="+rigBeads) {
+			t.Fatalf("bd call was not pinned to rig beads %q: %s\nfull log:\n%s", rigBeads, line, log)
+		}
+		if strings.Contains(line, "BEADS_DIR="+townBeads) {
+			t.Fatalf("bd call used inherited town BEADS_DIR %q: %s\nfull log:\n%s", townBeads, line, log)
+		}
+		if !strings.Contains(line, "DB=rigdb") || strings.Contains(line, "DB=town") {
+			t.Fatalf("bd call was not pinned to rig database: %s\nfull log:\n%s", line, log)
+		}
+		if strings.Contains(line, "cmd=show") {
+			if !strings.Contains(line, "READONLY=true") || !strings.Contains(line, "AUTO=off") {
+				t.Fatalf("bd read was not read-only pinned: %s\nfull log:\n%s", line, log)
+			}
+		}
+		if strings.Contains(line, "cmd=update") {
+			if !strings.Contains(line, "READONLY= ") || !strings.Contains(line, "AUTO=on") {
+				t.Fatalf("bd mutation was not mutation pinned: %s\nfull log:\n%s", line, log)
+			}
+		}
 	}
 }

--- a/internal/cmd/agents_resolve.go
+++ b/internal/cmd/agents_resolve.go
@@ -73,13 +73,9 @@ func runAgentsResolve(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("getting working directory: %w", err)
 	}
-	workDir, err := findLocalBeadsDir()
+	currentBeadsDir, err := resolveAgentTrackingBeadsDir()
 	if err != nil {
 		return err
-	}
-	currentBeadsDir := beads.ResolveBeadsDir(workDir)
-	if currentBeadsDir == "" {
-		return fmt.Errorf("not in a beads workspace")
 	}
 
 	candidates, err := findAgentBeadCandidates(cwd, currentBeadsDir)

--- a/internal/cmd/mail_identity.go
+++ b/internal/cmd/mail_identity.go
@@ -54,26 +54,7 @@ func findLocalBeadsDir() (string, error) {
 		}
 	}
 
-	// Fallback: walk up from CWD
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	path := cwd
-	for {
-		if _, err := os.Stat(filepath.Join(path, ".beads")); err == nil {
-			return path, nil
-		}
-
-		parent := filepath.Dir(path)
-		if parent == path {
-			break // Reached root
-		}
-		path = parent
-	}
-
-	return "", fmt.Errorf("no .beads directory found")
+	return findCwdBeadsWorkDir()
 }
 
 // detectSender determines the current context's address.

--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/channelevents"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -160,9 +159,9 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 	var backoffUntil time.Time
 	var beadsDir string
 	if awaitEventAgentBead != "" {
-		workDir, wdErr := findLocalBeadsDir()
+		var wdErr error
+		beadsDir, wdErr = resolveAgentTrackingBeadsDir()
 		if wdErr == nil {
-			beadsDir = beads.ResolveBeadsDir(workDir)
 			labels, labErr := getAgentLabels(awaitEventAgentBead, beadsDir)
 			if labErr != nil {
 				if !awaitEventQuiet {

--- a/internal/cmd/molecule_await_signal.go
+++ b/internal/cmd/molecule_await_signal.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -134,7 +133,7 @@ func init() {
 
 func runMoleculeAwaitSignal(cmd *cobra.Command, args []string) error {
 	// Find beads directory (rig-local for bead operations)
-	workDir, err := findLocalBeadsDir()
+	beadsDir, err := resolveAgentTrackingBeadsDir()
 	if err != nil {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}
@@ -144,8 +143,6 @@ func runMoleculeAwaitSignal(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("not in a Gas Town workspace: %w", err)
 	}
-
-	beadsDir := beads.ResolveBeadsDir(workDir)
 
 	// Read current idle cycles and backoff window from agent bead (if specified)
 	var idleCycles int
@@ -457,8 +454,7 @@ func updateAgentHeartbeat(agentBead, beadsDir string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	cmd := beads.CommandContext(ctx, filepath.Dir(beadsDir), beadsDir, beads.MutationPinned, args...)
 	return cmd.Run()
 }
 
@@ -493,8 +489,7 @@ func setAgentIdleCycles(agentBead, beadsDir string, cycles int) error {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	cmd := beads.CommandContext(ctx, filepath.Dir(beadsDir), beadsDir, beads.MutationPinned, args...)
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("setting idle label: %w", err)
@@ -529,8 +524,7 @@ func setAgentBackoffUntil(agentBead, beadsDir string, until time.Time) error {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	cmd := beads.CommandContext(ctx, filepath.Dir(beadsDir), beadsDir, beads.MutationPinned, args...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("setting backoff-until label: %w", err)
 	}
@@ -571,8 +565,7 @@ func clearAgentBackoffUntil(agentBead, beadsDir string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	cmd := beads.CommandContext(ctx, filepath.Dir(beadsDir), beadsDir, beads.MutationPinned, args...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("clearing backoff-until label: %w", err)
 	}

--- a/internal/cmd/molecule_await_signal_test.go
+++ b/internal/cmd/molecule_await_signal_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -305,5 +307,144 @@ func TestBackoffWindowResumption(t *testing.T) {
 				t.Errorf("timeout = %v, want ~%v (diff: %v)", timeout, tt.wantApproxTime, diff)
 			}
 		})
+	}
+}
+
+func TestRunMoleculeAwaitSignalAgentBeadUsesCwdRigBeadsDirWhenBeadsDirPointsTown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell fake bd")
+	}
+
+	tmp := t.TempDir()
+	townRoot := filepath.Join(tmp, "gt")
+	townBeads := filepath.Join(townRoot, ".beads")
+	rigWorkDir := filepath.Join(townRoot, "gastown", "refinery", "rig")
+	rigRedirect := filepath.Join(rigWorkDir, ".beads")
+	rigBeads := filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
+
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor"),
+		townBeads,
+		rigRedirect,
+		rigBeads,
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigRedirect, "redirect"), []byte("../../mayor/rig/.beads"), 0o644); err != nil {
+		t.Fatalf("write rig redirect: %v", err)
+	}
+	metadata := []byte(`{"dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`)
+	if err := os.WriteFile(filepath.Join(rigBeads, "metadata.json"), metadata, 0o644); err != nil {
+		t.Fatalf("write rig metadata: %v", err)
+	}
+
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	logPath := filepath.Join(tmp, "bd.log")
+	bdScript := `#!/bin/sh
+printf 'cmd=%s BEADS_DIR=%s DB=%s READONLY=%s AUTO=%s\n' "$1" "${BEADS_DIR-}" "${BEADS_DOLT_SERVER_DATABASE-}" "${BD_READONLY-}" "${BD_DOLT_AUTO_COMMIT-}" >> "$BD_LOG"
+case "$1" in
+  show)
+    printf '[{"labels":["gt:agent","idle:0"]}]\n'
+    ;;
+  update)
+    ;;
+  *)
+    printf 'unexpected bd command: %s\n' "$1" >&2
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("BEADS_DIR", townBeads)
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "town")
+	t.Setenv("BD_READONLY", "true")
+	t.Setenv("BD_DOLT_AUTO_COMMIT", "off")
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(rigWorkDir); err != nil {
+		t.Fatalf("chdir rig work dir: %v", err)
+	}
+
+	oldTimeout := awaitSignalTimeout
+	oldBackoffBase := awaitSignalBackoffBase
+	oldBackoffMult := awaitSignalBackoffMult
+	oldBackoffMax := awaitSignalBackoffMax
+	oldQuiet := awaitSignalQuiet
+	oldAgentBead := awaitSignalAgentBead
+	oldJSON := moleculeJSON
+	t.Cleanup(func() {
+		awaitSignalTimeout = oldTimeout
+		awaitSignalBackoffBase = oldBackoffBase
+		awaitSignalBackoffMult = oldBackoffMult
+		awaitSignalBackoffMax = oldBackoffMax
+		awaitSignalQuiet = oldQuiet
+		awaitSignalAgentBead = oldAgentBead
+		moleculeJSON = oldJSON
+	})
+
+	awaitSignalTimeout = "1ms"
+	awaitSignalBackoffBase = ""
+	awaitSignalBackoffMult = 2
+	awaitSignalBackoffMax = ""
+	awaitSignalQuiet = true
+	awaitSignalAgentBead = "gt-gastown-refinery"
+	moleculeJSON = false
+
+	if err := runMoleculeAwaitSignal(nil, nil); err != nil {
+		t.Fatalf("runMoleculeAwaitSignal() error = %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	log := strings.TrimSpace(string(data))
+	if log == "" {
+		t.Fatal("fake bd was not invoked")
+	}
+
+	for _, line := range strings.Split(log, "\n") {
+		if !strings.Contains(line, "BEADS_DIR="+rigBeads) {
+			t.Fatalf("bd call was not pinned to rig beads %q: %s\nfull log:\n%s", rigBeads, line, log)
+		}
+		if strings.Contains(line, "BEADS_DIR="+townBeads) {
+			t.Fatalf("bd call used inherited town BEADS_DIR %q: %s\nfull log:\n%s", townBeads, line, log)
+		}
+		if !strings.Contains(line, "DB=rigdb") {
+			t.Fatalf("bd call was not pinned to rig database: %s\nfull log:\n%s", line, log)
+		}
+		if strings.Contains(line, "DB=town") {
+			t.Fatalf("bd call used inherited town database: %s\nfull log:\n%s", line, log)
+		}
+		if strings.Contains(line, "cmd=show") {
+			if !strings.Contains(line, "READONLY=true") || !strings.Contains(line, "AUTO=off") {
+				t.Fatalf("bd read was not read-only pinned: %s\nfull log:\n%s", line, log)
+			}
+		}
+		if strings.Contains(line, "cmd=update") {
+			if !strings.Contains(line, "READONLY= ") && !strings.HasSuffix(line, "READONLY= AUTO=on") {
+				t.Fatalf("bd mutation inherited read-only mode: %s\nfull log:\n%s", line, log)
+			}
+			if !strings.Contains(line, "AUTO=on") {
+				t.Fatalf("bd mutation was not auto-commit pinned: %s\nfull log:\n%s", line, log)
+			}
+		}
 	}
 }


### PR DESCRIPTION
Replacement for #4367, rebuilt on current `gastownhall/gastown:main`.

This carries forward the accepted bugfix intent from #4367 while avoiding the stale 90-commit-behind branch and tightening the implementation around the cleanup-first review findings.

## What changed

- Add a dedicated agent-tracking beads resolver that prefers the cwd-local rig `.beads` redirect over inherited `BEADS_DIR`.
- Keep the existing env-first `findLocalBeadsDir` behavior for non-agent-tracking callers.
- Use the resolver for `gt agents resolve`, `gt agents state`, `gt mol step await-event --agent-bead`, and `gt mol step await-signal --agent-bead`.
- Route agent-bead `bd` reads/writes through `beads.CommandContext` with pinned read-only/mutation modes.
- Add regression coverage for inherited town `BEADS_DIR`/Dolt DB env while cwd points at a rig redirect.

## Attribution

Credits original PR #4367 and its authors:

- `enkemmc` / Mark Enkema for source commit `d274dfa65b76460b8bc0b5fcb2903c6fd916df37`.
- `Thalia-geraghty` / ghoul for source commit `11fedefd8415bdcf5284b973b83272620cf7d074`.

The replacement branch was generated by Gas Town PR Sheriff for bead `gt-vlt5` because #4367 remained `status/reviewing`, had no approvals/substantive CI, and was stale against current main. Do not close #4367 as superseded until this replacement merges.

## PR Sheriff Evidence

- 15/15 research legs completed.
- 5/5 pre-implementation reviews approved the replacement plan.
- 5/5 final post-implementation reviews approved head `3bc3533a112dde5dd3aefb1b5820f88ba7f36f01`.
- `gt-pr-sheriff-check --evidence /tmp/opencode/gt-vlt5-pr4367-evidence.json --merge-gate` passed:

```text
PR Sheriff: PASS
merge_path_allowed: true
verdict: merge_replacement
gates: 12 pass, 2 not_applicable, 0 waived, 0 fail
```

## Verification

```text
git diff upstream/main...HEAD --check
CGO_ENABLED=0 go test ./internal/cmd -run 'TestResolveAgentTrackingBeadsDirPrefersCwdRigRedirectOverBeadsDir|TestRunAgentStateUsesCwdRigBeadsDirWhenBeadsDirPointsTown|TestRunMoleculeAwaitSignalAgentBeadUsesCwdRigBeadsDirWhenBeadsDirPointsTown' -count=1 -v
CGO_ENABLED=0 go test ./internal/beads -count=1
CGO_ENABLED=0 go test ./internal/cmd -count=1 -timeout=300s
CGO_ENABLED=0 go build ./cmd/gt
```

Note: local non-`CGO_ENABLED=0` checks are known to fail on this host because ICU headers (`unicode/uregex.h`) are unavailable.
