### PR TITLE
feat(polecat): configurable branch delimiter for CI-constrained charsets

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -195,6 +195,24 @@ When `polecat_branch_template` is empty or not set:
 - With issue: `polecat/{name}/{issue}+{timestamp}`
 - Without issue: `polecat/{name}-{timestamp}`
 
+**Issue/timestamp delimiter (`polecat_branch_delimiter`):**
+
+Some CI systems constrain the branch-name charset — e.g. docker-compose
+project names derived from branch names allow only `[a-z0-9_-]`, rejecting
+the default `+`. Rigs whose CI needs this can pick a different delimiter for
+the default (non-template) branch format:
+
+```bash
+gt rig config set myrig polecat_branch_delimiter _
+# → polecat/{name}/{issue}_{timestamp}
+```
+
+Valid delimiters are `+` (default), `_`, and `@` (legacy) — characters that
+can never appear in issue IDs or polecat names, so branches always parse
+back to the right issue. Invalid values fall back to `+`. Parsing accepts
+all valid delimiters regardless of configuration, so branches created under
+a previous delimiter keep working after a config change.
+
 **Example Configurations:**
 
 ```bash

--- a/internal/polecat/branch_name.go
+++ b/internal/polecat/branch_name.go
@@ -9,7 +9,39 @@ const (
 	polecatBranchPrefix           = "polecat/"
 	generatedIssueBranchSeparator = "+"
 	legacyIssueBranchSeparator    = "@"
+
+	// BranchDelimiterConfigKey is the rig config key that selects which
+	// delimiter FormatGeneratedBranchName places between the issue ID and the
+	// generated suffix. Some CI systems constrain the branch-name charset
+	// (e.g. docker-compose project names allow only [a-z0-9_-]), so rigs whose
+	// CI rejects "+" can pick "_" instead.
+	BranchDelimiterConfigKey = "polecat_branch_delimiter"
 )
+
+// issueBranchSeparators lists every delimiter ParseBranchName recognizes
+// between the issue ID and the generated suffix. Parsing accepts all of them
+// regardless of the rig's configured delimiter, so branches created under a
+// previous delimiter configuration keep resolving to the right issue. None of
+// these characters can appear in issue IDs ([a-z0-9-] plus "." for subtasks)
+// or polecat names, so the split is unambiguous.
+var issueBranchSeparators = []string{
+	generatedIssueBranchSeparator,
+	legacyIssueBranchSeparator,
+	"_",
+}
+
+// ValidBranchDelimiter reports whether s may be used as the configured
+// branch delimiter. Only delimiters the parser recognizes are valid;
+// anything else would produce branches that no longer round-trip to an
+// issue ID.
+func ValidBranchDelimiter(s string) bool {
+	for _, sep := range issueBranchSeparators {
+		if s == sep {
+			return true
+		}
+	}
+	return false
+}
 
 // BranchNameMeta is the structured identity encoded in a polecat branch name.
 type BranchNameMeta struct {
@@ -18,10 +50,21 @@ type BranchNameMeta struct {
 	Generated bool
 }
 
-// FormatGeneratedBranchName returns the canonical generated polecat branch.
+// FormatGeneratedBranchName returns the canonical generated polecat branch
+// using the default "+" delimiter.
 func FormatGeneratedBranchName(polecatName, issue, suffix string) string {
+	return FormatGeneratedBranchNameWithDelimiter(polecatName, issue, suffix, generatedIssueBranchSeparator)
+}
+
+// FormatGeneratedBranchNameWithDelimiter returns the generated polecat branch
+// with the given issue/suffix delimiter. Invalid delimiters fall back to the
+// default "+" so a bad config value can never produce an unparseable branch.
+func FormatGeneratedBranchNameWithDelimiter(polecatName, issue, suffix, delimiter string) string {
+	if !ValidBranchDelimiter(delimiter) {
+		delimiter = generatedIssueBranchSeparator
+	}
 	if issue != "" {
-		return fmt.Sprintf("%s%s/%s%s%s", polecatBranchPrefix, polecatName, issue, generatedIssueBranchSeparator, suffix)
+		return fmt.Sprintf("%s%s/%s%s%s", polecatBranchPrefix, polecatName, issue, delimiter, suffix)
 	}
 	return fmt.Sprintf("%s%s-%s", polecatBranchPrefix, polecatName, suffix)
 }
@@ -60,8 +103,9 @@ func ParseBranchName(branch string) (BranchNameMeta, bool) {
 	return BranchNameMeta{Polecat: rest[:dash], Generated: true}, true
 }
 
-// ParseGeneratedBranchName decodes only branch names emitted by FormatGeneratedBranchName
-// and the legacy @ issue-suffix form kept for in-flight branches.
+// ParseGeneratedBranchName decodes only branch names emitted by
+// FormatGeneratedBranchName / FormatGeneratedBranchNameWithDelimiter and the
+// legacy @ issue-suffix form kept for in-flight branches.
 func ParseGeneratedBranchName(branch string) (BranchNameMeta, bool) {
 	meta, ok := ParseBranchName(branch)
 	if !ok || !meta.Generated {
@@ -72,7 +116,7 @@ func ParseGeneratedBranchName(branch string) (BranchNameMeta, bool) {
 
 func parseIssueTail(issueTail string) (issue string, generated bool, ok bool) {
 	delim := -1
-	for _, sep := range []string{generatedIssueBranchSeparator, legacyIssueBranchSeparator} {
+	for _, sep := range issueBranchSeparators {
 		if idx := strings.Index(issueTail, sep); idx >= 0 && (delim == -1 || idx < delim) {
 			delim = idx
 		}

--- a/internal/polecat/branch_name_test.go
+++ b/internal/polecat/branch_name_test.go
@@ -70,12 +70,44 @@ func TestParseBranchName(t *testing.T) {
 			wantPolecat:   "alpha",
 		},
 		{
+			name:          "generated issue with underscore suffix",
+			branch:        "polecat/alpha/cap-5gw_mrb05j24",
+			wantOk:        true,
+			wantGenerated: true,
+			wantPolecat:   "alpha",
+			wantIssue:     "cap-5gw",
+		},
+		{
+			name:          "generated dashed issue with underscore suffix",
+			branch:        "polecat/alpha/gt-pin-bd-metadata_mk123456",
+			wantOk:        true,
+			wantGenerated: true,
+			wantPolecat:   "alpha",
+			wantIssue:     "gt-pin-bd-metadata",
+		},
+		{
+			name:          "generated dotted subtask with underscore suffix",
+			branch:        "polecat/alpha/gt-4kp9.5.5.1_mk123456",
+			wantOk:        true,
+			wantGenerated: true,
+			wantPolecat:   "alpha",
+			wantIssue:     "gt-4kp9.5.5.1",
+		},
+		{
 			name:   "empty generated suffix is invalid",
 			branch: "polecat/alpha/gt-abc+",
 		},
 		{
+			name:   "empty underscore suffix is invalid",
+			branch: "polecat/alpha/gt-abc_",
+		},
+		{
 			name:   "empty generated issue is invalid",
 			branch: "polecat/alpha/+mk123456",
+		},
+		{
+			name:   "empty underscore issue is invalid",
+			branch: "polecat/alpha/_mk123456",
 		},
 	}
 
@@ -98,6 +130,62 @@ func TestParseBranchName(t *testing.T) {
 				t.Errorf("Issue = %q, want %q", got.Issue, tt.wantIssue)
 			}
 		})
+	}
+}
+
+func TestFormatGeneratedBranchNameWithDelimiter(t *testing.T) {
+	tests := []struct {
+		name      string
+		issue     string
+		delimiter string
+		want      string
+	}{
+		{name: "underscore delimiter", issue: "cap-5gw", delimiter: "_", want: "polecat/alpha/cap-5gw_mk123456"},
+		{name: "plus delimiter", issue: "cap-5gw", delimiter: "+", want: "polecat/alpha/cap-5gw+mk123456"},
+		{name: "invalid delimiter falls back to plus", issue: "cap-5gw", delimiter: "!", want: "polecat/alpha/cap-5gw+mk123456"},
+		{name: "empty delimiter falls back to plus", issue: "cap-5gw", delimiter: "", want: "polecat/alpha/cap-5gw+mk123456"},
+		{name: "multi-char delimiter falls back to plus", issue: "cap-5gw", delimiter: "__", want: "polecat/alpha/cap-5gw+mk123456"},
+		{name: "no issue ignores delimiter", issue: "", delimiter: "_", want: "polecat/alpha-mk123456"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatGeneratedBranchNameWithDelimiter("alpha", tt.issue, "mk123456", tt.delimiter)
+			if got != tt.want {
+				t.Errorf("FormatGeneratedBranchNameWithDelimiter() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnderscoreBranchRoundTrip(t *testing.T) {
+	// The docker-compose-safe delimiter must round-trip: format with "_" and
+	// parse back to the same issue (AA-849).
+	branch := FormatGeneratedBranchNameWithDelimiter("nux", "cap-5gw", "mrb05j24", "_")
+	if branch != "polecat/nux/cap-5gw_mrb05j24" {
+		t.Fatalf("format = %q, want polecat/nux/cap-5gw_mrb05j24", branch)
+	}
+	meta, ok := ParseGeneratedBranchName(branch)
+	if !ok {
+		t.Fatalf("ParseGeneratedBranchName(%q) not ok", branch)
+	}
+	if meta.Polecat != "nux" || meta.Issue != "cap-5gw" {
+		t.Fatalf("round-trip = %+v, want polecat nux issue cap-5gw", meta)
+	}
+	if err := exec.Command("git", "check-ref-format", "--branch", branch).Run(); err != nil {
+		t.Fatalf("branch %q rejected by git check-ref-format: %v", branch, err)
+	}
+}
+
+func TestValidBranchDelimiter(t *testing.T) {
+	for _, valid := range []string{"+", "@", "_"} {
+		if !ValidBranchDelimiter(valid) {
+			t.Errorf("ValidBranchDelimiter(%q) = false, want true", valid)
+		}
+	}
+	for _, invalid := range []string{"", "-", ".", "/", "!", "__", "+@", "a"} {
+		if ValidBranchDelimiter(invalid) {
+			t.Errorf("ValidBranchDelimiter(%q) = true, want false", invalid)
+		}
 	}
 }
 

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -555,25 +555,46 @@ type AddOptions struct {
 // - {timestamp}: unique timestamp
 //
 // If no template is configured or template is empty, uses default format:
-// - polecat/{name}/{issue}+{timestamp} when issue is available
-// - polecat/{name}-{timestamp} otherwise
+//   - polecat/{name}/{issue}<delimiter>{timestamp} when issue is available,
+//     where <delimiter> comes from the polecat_branch_delimiter rig config
+//     (default "+")
+//   - polecat/{name}-{timestamp} otherwise
 func (m *Manager) buildBranchName(name, issue string) string {
-	template := m.rig.GetStringConfig("polecat_branch_template")
+	return buildBranchNameFor(m.rig, m.git, m.beads, name, issue)
+}
+
+// buildBranchNameFor is the shared implementation behind Manager.buildBranchName
+// and SessionManager.freshBranchName, so polecat creation and session-restart
+// branch creation always agree on naming. r, g, and b may each be nil: a nil
+// rig means no template/delimiter config, a nil git skips the {user} lookup,
+// and nil beads skips the {description} lookup.
+func buildBranchNameFor(r *rig.Rig, g *git.Git, b *beads.Beads, name, issue string) string {
+	template := ""
+	if r != nil {
+		template = r.GetStringConfig("polecat_branch_template")
+	}
 
 	// No template configured - use default behavior for backward compatibility
 	if template == "" {
+		delimiter := generatedIssueBranchSeparator
+		if r != nil {
+			if d := r.GetStringConfig(BranchDelimiterConfigKey); d != "" {
+				delimiter = d
+			}
+		}
 		timestamp := strconv.FormatInt(time.Now().UnixMilli(), 36)
-		return FormatGeneratedBranchName(name, issue, timestamp)
+		return FormatGeneratedBranchNameWithDelimiter(name, issue, timestamp, delimiter)
 	}
 
 	// Build template variables
 	vars := make(map[string]string)
 
 	// {user} - from git config user.name
-	if userName, err := m.git.ConfigGet("user.name"); err == nil && userName != "" {
-		vars["{user}"] = userName
-	} else {
-		vars["{user}"] = "unknown"
+	vars["{user}"] = "unknown"
+	if g != nil {
+		if userName, err := g.ConfigGet("user.name"); err == nil && userName != "" {
+			vars["{user}"] = userName
+		}
 	}
 
 	// {year} and {month}
@@ -600,8 +621,9 @@ func (m *Manager) buildBranchName(name, issue string) string {
 	}
 
 	// {description} - try to get from beads if issue is set
-	if issue != "" {
-		if issueData, err := m.beads.Show(issue); err == nil && issueData.Title != "" {
+	vars["{description}"] = ""
+	if issue != "" && b != nil {
+		if issueData, err := b.Show(issue); err == nil && issueData.Title != "" {
 			// Sanitize title for branch name: lowercase, replace spaces/special chars with hyphens
 			desc := strings.ToLower(issueData.Title)
 			desc = strings.Map(func(r rune) rune {
@@ -620,11 +642,7 @@ func (m *Manager) buildBranchName(name, issue string) string {
 				desc = desc[:40]
 			}
 			vars["{description}"] = desc
-		} else {
-			vars["{description}"] = ""
 		}
-	} else {
-		vars["{description}"] = ""
 	}
 
 	// Replace all variables in template

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1247,6 +1247,53 @@ func TestBuildBranchName(t *testing.T) {
 	}
 }
 
+func TestBuildBranchName_ConfiguredDelimiter(t *testing.T) {
+	tmpDir := t.TempDir()
+	gitCmd := exec.Command("git", "init")
+	gitCmd.Dir = tmpDir
+	if err := gitCmd.Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		delimiter  string
+		issue      string
+		wantPrefix string
+	}{
+		{name: "underscore delimiter", delimiter: "_", issue: "cap-5gw", wantPrefix: "polecat/alpha/cap-5gw_"},
+		{name: "unset delimiter keeps plus", delimiter: "", issue: "cap-5gw", wantPrefix: "polecat/alpha/cap-5gw+"},
+		{name: "invalid delimiter falls back to plus", delimiter: "!", issue: "cap-5gw", wantPrefix: "polecat/alpha/cap-5gw+"},
+		{name: "no issue unaffected", delimiter: "_", issue: "", wantPrefix: "polecat/alpha-"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origDefault := rig.SystemDefaults[BranchDelimiterConfigKey]
+			rig.SystemDefaults[BranchDelimiterConfigKey] = tt.delimiter
+			defer func() {
+				rig.SystemDefaults[BranchDelimiterConfigKey] = origDefault
+			}()
+
+			r := &rig.Rig{Name: "test-rig", Path: tmpDir}
+			g := git.NewGit(tmpDir)
+			m := NewManager(r, g, nil)
+
+			got := m.buildBranchName("alpha", tt.issue)
+			if !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Errorf("buildBranchName() = %q, want prefix %q", got, tt.wantPrefix)
+			}
+			// A delimited branch must round-trip back to its issue.
+			if tt.issue != "" {
+				meta, ok := ParseBranchName(got)
+				if !ok || meta.Issue != tt.issue {
+					t.Errorf("ParseBranchName(%q) = %+v ok=%v, want issue %q", got, meta, ok, tt.issue)
+				}
+			}
+		})
+	}
+}
+
 func TestBuildBranchName_ClaudeActionCompatible(t *testing.T) {
 	tmpDir := t.TempDir()
 	gitCmd := exec.Command("git", "init")

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -175,14 +174,22 @@ func (m *SessionManager) clonePath(polecat string) string {
 }
 
 // freshBranchName returns a unique branch name for a new polecat session.
-// Mirrors the naming convention in Manager.buildBranchName:
+// It shares Manager.buildBranchName's implementation, so session restarts
+// honor the rig's polecat_branch_template and polecat_branch_delimiter config
+// instead of leaking the default separator. Without any config:
 //   - polecat/<name>/<issue>+<timestamp> when an issue is known
 //   - polecat/<name>-<timestamp> otherwise
 //
-// parseFreshBranchName is the structural inverse.
-func (m *SessionManager) freshBranchName(polecatName, issue string) string {
-	ts := strconv.FormatInt(time.Now().UnixMilli(), 36)
-	return FormatGeneratedBranchName(polecatName, issue, ts)
+// g is the polecat worktree's git handle ({user} template variable); it may
+// be nil. parseFreshBranchName is the structural inverse for the default
+// (non-template) forms.
+func (m *SessionManager) freshBranchName(g *git.Git, polecatName, issue string) string {
+	var b *beads.Beads
+	if m.rig != nil {
+		resolvedBeads := beads.ResolveBeadsDir(m.rig.Path)
+		b = beads.NewWithBeadsDir(filepath.Dir(resolvedBeads), resolvedBeads)
+	}
+	return buildBranchNameFor(m.rig, g, b, polecatName, issue)
 }
 
 // freshBranchMeta holds the identity decoded from a branch produced by
@@ -275,7 +282,7 @@ func (m *SessionManager) ensureCanonicalSessionBranch(g *git.Git, polecat string
 		return currentBranch
 	}
 
-	newBranch := m.freshBranchName(polecat, opts.Issue)
+	newBranch := m.freshBranchName(g, polecat, opts.Issue)
 	if err := g.CheckoutNewBranch(newBranch, startPoint); err != nil {
 		debugSession("auto-checkout fresh branch on canonical base", err)
 		return currentBranch

--- a/internal/polecat/session_manager_test.go
+++ b/internal/polecat/session_manager_test.go
@@ -877,7 +877,7 @@ func TestParseFreshBranchName_RoundTrip(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			branch := sm.freshBranchName(c.polecat, c.issue)
+			branch := sm.freshBranchName(nil, c.polecat, c.issue)
 			meta := parseFreshBranchName(branch)
 			if !meta.ok {
 				t.Fatalf("parseFreshBranchName(%q) not ok", branch)
@@ -890,6 +890,47 @@ func TestParseFreshBranchName_RoundTrip(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFreshBranchName_HonorsRigConfig(t *testing.T) {
+	// Session restarts must produce the same branch shape as polecat creation:
+	// both the configured delimiter and the branch template apply (AA-849).
+	tmpDir := t.TempDir()
+
+	t.Run("configured delimiter", func(t *testing.T) {
+		origDefault := rig.SystemDefaults[BranchDelimiterConfigKey]
+		rig.SystemDefaults[BranchDelimiterConfigKey] = "_"
+		defer func() {
+			rig.SystemDefaults[BranchDelimiterConfigKey] = origDefault
+		}()
+
+		sm := &SessionManager{rig: &rig.Rig{Name: "test-rig", Path: tmpDir}}
+		branch := sm.freshBranchName(nil, "nux", "cap-5gw")
+		if !strings.HasPrefix(branch, "polecat/nux/cap-5gw_") {
+			t.Fatalf("freshBranchName() = %q, want prefix polecat/nux/cap-5gw_", branch)
+		}
+		meta := parseFreshBranchName(branch)
+		if !meta.ok || meta.issue != "cap-5gw" || meta.polecat != "nux" {
+			t.Fatalf("parseFreshBranchName(%q) = %+v, want ok polecat nux issue cap-5gw", branch, meta)
+		}
+	})
+
+	t.Run("configured template", func(t *testing.T) {
+		origDefault := rig.SystemDefaults["polecat_branch_template"]
+		rig.SystemDefaults["polecat_branch_template"] = "polecat/{name}/cap-{issue}_{timestamp}"
+		defer func() {
+			rig.SystemDefaults["polecat_branch_template"] = origDefault
+		}()
+
+		sm := &SessionManager{rig: &rig.Rig{Name: "test-rig", Path: tmpDir}}
+		branch := sm.freshBranchName(nil, "nux", "cap-5gw")
+		if !strings.HasPrefix(branch, "polecat/nux/cap-5gw_") {
+			t.Fatalf("freshBranchName() = %q, want prefix polecat/nux/cap-5gw_ (template ignored?)", branch)
+		}
+		if strings.ContainsAny(branch, "@+") {
+			t.Fatalf("freshBranchName() = %q, must not contain @ or +", branch)
+		}
+	})
 }
 
 func TestParseFreshBranchName_IssueTimestampSeparators(t *testing.T) {

--- a/internal/rig/config.go
+++ b/internal/rig/config.go
@@ -31,14 +31,15 @@ type ConfigResult struct {
 // SystemDefaults contains compiled-in default values.
 // These are the fallback when no other layer provides a value.
 var SystemDefaults = map[string]interface{}{
-	"status":                  "operational",
-	"auto_restart":            true,
-	"auto_start_on_up":        false, // If true, rig agents start on gt up even when docked
-	"max_polecats":            10,
-	"priority_adjustment":     0,
-	"dnd":                     false,
-	"polecat_branch_template": "", // Empty = use default behavior (polecat/{name}/...)
-	"default_formula":         "mol-polecat-work",
+	"status":                   "operational",
+	"auto_restart":             true,
+	"auto_start_on_up":         false, // If true, rig agents start on gt up even when docked
+	"max_polecats":             10,
+	"priority_adjustment":      0,
+	"dnd":                      false,
+	"polecat_branch_template":  "", // Empty = use default behavior (polecat/{name}/...)
+	"polecat_branch_delimiter": "", // Empty = default "+"; rigs whose CI rejects "+" can set "_"
+	"default_formula":          "mol-polecat-work",
 }
 
 // StackingKeys defines which keys use stacking semantics (values add up).


### PR DESCRIPTION
## What

Adds a `polecat_branch_delimiter` rig config option that selects the delimiter placed between the issue ID and the generated timestamp suffix in polecat branch names (`polecat/{name}/{issue}<delimiter>{timestamp}`). Default remains `+` — behavior is unchanged unless a rig opts in.

## Why

Downstream CI infrastructure we don't control derives a docker-compose project name from the branch name, and docker-compose project names only allow `[a-z0-9_-]`. Both the legacy `@` and the current default `+` delimiter are rejected, which breaks every CI run for polecat branches on that repo. `_` is charset-safe **and** unambiguous — issue IDs are `[a-z0-9-]` (plus `.` for subtasks) and never contain `_`, so the parser can still split the issue from the timestamp cleanly.

Rather than hardcoding `_`, this makes the delimiter a general config option so any rig facing a branch-charset constraint can pick what its CI accepts.

## Changes

- **`internal/polecat/branch_name.go`**
  - New `BranchDelimiterConfigKey` (`polecat_branch_delimiter`) and `ValidBranchDelimiter` (valid: `+`, `_`, `@`).
  - `FormatGeneratedBranchNameWithDelimiter` — formats with a chosen delimiter; invalid values fall back to `+` so a bad config can never produce an unparseable branch. `FormatGeneratedBranchName` delegates with the default.
  - `parseIssueTail` now recognizes `_` alongside `+` and `@`. Parsing accepts **all** valid delimiters regardless of configuration, so branches created under a previous delimiter setting keep resolving to the right issue after a config change.
- **`internal/polecat/manager.go`** — `buildBranchName` body extracted to package-level `buildBranchNameFor(rig, git, beads, name, issue)` (nil-tolerant), and the default (non-template) path now honors the configured delimiter.
- **`internal/polecat/session_manager.go`** — `freshBranchName` now shares `buildBranchNameFor`, so session-restart branches honor `polecat_branch_template` and `polecat_branch_delimiter` instead of always emitting the default separator. Previously a restart leaked the default form even on rigs with a custom template.
- **`internal/rig/config.go`** — `polecat_branch_delimiter` added to `SystemDefaults` (shows up in `gt rig config show` automatically).
- **`docs/reference.md`** — documents the new key under Polecat Branch Naming.

## Tests

- Delimiter format/parse round-trip (`polecat/nux/cap-5gw_mrb05j24` ⇄ issue `cap-5gw`), including `git check-ref-format` validation.
- `ValidBranchDelimiter` accept/reject table; invalid/empty/multi-char delimiters fall back to `+`.
- `buildBranchName` with configured delimiter (underscore, unset, invalid, no-issue cases), each asserting parse round-trip.
- `freshBranchName` honors both the configured delimiter and a branch template.
- Existing `freshBranchName` tests adapted for the new `(g *git.Git, ...)` parameter (pass `nil`); assertions unchanged.

`go test ./...` and `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
