### PR TITLE
fix(refinery): load merge queue config from rig settings

### DIFF
--- a/internal/cmd/rig_settings_test.go
+++ b/internal/cmd/rig_settings_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/refinery"
 )
 
 // setupTestRigForSettings creates a test rig for settings testing.
@@ -27,9 +28,9 @@ func setupTestRigForSettings(t *testing.T) (string, string) {
 	// Create town.json (primary marker for workspace detection)
 	townConfig := &config.TownConfig{
 		Type:      "town",
-		Version:    config.CurrentTownVersion,
-		Name:       "test-town",
-		CreatedAt:  time.Now().Truncate(time.Second),
+		Version:   config.CurrentTownVersion,
+		Name:      "test-town",
+		CreatedAt: time.Now().Truncate(time.Second),
 	}
 	townConfigPath := filepath.Join(mayorDir, "town.json")
 	if err := config.SaveTownConfig(townConfigPath, townConfig); err != nil {
@@ -483,6 +484,34 @@ func TestRigSettingsSet(t *testing.T) {
 			t.Errorf("Agent should be empty, got %q", loaded.Agent)
 		}
 	})
+}
+
+func TestRigSettingsSetMergeQueueReadByRefinery(t *testing.T) {
+	_, rigName := setupTestRigForSettings(t)
+
+	if err := runRigSettingsSet(rigSettingsSetCmd, []string{rigName, "merge_queue.max_concurrent", "3"}); err != nil {
+		t.Fatalf("set max_concurrent: %v", err)
+	}
+	if err := runRigSettingsSet(rigSettingsSetCmd, []string{rigName, "merge_queue.on_conflict", "auto_rebase"}); err != nil {
+		t.Fatalf("set on_conflict: %v", err)
+	}
+
+	_, r, err := getRig(rigName)
+	if err != nil {
+		t.Fatalf("get rig: %v", err)
+	}
+	engineer := refinery.NewEngineer(r)
+	if err := engineer.LoadConfig(); err != nil {
+		t.Fatalf("load refinery config: %v", err)
+	}
+
+	cfg := engineer.Config()
+	if cfg.MaxConcurrent != 3 {
+		t.Errorf("MaxConcurrent = %d, want 3", cfg.MaxConcurrent)
+	}
+	if cfg.OnConflict != "auto_rebase" {
+		t.Errorf("OnConflict = %q, want auto_rebase", cfg.OnConflict)
+	}
 }
 
 func TestRigSettingsUnset(t *testing.T) {

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/crew"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/git"
@@ -312,14 +313,13 @@ func (e *Engineer) SetOutput(w io.Writer) {
 	e.output = w
 }
 
-// LoadConfig loads merge queue configuration from the rig's config.json.
+// LoadConfig loads merge queue configuration from the rig's settings/config.json.
 func (e *Engineer) LoadConfig() error {
-	configPath := filepath.Join(e.rig.Path, "config.json")
+	configPath := config.RigSettingsPath(e.rig.Path)
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// Use defaults if no config file
-			return nil
+			return e.rejectLegacyMergeQueueConfig(configPath)
 		}
 		return fmt.Errorf("reading config: %w", err)
 	}
@@ -333,8 +333,7 @@ func (e *Engineer) LoadConfig() error {
 	}
 
 	if rawConfig.MergeQueue == nil {
-		// No merge_queue section, use defaults
-		return nil
+		return e.rejectLegacyMergeQueueConfig(configPath)
 	}
 
 	// Parse merge_queue section into our config struct
@@ -451,6 +450,29 @@ func (e *Engineer) LoadConfig() error {
 	}
 
 	return nil
+}
+
+func (e *Engineer) rejectLegacyMergeQueueConfig(settingsPath string) error {
+	legacyPath := filepath.Join(e.rig.Path, "config.json")
+	data, err := os.ReadFile(legacyPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("checking legacy config: %w", err)
+	}
+
+	var rawConfig struct {
+		MergeQueue json.RawMessage `json:"merge_queue"`
+	}
+	if err := json.Unmarshal(data, &rawConfig); err != nil {
+		return fmt.Errorf("parsing legacy config: %w", err)
+	}
+	if rawConfig.MergeQueue == nil {
+		return nil
+	}
+
+	return fmt.Errorf("merge_queue belongs in %s, not legacy %s; move the merge_queue object to settings/config.json or run gt rig settings set merge_queue.<key> <value>", settingsPath, legacyPath)
 }
 
 // initPRProvider creates the appropriate PRProvider based on vcs_provider config.
@@ -1076,7 +1098,7 @@ func (e *Engineer) acquireMainPushSlot(ctx context.Context) (string, error) {
 }
 
 // ValidateTestCommand validates that a test command is safe to execute.
-// TestCommand comes from the rig's operator-controlled config.json, not from
+// TestCommand comes from the rig's operator-controlled settings/config.json, not from
 // user input or PR branches. This validation provides defense-in-depth for the
 // trusted infrastructure config path.
 func ValidateTestCommand(cmd string) error {
@@ -1107,7 +1129,7 @@ func (e *Engineer) runTests(ctx context.Context) ProcessResult {
 			_, _ = fmt.Fprintf(e.output, "[Engineer] Retrying tests (attempt %d/%d)...\n", attempt, maxRetries)
 		}
 
-		// Trust boundary: TestCommand comes from rig's config.json (operator-controlled
+		// Trust boundary: TestCommand comes from rig's settings/config.json (operator-controlled
 		// infrastructure config), not from PR branches or user input. Shell execution
 		// is intentional for flexibility (pipes, env vars, etc).
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Executing test command: %s\n", e.config.TestCommand)

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1338,6 +1338,10 @@ func (e *Engineer) syncCrewWorkspaces() {
 
 // ProcessMRInfo processes a merge request from MRInfo.
 func (e *Engineer) ProcessMRInfo(ctx context.Context, mr *MRInfo) ProcessResult {
+	if err := e.LoadConfig(); err != nil {
+		return ProcessResult{Success: false, Error: fmt.Sprintf("loading refinery config: %v", err)}
+	}
+
 	// MR fields are directly on the struct
 	_, _ = fmt.Fprintln(e.output, "[Engineer] Processing MR:")
 	_, _ = fmt.Fprintf(e.output, "  Branch: %s\n", mr.Branch)

--- a/internal/refinery/engineer_pr_merge_test.go
+++ b/internal/refinery/engineer_pr_merge_test.go
@@ -3,8 +3,6 @@ package refinery
 import (
 	"bytes"
 	"context"
-	"encoding/json"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -28,10 +26,7 @@ func TestEngineer_LoadConfig_MergeStrategyPR(t *testing.T) {
 		},
 	}
 
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeRigSettings(t, tmpDir, config)
 
 	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
 	e := NewEngineer(r)
@@ -57,10 +52,7 @@ func TestEngineer_LoadConfig_MergeStrategyDefault(t *testing.T) {
 		"merge_queue": map[string]interface{}{},
 	}
 
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeRigSettings(t, tmpDir, config)
 
 	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
 	e := NewEngineer(r)

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -515,6 +515,32 @@ func TestEngineer_LoadConfig_LegacyRootMergeQueueRequiresMigration(t *testing.T)
 	}
 }
 
+func TestEngineer_ProcessMRInfo_LoadsConfigAndFailsClosedOnLegacyMergeQueue(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeRigRootConfig(t, tmpDir, map[string]interface{}{
+		"merge_queue": map[string]interface{}{
+			"auto_push": false,
+		},
+	})
+
+	e := NewEngineer(&rig.Rig{Name: "test-rig", Path: tmpDir})
+	e.output = io.Discard
+	result := e.ProcessMRInfo(context.Background(), &MRInfo{
+		ID:     "gt-test",
+		Branch: "polecat/test/gt-test",
+		Target: "main",
+	})
+
+	if result.Success {
+		t.Fatal("expected legacy config to block processing")
+	}
+	for _, want := range []string{"loading refinery config", "merge_queue belongs", "settings/config.json"} {
+		if !strings.Contains(result.Error, want) {
+			t.Errorf("error = %q, want substring %q", result.Error, want)
+		}
+	}
+}
+
 func TestEngineer_LoadConfig_AutoPushDisabled(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "engineer-test-*")
 	if err != nil {

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -19,6 +19,34 @@ import (
 	"github.com/steveyegge/gastown/internal/testutil"
 )
 
+func writeRigSettings(t *testing.T, rigPath string, settings map[string]interface{}) {
+	t.Helper()
+
+	settingsPath := filepath.Join(rigPath, "settings", "config.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+		t.Fatalf("mkdir settings dir: %v", err)
+	}
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal settings: %v", err)
+	}
+	if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+}
+
+func writeRigRootConfig(t *testing.T, rigPath string, cfg map[string]interface{}) {
+	t.Helper()
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), data, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
 func TestDefaultMergeQueueConfig(t *testing.T) {
 	cfg := DefaultMergeQueueConfig()
 
@@ -333,7 +361,7 @@ func setupEngineerTerminalCloseTest(t *testing.T, activeMR string) (*Engineer, *
 }
 
 func TestEngineer_LoadConfig_NoFile(t *testing.T) {
-	// Create a temp directory without config.json
+	// Create a temp directory without settings/config.json
 	tmpDir, err := os.MkdirTemp("", "engineer-test-*")
 	if err != nil {
 		t.Fatal(err)
@@ -359,14 +387,14 @@ func TestEngineer_LoadConfig_NoFile(t *testing.T) {
 }
 
 func TestEngineer_LoadConfig_WithMergeQueue(t *testing.T) {
-	// Create a temp directory with config.json
+	// Create a temp directory with settings/config.json
 	tmpDir, err := os.MkdirTemp("", "engineer-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Write config file
+	// Write settings file
 	config := map[string]interface{}{
 		"type":    "rig",
 		"version": 1,
@@ -381,10 +409,7 @@ func TestEngineer_LoadConfig_WithMergeQueue(t *testing.T) {
 		},
 	}
 
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeRigSettings(t, tmpDir, config)
 
 	r := &rig.Rig{
 		Name: "test-rig",
@@ -424,6 +449,72 @@ func TestEngineer_LoadConfig_WithMergeQueue(t *testing.T) {
 	}
 }
 
+func TestEngineer_LoadConfig_PrefersCanonicalSettingsOverLegacyRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	writeRigRootConfig(t, tmpDir, map[string]interface{}{
+		"merge_queue": map[string]interface{}{
+			"max_concurrent": 99,
+		},
+	})
+	writeRigSettings(t, tmpDir, map[string]interface{}{
+		"merge_queue": map[string]interface{}{
+			"max_concurrent": 3,
+			"on_conflict":    "auto_rebase",
+		},
+	})
+
+	e := NewEngineer(&rig.Rig{Name: "test-rig", Path: tmpDir})
+	if err := e.LoadConfig(); err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
+
+	if e.config.MaxConcurrent != 3 {
+		t.Errorf("expected canonical MaxConcurrent 3, got %d", e.config.MaxConcurrent)
+	}
+	if e.config.OnConflict != "auto_rebase" {
+		t.Errorf("expected canonical OnConflict auto_rebase, got %q", e.config.OnConflict)
+	}
+}
+
+func TestEngineer_LoadConfig_LegacyRootMergeQueueRequiresMigration(t *testing.T) {
+	tests := []struct {
+		name          string
+		writeSettings bool
+	}{
+		{name: "missing settings file"},
+		{name: "settings without merge_queue", writeSettings: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			if tt.writeSettings {
+				writeRigSettings(t, tmpDir, map[string]interface{}{"agent": "claude"})
+			}
+			writeRigRootConfig(t, tmpDir, map[string]interface{}{
+				"type":    "rig",
+				"version": 1,
+				"name":    "test-rig",
+				"merge_queue": map[string]interface{}{
+					"max_concurrent": 7,
+				},
+			})
+
+			e := NewEngineer(&rig.Rig{Name: "test-rig", Path: tmpDir})
+			err := e.LoadConfig()
+			if err == nil {
+				t.Fatal("expected legacy merge_queue migration error")
+			}
+			for _, want := range []string{"merge_queue belongs", "settings/config.json", "config.json", "gt rig settings set"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want substring %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
 func TestEngineer_LoadConfig_AutoPushDisabled(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "engineer-test-*")
 	if err != nil {
@@ -440,10 +531,7 @@ func TestEngineer_LoadConfig_AutoPushDisabled(t *testing.T) {
 		},
 	}
 
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeRigSettings(t, tmpDir, config)
 
 	r := &rig.Rig{
 		Name: "test-rig",
@@ -461,24 +549,21 @@ func TestEngineer_LoadConfig_AutoPushDisabled(t *testing.T) {
 }
 
 func TestEngineer_LoadConfig_NoMergeQueueSection(t *testing.T) {
-	// Create a temp directory with config.json without merge_queue
+	// Create a temp directory with settings/config.json without merge_queue
 	tmpDir, err := os.MkdirTemp("", "engineer-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Write config file without merge_queue
+	// Write settings file without merge_queue
 	config := map[string]interface{}{
 		"type":    "rig",
 		"version": 1,
 		"name":    "test-rig",
 	}
 
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeRigSettings(t, tmpDir, config)
 
 	r := &rig.Rig{
 		Name: "test-rig",
@@ -510,10 +595,7 @@ func TestEngineer_LoadConfig_InvalidPollInterval(t *testing.T) {
 		},
 	}
 
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeRigSettings(t, tmpDir, config)
 
 	r := &rig.Rig{
 		Name: "test-rig",
@@ -552,10 +634,7 @@ func TestEngineer_LoadConfig_InvalidStaleClaimTimeout(t *testing.T) {
 				},
 			}
 
-			data, _ := json.MarshalIndent(config, "", "  ")
-			if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-				t.Fatal(err)
-			}
+			writeRigSettings(t, tmpDir, config)
 
 			r := &rig.Rig{
 				Name: "test-rig",
@@ -620,10 +699,7 @@ func TestEngineer_LoadConfig_WithGates(t *testing.T) {
 		},
 	}
 
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeRigSettings(t, tmpDir, config)
 
 	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
 	e := NewEngineer(r)
@@ -680,10 +756,7 @@ func TestEngineer_LoadConfig_GateInvalidTimeout(t *testing.T) {
 				},
 			}
 
-			data, _ := json.MarshalIndent(config, "", "  ")
-			if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-				t.Fatal(err)
-			}
+			writeRigSettings(t, tmpDir, config)
 
 			r := &rig.Rig{Name: "test-rig", Path: tmpDir}
 			e := NewEngineer(r)
@@ -717,10 +790,7 @@ func TestEngineer_LoadConfig_GatePhase(t *testing.T) {
 		},
 	}
 
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeRigSettings(t, tmpDir, config)
 
 	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
 	e := NewEngineer(r)
@@ -755,10 +825,7 @@ func TestEngineer_LoadConfig_GateInvalidPhase(t *testing.T) {
 		},
 	}
 
-	data, _ := json.MarshalIndent(config, "", "  ")
-	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeRigSettings(t, tmpDir, config)
 
 	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
 	e := NewEngineer(r)


### PR DESCRIPTION
Replacement for https://github.com/gastownhall/gastown/pull/4325.

Original PR submitted by @Ben-Williams-Founder. This is Sheriff-authored replacement work; no co-author trailer is claimed.

## Summary

- Load refinery `merge_queue` settings from canonical `<rig>/settings/config.json`, the path written by `gt rig settings set`.
- Fail closed when legacy root `<rig>/config.json` still contains `merge_queue` and canonical settings are absent, so operators migrate instead of silently losing merge controls.
- Apply settings at `ProcessMRInfo` entry before branch or merge work.
- Keep scope narrow: no `--effective` CLI surface, no exported helper, no legacy fallback loading.

## Verification

- `CGO_ENABLED=0 go test -count=1 ./internal/refinery ./internal/cmd`

## PR Sheriff

- Source PR #4325 is not merge-ready as-is: stale/red CI, `status/review-failed`, no approval, and cleanup concerns around fallback/helper surface.
- Replacement branch is based on current `upstream/main` and preserves the accepted bug-fix intent in a smaller cleanup-first form.
