### PR TITLE
fix: reclaim broken idle polecat worktrees

### DIFF
--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -68,6 +67,33 @@ func effectivePolecatDirCap(configured int) int {
 		return minPolecatDirsPerRig
 	}
 	return configured
+}
+
+func reclaimBrokenIdlePolecatForSling(polecatMgr *polecat.Manager) (bool, error) {
+	polecats, err := polecatMgr.List()
+	if err != nil {
+		return false, err
+	}
+
+	for _, candidate := range polecats {
+		if candidate == nil || candidate.State != polecat.StateIdle || candidate.Issue != "" {
+			continue
+		}
+		verifyErr := verifyWorktreeExists(candidate.ClonePath)
+		if verifyErr == nil || !polecat.IsStructuralWorktreeError(verifyErr) {
+			continue
+		}
+
+		fmt.Printf("  Reclaiming broken idle polecat %s before allocation: %v\n", candidate.Name, verifyErr)
+		if err := polecatMgr.ReclaimBrokenIdlePolecat(candidate.Name); err != nil {
+			fmt.Printf("  Broken idle polecat %s was not safe to reclaim: %v\n", candidate.Name, err)
+			continue
+		}
+		fmt.Printf("  %s Broken idle polecat %s reclaimed before assigning new work\n", style.Bold.Render("✓"), candidate.Name)
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // SpawnPolecatForSling creates a fresh polecat and optionally starts its session.
@@ -146,6 +172,12 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 				opts.HookBead, rigName, opts.HookBead)
 		}
 		witness.RecordBeadRespawn(townRoot, opts.HookBead)
+	}
+
+	if reclaimed, err := reclaimBrokenIdlePolecatForSling(polecatMgr); err != nil {
+		style.PrintWarning("could not reclaim broken idle polecat before allocation: %v", err)
+	} else if reclaimed {
+		fmt.Println("  Allocating fresh polecat after reclaiming broken idle sandbox...")
 	}
 
 	// Persistent polecat model (gt-4ac): try to reuse an idle polecat first.
@@ -493,49 +525,5 @@ func IsRigName(target string) (string, bool) {
 // and that it is a functional git repository. Returns an error if the worktree is missing,
 // has a broken .git reference, or fails basic git validation. (GH#2056)
 func verifyWorktreeExists(clonePath string) error {
-	// Check if directory exists
-	info, err := os.Stat(clonePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("worktree directory does not exist: %s", clonePath)
-		}
-		return fmt.Errorf("checking worktree directory: %w", err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("worktree path is not a directory: %s", clonePath)
-	}
-
-	// Check for .git file (worktrees have a .git file, not a .git directory)
-	gitPath := filepath.Join(clonePath, ".git")
-	if _, err := os.Stat(gitPath); err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("worktree missing .git file (not a valid git worktree): %s", clonePath)
-		}
-		return fmt.Errorf("checking .git: %w", err)
-	}
-
-	// For worktree .git files, verify the gitdir reference points to a valid path.
-	// A broken reference (e.g., from os.Rename instead of git worktree move) causes
-	// "fatal: not a git repository" for every git operation.
-	gitContent, err := os.ReadFile(gitPath)
-	if err == nil {
-		content := strings.TrimSpace(string(gitContent))
-		if strings.HasPrefix(content, "gitdir: ") {
-			gitdirPath := strings.TrimPrefix(content, "gitdir: ")
-			if !filepath.IsAbs(gitdirPath) {
-				gitdirPath = filepath.Join(clonePath, gitdirPath)
-			}
-			if _, err := os.Stat(gitdirPath); err != nil {
-				return fmt.Errorf("worktree .git references nonexistent gitdir %s: %w", gitdirPath, err)
-			}
-		}
-	}
-
-	// Final validation: run git rev-parse to confirm the worktree is functional
-	cmd := exec.Command("git", "-C", clonePath, "rev-parse", "--git-dir")
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("worktree at %s is not a valid git repository: %s", clonePath, strings.TrimSpace(string(output)))
-	}
-
-	return nil
+	return polecat.VerifyWorktreeExists(clonePath)
 }

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1132,6 +1132,10 @@ func (m *Manager) RemoveWithOptions(name string, force, nuclear, selfNuke bool) 
 	}
 	defer func() { _ = fl.Unlock() }()
 
+	return m.removeWithOptionsLocked(name, force, nuclear, selfNuke)
+}
+
+func (m *Manager) removeWithOptionsLocked(name string, force, nuclear, selfNuke bool) error {
 	if !m.exists(name) {
 		return ErrPolecatNotFound
 	}
@@ -1303,6 +1307,67 @@ func (m *Manager) RemoveWithOptions(name string, force, nuclear, selfNuke bool) 
 	_ = m.namePool.Save()
 
 	return nil
+}
+
+// ReclaimBrokenIdlePolecat removes a structurally broken idle sandbox before any
+// new hook is attached. It deliberately uses the normal non-force removal path.
+func (m *Manager) ReclaimBrokenIdlePolecat(name string) (retErr error) {
+	defer func() { telemetry.RecordPolecatRemove(context.Background(), name, retErr) }()
+
+	fl, err := m.lockPolecat(name)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	if !m.exists(name) {
+		return ErrPolecatNotFound
+	}
+
+	current, err := m.loadFromBeads(name)
+	if err != nil {
+		return err
+	}
+	if current.State != StateIdle || current.Issue != "" {
+		return fmt.Errorf("not a clean idle polecat: state=%s issue=%s", current.State, current.Issue)
+	}
+
+	if err := VerifyWorktreeExists(current.ClonePath); err == nil {
+		return fmt.Errorf("worktree is healthy: %s", current.ClonePath)
+	} else if !IsStructuralWorktreeError(err) {
+		return fmt.Errorf("worktree check did not prove structural damage: %w", err)
+	}
+
+	agentID := m.agentBeadID(name)
+	agentIssue, fields, err := m.agentBeads().GetAgentBead(agentID)
+	if err != nil {
+		return fmt.Errorf("not safe to reclaim: agent_bead=%s lookup_error: %w", agentID, err)
+	}
+	if agentIssue == nil || fields == nil {
+		return fmt.Errorf("not safe to reclaim: agent_bead=%s missing", agentID)
+	}
+	if blocker := brokenIdleReclaimAgentBlocker(fields); blocker != "" {
+		return fmt.Errorf("not safe to reclaim: %s", blocker)
+	}
+	if blocker := m.brokenIdleReclaimSessionBlocker(name); blocker != "" {
+		return fmt.Errorf("not safe to reclaim: %s", blocker)
+	}
+	issues, err := m.beads.ListByAssignee(m.assigneeID(name))
+	if err != nil {
+		return fmt.Errorf("not safe to reclaim: assigned_work lookup_error: %w", err)
+	}
+	if work := activeWorkBeadsForCleanup(issues); len(work) > 0 {
+		return fmt.Errorf("not safe to reclaim: assigned_work=%s status=%s", work[0].ID, work[0].Status)
+	}
+	if blocker := brokenIdleReclaimDispositionBlocker(m.WorkstateDispositionForPolecat(name, current.State, current.Issue)); blocker != "" {
+		return fmt.Errorf("not safe to reclaim: %s", blocker)
+	}
+	mr, mrErr := m.beads.FindMRForBranch(fields.Branch)
+	if blocker := brokenIdleReclaimMRBlocker(fields.Branch, mr, mrErr); blocker != "" {
+		return fmt.Errorf("not safe to reclaim: %s", blocker)
+	}
+
+	return m.removeWithOptionsLocked(name, false, false, false)
 }
 
 // verifyRemovalComplete checks that polecat directories were actually removed.
@@ -2061,24 +2126,51 @@ func (m *Manager) cleanupOrphanPolecatState() {
 		name := entry.Name()
 		polecatDir := filepath.Join(polecatsDir, name)
 
-		// Check if this is a valid polecat with a working worktree
+		// Only remove truly partial spawn artifacts here. Named polecats with any
+		// agent/work/session evidence must go through the locked reclaim path.
 		clonePath := filepath.Join(polecatDir, m.rig.Name)
 		gitPath := filepath.Join(clonePath, ".git")
 
-		// Check if clone directory exists
 		if _, err := os.Stat(clonePath); os.IsNotExist(err) {
-			// Empty polecat directory without clone - remove it
-			_ = os.RemoveAll(polecatDir)
+			_ = m.removePartialOrphanPolecatDir(name, polecatDir)
 			continue
 		}
-
-		// Check if .git exists (file for worktree, or directory for full clone)
 		if _, err := os.Stat(gitPath); os.IsNotExist(err) {
-			// Clone exists but no .git - incomplete worktree, remove it
-			_ = os.RemoveAll(polecatDir)
+			_ = m.removePartialOrphanPolecatDir(name, polecatDir)
 			continue
 		}
 	}
+}
+
+func (m *Manager) removePartialOrphanPolecatDir(name, polecatDir string) error {
+	fl, err := m.lockPolecat(name)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	if blocker := m.brokenIdleReclaimSessionBlocker(name); blocker != "" {
+		return fmt.Errorf("not safe to remove partial orphan: %s", blocker)
+	}
+
+	agentID := m.agentBeadID(name)
+	agentIssue, fields, err := m.agentBeads().GetAgentBead(agentID)
+	if err == nil && (agentIssue != nil || fields != nil) {
+		return fmt.Errorf("not safe to remove partial orphan: agent_bead=%s exists", agentID)
+	}
+	if err != nil && !errors.Is(err, beads.ErrNotFound) {
+		return err
+	}
+
+	issues, err := m.beads.ListByAssignee(m.assigneeID(name))
+	if err != nil {
+		return err
+	}
+	if work := activeWorkBeadsForCleanup(issues); len(work) > 0 {
+		return fmt.Errorf("not safe to remove partial orphan: assigned_work=%s status=%s", work[0].ID, work[0].Status)
+	}
+
+	return os.RemoveAll(polecatDir)
 }
 
 // PoolStatus returns information about the name pool.

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2128,7 +2128,7 @@ func (m *Manager) cleanupOrphanPolecatState() {
 
 		// Only remove truly partial spawn artifacts here. Named polecats with any
 		// agent/work/session evidence must go through the locked reclaim path.
-		clonePath := filepath.Join(polecatDir, m.rig.Name)
+		clonePath := m.clonePath(name)
 		gitPath := filepath.Join(clonePath, ".git")
 
 		if _, err := os.Stat(clonePath); os.IsNotExist(err) {

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -191,6 +191,37 @@ esac
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
+func installEmptyMockBd(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+case "$cmd" in
+  show|list)
+    printf '[]\n'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write mock bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 func setupCanonicalBranchManagerTest(t *testing.T) (*Manager, string) {
 	t.Helper()
 	installMockBd(t)
@@ -2054,6 +2085,35 @@ func TestCleanupOrphanPolecatStatePreservesUnverifiedBrokenPolecat(t *testing.T)
 
 	if _, err := os.Stat(polecatDir); err != nil {
 		t.Fatalf("broken named polecat dir was removed without safety proof: %v", err)
+	}
+}
+
+func TestCleanupOrphanPolecatStatePreservesOldLayoutWorktree(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+	installEmptyMockBd(t)
+
+	tmpDir := t.TempDir()
+	r := &rig.Rig{Name: "myrig", Path: tmpDir}
+	m := NewManager(r, nil, tmux.NewTmux())
+
+	polecatDir := filepath.Join(tmpDir, "polecats", "furiosa")
+	if err := os.MkdirAll(polecatDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(polecatDir, ".git"), []byte("gitdir: /tmp/nonexistent-for-layout-test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(polecatDir, "sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("old layout worktree\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m.cleanupOrphanPolecatState()
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("old-layout worktree was removed by orphan cleanup: %v", err)
 	}
 }
 

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -126,8 +126,8 @@ switch ($cmd) {
     exit 0
   }
   'show' {
-    Write-Error '{"error":"not found"}'
-    exit 1
+			Write-Output '[{"id":"gt-gastown-polecat-toast","title":"agent","issue_type":"agent","description":"agent\n\nrole_type: polecat\nagent_state: idle\nhook_bead: null\ncleanup_status: clean\nactive_mr: null\nbranch: polecat/toast/gt-work@abc123","status":"open","created_at":"2025-01-01T00:00:00Z"}]'
+			exit 0
   }
   default { exit 0 }
 }
@@ -176,7 +176,7 @@ case "$cmd" in
       id="$arg"
       break
     done
-    printf '[{"id":"%s","title":"agent","issue_type":"agent","description":"agent\\n\\nrole_type: polecat\\nagent_state: idle\\nhook_bead: null\\ncleanup_status: clean"}]\n' "$id"
+    printf '[{"id":"%s","title":"agent","issue_type":"agent","description":"agent\\n\\nrole_type: polecat\\nagent_state: idle\\nhook_bead: null\\ncleanup_status: clean\\nactive_mr: null\\nbranch: polecat/toast/gt-work@abc123"}]\n' "$id"
     exit 0
     ;;
   *)
@@ -2034,6 +2034,69 @@ func TestStalePendingMarkerIsCleanedUp(t *testing.T) {
 
 	if _, err := os.Stat(pendingPath); !os.IsNotExist(err) {
 		t.Errorf("stale .pending file was not cleaned up by cleanupOrphanPolecatState")
+	}
+}
+
+func TestCleanupOrphanPolecatStatePreservesUnverifiedBrokenPolecat(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	r := &rig.Rig{Name: "myrig", Path: tmpDir}
+	m := NewManager(r, nil, nil)
+
+	polecatDir := filepath.Join(tmpDir, "polecats", "furiosa")
+	clonePath := filepath.Join(polecatDir, r.Name)
+	if err := os.MkdirAll(clonePath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	m.cleanupOrphanPolecatState()
+
+	if _, err := os.Stat(polecatDir); err != nil {
+		t.Fatalf("broken named polecat dir was removed without safety proof: %v", err)
+	}
+}
+
+func TestReclaimBrokenIdlePolecatRemovesCleanStructuralFailure(t *testing.T) {
+	mgr, _ := setupCanonicalBranchManagerTest(t)
+	mgr.tmux = tmux.NewTmux()
+	if !mgr.tmux.IsAvailable() {
+		t.Skip("tmux is required to prove no live polecat session")
+	}
+
+	p, err := mgr.AddWithOptions("toast", AddOptions{})
+	if err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+	if err := os.Remove(filepath.Join(p.ClonePath, ".git")); err != nil {
+		t.Fatalf("break worktree .git: %v", err)
+	}
+
+	if err := mgr.ReclaimBrokenIdlePolecat("toast"); err != nil {
+		t.Fatalf("ReclaimBrokenIdlePolecat: %v", err)
+	}
+	if _, err := os.Stat(mgr.polecatDir("toast")); !os.IsNotExist(err) {
+		t.Fatalf("polecat dir still exists after reclaim, stat err=%v", err)
+	}
+}
+
+func TestReclaimBrokenIdlePolecatFailsClosedWithoutSessionEvidence(t *testing.T) {
+	mgr, _ := setupCanonicalBranchManagerTest(t)
+
+	p, err := mgr.AddWithOptions("toast", AddOptions{})
+	if err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+	if err := os.Remove(filepath.Join(p.ClonePath, ".git")); err != nil {
+		t.Fatalf("break worktree .git: %v", err)
+	}
+
+	err = mgr.ReclaimBrokenIdlePolecat("toast")
+	if err == nil || !strings.Contains(err.Error(), "session_state=unverified") {
+		t.Fatalf("ReclaimBrokenIdlePolecat error = %v, want session evidence blocker", err)
+	}
+	if _, statErr := os.Stat(mgr.polecatDir("toast")); statErr != nil {
+		t.Fatalf("polecat dir should be preserved after blocked reclaim: %v", statErr)
 	}
 }
 

--- a/internal/polecat/reclaim.go
+++ b/internal/polecat/reclaim.go
@@ -1,0 +1,81 @@
+package polecat
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/session"
+)
+
+func brokenIdleReclaimDispositionBlocker(d WorkstateDisposition) string {
+	if d.Reason != "git-check-failed" {
+		return fmt.Sprintf("workstate=%s reason=%s", d.Verdict, d.Reason)
+	}
+	if len(d.Blockers) != 1 || d.Blockers[0] != "git_state=unknown" {
+		return fmt.Sprintf("workstate blockers=%s", strings.Join(d.Blockers, ","))
+	}
+	return ""
+}
+
+func brokenIdleReclaimAgentBlocker(fields *beads.AgentFields) string {
+	if fields == nil {
+		return "agent_fields=<missing>"
+	}
+	if state := beads.AgentState(fields.AgentState); state != beads.AgentStateIdle {
+		if state == "" {
+			return "agent_state=<missing>"
+		}
+		return "agent_state=" + string(state)
+	}
+	if status := CleanupStatus(fields.CleanupStatus); status != CleanupClean {
+		if status == "" {
+			return "cleanup_status=<missing>"
+		}
+		return "cleanup_status=" + string(status)
+	}
+	if strings.TrimSpace(fields.HookBead) != "" {
+		return "hook_bead=" + fields.HookBead
+	}
+	if strings.TrimSpace(fields.ActiveMR) != "" {
+		return "active_mr=" + fields.ActiveMR
+	}
+	if fields.PushFailed {
+		return "push_failed=true"
+	}
+	if fields.MRFailed {
+		return "mr_failed=true"
+	}
+	if strings.TrimSpace(fields.Branch) == "" {
+		return "branch=<missing>"
+	}
+	return ""
+}
+
+func brokenIdleReclaimMRBlocker(branch string, mr *beads.Issue, err error) string {
+	if strings.TrimSpace(branch) == "" {
+		return "branch=<missing>"
+	}
+	if err != nil {
+		return fmt.Sprintf("checking MR for branch %s: %v", branch, err)
+	}
+	if mr != nil {
+		return fmt.Sprintf("branch %s has open MR %s status=%s", branch, mr.ID, mr.Status)
+	}
+	return ""
+}
+
+func (m *Manager) brokenIdleReclaimSessionBlocker(name string) string {
+	if m.tmux == nil {
+		return "session_state=unverified"
+	}
+	sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
+	running, err := m.tmux.HasSession(sessionName)
+	if err != nil {
+		return fmt.Sprintf("session_state=lookup_error: %v", err)
+	}
+	if running {
+		return "session_state=running"
+	}
+	return ""
+}

--- a/internal/polecat/reclaim_test.go
+++ b/internal/polecat/reclaim_test.go
@@ -1,0 +1,108 @@
+package polecat
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestBrokenIdleReclaimDispositionBlocker(t *testing.T) {
+	tests := []struct {
+		name string
+		d    WorkstateDisposition
+		want string
+	}{
+		{
+			name: "only git unknown passes",
+			d:    WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "git-check-failed", Blockers: []string{"git_state=unknown"}},
+			want: "",
+		},
+		{
+			name: "wrong reason blocks",
+			d:    WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "cleanup-unknown", Blockers: []string{"cleanup_status=<missing>"}},
+			want: "workstate=NEEDS_RECOVERY reason=cleanup-unknown",
+		},
+		{
+			name: "extra blocker blocks",
+			d:    WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "git-check-failed", Blockers: []string{"cleanup_status=<missing>", "git_state=unknown"}},
+			want: "workstate blockers=cleanup_status=<missing>,git_state=unknown",
+		},
+		{
+			name: "missing blocker blocks",
+			d:    WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "git-check-failed"},
+			want: "workstate blockers=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := brokenIdleReclaimDispositionBlocker(tt.d); got != tt.want {
+				t.Fatalf("brokenIdleReclaimDispositionBlocker() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrokenIdleReclaimMRBlocker(t *testing.T) {
+	tests := []struct {
+		name   string
+		branch string
+		mr     *beads.Issue
+		err    error
+		want   string
+	}{
+		{name: "no open mr passes", branch: "polecat/toast/gt-work@abc123", want: ""},
+		{name: "missing branch blocks", want: "branch=<missing>"},
+		{name: "lookup error blocks", branch: "polecat/toast/gt-work@abc123", err: errors.New("dolt locked"), want: "checking MR for branch polecat/toast/gt-work@abc123: dolt locked"},
+		{name: "open mr blocks", branch: "polecat/toast/gt-work@abc123", mr: &beads.Issue{ID: "gt-mr", Status: "open"}, want: "branch polecat/toast/gt-work@abc123 has open MR gt-mr status=open"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := brokenIdleReclaimMRBlocker(tt.branch, tt.mr, tt.err); got != tt.want {
+				t.Fatalf("brokenIdleReclaimMRBlocker() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrokenIdleReclaimAgentBlocker(t *testing.T) {
+	base := func() *beads.AgentFields {
+		return &beads.AgentFields{
+			AgentState:    string(beads.AgentStateIdle),
+			CleanupStatus: string(CleanupClean),
+			Branch:        "polecat/toast/gt-work@abc123",
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*beads.AgentFields) *beads.AgentFields
+		want   string
+	}{
+		{name: "clean idle passes", want: ""},
+		{name: "nil fields block", mutate: func(*beads.AgentFields) *beads.AgentFields { return nil }, want: "agent_fields=<missing>"},
+		{name: "missing agent state blocks", mutate: func(f *beads.AgentFields) *beads.AgentFields { f.AgentState = ""; return f }, want: "agent_state=<missing>"},
+		{name: "done state blocks", mutate: func(f *beads.AgentFields) *beads.AgentFields { f.AgentState = string(beads.AgentStateDone); return f }, want: "agent_state=done"},
+		{name: "missing cleanup blocks", mutate: func(f *beads.AgentFields) *beads.AgentFields { f.CleanupStatus = ""; return f }, want: "cleanup_status=<missing>"},
+		{name: "dirty cleanup blocks", mutate: func(f *beads.AgentFields) *beads.AgentFields { f.CleanupStatus = string(CleanupUncommitted); return f }, want: "cleanup_status=has_uncommitted"},
+		{name: "hook blocks", mutate: func(f *beads.AgentFields) *beads.AgentFields { f.HookBead = "gt-work"; return f }, want: "hook_bead=gt-work"},
+		{name: "active mr blocks", mutate: func(f *beads.AgentFields) *beads.AgentFields { f.ActiveMR = "gt-mr"; return f }, want: "active_mr=gt-mr"},
+		{name: "push failed blocks", mutate: func(f *beads.AgentFields) *beads.AgentFields { f.PushFailed = true; return f }, want: "push_failed=true"},
+		{name: "mr failed blocks", mutate: func(f *beads.AgentFields) *beads.AgentFields { f.MRFailed = true; return f }, want: "mr_failed=true"},
+		{name: "missing branch blocks", mutate: func(f *beads.AgentFields) *beads.AgentFields { f.Branch = ""; return f }, want: "branch=<missing>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := base()
+			if tt.mutate != nil {
+				fields = tt.mutate(fields)
+			}
+			if got := brokenIdleReclaimAgentBlocker(fields); got != tt.want {
+				t.Fatalf("brokenIdleReclaimAgentBlocker() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/polecat/worktree.go
+++ b/internal/polecat/worktree.go
@@ -1,0 +1,86 @@
+package polecat
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// WorktreeIntegrityError marks structural worktree damage that is safe to
+// distinguish from transient git, permission, or tooling failures.
+type WorktreeIntegrityError struct {
+	Path string
+	Err  error
+}
+
+func (e *WorktreeIntegrityError) Error() string {
+	if e.Err == nil {
+		return e.Path
+	}
+	return e.Err.Error()
+}
+
+func (e *WorktreeIntegrityError) Unwrap() error {
+	return e.Err
+}
+
+// IsStructuralWorktreeError reports whether err proves the worktree shape is
+// broken, rather than only proving git could not answer a runtime query.
+func IsStructuralWorktreeError(err error) bool {
+	var integrityErr *WorktreeIntegrityError
+	return errors.As(err, &integrityErr)
+}
+
+func structuralWorktreeError(path string, format string, args ...any) error {
+	return &WorktreeIntegrityError{Path: path, Err: fmt.Errorf(format, args...)}
+}
+
+// VerifyWorktreeExists checks that clonePath is a git worktree whose .git
+// indirection points at an existing gitdir.
+func VerifyWorktreeExists(clonePath string) error {
+	info, err := os.Stat(clonePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return structuralWorktreeError(clonePath, "worktree directory does not exist: %s", clonePath)
+		}
+		return fmt.Errorf("checking worktree directory: %w", err)
+	}
+	if !info.IsDir() {
+		return structuralWorktreeError(clonePath, "worktree path is not a directory: %s", clonePath)
+	}
+
+	gitPath := filepath.Join(clonePath, ".git")
+	if _, err := os.Stat(gitPath); err != nil {
+		if os.IsNotExist(err) {
+			return structuralWorktreeError(clonePath, "worktree missing .git file (not a valid git worktree): %s", clonePath)
+		}
+		return fmt.Errorf("checking .git: %w", err)
+	}
+
+	gitContent, err := os.ReadFile(gitPath)
+	if err == nil {
+		content := strings.TrimSpace(string(gitContent))
+		if strings.HasPrefix(content, "gitdir: ") {
+			gitdirPath := strings.TrimPrefix(content, "gitdir: ")
+			if !filepath.IsAbs(gitdirPath) {
+				gitdirPath = filepath.Join(clonePath, gitdirPath)
+			}
+			if _, err := os.Stat(gitdirPath); err != nil {
+				if os.IsNotExist(err) {
+					return structuralWorktreeError(clonePath, "worktree .git references nonexistent gitdir %s: %w", gitdirPath, err)
+				}
+				return fmt.Errorf("checking worktree gitdir %s: %w", gitdirPath, err)
+			}
+		}
+	}
+
+	cmd := exec.Command("git", "-C", clonePath, "rev-parse", "--git-dir")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("worktree at %s is not a valid git repository: %s", clonePath, strings.TrimSpace(string(output)))
+	}
+
+	return nil
+}

--- a/internal/polecat/worktree_test.go
+++ b/internal/polecat/worktree_test.go
@@ -1,0 +1,75 @@
+package polecat
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVerifyWorktreeExistsStructuralFailures(t *testing.T) {
+	tmp := t.TempDir()
+
+	t.Run("missing directory", func(t *testing.T) {
+		err := VerifyWorktreeExists(filepath.Join(tmp, "missing"))
+		if !IsStructuralWorktreeError(err) {
+			t.Fatalf("VerifyWorktreeExists missing dir structural = false, err=%v", err)
+		}
+		if !IsStructuralWorktreeError(fmt.Errorf("wrapped: %w", err)) {
+			t.Fatalf("wrapped structural error was not classified as structural: %v", err)
+		}
+	})
+
+	t.Run("path is file", func(t *testing.T) {
+		path := filepath.Join(tmp, "file")
+		if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		err := VerifyWorktreeExists(path)
+		if !IsStructuralWorktreeError(err) {
+			t.Fatalf("VerifyWorktreeExists file path structural = false, err=%v", err)
+		}
+	})
+
+	t.Run("missing git file", func(t *testing.T) {
+		path := filepath.Join(tmp, "missing-git")
+		if err := os.Mkdir(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+		err := VerifyWorktreeExists(path)
+		if !IsStructuralWorktreeError(err) {
+			t.Fatalf("VerifyWorktreeExists missing .git structural = false, err=%v", err)
+		}
+	})
+
+	t.Run("broken gitdir reference", func(t *testing.T) {
+		path := filepath.Join(tmp, "broken-gitdir")
+		if err := os.Mkdir(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, ".git"), []byte("gitdir: missing-gitdir\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		err := VerifyWorktreeExists(path)
+		if !IsStructuralWorktreeError(err) {
+			t.Fatalf("VerifyWorktreeExists broken gitdir structural = false, err=%v", err)
+		}
+	})
+
+	t.Run("invalid git content is non structural", func(t *testing.T) {
+		path := filepath.Join(tmp, "invalid-git")
+		if err := os.Mkdir(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, ".git"), []byte("not a gitdir"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		err := VerifyWorktreeExists(path)
+		if err == nil {
+			t.Fatal("VerifyWorktreeExists invalid git content returned nil")
+		}
+		if IsStructuralWorktreeError(err) {
+			t.Fatalf("VerifyWorktreeExists invalid git content structural = true, err=%v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Replacement for #4103 on current upstream/main.
- Reclaims structurally broken idle polecat worktrees before sling allocation and before any hook assignment.
- Keeps deletion fail-closed: idle + clean agent evidence, no hook, no active MR, no assigned work, no live session, and normal non-force removal only.
- Guards existing partial-orphan cleanup so named broken polecat directories are preserved unless no agent/work/session evidence exists.

## Attribution
Carries forward the accepted bug-fix intent from #4103 by Jacob-qd.
Original PR: https://github.com/gastownhall/gastown/pull/4103
Original head commit: 30e22433b62dc78a7b04596904cb1ea1698abaa8

## Verification
- CGO_ENABLED=0 go test ./internal/polecat -run 'Test(ReclaimBrokenIdlePolecat|VerifyWorktreeExistsStructuralFailures|BrokenIdleReclaim|CleanupOrphanPolecatStatePreservesUnverifiedBrokenPolecat|HasSubmittableWorkForWorkstateUsesBranchTargetStatus|DecideWorkstate|AssessActiveMR|ReuseIdlePolecat_RunsSetupCommand|ReuseIdlePolecat_SetupCommandFailureCleansWorktree|ReuseIdlePolecat_UsesCanonicalOriginDefaultBranch|ReuseIdlePolecat_KillsLiveSession|ReuseIdlePolecat_KillsStaleSession|ReuseIdlePolecat_NoSessionNoop)' -count=1\n- CGO_ENABLED=0 go test ./internal/cmd -run 'Test(EffectivePolecatDirCap|BuildPolecatInventoryItem|WorkstateDispositionProjectionAgreement|PolecatReuseStatus|ApplyAgentFieldsToCapacitySnapshotSeparatesPendingMR|CapacitySnapshotRecoveryBlockedDoesNotAlwaysConsumeFreeCapacity|GetGitState|HasSubmittableWorkForRecovery|StaleCleanupStatusCanBeIgnoredForRecovery)' -count=1\n- CGO_ENABLED=0 go build ./cmd/gt\n\n## PR Sheriff\nEvidence/checker will be persisted on bead gt-2d1i. No refinery/MQ path; this is GitHub-only. Original #4103 should remain open until this replacement lands.