### PR TITLE
feat: hard CI gate — block polecat done/reap and refinery merge until PR CI is green

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -84,7 +84,14 @@ town-level Gas Town beads.
     "integration_branch_polecat_enabled": true,
     "integration_branch_refinery_enabled": true,
     "integration_branch_template": "integration/{title}",
-    "integration_branch_auto_land": false
+    "integration_branch_auto_land": false,
+    "ci_gate": {
+      "enabled": true,
+      "pending_timeout": "30m",
+      "poll_interval": "30s",
+      "mayor_alert_after": "30m",
+      "escalation_cmd": ""
+    }
   }
 }
 ```
@@ -149,8 +156,29 @@ Town-level role defaults live in `mayor/config.json` under:
 | `integration_branch_refinery_enabled` | `*bool` | `true` | `gt done` / `gt mq submit` auto-target integration branches |
 | `integration_branch_template` | `string` | `"integration/{title}"` | Branch name template (`{title}`, `{epic}`, `{prefix}`, `{user}`) |
 | `integration_branch_auto_land` | `*bool` | `false` | Refinery patrol auto-lands when all children closed |
+| `ci_gate` | `object` | enabled | Hard CI gate (AA-851) — see below |
 
 See [Integration Branches](concepts/integration-branches.md) for integration branch details.
+
+**CI gate fields (`merge_queue.ci_gate`):**
+
+The hard CI gate blocks a polecat from completing (`gt done`) and from being
+nuked while its branch's PR has any CI check red or pending, and stops the
+refinery from merging such a PR (merge_strategy=pr). The gate only applies
+when a PR exists — no-PR branches and merged PRs pass through — so it is safe
+to leave enabled on direct-merge rigs. When CI state cannot be determined the
+gate FAILS OPEN but runs `escalation_cmd` so a human verifies.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `*bool` | `true` | Enable the gate. Process-level kill switch: `GT_CI_GATE=off` |
+| `pending_timeout` | `string` | `"30m"` | How long `gt done` waits for pending checks before aborting with a human escalation (sized for slow Jenkins pipelines) |
+| `poll_interval` | `string` | `"30s"` | Initial poll interval while waiting; backs off to 4x |
+| `mayor_alert_after` | `string` | `"30m"` | How long a nuke can stay CI-blocked before the mayor is nudged |
+| `escalation_cmd` | `string` | `""` | Command run via `sh -c` on CI-status errors and pending timeouts. Receives `GT_CIGATE_EVENT`, `GT_CIGATE_TICKET` (from the bead's `Jira:`/`Ticket:` line), `GT_CIGATE_DETAIL`, `GT_CIGATE_PR_URL`, `GT_CIGATE_BRANCH`, `GT_CIGATE_AGENT` in the environment. Wire it to your tracker, e.g. a script that comments on the ticket and transitions it to a human-attention status |
+
+Overrides: `gt polecat nuke --ignore-ci` bypasses the nuke gate for one
+invocation; `GT_CI_GATE=off` disables the gate process-wide (emergencies only).
 
 ### Runtime (`.runtime/` - gitignored)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -91,7 +91,13 @@ town-level Gas Town beads.
       "poll_interval": "30s",
       "mayor_alert_after": "30m",
       "human_gate_checks": ["pullapprove"],
-      "escalation_cmd": ""
+      "escalation_cmd": "",
+      "macroscope_settle": {
+        "enabled": true,
+        "check_patterns": ["macroscope"],
+        "bot_logins": ["macroscopeapp"],
+        "settle_timeout": "30m"
+      }
     }
   }
 }
@@ -178,9 +184,33 @@ gate FAILS OPEN but runs `escalation_cmd` so a human verifies.
 | `mayor_alert_after` | `string` | `"30m"` | How long a nuke can stay CI-blocked before the mayor is nudged |
 | `human_gate_checks` | `[]string` | `["pullapprove"]` | Status-check context names that are human approval gates, not CI (matched case-insensitively) — excluded from the gate's green/pending evaluation so a human merge gate doesn't burn the pending timeout on every completion (AA-859). Set to `[]` to exclude nothing; approval enforcement stays with branch protection / `require_review` |
 | `escalation_cmd` | `string` | `""` | Command run via `sh -c` on CI-status errors and pending timeouts. Receives `GT_CIGATE_EVENT`, `GT_CIGATE_TICKET` (from the bead's `Jira:`/`Ticket:` line), `GT_CIGATE_DETAIL`, `GT_CIGATE_PR_URL`, `GT_CIGATE_BRANCH`, `GT_CIGATE_AGENT` in the environment. Wire it to your tracker, e.g. a script that comments on the ticket and transitions it to a human-attention status |
+| `macroscope_settle` | `object` | enabled | Macroscope comment-settle phase of `gt done`'s gate — see below |
+
+**Macroscope settle fields (`merge_queue.ci_gate.macroscope_settle`):**
+
+Macroscope posts its inline review comments asynchronously AFTER its check
+runs turn green, so a gate that only looks at check state can race the
+review: the PR goes green, `gt done` passes, and substantive comments arrive
+minutes later with the author's session already dead. Once the CI verdict is
+GREEN, `gt done` additionally (a) waits for every Macroscope check context
+to reach a terminal state on the final head, (b) performs ONE review-comment
+fetch, and (c) aborts like CI red — plus a ticket comment + human-attention
+hold via `escalation_cmd` — if any Macroscope thread is unaddressed (not
+resolved and no reply from anyone but the bot). If Macroscope never settles
+or the fetch fails, the gate FAILS OPEN with an escalation. PRs with no
+Macroscope checks or comments pass straight through, so the default is safe
+for rigs without Macroscope.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `*bool` | `true` | Enable the settle phase. Process-level kill switch: `GT_MACROSCOPE_SETTLE=off` |
+| `check_patterns` | `[]string` | `["macroscope"]` | Case-insensitive substrings identifying Macroscope check contexts by display name. `[]` matches nothing |
+| `bot_logins` | `[]string` | `["macroscopeapp"]` | Review-comment author logins that count as Macroscope (`[bot]` suffix ignored) |
+| `settle_timeout` | `string` | `pending_timeout` | How long to wait for Macroscope contexts to reach a terminal state before failing open with an escalation |
 
 Overrides: `gt polecat nuke --ignore-ci` bypasses the nuke gate for one
-invocation; `GT_CI_GATE=off` disables the gate process-wide (emergencies only).
+invocation; `GT_CI_GATE=off` disables the gate process-wide (emergencies only);
+`GT_MACROSCOPE_SETTLE=off` disables only the Macroscope settle phase.
 
 ### Runtime (`.runtime/` - gitignored)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -90,6 +90,7 @@ town-level Gas Town beads.
       "pending_timeout": "30m",
       "poll_interval": "30s",
       "mayor_alert_after": "30m",
+      "human_gate_checks": ["pullapprove"],
       "escalation_cmd": ""
     }
   }
@@ -175,6 +176,7 @@ gate FAILS OPEN but runs `escalation_cmd` so a human verifies.
 | `pending_timeout` | `string` | `"30m"` | How long `gt done` waits for pending checks before aborting with a human escalation (sized for slow Jenkins pipelines) |
 | `poll_interval` | `string` | `"30s"` | Initial poll interval while waiting; backs off to 4x |
 | `mayor_alert_after` | `string` | `"30m"` | How long a nuke can stay CI-blocked before the mayor is nudged |
+| `human_gate_checks` | `[]string` | `["pullapprove"]` | Status-check context names that are human approval gates, not CI (matched case-insensitively) — excluded from the gate's green/pending evaluation so a human merge gate doesn't burn the pending timeout on every completion (AA-859). Set to `[]` to exclude nothing; approval enforcement stays with branch protection / `require_review` |
 | `escalation_cmd` | `string` | `""` | Command run via `sh -c` on CI-status errors and pending timeouts. Receives `GT_CIGATE_EVENT`, `GT_CIGATE_TICKET` (from the bead's `Jira:`/`Ticket:` line), `GT_CIGATE_DETAIL`, `GT_CIGATE_PR_URL`, `GT_CIGATE_BRANCH`, `GT_CIGATE_AGENT` in the environment. Wire it to your tracker, e.g. a script that comments on the ticket and transitions it to a human-attention status |
 
 Overrides: `gt polecat nuke --ignore-ci` bypasses the nuke gate for one

--- a/internal/cigate/cigate.go
+++ b/internal/cigate/cigate.go
@@ -121,10 +121,22 @@ func defaultRunner(dir, name string, args ...string) ([]byte, error) {
 type Gate struct {
 	// Run executes external commands (gh). Defaults to a real exec runner.
 	Run Runner
+	// IgnoreChecks lists status-check context names that are human approval
+	// gates rather than CI (e.g. pullapprove) — matched case-insensitively
+	// against the check's display name and excluded from the green/pending
+	// evaluation. A human merge gate pends on every PR until a person acts,
+	// so counting it would burn the full pending timeout on every completion
+	// (AA-859). Approval enforcement stays with the merge layer (branch
+	// protection / refinery require_review), not this gate.
+	IgnoreChecks []string
 }
 
-// New returns a Gate backed by the real gh CLI.
-func New() *Gate { return &Gate{Run: defaultRunner} }
+// New returns a Gate backed by the real gh CLI. ignoreChecks lists
+// human-gate check names to exclude from evaluation (see Gate.IgnoreChecks);
+// callers with a rig config should pass cfg.HumanGateChecksOrDefault().
+func New(ignoreChecks ...string) *Gate {
+	return &Gate{Run: defaultRunner, IgnoreChecks: ignoreChecks}
+}
 
 // prInfo mirrors the fields requested from `gh pr list --json`.
 type prInfo struct {
@@ -193,7 +205,7 @@ func (g *Gate) CheckBranch(dir, branch string) CheckResult {
 	}
 	switch {
 	case open != nil:
-		res := evaluateRollup(open.StatusCheckRollup)
+		res := evaluateRollup(open.StatusCheckRollup, g.IgnoreChecks)
 		res.PRNumber = open.Number
 		res.PRURL = open.URL
 		return res
@@ -207,12 +219,15 @@ func (g *Gate) CheckBranch(dir, branch string) CheckResult {
 
 // evaluateRollup ports determineCIStatus (internal/web/fetcher.go) semantics
 // to a gate verdict, additionally collecting failing/pending check names.
+// Checks whose display name matches ignore (case-insensitive) are human
+// approval gates, not CI — they are excluded from the evaluation entirely,
+// whatever state they report (AA-859).
 //
 // Case note: gh renders the GraphQL rollup enums in UPPERCASE for check runs
 // ("conclusion":"SUCCESS", "status":"COMPLETED" — verified live against
 // gh 2.45), while older code paths compared lowercase. Normalize both ways
 // so the gate works across gh versions.
-func evaluateRollup(checks []rollupEntry) CheckResult {
+func evaluateRollup(checks []rollupEntry, ignore []string) CheckResult {
 	if len(checks) == 0 {
 		// Open PR with no checks reported yet — treat as pending so a
 		// just-pushed PR isn't waved through before CI registers. The
@@ -220,7 +235,12 @@ func evaluateRollup(checks []rollupEntry) CheckResult {
 		return CheckResult{Verdict: VerdictPending, PendingChecks: []string{"checks not yet reported"}}
 	}
 	var failing, pending []string
+	kept := 0
 	for _, check := range checks {
+		if isIgnoredCheck(check.displayName(), ignore) {
+			continue
+		}
+		kept++
 		// Conclusion first (completed check runs).
 		switch strings.ToLower(check.Conclusion) {
 		case "failure", "cancelled", "timed_out", "action_required", "startup_failure": //nolint:misspell // GitHub API returns "cancelled" (British spelling)
@@ -250,8 +270,25 @@ func evaluateRollup(checks []rollupEntry) CheckResult {
 		return CheckResult{Verdict: VerdictRed, FailingChecks: failing, PendingChecks: pending}
 	case len(pending) > 0:
 		return CheckResult{Verdict: VerdictPending, PendingChecks: pending}
+	case kept == 0:
+		// Every reported check was an ignored human gate. Human gates
+		// (e.g. pullapprove) register near-instantly on push, often before
+		// the real CI does — treat this like the empty rollup so a
+		// just-pushed PR isn't waved through before CI registers.
+		return CheckResult{Verdict: VerdictPending, PendingChecks: []string{"CI checks not yet reported (only ignored human gates present)"}}
 	}
 	return CheckResult{Verdict: VerdictGreen}
+}
+
+// isIgnoredCheck reports whether a check's display name matches the ignore
+// list (case-insensitive exact match).
+func isIgnoredCheck(name string, ignore []string) bool {
+	for _, ig := range ignore {
+		if ig != "" && strings.EqualFold(name, ig) {
+			return true
+		}
+	}
+	return false
 }
 
 // WaitOptions configures WaitForGreen.

--- a/internal/cigate/cigate.go
+++ b/internal/cigate/cigate.go
@@ -1,0 +1,314 @@
+// Package cigate implements the hard CI gate (AA-851): a polecat cannot
+// complete (gt done) and cannot be reaped while its branch's pull request
+// has any CI check red or pending, and the refinery will not merge such a
+// PR. The gate applies only when a PR exists — branches with no PR and
+// already-merged PRs pass through.
+//
+// CI state is read via the gh CLI (`gh pr list ... --json statusCheckRollup`),
+// matching the existing PR-state precedents in internal/git (HasOpenPR,
+// FindPRNumber). The rollup evaluation is a port of the display-layer
+// determineCIStatus (internal/web/fetcher.go): it handles both GitHub check
+// runs (Status/Conclusion) and commit statuses (State — how Jenkins contexts
+// report), so GitHub Actions, Jenkins, and other status providers are all
+// covered by one rollup.
+//
+// Failure semantics: when CI state cannot be determined (gh missing, rate
+// limit, network), the verdict is ERROR and callers FAIL OPEN — a GitHub
+// outage must not brick every completion town-wide — but must escalate
+// loudly (see RunEscalationCmd) so a silently-disabled gate is visible.
+package cigate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Verdict classifies the CI state of a branch's pull request.
+type Verdict string
+
+const (
+	// VerdictGreen means all reported checks passed.
+	VerdictGreen Verdict = "GREEN"
+	// VerdictRed means at least one check failed.
+	VerdictRed Verdict = "RED"
+	// VerdictPending means no failures but at least one check is still
+	// running (or the PR has no checks reported yet).
+	VerdictPending Verdict = "PENDING"
+	// VerdictNoPR means the branch has no pull request — the gate does not apply.
+	VerdictNoPR Verdict = "NO_PR"
+	// VerdictMerged means the branch's PR is already merged.
+	VerdictMerged Verdict = "MERGED"
+	// VerdictClosedUnmerged means the PR was closed without merging
+	// (a deliberate human action; callers pass through with a warning).
+	VerdictClosedUnmerged Verdict = "CLOSED_UNMERGED"
+	// VerdictError means CI state could not be determined; callers fail open.
+	VerdictError Verdict = "ERROR"
+)
+
+// Blocks reports whether the verdict blocks completion/reaping.
+// Only RED and PENDING block; ERROR fails open (callers escalate it loudly).
+func (v Verdict) Blocks() bool {
+	return v == VerdictRed || v == VerdictPending
+}
+
+// CheckResult is the outcome of one CI gate evaluation for a branch.
+type CheckResult struct {
+	Verdict       Verdict
+	PRNumber      int
+	PRURL         string
+	FailingChecks []string
+	PendingChecks []string
+	Err           error // set when Verdict == VerdictError
+}
+
+// Summary renders a one-line human-readable description of the result.
+func (r CheckResult) Summary() string {
+	switch r.Verdict {
+	case VerdictRed:
+		return fmt.Sprintf("PR #%d has failing checks [%s]", r.PRNumber, strings.Join(r.FailingChecks, ", "))
+	case VerdictPending:
+		return fmt.Sprintf("PR #%d has pending checks [%s]", r.PRNumber, strings.Join(r.PendingChecks, ", "))
+	case VerdictGreen:
+		return fmt.Sprintf("PR #%d all checks green", r.PRNumber)
+	case VerdictMerged:
+		return fmt.Sprintf("PR #%d already merged", r.PRNumber)
+	case VerdictClosedUnmerged:
+		return fmt.Sprintf("PR #%d closed without merging", r.PRNumber)
+	case VerdictNoPR:
+		return "no PR for branch"
+	case VerdictError:
+		return fmt.Sprintf("CI status unknown: %v", r.Err)
+	}
+	return string(r.Verdict)
+}
+
+// EnvDisabled reports whether the gate is force-disabled process-wide via
+// GT_CI_GATE=off (emergency kill switch that needs no config edit or redeploy).
+func EnvDisabled() bool {
+	switch strings.ToLower(os.Getenv("GT_CI_GATE")) {
+	case "off", "0", "false", "disabled":
+		return true
+	}
+	return false
+}
+
+// Runner executes a command in dir and returns its stdout. Swappable in tests.
+type Runner func(dir, name string, args ...string) ([]byte, error)
+
+func defaultRunner(dir, name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return nil, fmt.Errorf("%s: %w (%s)", name, err, msg)
+		}
+		return nil, fmt.Errorf("%s: %w", name, err)
+	}
+	return out, nil
+}
+
+// Gate evaluates PR CI status for branches.
+type Gate struct {
+	// Run executes external commands (gh). Defaults to a real exec runner.
+	Run Runner
+}
+
+// New returns a Gate backed by the real gh CLI.
+func New() *Gate { return &Gate{Run: defaultRunner} }
+
+// prInfo mirrors the fields requested from `gh pr list --json`.
+type prInfo struct {
+	Number            int           `json:"number"`
+	State             string        `json:"state"` // OPEN | MERGED | CLOSED
+	URL               string        `json:"url"`
+	StatusCheckRollup []rollupEntry `json:"statusCheckRollup"`
+}
+
+// rollupEntry covers both rollup shapes GitHub returns: check runs
+// (name/status/conclusion) and commit statuses (context/state).
+type rollupEntry struct {
+	Name       string `json:"name"`    // check runs
+	Context    string `json:"context"` // commit statuses (Jenkins-style)
+	State      string `json:"state"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+func (e rollupEntry) displayName() string {
+	if e.Name != "" {
+		return e.Name
+	}
+	if e.Context != "" {
+		return e.Context
+	}
+	return "unnamed-check"
+}
+
+// CheckBranch resolves the branch's PR via gh and evaluates its check rollup.
+// PR resolution: newest OPEN PR wins; with no open PR, a merged PR yields
+// MERGED, a closed-unmerged PR yields CLOSED_UNMERGED, and none yields NO_PR.
+// dir must be inside a clone whose origin is the repo to query (gh resolves
+// the repo from git remotes).
+func (g *Gate) CheckBranch(dir, branch string) CheckResult {
+	run := g.Run
+	if run == nil {
+		run = defaultRunner
+	}
+	out, err := run(dir, "gh", "pr", "list", "--head", branch, "--state", "all",
+		"--json", "number,state,url,statusCheckRollup", "--limit", "20")
+	if err != nil {
+		return CheckResult{Verdict: VerdictError, Err: err}
+	}
+	var prs []prInfo
+	if err := json.Unmarshal(bytes.TrimSpace(out), &prs); err != nil {
+		return CheckResult{Verdict: VerdictError, Err: fmt.Errorf("parsing gh pr list output: %w", err)}
+	}
+	// gh returns newest-first; keep the first PR seen in each state.
+	var open, merged, closed *prInfo
+	for i := range prs {
+		switch prs[i].State {
+		case "OPEN":
+			if open == nil {
+				open = &prs[i]
+			}
+		case "MERGED":
+			if merged == nil {
+				merged = &prs[i]
+			}
+		case "CLOSED":
+			if closed == nil {
+				closed = &prs[i]
+			}
+		}
+	}
+	switch {
+	case open != nil:
+		res := evaluateRollup(open.StatusCheckRollup)
+		res.PRNumber = open.Number
+		res.PRURL = open.URL
+		return res
+	case merged != nil:
+		return CheckResult{Verdict: VerdictMerged, PRNumber: merged.Number, PRURL: merged.URL}
+	case closed != nil:
+		return CheckResult{Verdict: VerdictClosedUnmerged, PRNumber: closed.Number, PRURL: closed.URL}
+	}
+	return CheckResult{Verdict: VerdictNoPR}
+}
+
+// evaluateRollup ports determineCIStatus (internal/web/fetcher.go) semantics
+// to a gate verdict, additionally collecting failing/pending check names.
+//
+// Case note: gh renders the GraphQL rollup enums in UPPERCASE for check runs
+// ("conclusion":"SUCCESS", "status":"COMPLETED" — verified live against
+// gh 2.45), while older code paths compared lowercase. Normalize both ways
+// so the gate works across gh versions.
+func evaluateRollup(checks []rollupEntry) CheckResult {
+	if len(checks) == 0 {
+		// Open PR with no checks reported yet — treat as pending so a
+		// just-pushed PR isn't waved through before CI registers. The
+		// pending wait window absorbs webhook lag.
+		return CheckResult{Verdict: VerdictPending, PendingChecks: []string{"checks not yet reported"}}
+	}
+	var failing, pending []string
+	for _, check := range checks {
+		// Conclusion first (completed check runs).
+		switch strings.ToLower(check.Conclusion) {
+		case "failure", "cancelled", "timed_out", "action_required", "startup_failure": //nolint:misspell // GitHub API returns "cancelled" (British spelling)
+			failing = append(failing, check.displayName())
+		case "success", "skipped", "neutral":
+			// Pass.
+		case "stale":
+			// Marked stale by a newer commit — results no longer trustworthy.
+			pending = append(pending, check.displayName())
+		default:
+			// In-progress check runs report via Status.
+			switch strings.ToLower(check.Status) {
+			case "queued", "in_progress", "waiting", "pending", "requested":
+				pending = append(pending, check.displayName())
+			}
+			// Commit statuses (Jenkins contexts) report via State.
+			switch strings.ToUpper(check.State) {
+			case "FAILURE", "ERROR":
+				failing = append(failing, check.displayName())
+			case "PENDING", "EXPECTED":
+				pending = append(pending, check.displayName())
+			}
+		}
+	}
+	switch {
+	case len(failing) > 0:
+		return CheckResult{Verdict: VerdictRed, FailingChecks: failing, PendingChecks: pending}
+	case len(pending) > 0:
+		return CheckResult{Verdict: VerdictPending, PendingChecks: pending}
+	}
+	return CheckResult{Verdict: VerdictGreen}
+}
+
+// WaitOptions configures WaitForGreen.
+type WaitOptions struct {
+	// Timeout is the total time to wait for pending checks to settle.
+	Timeout time.Duration
+	// PollInterval is the initial poll interval; it doubles per poll up to
+	// 4x (30s → 60s → 120s with the 30s default).
+	PollInterval time.Duration
+	// Progress, when set, receives one line per poll.
+	Progress io.Writer
+	// Sleep is a test hook; nil means time.Sleep.
+	Sleep func(time.Duration)
+	// Now is a test hook; nil means time.Now.
+	Now func() time.Time
+}
+
+// WaitForGreen polls CheckBranch while the verdict is PENDING, with backoff,
+// until the checks settle or the timeout elapses. It returns the last result
+// and whether the wait timed out with checks still pending.
+func (g *Gate) WaitForGreen(dir, branch string, opts WaitOptions) (CheckResult, bool) {
+	sleep := opts.Sleep
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	interval := opts.PollInterval
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	maxInterval := interval * 4
+	deadline := now().Add(opts.Timeout)
+
+	res := g.CheckBranch(dir, branch)
+	for res.Verdict == VerdictPending {
+		remaining := deadline.Sub(now())
+		if remaining <= 0 {
+			return res, true
+		}
+		if interval > remaining {
+			interval = remaining
+		}
+		if opts.Progress != nil {
+			fmt.Fprintf(opts.Progress, "  CI pending (%s) — next poll in %s, %s remaining\n",
+				strings.Join(res.PendingChecks, ", "), interval.Round(time.Second), remaining.Round(time.Second))
+		}
+		sleep(interval)
+		if interval < maxInterval {
+			interval *= 2
+			if interval > maxInterval {
+				interval = maxInterval
+			}
+		}
+		res = g.CheckBranch(dir, branch)
+	}
+	return res, false
+}

--- a/internal/cigate/cigate_test.go
+++ b/internal/cigate/cigate_test.go
@@ -1,0 +1,364 @@
+package cigate
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func stubRunner(out string, err error) Runner {
+	return func(dir, name string, args ...string) ([]byte, error) {
+		if err != nil {
+			return nil, err
+		}
+		return []byte(out), nil
+	}
+}
+
+func TestEvaluateRollup(t *testing.T) {
+	tests := []struct {
+		name    string
+		checks  []rollupEntry
+		verdict Verdict
+		failing []string
+		pending []string
+	}{
+		{
+			name:    "empty rollup is pending (checks not registered yet)",
+			checks:  nil,
+			verdict: VerdictPending,
+			pending: []string{"checks not yet reported"},
+		},
+		{
+			name: "all check runs green",
+			checks: []rollupEntry{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "lint", Status: "completed", Conclusion: "skipped"},
+				{Name: "note", Status: "completed", Conclusion: "neutral"},
+			},
+			verdict: VerdictGreen,
+		},
+		{
+			name: "one failing check run is red",
+			checks: []rollupEntry{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "test", Status: "completed", Conclusion: "failure"},
+			},
+			verdict: VerdictRed,
+			failing: []string{"test"},
+		},
+		{
+			name: "cancelled and timed_out are red",
+			checks: []rollupEntry{
+				{Name: "a", Conclusion: "cancelled"},
+				{Name: "b", Conclusion: "timed_out"},
+				{Name: "c", Conclusion: "action_required"},
+			},
+			verdict: VerdictRed,
+			failing: []string{"a", "b", "c"},
+		},
+		{
+			name: "in-progress check run is pending",
+			checks: []rollupEntry{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "test", Status: "in_progress"},
+			},
+			verdict: VerdictPending,
+			pending: []string{"test"},
+		},
+		{
+			name: "jenkins commit status failure is red",
+			checks: []rollupEntry{
+				{Context: "continuous-integration/jenkins/branch", State: "FAILURE"},
+			},
+			verdict: VerdictRed,
+			failing: []string{"continuous-integration/jenkins/branch"},
+		},
+		{
+			name: "jenkins commit status pending is pending",
+			checks: []rollupEntry{
+				{Context: "continuous-integration/jenkins/pr-merge", State: "PENDING"},
+				{Name: "gha", Status: "completed", Conclusion: "success"},
+			},
+			verdict: VerdictPending,
+			pending: []string{"continuous-integration/jenkins/pr-merge"},
+		},
+		{
+			name: "jenkins success plus gha success is green",
+			checks: []rollupEntry{
+				{Context: "jenkins/build", State: "SUCCESS"},
+				{Name: "gha", Status: "completed", Conclusion: "success"},
+			},
+			verdict: VerdictGreen,
+		},
+		{
+			name: "red wins over pending",
+			checks: []rollupEntry{
+				{Name: "test", Conclusion: "failure"},
+				{Name: "deploy", Status: "queued"},
+			},
+			verdict: VerdictRed,
+			failing: []string{"test"},
+			pending: []string{"deploy"},
+		},
+		{
+			name: "expected commit status is pending",
+			checks: []rollupEntry{
+				{Context: "macroscope", State: "EXPECTED"},
+			},
+			verdict: VerdictPending,
+			pending: []string{"macroscope"},
+		},
+		{
+			// Real gh 2.45 output uses UPPERCASE GraphQL enums (verified live).
+			name: "uppercase enums from modern gh: green",
+			checks: []rollupEntry{
+				{Name: "API & Page Tests", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "Mergify Merge Queue", Status: "COMPLETED", Conclusion: "NEUTRAL"},
+			},
+			verdict: VerdictGreen,
+		},
+		{
+			name: "uppercase enums from modern gh: red",
+			checks: []rollupEntry{
+				{Name: "API & Page Tests", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			verdict: VerdictRed,
+			failing: []string{"API & Page Tests"},
+		},
+		{
+			name: "uppercase enums from modern gh: pending",
+			checks: []rollupEntry{
+				{Name: "build", Status: "IN_PROGRESS", Conclusion: ""},
+			},
+			verdict: VerdictPending,
+			pending: []string{"build"},
+		},
+		{
+			name: "startup_failure is red, stale is pending",
+			checks: []rollupEntry{
+				{Name: "a", Conclusion: "STARTUP_FAILURE"},
+				{Name: "b", Conclusion: "STALE"},
+			},
+			verdict: VerdictRed,
+			failing: []string{"a"},
+			pending: []string{"b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := evaluateRollup(tt.checks)
+			if res.Verdict != tt.verdict {
+				t.Fatalf("verdict = %s, want %s", res.Verdict, tt.verdict)
+			}
+			if got, want := strings.Join(res.FailingChecks, ","), strings.Join(tt.failing, ","); got != want {
+				t.Errorf("failing = %q, want %q", got, want)
+			}
+			if got, want := strings.Join(res.PendingChecks, ","), strings.Join(tt.pending, ","); got != want {
+				t.Errorf("pending = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestVerdictBlocks(t *testing.T) {
+	blocking := map[Verdict]bool{
+		VerdictRed:            true,
+		VerdictPending:        true,
+		VerdictGreen:          false,
+		VerdictNoPR:           false,
+		VerdictMerged:         false,
+		VerdictClosedUnmerged: false,
+		VerdictError:          false, // fail-open
+	}
+	for v, want := range blocking {
+		if v.Blocks() != want {
+			t.Errorf("%s.Blocks() = %v, want %v", v, v.Blocks(), want)
+		}
+	}
+}
+
+func TestCheckBranch(t *testing.T) {
+	tests := []struct {
+		name     string
+		ghOutput string
+		ghErr    error
+		verdict  Verdict
+		prNumber int
+	}{
+		{
+			name:     "no PR",
+			ghOutput: `[]`,
+			verdict:  VerdictNoPR,
+		},
+		{
+			name: "open PR green",
+			ghOutput: `[{"number":42,"state":"OPEN","url":"https://github.com/x/y/pull/42",
+				"statusCheckRollup":[{"name":"build","status":"completed","conclusion":"success"}]}]`,
+			verdict:  VerdictGreen,
+			prNumber: 42,
+		},
+		{
+			name: "open PR red",
+			ghOutput: `[{"number":7,"state":"OPEN","url":"u",
+				"statusCheckRollup":[{"name":"test","status":"completed","conclusion":"failure"}]}]`,
+			verdict:  VerdictRed,
+			prNumber: 7,
+		},
+		{
+			name: "open PR pending",
+			ghOutput: `[{"number":8,"state":"OPEN","url":"u",
+				"statusCheckRollup":[{"context":"jenkins/pr","state":"PENDING"}]}]`,
+			verdict:  VerdictPending,
+			prNumber: 8,
+		},
+		{
+			name:     "merged PR only",
+			ghOutput: `[{"number":9,"state":"MERGED","url":"u","statusCheckRollup":[]}]`,
+			verdict:  VerdictMerged,
+			prNumber: 9,
+		},
+		{
+			name:     "closed unmerged PR only",
+			ghOutput: `[{"number":10,"state":"CLOSED","url":"u","statusCheckRollup":[]}]`,
+			verdict:  VerdictClosedUnmerged,
+			prNumber: 10,
+		},
+		{
+			name: "open PR preferred over merged",
+			ghOutput: `[{"number":12,"state":"OPEN","url":"u",
+				"statusCheckRollup":[{"name":"b","conclusion":"success"}]},
+				{"number":11,"state":"MERGED","url":"u","statusCheckRollup":[]}]`,
+			verdict:  VerdictGreen,
+			prNumber: 12,
+		},
+		{
+			name:    "gh error fails open as ERROR",
+			ghErr:   errors.New("gh: rate limited"),
+			verdict: VerdictError,
+		},
+		{
+			name:     "garbage output is ERROR",
+			ghOutput: `not json`,
+			verdict:  VerdictError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &Gate{Run: stubRunner(tt.ghOutput, tt.ghErr)}
+			res := g.CheckBranch("/tmp", "polecat/test")
+			if res.Verdict != tt.verdict {
+				t.Fatalf("verdict = %s, want %s (err=%v)", res.Verdict, tt.verdict, res.Err)
+			}
+			if tt.prNumber != 0 && res.PRNumber != tt.prNumber {
+				t.Errorf("prNumber = %d, want %d", res.PRNumber, tt.prNumber)
+			}
+			if tt.verdict == VerdictError && res.Err == nil {
+				t.Errorf("VerdictError should carry Err")
+			}
+		})
+	}
+}
+
+// sequenceGate returns a Gate whose CheckBranch yields canned outputs in order,
+// repeating the last one.
+func sequenceGate(outputs ...string) *Gate {
+	i := 0
+	return &Gate{Run: func(dir, name string, args ...string) ([]byte, error) {
+		out := outputs[i]
+		if i < len(outputs)-1 {
+			i++
+		}
+		return []byte(out), nil
+	}}
+}
+
+const (
+	prPending = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"context":"jenkins","state":"PENDING"}]}]`
+	prGreen   = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"context":"jenkins","state":"SUCCESS"}]}]`
+	prRed     = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"context":"jenkins","state":"FAILURE"}]}]`
+)
+
+// fakeClock drives WaitForGreen without real sleeping.
+type fakeClock struct{ now time.Time }
+
+func (c *fakeClock) Now() time.Time        { return c.now }
+func (c *fakeClock) Sleep(d time.Duration) { c.now = c.now.Add(d) }
+
+func TestWaitForGreen(t *testing.T) {
+	t.Run("pending then green", func(t *testing.T) {
+		clock := &fakeClock{now: time.Unix(0, 0)}
+		g := sequenceGate(prPending, prPending, prGreen)
+		res, timedOut := g.WaitForGreen("/tmp", "b", WaitOptions{
+			Timeout: 30 * time.Minute, PollInterval: 30 * time.Second,
+			Sleep: clock.Sleep, Now: clock.Now,
+		})
+		if timedOut || res.Verdict != VerdictGreen {
+			t.Fatalf("got %s timedOut=%v, want GREEN", res.Verdict, timedOut)
+		}
+	})
+
+	t.Run("pending then red", func(t *testing.T) {
+		clock := &fakeClock{now: time.Unix(0, 0)}
+		g := sequenceGate(prPending, prRed)
+		res, timedOut := g.WaitForGreen("/tmp", "b", WaitOptions{
+			Timeout: 30 * time.Minute, PollInterval: 30 * time.Second,
+			Sleep: clock.Sleep, Now: clock.Now,
+		})
+		if timedOut || res.Verdict != VerdictRed {
+			t.Fatalf("got %s timedOut=%v, want RED", res.Verdict, timedOut)
+		}
+	})
+
+	t.Run("stuck pending times out", func(t *testing.T) {
+		clock := &fakeClock{now: time.Unix(0, 0)}
+		g := sequenceGate(prPending)
+		start := clock.now
+		res, timedOut := g.WaitForGreen("/tmp", "b", WaitOptions{
+			Timeout: 10 * time.Minute, PollInterval: 30 * time.Second,
+			Sleep: clock.Sleep, Now: clock.Now,
+		})
+		if !timedOut || res.Verdict != VerdictPending {
+			t.Fatalf("got %s timedOut=%v, want PENDING + timeout", res.Verdict, timedOut)
+		}
+		if waited := clock.now.Sub(start); waited < 10*time.Minute || waited > 12*time.Minute {
+			t.Errorf("waited %s, want ~10m", waited)
+		}
+	})
+
+	t.Run("backoff caps at 4x", func(t *testing.T) {
+		clock := &fakeClock{now: time.Unix(0, 0)}
+		var sleeps []time.Duration
+		g := sequenceGate(prPending)
+		_, _ = g.WaitForGreen("/tmp", "b", WaitOptions{
+			Timeout: 20 * time.Minute, PollInterval: 30 * time.Second,
+			Sleep: func(d time.Duration) { sleeps = append(sleeps, d); clock.Sleep(d) },
+			Now:   clock.Now,
+		})
+		if len(sleeps) < 4 {
+			t.Fatalf("expected several polls, got %d", len(sleeps))
+		}
+		want := []time.Duration{30 * time.Second, 60 * time.Second, 120 * time.Second, 120 * time.Second}
+		for i, w := range want {
+			if sleeps[i] != w {
+				t.Errorf("sleep[%d] = %s, want %s (all: %v)", i, sleeps[i], w, sleeps)
+			}
+		}
+	})
+}
+
+func TestSummary(t *testing.T) {
+	res := CheckResult{Verdict: VerdictRed, PRNumber: 3, FailingChecks: []string{"jenkins/build", "macroscope"}}
+	want := "PR #3 has failing checks [jenkins/build, macroscope]"
+	if got := res.Summary(); got != want {
+		t.Errorf("Summary() = %q, want %q", got, want)
+	}
+	errRes := CheckResult{Verdict: VerdictError, Err: fmt.Errorf("boom")}
+	if !strings.Contains(errRes.Summary(), "boom") {
+		t.Errorf("error summary should include cause: %q", errRes.Summary())
+	}
+}

--- a/internal/cigate/cigate_test.go
+++ b/internal/cigate/cigate_test.go
@@ -21,6 +21,7 @@ func TestEvaluateRollup(t *testing.T) {
 	tests := []struct {
 		name    string
 		checks  []rollupEntry
+		ignore  []string
 		verdict Verdict
 		failing []string
 		pending []string
@@ -146,11 +147,74 @@ func TestEvaluateRollup(t *testing.T) {
 			failing: []string{"a"},
 			pending: []string{"b"},
 		},
+		{
+			// AA-859: pullapprove is Blair's human merge gate — it pends on
+			// every PR until a human merges, and must not hold the CI gate.
+			name: "pending human gate is excluded: CI green wins",
+			checks: []rollupEntry{
+				{Context: "pullapprove", State: "PENDING"},
+				{Context: "continuous-integration/jenkins/pr-merge", State: "SUCCESS"},
+				{Name: "gha", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			ignore:  []string{"pullapprove"},
+			verdict: VerdictGreen,
+		},
+		{
+			name: "human gate exclusion is case-insensitive",
+			checks: []rollupEntry{
+				{Context: "PullApprove", State: "PENDING"},
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			ignore:  []string{"pullapprove"},
+			verdict: VerdictGreen,
+		},
+		{
+			name: "excluded human gate does not mask a red CI check",
+			checks: []rollupEntry{
+				{Context: "pullapprove", State: "PENDING"},
+				{Name: "test", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			ignore:  []string{"pullapprove"},
+			verdict: VerdictRed,
+			failing: []string{"test"},
+		},
+		{
+			// Even a rejected human gate is not CI — approval enforcement
+			// belongs to branch protection / require_review, not this gate.
+			name: "failing human gate is excluded too",
+			checks: []rollupEntry{
+				{Context: "pullapprove", State: "FAILURE"},
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			ignore:  []string{"pullapprove"},
+			verdict: VerdictGreen,
+		},
+		{
+			// Human gates register near-instantly on push, often before real
+			// CI does — an all-excluded rollup must stay pending, not green.
+			name: "only human gates reported yet is pending",
+			checks: []rollupEntry{
+				{Context: "pullapprove", State: "PENDING"},
+			},
+			ignore:  []string{"pullapprove"},
+			verdict: VerdictPending,
+			pending: []string{"CI checks not yet reported (only ignored human gates present)"},
+		},
+		{
+			name: "non-matching ignore list changes nothing",
+			checks: []rollupEntry{
+				{Context: "pullapprove", State: "PENDING"},
+				{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			ignore:  []string{"some-other-gate"},
+			verdict: VerdictPending,
+			pending: []string{"pullapprove"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res := evaluateRollup(tt.checks)
+			res := evaluateRollup(tt.checks, tt.ignore)
 			if res.Verdict != tt.verdict {
 				t.Fatalf("verdict = %s, want %s", res.Verdict, tt.verdict)
 			}
@@ -161,6 +225,16 @@ func TestEvaluateRollup(t *testing.T) {
 				t.Errorf("pending = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestNewSetsIgnoreChecks(t *testing.T) {
+	g := New("pullapprove", "some-other-gate")
+	if got := strings.Join(g.IgnoreChecks, ","); got != "pullapprove,some-other-gate" {
+		t.Errorf("IgnoreChecks = %q, want %q", got, "pullapprove,some-other-gate")
+	}
+	if New().IgnoreChecks != nil && len(New().IgnoreChecks) != 0 {
+		t.Errorf("New() should have no ignores")
 	}
 }
 
@@ -186,6 +260,7 @@ func TestCheckBranch(t *testing.T) {
 		name     string
 		ghOutput string
 		ghErr    error
+		ignore   []string
 		verdict  Verdict
 		prNumber int
 	}{
@@ -236,6 +311,18 @@ func TestCheckBranch(t *testing.T) {
 			prNumber: 12,
 		},
 		{
+			// AA-859 live repro (capital #21400): Jenkins green, pullapprove
+			// (Blair's human merge gate) pending — the gate must report GREEN
+			// instead of burning the 30m pending timeout.
+			name: "open PR green when only the ignored human gate pends",
+			ghOutput: `[{"number":21400,"state":"OPEN","url":"u",
+				"statusCheckRollup":[{"context":"pullapprove","state":"PENDING"},
+					{"context":"continuous-integration/jenkins/pr-merge","state":"SUCCESS"}]}]`,
+			ignore:   []string{"pullapprove"},
+			verdict:  VerdictGreen,
+			prNumber: 21400,
+		},
+		{
 			name:    "gh error fails open as ERROR",
 			ghErr:   errors.New("gh: rate limited"),
 			verdict: VerdictError,
@@ -249,7 +336,7 @@ func TestCheckBranch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := &Gate{Run: stubRunner(tt.ghOutput, tt.ghErr)}
+			g := &Gate{Run: stubRunner(tt.ghOutput, tt.ghErr), IgnoreChecks: tt.ignore}
 			res := g.CheckBranch("/tmp", "polecat/test")
 			if res.Verdict != tt.verdict {
 				t.Fatalf("verdict = %s, want %s (err=%v)", res.Verdict, tt.verdict, res.Err)

--- a/internal/cigate/escalate.go
+++ b/internal/cigate/escalate.go
@@ -20,6 +20,20 @@ const (
 	// EventPendingTimeout: checks were still pending when the configured
 	// pending_timeout elapsed and the completion was aborted.
 	EventPendingTimeout EscalationEvent = "pending_timeout"
+	// EventMacroscopeTimeout: Macroscope check contexts never reached a
+	// terminal state within the settle timeout (likely a Macroscope outage);
+	// the completion proceeded FAIL-OPEN. A human must check the PR for
+	// review comments that post late.
+	EventMacroscopeTimeout EscalationEvent = "macroscope_settle_timeout"
+	// EventMacroscopeError: the post-settle review-comment fetch failed;
+	// the completion proceeded FAIL-OPEN. A human must check the PR for
+	// unaddressed review comments.
+	EventMacroscopeError EscalationEvent = "macroscope_comments_error"
+	// EventMacroscopeUnaddressed: unaddressed Macroscope review comments
+	// were found after its checks settled — the completion was aborted
+	// (ticket comment + human-attention hold, like CI red) and the author
+	// stays assigned to address them.
+	EventMacroscopeUnaddressed EscalationEvent = "macroscope_unaddressed_comments"
 )
 
 // Escalation carries the context handed to the configured escalation command.

--- a/internal/cigate/escalate.go
+++ b/internal/cigate/escalate.go
@@ -1,0 +1,94 @@
+package cigate
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// EscalationEvent identifies why the gate needs a human.
+type EscalationEvent string
+
+const (
+	// EventCIStatusError: the gate could not determine CI state and failed
+	// open. A human must confirm the completion was actually green.
+	EventCIStatusError EscalationEvent = "ci_status_error"
+	// EventPendingTimeout: checks were still pending when the configured
+	// pending_timeout elapsed and the completion was aborted.
+	EventPendingTimeout EscalationEvent = "pending_timeout"
+)
+
+// Escalation carries the context handed to the configured escalation command.
+type Escalation struct {
+	Event  EscalationEvent
+	Ticket string // external ticket key (e.g. Jira "AA-851"); may be empty
+	Detail string // human-readable description of what happened
+	PRURL  string
+	Branch string
+	Agent  string // e.g. "openclaw/polecats/furiosa"
+}
+
+// ticketLineRe matches the `Jira: AA-123 ...` (or `Ticket: AA-123 ...`)
+// convention used in bead descriptions to link Gas Town work to an external
+// tracker. The key may be followed by a title (`Jira: AA-851 — Implement …`).
+var ticketLineRe = regexp.MustCompile(`(?mi)^\s*(?:jira|ticket):\s*([A-Za-z][A-Za-z0-9]*-\d+)\b`)
+
+// ExtractTicket returns the external ticket key referenced by a bead
+// description, or "" when the bead carries no ticket line.
+func ExtractTicket(description string) string {
+	m := ticketLineRe.FindStringSubmatch(description)
+	if m == nil {
+		return ""
+	}
+	return strings.ToUpper(m[1])
+}
+
+// escalationTimeout bounds the external escalation command so a hung tracker
+// integration cannot wedge gt done / the refinery.
+const escalationTimeout = 60 * time.Second
+
+// RunEscalationCmd runs the rig-configured ci_gate.escalation_cmd via
+// `sh -c` with GT_CIGATE_* environment variables describing the event.
+// The command is the rig's bridge to its external tracker — e.g. a script
+// that comments on the ticket and transitions it to a human-attention
+// status. Errors are returned for logging but must never block completion:
+// escalation paths are fail-open by design.
+func RunEscalationCmd(cmdStr, dir string, esc Escalation) error {
+	if strings.TrimSpace(cmdStr) == "" {
+		return fmt.Errorf("no ci_gate.escalation_cmd configured")
+	}
+	cmd := exec.Command("sh", "-c", cmdStr)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GT_CIGATE_EVENT="+string(esc.Event),
+		"GT_CIGATE_TICKET="+esc.Ticket,
+		"GT_CIGATE_DETAIL="+esc.Detail,
+		"GT_CIGATE_PR_URL="+esc.PRURL,
+		"GT_CIGATE_BRANCH="+esc.Branch,
+		"GT_CIGATE_AGENT="+esc.Agent,
+	)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("escalation_cmd failed to start: %w", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			return fmt.Errorf("escalation_cmd failed: %w (%s)", err, strings.TrimSpace(out.String()))
+		}
+		return nil
+	case <-time.After(escalationTimeout):
+		_ = cmd.Process.Kill()
+		<-done
+		return fmt.Errorf("escalation_cmd timed out after %s", escalationTimeout)
+	}
+}

--- a/internal/cigate/escalate_test.go
+++ b/internal/cigate/escalate_test.go
@@ -1,0 +1,70 @@
+package cigate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtractTicket(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+		want string
+	}{
+		{"jira line with title", "attached_molecule: x\n\nJira: AA-851 — Implement the HARD GATE", "AA-851"},
+		{"jira line bare", "some text\nJira: AA-851\nmore", "AA-851"},
+		{"ticket alias", "Ticket: proj-42", "PROJ-42"},
+		{"lowercase key", "jira: aa-99", "AA-99"},
+		{"no line", "just a description", ""},
+		{"empty", "", ""},
+		{"key not on own line", "fixes Jira: AA-1 inline", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractTicket(tt.desc); got != tt.want {
+				t.Errorf("ExtractTicket(%q) = %q, want %q", tt.desc, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunEscalationCmd(t *testing.T) {
+	t.Run("passes context via environment", func(t *testing.T) {
+		outFile := filepath.Join(t.TempDir(), "esc.txt")
+		cmd := `echo "$GT_CIGATE_EVENT|$GT_CIGATE_TICKET|$GT_CIGATE_BRANCH|$GT_CIGATE_AGENT" > ` + outFile
+		err := RunEscalationCmd(cmd, t.TempDir(), Escalation{
+			Event:  EventPendingTimeout,
+			Ticket: "AA-851",
+			Branch: "polecat/furiosa",
+			Agent:  "openclaw/polecats/furiosa",
+			Detail: "CI pending too long",
+		})
+		if err != nil {
+			t.Fatalf("RunEscalationCmd: %v", err)
+		}
+		data, err := os.ReadFile(outFile)
+		if err != nil {
+			t.Fatalf("reading output: %v", err)
+		}
+		got := strings.TrimSpace(string(data))
+		want := "pending_timeout|AA-851|polecat/furiosa|openclaw/polecats/furiosa"
+		if got != want {
+			t.Errorf("escalation env = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty command errors", func(t *testing.T) {
+		if err := RunEscalationCmd("  ", ".", Escalation{}); err == nil {
+			t.Error("want error for empty escalation_cmd")
+		}
+	})
+
+	t.Run("failing command returns error with output", func(t *testing.T) {
+		err := RunEscalationCmd("echo tracker down >&2; exit 3", ".", Escalation{Event: EventCIStatusError})
+		if err == nil || !strings.Contains(err.Error(), "tracker down") {
+			t.Errorf("want failure containing command output, got %v", err)
+		}
+	})
+}

--- a/internal/cigate/execpath_test.go
+++ b/internal/cigate/execpath_test.go
@@ -1,0 +1,43 @@
+package cigate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCheckBranchRealExecPath exercises the default (non-stubbed) runner by
+// putting a fake gh binary on PATH, proving the exec wiring end to end:
+// argument passing, stdout capture, JSON decode, and stderr propagation on
+// failure. This is the "fake gh shim" simulation from the AA-851 test plan.
+func TestCheckBranchRealExecPath(t *testing.T) {
+	writeFakeGh := func(t *testing.T, script string) string {
+		t.Helper()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "gh")
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+
+	t.Run("green PR via real exec", func(t *testing.T) {
+		shim := writeFakeGh(t, fmt.Sprintf(`echo '%s'`,
+			`[{"number":21,"state":"OPEN","url":"u","statusCheckRollup":[{"__typename":"CheckRun","name":"CI","status":"COMPLETED","conclusion":"SUCCESS"}]}]`))
+		t.Setenv("PATH", shim+string(os.PathListSeparator)+os.Getenv("PATH"))
+		res := New().CheckBranch(t.TempDir(), "polecat/shim-test")
+		if res.Verdict != VerdictGreen || res.PRNumber != 21 {
+			t.Fatalf("got %s pr=%d err=%v, want GREEN pr=21", res.Verdict, res.PRNumber, res.Err)
+		}
+	})
+
+	t.Run("gh failure yields ERROR with stderr detail", func(t *testing.T) {
+		shim := writeFakeGh(t, `echo "gh: Bad credentials" >&2; exit 1`)
+		t.Setenv("PATH", shim+string(os.PathListSeparator)+os.Getenv("PATH"))
+		res := New().CheckBranch(t.TempDir(), "polecat/shim-test")
+		if res.Verdict != VerdictError || res.Err == nil {
+			t.Fatalf("got %s err=%v, want ERROR", res.Verdict, res.Err)
+		}
+	})
+}

--- a/internal/cigate/live_test.go
+++ b/internal/cigate/live_test.go
@@ -2,6 +2,7 @@ package cigate
 
 import (
 	"os"
+	"strconv"
 	"testing"
 )
 
@@ -22,5 +23,47 @@ func TestCheckBranchLive(t *testing.T) {
 		res.Verdict, res.PRNumber, res.PRURL, res.FailingChecks, res.PendingChecks, res.Err)
 	if want != "" && string(res.Verdict) != want {
 		t.Fatalf("verdict = %s, want %s", res.Verdict, want)
+	}
+}
+
+// TestMacroscopeLive runs the settle check and the comment fetch against a
+// real PR (op-sr9u). Opt-in:
+//
+//	GT_CIGATE_LIVE_TEST_DIR=<repo clone> \
+//	GT_CIGATE_LIVE_TEST_BRANCH=<branch> \
+//	GT_CIGATE_LIVE_TEST_PR=<pr number> go test ./internal/cigate -run Live -v
+func TestMacroscopeLive(t *testing.T) {
+	dir := os.Getenv("GT_CIGATE_LIVE_TEST_DIR")
+	branch := os.Getenv("GT_CIGATE_LIVE_TEST_BRANCH")
+	prStr := os.Getenv("GT_CIGATE_LIVE_TEST_PR")
+	if dir == "" || (branch == "" && prStr == "") {
+		t.Skip("set GT_CIGATE_LIVE_TEST_DIR and GT_CIGATE_LIVE_TEST_BRANCH or _PR to run")
+	}
+	opts := MacroscopeOptions{CheckPatterns: []string{"macroscope"}, BotLogins: []string{"macroscopeapp"}}
+	g := New()
+	if branch != "" {
+		res := g.CheckMacroscopeSettle(dir, branch, opts)
+		t.Logf("live settle: settled=%v pending=%v pr=%d err=%v", res.Settled, res.PendingChecks, res.PRNumber, res.Err)
+		if res.Err != nil {
+			t.Fatalf("settle check failed: %v", res.Err)
+		}
+		if prStr == "" && res.PRNumber != 0 {
+			prStr = strconv.Itoa(res.PRNumber)
+		}
+	}
+	if prStr == "" {
+		return
+	}
+	pr, err := strconv.Atoi(prStr)
+	if err != nil {
+		t.Fatalf("bad GT_CIGATE_LIVE_TEST_PR: %v", err)
+	}
+	comments, err := g.FetchUnaddressedComments(dir, pr, opts)
+	if err != nil {
+		t.Fatalf("comment fetch failed: %v", err)
+	}
+	t.Logf("live fetch: %d unaddressed Macroscope comment(s)", len(comments))
+	for _, c := range comments {
+		t.Logf("  - %s (%s): %s", c.URL, c.Path, c.Excerpt)
 	}
 }

--- a/internal/cigate/live_test.go
+++ b/internal/cigate/live_test.go
@@ -1,0 +1,26 @@
+package cigate
+
+import (
+	"os"
+	"testing"
+)
+
+// TestCheckBranchLive runs the gate against real GitHub. Opt-in:
+//
+//	GT_CIGATE_LIVE_TEST_DIR=<repo clone> \
+//	GT_CIGATE_LIVE_TEST_BRANCH=<branch> \
+//	GT_CIGATE_LIVE_TEST_WANT=<verdict> go test ./internal/cigate -run Live
+func TestCheckBranchLive(t *testing.T) {
+	dir := os.Getenv("GT_CIGATE_LIVE_TEST_DIR")
+	branch := os.Getenv("GT_CIGATE_LIVE_TEST_BRANCH")
+	want := os.Getenv("GT_CIGATE_LIVE_TEST_WANT")
+	if dir == "" || branch == "" {
+		t.Skip("set GT_CIGATE_LIVE_TEST_DIR and GT_CIGATE_LIVE_TEST_BRANCH to run")
+	}
+	res := New().CheckBranch(dir, branch)
+	t.Logf("live verdict=%s pr=%d url=%s failing=%v pending=%v err=%v",
+		res.Verdict, res.PRNumber, res.PRURL, res.FailingChecks, res.PendingChecks, res.Err)
+	if want != "" && string(res.Verdict) != want {
+		t.Fatalf("verdict = %s, want %s", res.Verdict, want)
+	}
+}

--- a/internal/cigate/macroscope.go
+++ b/internal/cigate/macroscope.go
@@ -1,0 +1,336 @@
+package cigate
+
+// Macroscope comment-settle extension of the AA-851 CI gate (op-sr9u /
+// hq-owe9c): Macroscope posts its inline review comments asynchronously
+// AFTER its check runs report a conclusion, so a completion gated only on
+// check state can race the review — the PR goes green, gt done passes, and
+// substantive comments arrive minutes later with the author's session
+// already dead (observed 3/3 on capital #21457/#21459/#21461, 2026-07-11;
+// each cost an adoption-dispatch cycle).
+//
+// The settle phase runs only after the CI verdict is GREEN:
+//  1. wait for every Macroscope check context to reach a TERMINAL state on
+//     the final head (same poll/backoff machinery as WaitForGreen);
+//  2. then perform ONE review-comment fetch;
+//  3. unaddressed Macroscope threads fail the gate like CI red — the author
+//     stays assigned and must address each comment (fix, or refute with
+//     evidence, replying on the thread) before re-running gt done;
+//  4. if Macroscope never settles (outage), the caller FAILS OPEN after the
+//     settle timeout with a human escalation, per the gate's existing
+//     30m pending rule.
+//
+// A rollup with no Macroscope contexts at all is settled trivially: on rigs
+// without Macroscope any wait would burn the full timeout on every
+// completion, and on rigs with it the Macroscope check registers within
+// seconds of push — long before the rest of CI turns green.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// MacroscopeOptions selects which checks and comment authors belong to
+// Macroscope. Zero values mean "match nothing" — callers should populate
+// from config (CheckPatternsOrDefault / BotLoginsOrDefault).
+type MacroscopeOptions struct {
+	// CheckPatterns are case-insensitive substrings matched against check
+	// display names (e.g. "macroscope" matches both
+	// "Macroscope - Correctness Check" and "Macroscope - Approvability Check").
+	CheckPatterns []string
+	// BotLogins are review-comment author logins that count as Macroscope,
+	// compared case-insensitively with any "[bot]" suffix stripped
+	// (GraphQL reports "macroscopeapp", REST "macroscopeapp[bot]").
+	BotLogins []string
+}
+
+// MacroscopeSettleResult is the outcome of one settle evaluation.
+type MacroscopeSettleResult struct {
+	// Settled is true when every matched Macroscope check context reports a
+	// terminal state (or the PR has no Macroscope contexts / no open PR).
+	Settled bool
+	// PendingChecks lists the Macroscope contexts not yet terminal.
+	PendingChecks []string
+	PRNumber      int
+	PRURL         string
+	Err           error
+}
+
+// UnaddressedComment describes one Macroscope review thread that has
+// neither been resolved nor replied to by anyone but the bot.
+type UnaddressedComment struct {
+	Author  string
+	Path    string
+	URL     string
+	Excerpt string
+}
+
+// MacroscopeEnvDisabled reports whether the settle phase is force-disabled
+// process-wide via GT_MACROSCOPE_SETTLE=off (parallel to GT_CI_GATE=off;
+// GT_CI_GATE=off also disables it since the whole gate is skipped).
+func MacroscopeEnvDisabled() bool {
+	switch strings.ToLower(os.Getenv("GT_MACROSCOPE_SETTLE")) {
+	case "off", "0", "false", "disabled":
+		return true
+	}
+	return false
+}
+
+// matchesMacroscope reports whether a check display name matches any
+// configured pattern (case-insensitive substring).
+func matchesMacroscope(name string, patterns []string) bool {
+	lower := strings.ToLower(name)
+	for _, p := range patterns {
+		if p != "" && strings.Contains(lower, strings.ToLower(p)) {
+			return true
+		}
+	}
+	return false
+}
+
+// terminal reports whether a rollup entry has finished reporting: a check
+// run with status COMPLETED (or any conclusion), or a commit status in a
+// state other than PENDING/EXPECTED. Failure states are terminal — the
+// settle phase only asks "has Macroscope finished?", not "did it pass?"
+// (pass/fail already belongs to the main CI verdict).
+func (e rollupEntry) terminal() bool {
+	if e.Status != "" || e.Conclusion != "" {
+		return strings.EqualFold(e.Status, "completed") || e.Conclusion != ""
+	}
+	switch strings.ToUpper(e.State) {
+	case "", "PENDING", "EXPECTED":
+		return false
+	}
+	return true
+}
+
+// CheckMacroscopeSettle resolves the branch's open PR and reports whether
+// its Macroscope check contexts have all reached a terminal state on the
+// current (final) head. No open PR, or an open PR with no Macroscope
+// contexts, is settled trivially.
+func (g *Gate) CheckMacroscopeSettle(dir, branch string, opts MacroscopeOptions) MacroscopeSettleResult {
+	run := g.Run
+	if run == nil {
+		run = defaultRunner
+	}
+	out, err := run(dir, "gh", "pr", "list", "--head", branch, "--state", "all",
+		"--json", "number,state,url,statusCheckRollup", "--limit", "20")
+	if err != nil {
+		return MacroscopeSettleResult{Err: err}
+	}
+	var prs []prInfo
+	if err := json.Unmarshal(bytes.TrimSpace(out), &prs); err != nil {
+		return MacroscopeSettleResult{Err: fmt.Errorf("parsing gh pr list output: %w", err)}
+	}
+	var open *prInfo
+	for i := range prs {
+		if prs[i].State == "OPEN" {
+			open = &prs[i]
+			break
+		}
+	}
+	if open == nil {
+		return MacroscopeSettleResult{Settled: true}
+	}
+	res := MacroscopeSettleResult{Settled: true, PRNumber: open.Number, PRURL: open.URL}
+	for _, check := range open.StatusCheckRollup {
+		if !matchesMacroscope(check.displayName(), opts.CheckPatterns) {
+			continue
+		}
+		if !check.terminal() {
+			res.Settled = false
+			res.PendingChecks = append(res.PendingChecks, check.displayName())
+		}
+	}
+	return res
+}
+
+// WaitForMacroscopeSettle polls CheckMacroscopeSettle with the same backoff
+// as WaitForGreen until the Macroscope contexts settle, an error occurs, or
+// the timeout elapses. It returns the last result and whether the wait
+// timed out with contexts still pending.
+func (g *Gate) WaitForMacroscopeSettle(dir, branch string, opts MacroscopeOptions, w WaitOptions) (MacroscopeSettleResult, bool) {
+	sleep := w.Sleep
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	now := w.Now
+	if now == nil {
+		now = time.Now
+	}
+	interval := w.PollInterval
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	maxInterval := interval * 4
+	deadline := now().Add(w.Timeout)
+
+	res := g.CheckMacroscopeSettle(dir, branch, opts)
+	for !res.Settled && res.Err == nil {
+		remaining := deadline.Sub(now())
+		if remaining <= 0 {
+			return res, true
+		}
+		if interval > remaining {
+			interval = remaining
+		}
+		if w.Progress != nil {
+			fmt.Fprintf(w.Progress, "  Macroscope not settled (%s) — next poll in %s, %s remaining\n",
+				strings.Join(res.PendingChecks, ", "), interval.Round(time.Second), remaining.Round(time.Second))
+		}
+		sleep(interval)
+		if interval < maxInterval {
+			interval *= 2
+			if interval > maxInterval {
+				interval = maxInterval
+			}
+		}
+		res = g.CheckMacroscopeSettle(dir, branch, opts)
+	}
+	return res, false
+}
+
+// reviewThreadsQuery fetches the PR's review threads with resolution state —
+// resolution is GraphQL-only (the REST pulls/comments endpoint has no
+// isResolved), and a thread resolved without a reply must count as
+// addressed. first:100/first:50 comfortably covers real PRs; a busier PR
+// degrades to evaluating the first 100 threads rather than failing.
+const reviewThreadsQuery = `query($owner:String!,$name:String!,$pr:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$pr){
+      reviewThreads(first:100){
+        nodes{
+          isResolved
+          comments(first:50){
+            nodes{ author{login} path url bodyText isMinimized }
+          }
+        }
+      }
+    }
+  }
+}`
+
+// reviewThreadsResponse mirrors the GraphQL response shape.
+type reviewThreadsResponse struct {
+	Data struct {
+		Repository struct {
+			PullRequest struct {
+				ReviewThreads struct {
+					Nodes []reviewThread `json:"nodes"`
+				} `json:"reviewThreads"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+type reviewThread struct {
+	IsResolved bool `json:"isResolved"`
+	Comments   struct {
+		Nodes []reviewComment `json:"nodes"`
+	} `json:"comments"`
+}
+
+type reviewComment struct {
+	Author struct {
+		Login string `json:"login"`
+	} `json:"author"`
+	Path        string `json:"path"`
+	URL         string `json:"url"`
+	BodyText    string `json:"bodyText"`
+	IsMinimized bool   `json:"isMinimized"`
+}
+
+// isBotLogin reports whether a comment author login matches the configured
+// Macroscope bot logins ("[bot]" suffix stripped, case-insensitive).
+func isBotLogin(login string, bots []string) bool {
+	login = strings.TrimSuffix(strings.ToLower(login), "[bot]")
+	for _, b := range bots {
+		if b != "" && login == strings.TrimSuffix(strings.ToLower(b), "[bot]") {
+			return true
+		}
+	}
+	return false
+}
+
+// FetchUnaddressedComments performs the single post-settle comment fetch:
+// it lists the PR's review threads and returns those opened by a Macroscope
+// bot that are unaddressed — not resolved, not minimized, and with no reply
+// from anyone but the bot. Addressing a comment per the review convention
+// (fix + reply with the commit, or refute with evidence on the thread) or
+// resolving the thread clears it.
+func (g *Gate) FetchUnaddressedComments(dir string, prNumber int, opts MacroscopeOptions) ([]UnaddressedComment, error) {
+	run := g.Run
+	if run == nil {
+		run = defaultRunner
+	}
+	repoOut, err := run(dir, "gh", "repo", "view", "--json", "owner,name")
+	if err != nil {
+		return nil, fmt.Errorf("resolving repo for comment fetch: %w", err)
+	}
+	var repo struct {
+		Owner struct {
+			Login string `json:"login"`
+		} `json:"owner"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(repoOut), &repo); err != nil {
+		return nil, fmt.Errorf("parsing gh repo view output: %w", err)
+	}
+	out, err := run(dir, "gh", "api", "graphql",
+		"-f", "query="+reviewThreadsQuery,
+		"-F", "owner="+repo.Owner.Login,
+		"-F", "name="+repo.Name,
+		"-F", "pr="+strconv.Itoa(prNumber))
+	if err != nil {
+		return nil, fmt.Errorf("fetching review threads: %w", err)
+	}
+	var resp reviewThreadsResponse
+	if err := json.Unmarshal(bytes.TrimSpace(out), &resp); err != nil {
+		return nil, fmt.Errorf("parsing review threads: %w", err)
+	}
+
+	var unaddressed []UnaddressedComment
+	for _, thread := range resp.Data.Repository.PullRequest.ReviewThreads.Nodes {
+		if thread.IsResolved || len(thread.Comments.Nodes) == 0 {
+			continue
+		}
+		first := thread.Comments.Nodes[0]
+		if first.IsMinimized || !isBotLogin(first.Author.Login, opts.BotLogins) {
+			continue
+		}
+		replied := false
+		for _, c := range thread.Comments.Nodes[1:] {
+			if !isBotLogin(c.Author.Login, opts.BotLogins) {
+				replied = true
+				break
+			}
+		}
+		if replied {
+			continue
+		}
+		unaddressed = append(unaddressed, UnaddressedComment{
+			Author:  first.Author.Login,
+			Path:    first.Path,
+			URL:     first.URL,
+			Excerpt: commentExcerpt(first.BodyText),
+		})
+	}
+	return unaddressed, nil
+}
+
+// commentExcerpt reduces a comment body to its first line, truncated.
+func commentExcerpt(body string) string {
+	line := strings.TrimSpace(body)
+	if i := strings.IndexByte(line, '\n'); i >= 0 {
+		line = strings.TrimSpace(line[:i])
+	}
+	const max = 120
+	if len(line) > max {
+		line = line[:max] + "…"
+	}
+	return line
+}

--- a/internal/cigate/macroscope_test.go
+++ b/internal/cigate/macroscope_test.go
@@ -1,0 +1,329 @@
+package cigate
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+var msOpts = MacroscopeOptions{
+	CheckPatterns: []string{"macroscope"},
+	BotLogins:     []string{"macroscopeapp"},
+}
+
+func TestRollupEntryTerminal(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    rollupEntry
+		terminal bool
+	}{
+		{"completed check run", rollupEntry{Name: "Macroscope - Correctness Check", Status: "COMPLETED", Conclusion: "SUCCESS"}, true},
+		{"completed neutral check run (live Approvability shape)", rollupEntry{Name: "Macroscope - Approvability Check", Status: "COMPLETED", Conclusion: "NEUTRAL"}, true},
+		{"completed failing check run is terminal (pass/fail is the CI verdict's job)", rollupEntry{Name: "m", Status: "COMPLETED", Conclusion: "FAILURE"}, true},
+		{"in-progress check run", rollupEntry{Name: "m", Status: "IN_PROGRESS"}, false},
+		{"queued check run", rollupEntry{Name: "m", Status: "QUEUED"}, false},
+		{"commit status success", rollupEntry{Context: "macroscope/review", State: "SUCCESS"}, true},
+		{"commit status failure is terminal", rollupEntry{Context: "macroscope/review", State: "FAILURE"}, true},
+		{"commit status pending", rollupEntry{Context: "macroscope/review", State: "PENDING"}, false},
+		{"commit status expected", rollupEntry{Context: "macroscope/review", State: "EXPECTED"}, false},
+		{"empty entry is not terminal", rollupEntry{Name: "m"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.entry.terminal(); got != tt.terminal {
+				t.Errorf("terminal() = %v, want %v", got, tt.terminal)
+			}
+		})
+	}
+}
+
+func TestCheckMacroscopeSettle(t *testing.T) {
+	tests := []struct {
+		name     string
+		ghOutput string
+		ghErr    error
+		settled  bool
+		pending  []string
+		wantErr  bool
+	}{
+		{
+			name:     "no PR settles trivially",
+			ghOutput: `[]`,
+			settled:  true,
+		},
+		{
+			name: "no macroscope contexts settles trivially (rig without Macroscope)",
+			ghOutput: `[{"number":5,"state":"OPEN","url":"u",
+				"statusCheckRollup":[{"context":"jenkins","state":"SUCCESS"}]}]`,
+			settled: true,
+		},
+		{
+			// Live shape from capital #21457: both Macroscope check runs
+			// COMPLETED while Jenkins contexts still pend — the CI verdict
+			// owns those; the settle phase only watches Macroscope.
+			name: "macroscope terminal amid pending jenkins is settled",
+			ghOutput: `[{"number":21457,"state":"OPEN","url":"u","statusCheckRollup":[
+				{"name":"Macroscope - Approvability Check","status":"COMPLETED","conclusion":"NEUTRAL"},
+				{"name":"Macroscope - Correctness Check","status":"COMPLETED","conclusion":"SUCCESS"},
+				{"context":"continuous-integration/jenkins/branch","state":"PENDING"}]}]`,
+			settled: true,
+		},
+		{
+			name: "in-progress macroscope check is not settled",
+			ghOutput: `[{"number":6,"state":"OPEN","url":"u","statusCheckRollup":[
+				{"name":"Macroscope - Correctness Check","status":"IN_PROGRESS"},
+				{"context":"jenkins","state":"SUCCESS"}]}]`,
+			settled: false,
+			pending: []string{"Macroscope - Correctness Check"},
+		},
+		{
+			name: "macroscope commit status pending is not settled",
+			ghOutput: `[{"number":7,"state":"OPEN","url":"u","statusCheckRollup":[
+				{"context":"macroscope/review","state":"PENDING"}]}]`,
+			settled: false,
+			pending: []string{"macroscope/review"},
+		},
+		{
+			name:    "gh error surfaces",
+			ghErr:   errors.New("gh: rate limited"),
+			wantErr: true,
+		},
+		{
+			name:     "garbage output surfaces as error",
+			ghOutput: `not json`,
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &Gate{Run: stubRunner(tt.ghOutput, tt.ghErr)}
+			res := g.CheckMacroscopeSettle("/tmp", "polecat/test", msOpts)
+			if tt.wantErr {
+				if res.Err == nil {
+					t.Fatal("want error, got nil")
+				}
+				return
+			}
+			if res.Err != nil {
+				t.Fatalf("unexpected error: %v", res.Err)
+			}
+			if res.Settled != tt.settled {
+				t.Errorf("Settled = %v, want %v", res.Settled, tt.settled)
+			}
+			if got, want := strings.Join(res.PendingChecks, ","), strings.Join(tt.pending, ","); got != want {
+				t.Errorf("pending = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+const (
+	msPending = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"name":"Macroscope - Correctness Check","status":"IN_PROGRESS"}]}]`
+	msSettled = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"name":"Macroscope - Correctness Check","status":"COMPLETED","conclusion":"SUCCESS"}]}]`
+)
+
+func TestWaitForMacroscopeSettle(t *testing.T) {
+	t.Run("pending then settled", func(t *testing.T) {
+		clock := &fakeClock{now: time.Unix(0, 0)}
+		g := sequenceGate(msPending, msPending, msSettled)
+		res, timedOut := g.WaitForMacroscopeSettle("/tmp", "b", msOpts, WaitOptions{
+			Timeout: 30 * time.Minute, PollInterval: 30 * time.Second,
+			Sleep: clock.Sleep, Now: clock.Now,
+		})
+		if timedOut || !res.Settled {
+			t.Fatalf("got settled=%v timedOut=%v, want settled", res.Settled, timedOut)
+		}
+	})
+
+	t.Run("stuck pending times out", func(t *testing.T) {
+		clock := &fakeClock{now: time.Unix(0, 0)}
+		g := sequenceGate(msPending)
+		start := clock.now
+		res, timedOut := g.WaitForMacroscopeSettle("/tmp", "b", msOpts, WaitOptions{
+			Timeout: 10 * time.Minute, PollInterval: 30 * time.Second,
+			Sleep: clock.Sleep, Now: clock.Now,
+		})
+		if !timedOut || res.Settled {
+			t.Fatalf("got settled=%v timedOut=%v, want timeout", res.Settled, timedOut)
+		}
+		if waited := clock.now.Sub(start); waited < 10*time.Minute || waited > 12*time.Minute {
+			t.Errorf("waited %s, want ~10m", waited)
+		}
+	})
+
+	t.Run("error stops the wait", func(t *testing.T) {
+		g := &Gate{Run: stubRunner("", errors.New("boom"))}
+		res, timedOut := g.WaitForMacroscopeSettle("/tmp", "b", msOpts, WaitOptions{
+			Timeout: 10 * time.Minute, PollInterval: 30 * time.Second,
+			Sleep: func(time.Duration) {}, Now: time.Now,
+		})
+		if timedOut || res.Err == nil {
+			t.Fatalf("want error without timeout, got err=%v timedOut=%v", res.Err, timedOut)
+		}
+	})
+}
+
+func TestIsBotLogin(t *testing.T) {
+	bots := []string{"macroscopeapp"}
+	for login, want := range map[string]bool{
+		"macroscopeapp":      true, // GraphQL shape
+		"macroscopeapp[bot]": true, // REST shape
+		"MacroscopeApp[BOT]": true,
+		"blairsilverberg":    false,
+		"":                   false,
+	} {
+		if got := isBotLogin(login, bots); got != want {
+			t.Errorf("isBotLogin(%q) = %v, want %v", login, got, want)
+		}
+	}
+	if isBotLogin("macroscopeapp", nil) {
+		t.Error("empty bot list must match nothing")
+	}
+	if !isBotLogin("macroscopeapp", []string{"macroscopeapp[bot]"}) {
+		t.Error("configured [bot] suffix should be normalized too")
+	}
+}
+
+// threadsJSON builds a GraphQL reviewThreads response body.
+func threadsJSON(threads ...string) string {
+	return fmt.Sprintf(`{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[%s]}}}}}`,
+		strings.Join(threads, ","))
+}
+
+func msThread(resolved bool, comments ...string) string {
+	return fmt.Sprintf(`{"isResolved":%v,"comments":{"nodes":[%s]}}`, resolved, strings.Join(comments, ","))
+}
+
+func msComment(login, body string) string {
+	return fmt.Sprintf(`{"author":{"login":%q},"path":"a.py","url":"https://x/r1","bodyText":%q,"isMinimized":false}`, login, body)
+}
+
+// fetchRunner dispatches on the gh subcommand: repo view vs api graphql.
+func fetchRunner(graphqlOut string, graphqlErr error) Runner {
+	return func(dir, name string, args ...string) ([]byte, error) {
+		if len(args) > 1 && args[0] == "repo" && args[1] == "view" {
+			return []byte(`{"owner":{"login":"captec"},"name":"capital"}`), nil
+		}
+		if graphqlErr != nil {
+			return nil, graphqlErr
+		}
+		return []byte(graphqlOut), nil
+	}
+}
+
+func TestFetchUnaddressedComments(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want int
+	}{
+		{
+			name: "unresolved bot thread with no reply is unaddressed",
+			out:  threadsJSON(msThread(false, msComment("macroscopeapp", "🟡 Medium: thin-data guard"))),
+			want: 1,
+		},
+		{
+			name: "resolved thread is addressed",
+			out:  threadsJSON(msThread(true, msComment("macroscopeapp", "issue"))),
+			want: 0,
+		},
+		{
+			name: "non-bot reply addresses the thread",
+			out: threadsJSON(msThread(false,
+				msComment("macroscopeapp", "issue"),
+				msComment("blairsilverberg", "fixed in abc123"))),
+			want: 0,
+		},
+		{
+			name: "bot-only replies do not address the thread",
+			out: threadsJSON(msThread(false,
+				msComment("macroscopeapp", "issue"),
+				msComment("macroscopeapp", "still an issue"))),
+			want: 1,
+		},
+		{
+			name: "non-macroscope thread is ignored",
+			out:  threadsJSON(msThread(false, msComment("humanreviewer", "nit"))),
+			want: 0,
+		},
+		{
+			name: "minimized first comment is ignored (deliberately hidden)",
+			out: threadsJSON(`{"isResolved":false,"comments":{"nodes":[
+				{"author":{"login":"macroscopeapp"},"path":"a.py","url":"u","bodyText":"x","isMinimized":true}]}}`),
+			want: 0,
+		},
+		{
+			name: "empty thread list",
+			out:  threadsJSON(),
+			want: 0,
+		},
+		{
+			name: "mixed threads count only the unaddressed",
+			out: threadsJSON(
+				msThread(false, msComment("macroscopeapp", "🟡 Medium one")),
+				msThread(true, msComment("macroscopeapp", "resolved one")),
+				msThread(false, msComment("macroscopeapp", "🟡 Medium two")),
+			),
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &Gate{Run: fetchRunner(tt.out, nil)}
+			got, err := g.FetchUnaddressedComments("/tmp", 21457, msOpts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != tt.want {
+				t.Errorf("got %d unaddressed, want %d: %+v", len(got), tt.want, got)
+			}
+		})
+	}
+
+	t.Run("graphql error surfaces", func(t *testing.T) {
+		g := &Gate{Run: fetchRunner("", errors.New("gh: 502"))}
+		if _, err := g.FetchUnaddressedComments("/tmp", 1, msOpts); err == nil {
+			t.Fatal("want error, got nil")
+		}
+	})
+
+	t.Run("repo view error surfaces", func(t *testing.T) {
+		g := &Gate{Run: stubRunner("", errors.New("no remote"))}
+		if _, err := g.FetchUnaddressedComments("/tmp", 1, msOpts); err == nil {
+			t.Fatal("want error, got nil")
+		}
+	})
+
+	t.Run("comment fields populated", func(t *testing.T) {
+		g := &Gate{Run: fetchRunner(threadsJSON(msThread(false,
+			msComment("macroscopeapp", "🟡 Medium first line\nsecond line"))), nil)}
+		got, err := g.FetchUnaddressedComments("/tmp", 1, msOpts)
+		if err != nil || len(got) != 1 {
+			t.Fatalf("got %v, %v", got, err)
+		}
+		c := got[0]
+		if c.Author != "macroscopeapp" || c.Path != "a.py" || c.URL != "https://x/r1" {
+			t.Errorf("fields = %+v", c)
+		}
+		if c.Excerpt != "🟡 Medium first line" {
+			t.Errorf("excerpt = %q, want first line only", c.Excerpt)
+		}
+	})
+}
+
+func TestMacroscopeEnvKillSwitch(t *testing.T) {
+	for _, v := range []string{"off", "0", "false", "disabled", "OFF"} {
+		t.Setenv("GT_MACROSCOPE_SETTLE", v)
+		if !MacroscopeEnvDisabled() {
+			t.Errorf("GT_MACROSCOPE_SETTLE=%s should disable the settle phase", v)
+		}
+	}
+	for _, v := range []string{"", "on", "1", "true"} {
+		t.Setenv("GT_MACROSCOPE_SETTLE", v)
+		if MacroscopeEnvDisabled() {
+			t.Errorf("GT_MACROSCOPE_SETTLE=%s should NOT disable the settle phase", v)
+		}
+	}
+}

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1207,6 +1207,15 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		}
 		bd := beads.NewWithBeadsDir(cwd, resolvedBeads)
 
+		// AA-851 hard CI gate: block COMPLETED while this branch's PR has any
+		// check red or pending. Runs after push verification and BEFORE any
+		// issue close or MR-bead creation, so an abort leaves the polecat
+		// assigned with its hook bead open. No-PR and merged-PR pass through;
+		// CI-status errors fail open with a loud human escalation.
+		if gateErr := runDoneCIGate(bd, townRoot, rigName, cwd, branch, issueID, agentBeadID, sender); gateErr != nil {
+			return gateErr
+		}
+
 		// Check for no_merge flag - if set, skip merge queue and notify for review
 		sourceIssueForNoMerge, err := bd.Show(issueID)
 		if err == nil {
@@ -1257,19 +1266,33 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 					prBodyBuilder.WriteString("---\n")
 					prBodyBuilder.WriteString(fmt.Sprintf("*Polecat: %s | Issue: %s*\n", worker, issueID))
 					prBody := prBodyBuilder.String()
-					ghCmd := exec.CommandContext(context.Background(), "gh", "pr", "create",
-						"--base", defaultBranch,
-						"--head", branch,
-						"--title", prTitle,
-						"--body", prBody,
-					)
-					ghCmd.Dir = cwd
-					prOutput, prErr := ghCmd.Output()
-					if prErr != nil {
-						style.PrintWarning("could not create GitHub PR: %v", prErr)
-					} else {
-						prURL = strings.TrimSpace(string(prOutput))
-						fmt.Printf("%s GitHub PR created: %s\n", style.Bold.Render("✓"), prURL)
+					// Re-run idempotency (AA-851): a gt done that was aborted by
+					// the CI gate after creating the PR would otherwise fail here
+					// on a duplicate `gh pr create`. Reuse the existing open PR.
+					if existingNum, findErr := g.FindPRNumber(branch); findErr == nil && existingNum > 0 {
+						viewCmd := exec.CommandContext(context.Background(), "gh", "pr", "view",
+							fmt.Sprintf("%d", existingNum), "--json", "url", "--jq", ".url")
+						viewCmd.Dir = cwd
+						if viewOut, viewErr := viewCmd.Output(); viewErr == nil && len(strings.TrimSpace(string(viewOut))) > 0 {
+							prURL = strings.TrimSpace(string(viewOut))
+							fmt.Printf("%s Reusing existing GitHub PR: %s\n", style.Bold.Render("✓"), prURL)
+						}
+					}
+					if prURL == "" {
+						ghCmd := exec.CommandContext(context.Background(), "gh", "pr", "create",
+							"--base", defaultBranch,
+							"--head", branch,
+							"--title", prTitle,
+							"--body", prBody,
+						)
+						ghCmd.Dir = cwd
+						prOutput, prErr := ghCmd.Output()
+						if prErr != nil {
+							style.PrintWarning("could not create GitHub PR: %v", prErr)
+						} else {
+							prURL = strings.TrimSpace(string(prOutput))
+							fmt.Printf("%s GitHub PR created: %s\n", style.Bold.Render("✓"), prURL)
+						}
 					}
 				} else {
 					fmt.Printf("%s\n", style.Dim.Render("Work stays on feature branch for human review."))

--- a/internal/cmd/done_cigate.go
+++ b/internal/cmd/done_cigate.go
@@ -159,7 +159,7 @@ func runDoneCIGate(bd *beads.Beads, townRoot, rigName, cwd, branch, issueID, age
 
 	agentBd := beads.New(cwd).ForAgentBead()
 	deps := &doneCIGateDeps{
-		gate:   cigate.New(),
+		gate:   cigate.New(cfg.HumanGateChecksOrDefault()...),
 		cfg:    cfg,
 		dir:    cwd,
 		branch: branch,

--- a/internal/cmd/done_cigate.go
+++ b/internal/cmd/done_cigate.go
@@ -59,6 +59,10 @@ type doneCIGateDeps struct {
 	nudgeMayor        func(msg string)
 	// wait overrides gate.WaitForGreen in tests; nil = real wait.
 	wait func(timeout, poll time.Duration) (cigate.CheckResult, bool)
+	// settleWait overrides gate.WaitForMacroscopeSettle in tests; nil = real.
+	settleWait func(opts cigate.MacroscopeOptions, timeout, poll time.Duration) (cigate.MacroscopeSettleResult, bool)
+	// fetchComments overrides gate.FetchUnaddressedComments in tests; nil = real.
+	fetchComments func(prNumber int, opts cigate.MacroscopeOptions) ([]cigate.UnaddressedComment, error)
 }
 
 // enforce runs the gate. A nil return means gt done may proceed; a non-nil
@@ -119,6 +123,9 @@ func (d *doneCIGateDeps) enforce() error {
 		return nil
 	case cigate.VerdictGreen:
 		fmt.Fprintf(d.out, "%s CI gate: %s\n", style.Bold.Render("✓"), res.Summary())
+		if err := d.enforceMacroscopeSettle(res); err != nil {
+			return err
+		}
 		d.clearNeedsCIGreen()
 		return nil
 	case cigate.VerdictError:
@@ -146,6 +153,109 @@ func (d *doneCIGateDeps) enforce() error {
 	// Unknown verdict — treat like fail-open but warn.
 	fmt.Fprintf(d.out, "%s CI gate: unexpected verdict %s — failing open\n",
 		style.Warning.Render("⚠"), res.Verdict)
+	return nil
+}
+
+// enforceMacroscopeSettle runs the Macroscope comment-settle phase of the
+// gate (op-sr9u / hq-owe9c) after the CI verdict is GREEN. Macroscope posts
+// its inline review comments asynchronously AFTER its checks turn green, so
+// a green-checks-only gate races the review: capital #21457/#21459/#21461
+// each went gt done clean and grew substantive Mediums minutes later with
+// their authors' sessions already dead.
+//
+// Phases: (a) wait for Macroscope check contexts to reach a terminal state
+// on the final head; (b) ONE review-comment fetch; (c) unaddressed comments
+// abort gt done like CI red — plus a ticket comment + human-attention hold
+// via escalation_cmd; (d) if Macroscope never settles or the fetch fails,
+// FAIL OPEN with an escalation, per the gate's existing 30m rule.
+func (d *doneCIGateDeps) enforceMacroscopeSettle(res cigate.CheckResult) error {
+	mcfg := d.cfg.MacroscopeSettings()
+	if !mcfg.IsEnabled() || cigate.MacroscopeEnvDisabled() {
+		return nil
+	}
+	opts := cigate.MacroscopeOptions{
+		CheckPatterns: mcfg.CheckPatternsOrDefault(),
+		BotLogins:     mcfg.BotLoginsOrDefault(),
+	}
+	timeout := mcfg.SettleTimeoutOrDefault(d.cfg.PendingTimeoutOrDefault())
+	poll := d.cfg.PollIntervalOrDefault()
+
+	var settle cigate.MacroscopeSettleResult
+	var timedOut bool
+	if d.settleWait != nil {
+		settle, timedOut = d.settleWait(opts, timeout, poll)
+	} else {
+		settle, timedOut = d.gate.WaitForMacroscopeSettle(d.dir, d.branch, opts, cigate.WaitOptions{
+			Timeout:      timeout,
+			PollInterval: poll,
+			Progress:     d.out,
+		})
+	}
+	if settle.Err != nil {
+		return d.macroscopeFailOpen(cigate.EventMacroscopeError, res,
+			fmt.Sprintf("could not determine Macroscope settle state (%v)", settle.Err))
+	}
+	if timedOut {
+		return d.macroscopeFailOpen(cigate.EventMacroscopeTimeout, res,
+			fmt.Sprintf("Macroscope checks [%s] never reached a terminal state within %s",
+				strings.Join(settle.PendingChecks, ", "), timeout))
+	}
+
+	var comments []cigate.UnaddressedComment
+	var err error
+	if d.fetchComments != nil {
+		comments, err = d.fetchComments(res.PRNumber, opts)
+	} else {
+		comments, err = d.gate.FetchUnaddressedComments(d.dir, res.PRNumber, opts)
+	}
+	if err != nil {
+		return d.macroscopeFailOpen(cigate.EventMacroscopeError, res,
+			fmt.Sprintf("post-settle comment fetch failed (%v)", err))
+	}
+	if len(comments) == 0 {
+		fmt.Fprintf(d.out, "%s CI gate: Macroscope settled, no unaddressed review comments\n",
+			style.Bold.Render("✓"))
+		return nil
+	}
+
+	var lines []string
+	for _, c := range comments {
+		lines = append(lines, fmt.Sprintf("  - %s (%s): %s", c.URL, c.Path, c.Excerpt))
+	}
+	list := strings.Join(lines, "\n")
+	d.setNeedsCIGreen(res.PRNumber)
+	d.clearDoneIntent()
+	d.escalate(cigate.Escalation{
+		Event: cigate.EventMacroscopeUnaddressed,
+		Detail: fmt.Sprintf("CI gate (op-sr9u): gt done aborted — PR #%d is CI-green but has %d unaddressed "+
+			"Macroscope comment(s) after settle. Agent %s on branch %s stays assigned and must address "+
+			"each (fix, or refute with evidence, replying on the thread) before re-running gt done.\n%s",
+			res.PRNumber, len(comments), d.agent, d.branch, list),
+		PRURL:  res.PRURL,
+		Branch: d.branch,
+		Agent:  d.agent,
+	})
+	return fmt.Errorf("NEEDS_MACROSCOPE_ADDRESSED: PR #%d has %d unaddressed Macroscope comment(s):\n%s\n"+
+		"Address each — fix it (with a regression test where applicable) or refute it with runtime "+
+		"evidence — reply on the thread, then re-run `gt done`. You stay assigned to this work.\n"+
+		"(Override: GT_MACROSCOPE_SETTLE=off)",
+		res.PRNumber, len(comments), list)
+}
+
+// macroscopeFailOpen logs and escalates a Macroscope settle failure, then
+// lets gt done proceed — a Macroscope outage must not brick completions,
+// but a human must check the PR for late review comments.
+func (d *doneCIGateDeps) macroscopeFailOpen(event cigate.EscalationEvent, res cigate.CheckResult, why string) error {
+	fmt.Fprintf(d.out, "%s CI gate: %s — FAILING OPEN (op-sr9u)\n", style.Warning.Render("⚠"), why)
+	d.escalate(cigate.Escalation{
+		Event: event,
+		Detail: fmt.Sprintf("CI gate (op-sr9u): %s. gt done by %s on branch %s (PR #%d) proceeded "+
+			"FAIL-OPEN — a human must check the PR for unaddressed Macroscope review comments.",
+			why, d.agent, d.branch, res.PRNumber),
+		PRURL:  res.PRURL,
+		Branch: d.branch,
+		Agent:  d.agent,
+	})
 	return nil
 }
 

--- a/internal/cmd/done_cigate.go
+++ b/internal/cmd/done_cigate.go
@@ -1,0 +1,270 @@
+package cmd
+
+// AA-851 hard CI gate for gt done: a polecat cannot transition to COMPLETED
+// while its branch's PR has any CI check red or pending. The gate runs after
+// the branch push is verified and BEFORE any issue close or MR-bead creation,
+// so an abort leaves the polecat assigned with its hook bead open — it keeps
+// iterating until the PR is green.
+//
+// Pass-through verdicts: no PR (merge-strategy=direct rigs), PR already
+// merged, PR closed-unmerged (deliberate human action, warn only).
+// Fail-open verdict: ERROR (CI state unknown) — completion proceeds, but the
+// event escalates to a human via ci_gate.escalation_cmd so a silently
+// broken gate is loudly visible.
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/cigate"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/style"
+)
+
+// needsCIGreenLabelPrefix marks an agent bead whose last gt done was blocked
+// by the CI gate: needs-ci-green:<pr>:<unix-ts>. Cleared on the next gt done
+// that passes the gate.
+const needsCIGreenLabelPrefix = "needs-ci-green:"
+
+// loadCIGateConfig reads the rig's merge_queue.ci_gate settings.
+// Missing settings file or block yields the enabled defaults.
+func loadCIGateConfig(rigPath string) *config.CIGateConfig {
+	settingsPath := filepath.Join(rigPath, "settings", "config.json")
+	if settings, err := config.LoadRigSettings(settingsPath); err == nil && settings.MergeQueue != nil {
+		return settings.MergeQueue.CIGateSettings()
+	}
+	return &config.CIGateConfig{}
+}
+
+// doneCIGateDeps carries the gate inputs plus injectable side effects so the
+// decision logic is unit-testable without beads/tmux/gh.
+type doneCIGateDeps struct {
+	gate   *cigate.Gate
+	cfg    *config.CIGateConfig
+	dir    string
+	branch string
+	agent  string
+	out    io.Writer
+
+	setNeedsCIGreen   func(prNumber int)
+	clearNeedsCIGreen func()
+	clearDoneIntent   func()
+	escalate          func(esc cigate.Escalation)
+	nudgeMayor        func(msg string)
+	// wait overrides gate.WaitForGreen in tests; nil = real wait.
+	wait func(timeout, poll time.Duration) (cigate.CheckResult, bool)
+}
+
+// enforce runs the gate. A nil return means gt done may proceed; a non-nil
+// error aborts gt done with the polecat still assigned.
+func (d *doneCIGateDeps) enforce() error {
+	res := d.gate.CheckBranch(d.dir, d.branch)
+
+	if res.Verdict == cigate.VerdictPending {
+		timeout := d.cfg.PendingTimeoutOrDefault()
+		poll := d.cfg.PollIntervalOrDefault()
+		fmt.Fprintf(d.out, "%s CI gate: %s — waiting up to %s for checks to settle\n",
+			style.Bold.Render("→"), res.Summary(), timeout)
+		var timedOut bool
+		if d.wait != nil {
+			res, timedOut = d.wait(timeout, poll)
+		} else {
+			res, timedOut = d.gate.WaitForGreen(d.dir, d.branch, cigate.WaitOptions{
+				Timeout:      timeout,
+				PollInterval: poll,
+				Progress:     d.out,
+			})
+		}
+		if timedOut {
+			detail := fmt.Sprintf("CI gate (AA-851): gt done aborted — %s after waiting %s. "+
+				"Agent %s on branch %s stays assigned and must re-run gt done once CI completes.",
+				res.Summary(), timeout, d.agent, d.branch)
+			d.escalate(cigate.Escalation{
+				Event:  cigate.EventPendingTimeout,
+				Detail: detail,
+				PRURL:  res.PRURL,
+				Branch: d.branch,
+				Agent:  d.agent,
+			})
+			d.nudgeMayor(fmt.Sprintf("NEEDS_CI_GREEN: %s stuck pending >%s for %s (branch %s)",
+				res.Summary(), timeout, d.agent, d.branch))
+			d.setNeedsCIGreen(res.PRNumber)
+			d.clearDoneIntent()
+			return fmt.Errorf("NEEDS_CI_GREEN: %s — still pending after %s.\n"+
+				"Poll `gh pr checks %d` and re-run `gt done` when CI completes.\n"+
+				"(Escalated for human attention; override: GT_CI_GATE=off)",
+				res.Summary(), timeout, res.PRNumber)
+		}
+	}
+
+	switch res.Verdict {
+	case cigate.VerdictNoPR:
+		// No PR for this branch — the gate only applies when a PR exists.
+		d.clearNeedsCIGreen()
+		return nil
+	case cigate.VerdictMerged:
+		fmt.Fprintf(d.out, "%s CI gate: %s\n", style.Bold.Render("✓"), res.Summary())
+		d.clearNeedsCIGreen()
+		return nil
+	case cigate.VerdictClosedUnmerged:
+		fmt.Fprintf(d.out, "%s CI gate: %s — passing through (deliberate close?)\n",
+			style.Warning.Render("⚠"), res.Summary())
+		d.clearNeedsCIGreen()
+		return nil
+	case cigate.VerdictGreen:
+		fmt.Fprintf(d.out, "%s CI gate: %s\n", style.Bold.Render("✓"), res.Summary())
+		d.clearNeedsCIGreen()
+		return nil
+	case cigate.VerdictError:
+		// Fail-open: a GitHub outage must not brick every completion, but a
+		// human must verify — escalate via the rig's tracker integration.
+		fmt.Fprintf(d.out, "%s CI gate: could not determine CI status (%v) — FAILING OPEN (AA-851)\n",
+			style.Warning.Render("⚠"), res.Err)
+		d.escalate(cigate.Escalation{
+			Event: cigate.EventCIStatusError,
+			Detail: fmt.Sprintf("CI gate (AA-851): could not determine CI status for branch %s (%v). "+
+				"gt done by %s proceeded FAIL-OPEN — a human must verify the PR's checks were green.",
+				d.branch, res.Err, d.agent),
+			Branch: d.branch,
+			Agent:  d.agent,
+		})
+		return nil
+	case cigate.VerdictRed:
+		d.setNeedsCIGreen(res.PRNumber)
+		d.clearDoneIntent()
+		return fmt.Errorf("NEEDS_CI_GREEN: %s.\n"+
+			"Fix the failures, push, and re-run `gt done`. You stay assigned to this work.\n"+
+			"(Inspect: `gh pr checks %d`; override: GT_CI_GATE=off)",
+			res.Summary(), res.PRNumber)
+	}
+	// Unknown verdict — treat like fail-open but warn.
+	fmt.Fprintf(d.out, "%s CI gate: unexpected verdict %s — failing open\n",
+		style.Warning.Render("⚠"), res.Verdict)
+	return nil
+}
+
+// runDoneCIGate wires the gate with real side effects and enforces it.
+// Called from the COMPLETED path of runDone after push verification.
+func runDoneCIGate(bd *beads.Beads, townRoot, rigName, cwd, branch, issueID, agentBeadID, sender string) error {
+	cfg := loadCIGateConfig(filepath.Join(townRoot, rigName))
+	if !cfg.IsEnabled() || cigate.EnvDisabled() {
+		return nil
+	}
+
+	agentBd := beads.New(cwd).ForAgentBead()
+	deps := &doneCIGateDeps{
+		gate:   cigate.New(),
+		cfg:    cfg,
+		dir:    cwd,
+		branch: branch,
+		agent:  sender,
+		out:    os.Stdout,
+		setNeedsCIGreen: func(prNumber int) {
+			setNeedsCIGreenLabel(agentBd, agentBeadID, prNumber)
+		},
+		clearNeedsCIGreen: func() {
+			clearNeedsCIGreenLabel(agentBd, agentBeadID)
+		},
+		clearDoneIntent: func() {
+			clearDoneIntentLabel(agentBd, agentBeadID)
+		},
+		escalate: func(esc cigate.Escalation) {
+			esc.Ticket = ticketForIssue(bd, issueID)
+			escalateCIGate(cfg, cwd, esc)
+		},
+		nudgeMayor: nudgeMayorBestEffort,
+	}
+	return deps.enforce()
+}
+
+// ticketForIssue extracts the external tracker key (`Jira: AA-123` line)
+// from the worked issue's description. Best-effort: "" when unavailable.
+func ticketForIssue(bd *beads.Beads, issueID string) string {
+	if bd == nil || issueID == "" {
+		return ""
+	}
+	issue, err := bd.Show(issueID)
+	if err != nil || issue == nil {
+		return ""
+	}
+	return cigate.ExtractTicket(issue.Description)
+}
+
+// escalateCIGate runs the rig's ci_gate.escalation_cmd (tracker integration:
+// comment on the ticket + move it to a human-attention status). Best-effort —
+// escalation failures are logged, never fatal.
+func escalateCIGate(cfg *config.CIGateConfig, dir string, esc cigate.Escalation) {
+	cmdStr := cfg.EscalationCmdOrEmpty()
+	if cmdStr == "" {
+		fmt.Fprintf(os.Stderr, "Warning: CI gate %s event but no ci_gate.escalation_cmd configured (ticket=%s): %s\n",
+			esc.Event, esc.Ticket, esc.Detail)
+		return
+	}
+	if err := cigate.RunEscalationCmd(cmdStr, dir, esc); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: CI gate escalation failed: %v\n", err)
+		return
+	}
+	fmt.Printf("%s CI gate: escalated %s to human attention (ticket %s)\n",
+		style.Bold.Render("→"), esc.Event, esc.Ticket)
+}
+
+// nudgeMayorBestEffort sends a gt nudge to the mayor, mirroring the
+// refinery's BRANCH_MISSING escalation precedent. Best-effort.
+func nudgeMayorBestEffort(msg string) {
+	cmd := exec.Command("gt", "nudge", "mayor/", msg)
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to nudge mayor: %v\n", err)
+	}
+}
+
+// setNeedsCIGreenLabel marks the agent bead as CI-gate-blocked:
+// needs-ci-green:<pr>:<unix-ts>. Replaces any prior needs-ci-green label.
+func setNeedsCIGreenLabel(bd *beads.Beads, agentBeadID string, prNumber int) {
+	if agentBeadID == "" {
+		return
+	}
+	label := fmt.Sprintf("%s%d:%d", needsCIGreenLabelPrefix, prNumber, time.Now().Unix())
+	toRemove := needsCIGreenLabels(bd, agentBeadID)
+	if err := bd.Update(agentBeadID, beads.UpdateOptions{
+		AddLabels:    []string{label},
+		RemoveLabels: toRemove,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: couldn't set needs-ci-green label on %s: %v\n", agentBeadID, err)
+	}
+}
+
+// clearNeedsCIGreenLabel removes any needs-ci-green:* label from the agent
+// bead (called when a later gt done passes the gate).
+func clearNeedsCIGreenLabel(bd *beads.Beads, agentBeadID string) {
+	if agentBeadID == "" {
+		return
+	}
+	toRemove := needsCIGreenLabels(bd, agentBeadID)
+	if len(toRemove) == 0 {
+		return
+	}
+	if err := bd.Update(agentBeadID, beads.UpdateOptions{RemoveLabels: toRemove}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: couldn't clear needs-ci-green label on %s: %v\n", agentBeadID, err)
+	}
+}
+
+// needsCIGreenLabels lists the agent bead's needs-ci-green:* labels.
+func needsCIGreenLabels(bd *beads.Beads, agentBeadID string) []string {
+	issue, err := bd.Show(agentBeadID)
+	if err != nil || issue == nil {
+		return nil
+	}
+	var labels []string
+	for _, label := range issue.Labels {
+		if strings.HasPrefix(label, needsCIGreenLabelPrefix) {
+			labels = append(labels, label)
+		}
+	}
+	return labels
+}

--- a/internal/cmd/done_cigate_test.go
+++ b/internal/cmd/done_cigate_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +10,8 @@ import (
 	"github.com/steveyegge/gastown/internal/cigate"
 	"github.com/steveyegge/gastown/internal/config"
 )
+
+var errGHDown = errors.New("gh: 502")
 
 // gateRecorder captures the side effects of a doneCIGateDeps.enforce run.
 type gateRecorder struct {
@@ -20,8 +23,17 @@ type gateRecorder struct {
 	mayorNudges   []string
 }
 
+// gateDeps stubs the Macroscope settle phase as settled-and-clean so the
+// pre-existing CI-verdict tests keep exercising exactly the verdict logic;
+// the Macroscope tests below override settleWait/fetchComments.
 func gateDeps(ghOutput string, rec *gateRecorder) *doneCIGateDeps {
 	return &doneCIGateDeps{
+		settleWait: func(opts cigate.MacroscopeOptions, timeout, poll time.Duration) (cigate.MacroscopeSettleResult, bool) {
+			return cigate.MacroscopeSettleResult{Settled: true}, false
+		},
+		fetchComments: func(prNumber int, opts cigate.MacroscopeOptions) ([]cigate.UnaddressedComment, error) {
+			return nil, nil
+		},
 		gate: &cigate.Gate{Run: func(dir, name string, args ...string) ([]byte, error) {
 			return []byte(ghOutput), nil
 		}},
@@ -188,6 +200,193 @@ func TestCIGateConfigDefaults(t *testing.T) {
 	}
 	if got := (&config.CIGateConfig{PendingTimeout: "garbage"}).PendingTimeoutOrDefault(); got != 30*time.Minute {
 		t.Errorf("invalid pending_timeout should fall back to 30m, got %s", got)
+	}
+}
+
+// macroscopeDeps returns green-CI deps with the Macroscope settle phase
+// stubbed: settled immediately, fetch returning the given comments/error.
+func macroscopeDeps(rec *gateRecorder, comments []cigate.UnaddressedComment, fetchErr error) *doneCIGateDeps {
+	deps := gateDeps(ghGreen, rec)
+	deps.settleWait = func(opts cigate.MacroscopeOptions, timeout, poll time.Duration) (cigate.MacroscopeSettleResult, bool) {
+		return cigate.MacroscopeSettleResult{Settled: true, PRNumber: 5}, false
+	}
+	deps.fetchComments = func(prNumber int, opts cigate.MacroscopeOptions) ([]cigate.UnaddressedComment, error) {
+		return comments, fetchErr
+	}
+	return deps
+}
+
+func TestDoneCIGateMacroscopeCleanPasses(t *testing.T) {
+	rec := &gateRecorder{}
+	if err := macroscopeDeps(rec, nil, nil).enforce(); err != nil {
+		t.Fatalf("enforce() = %v, want nil (green + settled + no comments)", err)
+	}
+	if !rec.needsCleared || rec.needsSet || len(rec.escalations) != 0 {
+		t.Errorf("unexpected side effects: %+v", rec)
+	}
+}
+
+func TestDoneCIGateMacroscopeUnaddressedBlocks(t *testing.T) {
+	rec := &gateRecorder{}
+	err := macroscopeDeps(rec, []cigate.UnaddressedComment{
+		{Author: "macroscopeapp", Path: "query/query.py", URL: "https://x/r1", Excerpt: "🟡 Medium thin-data guard"},
+	}, nil).enforce()
+	if err == nil {
+		t.Fatal("enforce() = nil, want NEEDS_MACROSCOPE_ADDRESSED block")
+	}
+	if !strings.Contains(err.Error(), "NEEDS_MACROSCOPE_ADDRESSED") || !strings.Contains(err.Error(), "https://x/r1") {
+		t.Errorf("error should name the gate and list the comment: %v", err)
+	}
+	if !rec.needsSet || rec.needsSetPR != 5 {
+		t.Errorf("needs-ci-green label not set for PR 5: %+v", rec)
+	}
+	if !rec.intentCleared {
+		t.Error("done-intent label must be cleared so witness doesn't treat abort as crash-mid-done")
+	}
+	// Unlike plain CI red, unaddressed comments escalate: the spec is
+	// "comment + Requires-Human-Input hold" (hq-owe9c) via escalation_cmd.
+	if len(rec.escalations) != 1 || rec.escalations[0].Event != cigate.EventMacroscopeUnaddressed {
+		t.Fatalf("want one macroscope_unaddressed_comments escalation, got %+v", rec.escalations)
+	}
+	if rec.needsCleared {
+		t.Error("needs-ci-green must not be cleared on a blocked completion")
+	}
+}
+
+func TestDoneCIGateMacroscopeSettleTimeoutFailsOpen(t *testing.T) {
+	rec := &gateRecorder{}
+	deps := gateDeps(ghGreen, rec)
+	deps.settleWait = func(opts cigate.MacroscopeOptions, timeout, poll time.Duration) (cigate.MacroscopeSettleResult, bool) {
+		return cigate.MacroscopeSettleResult{PendingChecks: []string{"Macroscope - Correctness Check"}}, true
+	}
+	deps.fetchComments = func(int, cigate.MacroscopeOptions) ([]cigate.UnaddressedComment, error) {
+		t.Fatal("no comment fetch after a settle timeout")
+		return nil, nil
+	}
+	if err := deps.enforce(); err != nil {
+		t.Fatalf("enforce() = %v, want nil (fail-open on Macroscope outage)", err)
+	}
+	if len(rec.escalations) != 1 || rec.escalations[0].Event != cigate.EventMacroscopeTimeout {
+		t.Fatalf("want one macroscope_settle_timeout escalation, got %+v", rec.escalations)
+	}
+	if rec.needsSet || rec.intentCleared {
+		t.Errorf("fail-open must not block: %+v", rec)
+	}
+}
+
+func TestDoneCIGateMacroscopeFetchErrorFailsOpen(t *testing.T) {
+	rec := &gateRecorder{}
+	err := macroscopeDeps(rec, nil, errGHDown).enforce()
+	if err != nil {
+		t.Fatalf("enforce() = %v, want nil (fail-open on fetch error)", err)
+	}
+	if len(rec.escalations) != 1 || rec.escalations[0].Event != cigate.EventMacroscopeError {
+		t.Fatalf("want one macroscope_comments_error escalation, got %+v", rec.escalations)
+	}
+	if rec.needsSet || rec.intentCleared {
+		t.Errorf("fail-open must not block: %+v", rec)
+	}
+}
+
+func TestDoneCIGateMacroscopeConfigDisabled(t *testing.T) {
+	rec := &gateRecorder{}
+	off := false
+	deps := gateDeps(ghGreen, rec)
+	deps.cfg = &config.CIGateConfig{MacroscopeSettle: &config.MacroscopeSettleConfig{Enabled: &off}}
+	deps.settleWait = func(cigate.MacroscopeOptions, time.Duration, time.Duration) (cigate.MacroscopeSettleResult, bool) {
+		t.Fatal("settle phase must not run when disabled")
+		return cigate.MacroscopeSettleResult{}, false
+	}
+	if err := deps.enforce(); err != nil {
+		t.Fatalf("enforce() = %v, want nil", err)
+	}
+	if len(rec.escalations) != 0 {
+		t.Errorf("unexpected escalations: %+v", rec.escalations)
+	}
+}
+
+func TestDoneCIGateMacroscopeEnvDisabled(t *testing.T) {
+	t.Setenv("GT_MACROSCOPE_SETTLE", "off")
+	rec := &gateRecorder{}
+	deps := gateDeps(ghGreen, rec)
+	deps.settleWait = func(cigate.MacroscopeOptions, time.Duration, time.Duration) (cigate.MacroscopeSettleResult, bool) {
+		t.Fatal("settle phase must not run under GT_MACROSCOPE_SETTLE=off")
+		return cigate.MacroscopeSettleResult{}, false
+	}
+	if err := deps.enforce(); err != nil {
+		t.Fatalf("enforce() = %v, want nil", err)
+	}
+}
+
+func TestDoneCIGateMacroscopeRunsAfterPendingResolvesGreen(t *testing.T) {
+	rec := &gateRecorder{}
+	deps := gateDeps(ghPending, rec)
+	deps.wait = func(timeout, poll time.Duration) (cigate.CheckResult, bool) {
+		return cigate.CheckResult{Verdict: cigate.VerdictGreen, PRNumber: 5}, false
+	}
+	deps.settleWait = func(opts cigate.MacroscopeOptions, timeout, poll time.Duration) (cigate.MacroscopeSettleResult, bool) {
+		return cigate.MacroscopeSettleResult{Settled: true, PRNumber: 5}, false
+	}
+	deps.fetchComments = func(int, cigate.MacroscopeOptions) ([]cigate.UnaddressedComment, error) {
+		return []cigate.UnaddressedComment{{Author: "macroscopeapp", URL: "https://x/r9", Excerpt: "raced"}}, nil
+	}
+	err := deps.enforce()
+	if err == nil || !strings.Contains(err.Error(), "NEEDS_MACROSCOPE_ADDRESSED") {
+		t.Fatalf("enforce() = %v, want NEEDS_MACROSCOPE_ADDRESSED after pending→green with raced comments", err)
+	}
+}
+
+func TestDoneCIGateMacroscopeSettleTimeoutConfig(t *testing.T) {
+	rec := &gateRecorder{}
+	deps := gateDeps(ghGreen, rec)
+	deps.cfg = &config.CIGateConfig{
+		PendingTimeout:   "30m",
+		MacroscopeSettle: &config.MacroscopeSettleConfig{SettleTimeout: "10m"},
+	}
+	deps.settleWait = func(opts cigate.MacroscopeOptions, timeout, poll time.Duration) (cigate.MacroscopeSettleResult, bool) {
+		if timeout != 10*time.Minute {
+			t.Errorf("settle timeout = %s, want configured 10m", timeout)
+		}
+		return cigate.MacroscopeSettleResult{Settled: true}, false
+	}
+	deps.fetchComments = func(int, cigate.MacroscopeOptions) ([]cigate.UnaddressedComment, error) { return nil, nil }
+	if err := deps.enforce(); err != nil {
+		t.Fatalf("enforce() = %v, want nil", err)
+	}
+
+	// Unset settle_timeout falls back to pending_timeout.
+	deps.cfg = &config.CIGateConfig{PendingTimeout: "20m"}
+	deps.settleWait = func(opts cigate.MacroscopeOptions, timeout, poll time.Duration) (cigate.MacroscopeSettleResult, bool) {
+		if timeout != 20*time.Minute {
+			t.Errorf("settle timeout = %s, want pending_timeout fallback 20m", timeout)
+		}
+		return cigate.MacroscopeSettleResult{Settled: true}, false
+	}
+	if err := deps.enforce(); err != nil {
+		t.Fatalf("enforce() = %v, want nil", err)
+	}
+}
+
+func TestMacroscopeSettleConfigDefaults(t *testing.T) {
+	var nilGate *config.CIGateConfig
+	mcfg := nilGate.MacroscopeSettings()
+	if mcfg == nil || !mcfg.IsEnabled() {
+		t.Fatal("nil ci_gate config must yield an enabled macroscope_settle default")
+	}
+	if got := mcfg.CheckPatternsOrDefault(); len(got) != 1 || got[0] != "macroscope" {
+		t.Errorf("default check_patterns = %v, want [macroscope]", got)
+	}
+	if got := mcfg.BotLoginsOrDefault(); len(got) != 1 || got[0] != "macroscopeapp" {
+		t.Errorf("default bot_logins = %v, want [macroscopeapp]", got)
+	}
+	if got := mcfg.SettleTimeoutOrDefault(30 * time.Minute); got != 30*time.Minute {
+		t.Errorf("default settle_timeout = %s, want the 30m fallback", got)
+	}
+	if got := (&config.MacroscopeSettleConfig{SettleTimeout: "garbage"}).SettleTimeoutOrDefault(30 * time.Minute); got != 30*time.Minute {
+		t.Errorf("invalid settle_timeout should fall back, got %s", got)
+	}
+	if got := (&config.MacroscopeSettleConfig{CheckPatterns: []string{}}).CheckPatternsOrDefault(); len(got) != 0 {
+		t.Errorf("explicit empty check_patterns must match nothing, got %v", got)
 	}
 }
 

--- a/internal/cmd/done_cigate_test.go
+++ b/internal/cmd/done_cigate_test.go
@@ -1,0 +1,207 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/cigate"
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+// gateRecorder captures the side effects of a doneCIGateDeps.enforce run.
+type gateRecorder struct {
+	needsSetPR    int
+	needsSet      bool
+	needsCleared  bool
+	intentCleared bool
+	escalations   []cigate.Escalation
+	mayorNudges   []string
+}
+
+func gateDeps(ghOutput string, rec *gateRecorder) *doneCIGateDeps {
+	return &doneCIGateDeps{
+		gate: &cigate.Gate{Run: func(dir, name string, args ...string) ([]byte, error) {
+			return []byte(ghOutput), nil
+		}},
+		cfg:    &config.CIGateConfig{},
+		dir:    "/tmp",
+		branch: "polecat/test",
+		agent:  "rig/polecats/test",
+		out:    &bytes.Buffer{},
+		setNeedsCIGreen: func(pr int) {
+			rec.needsSet = true
+			rec.needsSetPR = pr
+		},
+		clearNeedsCIGreen: func() { rec.needsCleared = true },
+		clearDoneIntent:   func() { rec.intentCleared = true },
+		escalate:          func(esc cigate.Escalation) { rec.escalations = append(rec.escalations, esc) },
+		nudgeMayor:        func(msg string) { rec.mayorNudges = append(rec.mayorNudges, msg) },
+	}
+}
+
+const (
+	ghNoPR        = `[]`
+	ghGreen       = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"context":"jenkins","state":"SUCCESS"}]}]`
+	ghRed         = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"name":"test","conclusion":"failure"}]}]`
+	ghPending     = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"context":"jenkins","state":"PENDING"}]}]`
+	ghMerged      = `[{"number":5,"state":"MERGED","url":"u","statusCheckRollup":[]}]`
+	ghClosed      = `[{"number":5,"state":"CLOSED","url":"u","statusCheckRollup":[]}]`
+	ghUnparseable = `oops`
+)
+
+func TestDoneCIGateAllows(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		ghOutput string
+	}{
+		{"no PR passes through", ghNoPR},
+		{"green PR allowed", ghGreen},
+		{"merged PR allowed", ghMerged},
+		{"closed-unmerged PR allowed with warning", ghClosed},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &gateRecorder{}
+			if err := gateDeps(tt.ghOutput, rec).enforce(); err != nil {
+				t.Fatalf("enforce() = %v, want nil", err)
+			}
+			if !rec.needsCleared {
+				t.Error("expected stale needs-ci-green label cleared on pass")
+			}
+			if rec.needsSet || rec.intentCleared || len(rec.escalations) != 0 {
+				t.Errorf("unexpected side effects: %+v", rec)
+			}
+		})
+	}
+}
+
+func TestDoneCIGateBlocksRed(t *testing.T) {
+	rec := &gateRecorder{}
+	err := gateDeps(ghRed, rec).enforce()
+	if err == nil {
+		t.Fatal("enforce() = nil, want NEEDS_CI_GREEN error")
+	}
+	if !strings.Contains(err.Error(), "NEEDS_CI_GREEN") || !strings.Contains(err.Error(), "test") {
+		t.Errorf("error should name the gate and failing check: %v", err)
+	}
+	if !rec.needsSet || rec.needsSetPR != 5 {
+		t.Errorf("needs-ci-green label not set for PR 5: %+v", rec)
+	}
+	if !rec.intentCleared {
+		t.Error("done-intent label must be cleared so witness doesn't treat abort as crash-mid-done")
+	}
+	if len(rec.escalations) != 0 {
+		t.Errorf("red is the polecat's job, not a human escalation: %+v", rec.escalations)
+	}
+}
+
+func TestDoneCIGateErrorFailsOpenAndEscalates(t *testing.T) {
+	rec := &gateRecorder{}
+	if err := gateDeps(ghUnparseable, rec).enforce(); err != nil {
+		t.Fatalf("enforce() = %v, want nil (fail-open)", err)
+	}
+	if len(rec.escalations) != 1 || rec.escalations[0].Event != cigate.EventCIStatusError {
+		t.Fatalf("want one ci_status_error escalation, got %+v", rec.escalations)
+	}
+	if rec.needsSet || rec.intentCleared {
+		t.Errorf("fail-open must not block: %+v", rec)
+	}
+}
+
+func TestDoneCIGatePendingResolvesGreen(t *testing.T) {
+	rec := &gateRecorder{}
+	deps := gateDeps(ghPending, rec)
+	deps.wait = func(timeout, poll time.Duration) (cigate.CheckResult, bool) {
+		return cigate.CheckResult{Verdict: cigate.VerdictGreen, PRNumber: 5}, false
+	}
+	if err := deps.enforce(); err != nil {
+		t.Fatalf("enforce() = %v, want nil after pending→green", err)
+	}
+	if !rec.needsCleared || len(rec.escalations) != 0 {
+		t.Errorf("unexpected side effects: %+v", rec)
+	}
+}
+
+func TestDoneCIGatePendingResolvesRed(t *testing.T) {
+	rec := &gateRecorder{}
+	deps := gateDeps(ghPending, rec)
+	deps.wait = func(timeout, poll time.Duration) (cigate.CheckResult, bool) {
+		return cigate.CheckResult{Verdict: cigate.VerdictRed, PRNumber: 5, FailingChecks: []string{"jenkins"}}, false
+	}
+	err := deps.enforce()
+	if err == nil || !strings.Contains(err.Error(), "NEEDS_CI_GREEN") {
+		t.Fatalf("enforce() = %v, want NEEDS_CI_GREEN block after pending→red", err)
+	}
+	if !rec.needsSet || !rec.intentCleared {
+		t.Errorf("expected block side effects: %+v", rec)
+	}
+}
+
+func TestDoneCIGatePendingTimeoutEscalatesAndBlocks(t *testing.T) {
+	rec := &gateRecorder{}
+	deps := gateDeps(ghPending, rec)
+	deps.cfg = &config.CIGateConfig{PendingTimeout: "30m"}
+	deps.wait = func(timeout, poll time.Duration) (cigate.CheckResult, bool) {
+		if timeout != 30*time.Minute {
+			t.Errorf("timeout = %s, want 30m", timeout)
+		}
+		return cigate.CheckResult{Verdict: cigate.VerdictPending, PRNumber: 5, PendingChecks: []string{"jenkins"}}, true
+	}
+	err := deps.enforce()
+	if err == nil || !strings.Contains(err.Error(), "NEEDS_CI_GREEN") {
+		t.Fatalf("enforce() = %v, want NEEDS_CI_GREEN block on timeout", err)
+	}
+	if len(rec.escalations) != 1 || rec.escalations[0].Event != cigate.EventPendingTimeout {
+		t.Fatalf("want one pending_timeout escalation (Blair: comment + Requires Human Input), got %+v", rec.escalations)
+	}
+	if len(rec.mayorNudges) != 1 {
+		t.Errorf("want mayor nudge on pending timeout, got %v", rec.mayorNudges)
+	}
+	if !rec.needsSet || !rec.intentCleared {
+		t.Errorf("expected block side effects: %+v", rec)
+	}
+}
+
+func TestCIGateConfigDefaults(t *testing.T) {
+	var nilCfg *config.CIGateConfig
+	if !nilCfg.IsEnabled() {
+		t.Error("nil ci_gate config must default to enabled")
+	}
+	if got := nilCfg.PendingTimeoutOrDefault(); got != 30*time.Minute {
+		t.Errorf("default pending_timeout = %s, want 30m (Blair: capital Jenkins green runs take ~18m)", got)
+	}
+	if got := nilCfg.PollIntervalOrDefault(); got != 30*time.Second {
+		t.Errorf("default poll_interval = %s, want 30s", got)
+	}
+	if got := nilCfg.MayorAlertAfterOrDefault(); got != 30*time.Minute {
+		t.Errorf("default mayor_alert_after = %s, want 30m", got)
+	}
+
+	off := false
+	cfg := &config.CIGateConfig{Enabled: &off, PendingTimeout: "10m"}
+	if cfg.IsEnabled() {
+		t.Error("enabled=false must disable")
+	}
+	if got := cfg.PendingTimeoutOrDefault(); got != 10*time.Minute {
+		t.Errorf("configured pending_timeout = %s, want 10m", got)
+	}
+	if got := (&config.CIGateConfig{PendingTimeout: "garbage"}).PendingTimeoutOrDefault(); got != 30*time.Minute {
+		t.Errorf("invalid pending_timeout should fall back to 30m, got %s", got)
+	}
+}
+
+func TestCIGateEnvKillSwitch(t *testing.T) {
+	for _, v := range []string{"off", "0", "false", "disabled", "OFF"} {
+		t.Setenv("GT_CI_GATE", v)
+		if !cigate.EnvDisabled() {
+			t.Errorf("GT_CI_GATE=%s should disable the gate", v)
+		}
+	}
+	for _, v := range []string{"", "on", "1", "true"} {
+		t.Setenv("GT_CI_GATE", v)
+		if cigate.EnvDisabled() {
+			t.Errorf("GT_CI_GATE=%s should NOT disable the gate", v)
+		}
+	}
+}

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -142,6 +142,7 @@ var (
 	polecatNukeAll                       bool
 	polecatNukeDryRun                    bool
 	polecatNukeForce                     bool
+	polecatNukeIgnoreCI                  bool
 	polecatCheckRecoveryJSON             bool
 	polecatCheckRecoveryReconcileCleanup bool
 	polecatPoolInitDryRun                bool
@@ -346,6 +347,7 @@ func init() {
 	polecatNukeCmd.Flags().BoolVar(&polecatNukeAll, "all", false, "Nuke all polecats in the rig")
 	polecatNukeCmd.Flags().BoolVar(&polecatNukeDryRun, "dry-run", false, "Show what would be nuked without doing it")
 	polecatNukeCmd.Flags().BoolVarP(&polecatNukeForce, "force", "f", false, "Force nuke, bypassing all safety checks (LOSES WORK)")
+	polecatNukeCmd.Flags().BoolVar(&polecatNukeIgnoreCI, "ignore-ci", false, "Bypass the AA-851 CI gate (nuke even when the branch's PR has red/pending checks)")
 
 	// Check-recovery flags
 	polecatCheckRecoveryCmd.Flags().BoolVar(&polecatCheckRecoveryJSON, "json", false, "Output as JSON")
@@ -1791,7 +1793,7 @@ func runPolecatNuke(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Nuking %s/%s...\n", p.rigName, p.polecatName)
 		}
 
-		if err := nukePolecatFullWithOptions(p.polecatName, p.rigName, p.mgr, p.r, nukePolecatOptions{PurgeClosedEphemerals: !batchPurge}); err != nil {
+		if err := nukePolecatFullWithOptions(p.polecatName, p.rigName, p.mgr, p.r, nukePolecatOptions{PurgeClosedEphemerals: !batchPurge, IgnoreCIGate: polecatNukeIgnoreCI}); err != nil {
 			nukeErrors = append(nukeErrors, fmt.Sprintf("%s/%s: %v", p.rigName, p.polecatName, err))
 			continue
 		}
@@ -1860,9 +1862,23 @@ func nukePolecatFull(polecatName, rigName string, mgr *polecat.Manager, r *rig.R
 
 type nukePolecatOptions struct {
 	PurgeClosedEphemerals bool
+	// IgnoreCIGate bypasses the AA-851 CI gate (nuke even when the branch's
+	// PR has red/pending checks). Set only by explicit --ignore-ci.
+	IgnoreCIGate bool
 }
 
 func nukePolecatFullWithOptions(polecatName, rigName string, mgr *polecat.Manager, r *rig.Rig, opts nukePolecatOptions) error {
+	// Step 0: AA-851 hard CI gate — refuse to reap a polecat whose branch has
+	// an open PR with red or pending checks. Runs before the tmux kill so a
+	// refused nuke leaves the session intact. Covers nuke (incl. --force),
+	// stale --cleanup, and the witness auto-nuke. Override: --ignore-ci or
+	// GT_CI_GATE=off.
+	if !opts.IgnoreCIGate {
+		if err := checkNukeCIGate(polecatName, rigName, mgr, r); err != nil {
+			return err
+		}
+	}
+
 	t := tmux.NewTmux()
 
 	// Step 1: Kill tmux session unconditionally to prevent ghost sessions

--- a/internal/cmd/polecat_cigate.go
+++ b/internal/cmd/polecat_cigate.go
@@ -1,0 +1,145 @@
+package cmd
+
+// AA-851 hard CI gate for the reap funnel: a polecat cannot be nuked while
+// its branch's PR has any CI check red or pending. This single hook at the
+// top of nukePolecatFullWithOptions covers every deliberate destroy path —
+// `gt polecat nuke` (including --force), `gt polecat stale --cleanup`, and
+// the witness's auto-nuke (which shells out to `gt polecat nuke`).
+//
+// Unlike the gt done gate, the nuke gate never waits: it refuses immediately
+// and lets the caller retry later. Repeated refusals past
+// ci_gate.mayor_alert_after nudge the mayor. Explicit overrides:
+// `gt polecat nuke --ignore-ci` or GT_CI_GATE=off.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/cigate"
+	"github.com/steveyegge/gastown/internal/polecat"
+	"github.com/steveyegge/gastown/internal/rig"
+)
+
+// ciGateBlockedLabelPrefix marks an agent bead whose nuke was refused by the
+// CI gate: ci-gate-blocked:<unix-ts-of-first-refusal>. Cleared when the gate
+// passes; used to alert the mayor when a nuke stays blocked too long.
+const ciGateBlockedLabelPrefix = "ci-gate-blocked:"
+
+// checkNukeCIGate refuses the nuke (returns an error) when the polecat's
+// branch has an open PR with red or pending checks. Pass-through: no PR,
+// merged PR, closed-unmerged PR, CI-status errors (fail-open with warning),
+// no resolvable branch, gate disabled.
+func checkNukeCIGate(polecatName, rigName string, mgr *polecat.Manager, r *rig.Rig) error {
+	cfg := loadCIGateConfig(r.Path)
+	if !cfg.IsEnabled() || cigate.EnvDisabled() {
+		return nil
+	}
+
+	info, err := mgr.Get(polecatName)
+	if err != nil || info == nil || info.Branch == "" {
+		return nil // no branch to check — nothing to gate
+	}
+
+	res := cigate.New().CheckBranch(ciGateDirForPolecat(info.ClonePath, r.Path), info.Branch)
+	agentBd := beads.New(r.Path).ForAgentBead()
+	agentBeadID := polecatBeadIDForRig(r, rigName, polecatName)
+
+	if res.Verdict == cigate.VerdictError {
+		fmt.Fprintf(os.Stderr, "Warning: CI gate could not determine CI status for %s/%s branch %s (%v) — failing open (AA-851)\n",
+			rigName, polecatName, info.Branch, res.Err)
+		return nil
+	}
+	if !res.Verdict.Blocks() {
+		clearCIGateBlockedLabel(agentBd, agentBeadID)
+		return nil
+	}
+
+	// Blocked. Track the first refusal so long-standing blocks alert the mayor.
+	firstBlocked := markCIGateBlocked(agentBd, agentBeadID)
+	if !firstBlocked.IsZero() && time.Since(firstBlocked) > cfg.MayorAlertAfterOrDefault() {
+		nudgeMayorBestEffort(fmt.Sprintf("CI_GATE_BLOCKED: nuke of %s/%s blocked >%s — %s (branch %s). Investigate the PR or override with --ignore-ci.",
+			rigName, polecatName, cfg.MayorAlertAfterOrDefault(), res.Summary(), info.Branch))
+	}
+	return fmt.Errorf("CI gate (AA-851): refusing to nuke %s/%s — %s.\n"+
+		"The polecat's work is not landed; nuking would strand a red/pending PR.\n"+
+		"Wait for CI (or fix the PR), or override with --ignore-ci / GT_CI_GATE=off",
+		rigName, polecatName, res.Summary())
+}
+
+// ciGateDirForPolecat picks the directory for gh invocations: gh resolves
+// the repo from the git remotes of its working directory, so prefer the
+// polecat worktree and fall back to the rig's mayor clone when it's gone.
+func ciGateDirForPolecat(clonePath, rigPath string) string {
+	if clonePath != "" {
+		if _, err := os.Stat(clonePath); err == nil {
+			return clonePath
+		}
+	}
+	return filepath.Join(rigPath, "mayor", "rig")
+}
+
+// markCIGateBlocked records the first CI-gate refusal timestamp on the agent
+// bead and returns it (zero time when the bead is unavailable). Subsequent
+// refusals reuse the existing timestamp so the mayor-alert threshold measures
+// total blocked time, not time since the latest attempt.
+func markCIGateBlocked(bd *beads.Beads, agentBeadID string) time.Time {
+	if agentBeadID == "" {
+		return time.Time{}
+	}
+	issue, err := bd.Show(agentBeadID)
+	if err != nil || issue == nil {
+		return time.Time{}
+	}
+	for _, label := range issue.Labels {
+		if ts, ok := parseCIGateBlockedLabel(label); ok {
+			return ts
+		}
+	}
+	now := time.Now()
+	label := fmt.Sprintf("%s%d", ciGateBlockedLabelPrefix, now.Unix())
+	if err := bd.Update(agentBeadID, beads.UpdateOptions{AddLabels: []string{label}}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: couldn't set ci-gate-blocked label on %s: %v\n", agentBeadID, err)
+	}
+	return now
+}
+
+// clearCIGateBlockedLabel removes any ci-gate-blocked:* label (gate passed).
+func clearCIGateBlockedLabel(bd *beads.Beads, agentBeadID string) {
+	if agentBeadID == "" {
+		return
+	}
+	issue, err := bd.Show(agentBeadID)
+	if err != nil || issue == nil {
+		return
+	}
+	var toRemove []string
+	for _, label := range issue.Labels {
+		if strings.HasPrefix(label, ciGateBlockedLabelPrefix) {
+			toRemove = append(toRemove, label)
+		}
+	}
+	if len(toRemove) == 0 {
+		return
+	}
+	if err := bd.Update(agentBeadID, beads.UpdateOptions{RemoveLabels: toRemove}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: couldn't clear ci-gate-blocked label on %s: %v\n", agentBeadID, err)
+	}
+}
+
+// parseCIGateBlockedLabel extracts the first-refusal time from a
+// ci-gate-blocked:<unix> label.
+func parseCIGateBlockedLabel(label string) (time.Time, bool) {
+	if !strings.HasPrefix(label, ciGateBlockedLabelPrefix) {
+		return time.Time{}, false
+	}
+	ts, err := strconv.ParseInt(strings.TrimPrefix(label, ciGateBlockedLabelPrefix), 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return time.Unix(ts, 0), true
+}

--- a/internal/cmd/polecat_cigate.go
+++ b/internal/cmd/polecat_cigate.go
@@ -45,7 +45,7 @@ func checkNukeCIGate(polecatName, rigName string, mgr *polecat.Manager, r *rig.R
 		return nil // no branch to check — nothing to gate
 	}
 
-	res := cigate.New().CheckBranch(ciGateDirForPolecat(info.ClonePath, r.Path), info.Branch)
+	res := cigate.New(cfg.HumanGateChecksOrDefault()...).CheckBranch(ciGateDirForPolecat(info.ClonePath, r.Path), info.Branch)
 	agentBd := beads.New(r.Path).ForAgentBead()
 	agentBeadID := polecatBeadIDForRig(r, rigName, polecatName)
 

--- a/internal/cmd/polecat_cigate_test.go
+++ b/internal/cmd/polecat_cigate_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseCIGateBlockedLabel(t *testing.T) {
+	ts, ok := parseCIGateBlockedLabel("ci-gate-blocked:1720000000")
+	if !ok {
+		t.Fatal("want ok for valid label")
+	}
+	if want := time.Unix(1720000000, 0); !ts.Equal(want) {
+		t.Errorf("ts = %v, want %v", ts, want)
+	}
+	for _, bad := range []string{"ci-gate-blocked:", "ci-gate-blocked:abc", "needs-ci-green:5:1", "other"} {
+		if _, ok := parseCIGateBlockedLabel(bad); ok {
+			t.Errorf("parseCIGateBlockedLabel(%q) = ok, want !ok", bad)
+		}
+	}
+}
+
+func TestCIGateDirForPolecat(t *testing.T) {
+	rigPath := t.TempDir()
+	mayorClone := filepath.Join(rigPath, "mayor", "rig")
+
+	t.Run("missing clone falls back to mayor clone", func(t *testing.T) {
+		if got := ciGateDirForPolecat(filepath.Join(rigPath, "gone"), rigPath); got != mayorClone {
+			t.Errorf("dir = %q, want %q", got, mayorClone)
+		}
+	})
+	t.Run("empty clone falls back to mayor clone", func(t *testing.T) {
+		if got := ciGateDirForPolecat("", rigPath); got != mayorClone {
+			t.Errorf("dir = %q, want %q", got, mayorClone)
+		}
+	})
+	t.Run("existing clone preferred", func(t *testing.T) {
+		clone := filepath.Join(rigPath, "polecats", "x", "rig")
+		if err := os.MkdirAll(clone, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := ciGateDirForPolecat(clone, rigPath); got != clone {
+			t.Errorf("dir = %q, want %q", got, clone)
+		}
+	})
+}

--- a/internal/cmd/polecat_helpers.go
+++ b/internal/cmd/polecat_helpers.go
@@ -223,7 +223,7 @@ func checkPolecatSafety(target polecatTarget) *SafetyCheckResult {
 	if infoErr == nil && polecatInfo != nil && polecatInfo.Branch != "" {
 		cfg := loadCIGateConfig(target.r.Path)
 		if cfg.IsEnabled() && !cigate.EnvDisabled() {
-			res := cigate.New().CheckBranch(ciGateDirForPolecat(polecatInfo.ClonePath, target.r.Path), polecatInfo.Branch)
+			res := cigate.New(cfg.HumanGateChecksOrDefault()...).CheckBranch(ciGateDirForPolecat(polecatInfo.ClonePath, target.r.Path), polecatInfo.Branch)
 			if res.Verdict.Blocks() {
 				result.Reasons = append(result.Reasons, fmt.Sprintf("PR CI not green: %s", res.Summary()))
 			}

--- a/internal/cmd/polecat_helpers.go
+++ b/internal/cmd/polecat_helpers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/cigate"
 	"github.com/steveyegge/gastown/internal/polecat"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
@@ -213,6 +214,19 @@ func checkPolecatSafety(target polecatTarget) *SafetyCheckResult {
 		} else if mr != nil {
 			result.OpenMR = mr.ID
 			result.Reasons = append(result.Reasons, fmt.Sprintf("has open MR (%s)", mr.ID))
+		}
+	}
+
+	// Check 4 (AA-851): PR CI not green — friendly early error surfaced by
+	// safety checks/dry-run. The nuke funnel (checkNukeCIGate) enforces the
+	// same gate even under --force.
+	if infoErr == nil && polecatInfo != nil && polecatInfo.Branch != "" {
+		cfg := loadCIGateConfig(target.r.Path)
+		if cfg.IsEnabled() && !cigate.EnvDisabled() {
+			res := cigate.New().CheckBranch(ciGateDirForPolecat(polecatInfo.ClonePath, target.r.Path), polecatInfo.Branch)
+			if res.Verdict.Blocks() {
+				result.Reasons = append(result.Reasons, fmt.Sprintf("PR CI not green: %s", res.Summary()))
+			}
 		}
 	}
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1400,6 +1400,104 @@ type MergeQueueConfig struct {
 	// is enabled. Valid values: "quick", "standard", "deep".
 	// Nil defaults to "standard".
 	ReviewDepth string `json:"review_depth,omitempty"`
+
+	// CIGate configures the hard CI gate (AA-851): a polecat cannot complete
+	// (gt done) and cannot be nuked while its branch's PR has failing or
+	// pending CI checks, and the refinery will not merge such a PR.
+	// Nil = enabled with defaults; the gate only applies when a PR exists
+	// for the branch (no-PR and merged-PR pass through), which makes the
+	// default safe for direct-merge rigs.
+	CIGate *CIGateConfig `json:"ci_gate,omitempty"`
+}
+
+// CIGateConfig configures the hard CI gate (AA-851).
+type CIGateConfig struct {
+	// Enabled controls the gate. Nil defaults to true.
+	// Emergency process-level kill switch (no config edit): GT_CI_GATE=off.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// PendingTimeout is how long gt done waits for pending checks to settle
+	// before aborting with a human escalation. Default "30m" — sized for
+	// slow Jenkins pipelines (capital green runs take ~18m).
+	PendingTimeout string `json:"pending_timeout,omitempty"`
+
+	// PollInterval is the initial poll interval while waiting on pending
+	// checks; it backs off to 4x. Default "30s".
+	PollInterval string `json:"poll_interval,omitempty"`
+
+	// MayorAlertAfter is how long a polecat nuke can stay CI-blocked before
+	// the gate nudges the mayor. Default "30m".
+	MayorAlertAfter string `json:"mayor_alert_after,omitempty"`
+
+	// EscalationCmd is run via `sh -c` when the gate needs a human: on CI
+	// status errors (fail-open) and pending-timeout aborts. It receives
+	// GT_CIGATE_EVENT, GT_CIGATE_TICKET, GT_CIGATE_DETAIL, GT_CIGATE_PR_URL,
+	// GT_CIGATE_BRANCH and GT_CIGATE_AGENT in the environment. Wire it to
+	// your external tracker — e.g. a script that comments on the ticket and
+	// transitions it to a human-attention status.
+	EscalationCmd string `json:"escalation_cmd,omitempty"`
+}
+
+// IsEnabled returns whether the CI gate is on. Nil-safe, defaults to true.
+func (c *CIGateConfig) IsEnabled() bool {
+	if c == nil || c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// ciGateDuration parses s, falling back to def on empty or invalid values.
+func ciGateDuration(s string, def time.Duration) time.Duration {
+	if s == "" {
+		return def
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return def
+	}
+	return d
+}
+
+// PendingTimeoutOrDefault returns the pending-check wait budget (default 30m).
+func (c *CIGateConfig) PendingTimeoutOrDefault() time.Duration {
+	if c == nil {
+		return 30 * time.Minute
+	}
+	return ciGateDuration(c.PendingTimeout, 30*time.Minute)
+}
+
+// PollIntervalOrDefault returns the initial poll interval (default 30s).
+func (c *CIGateConfig) PollIntervalOrDefault() time.Duration {
+	if c == nil {
+		return 30 * time.Second
+	}
+	return ciGateDuration(c.PollInterval, 30*time.Second)
+}
+
+// MayorAlertAfterOrDefault returns the CI-blocked-nuke mayor alert threshold
+// (default 30m).
+func (c *CIGateConfig) MayorAlertAfterOrDefault() time.Duration {
+	if c == nil {
+		return 30 * time.Minute
+	}
+	return ciGateDuration(c.MayorAlertAfter, 30*time.Minute)
+}
+
+// EscalationCmdOrEmpty returns the configured escalation command. Nil-safe.
+func (c *CIGateConfig) EscalationCmdOrEmpty() string {
+	if c == nil {
+		return ""
+	}
+	return c.EscalationCmd
+}
+
+// CIGateSettings returns the rig's CI gate configuration, never nil.
+// A nil receiver or missing ci_gate block yields the enabled defaults.
+func (c *MergeQueueConfig) CIGateSettings() *CIGateConfig {
+	if c == nil || c.CIGate == nil {
+		return &CIGateConfig{}
+	}
+	return c.CIGate
 }
 
 // OnConflict strategy constants.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1429,6 +1429,15 @@ type CIGateConfig struct {
 	// the gate nudges the mayor. Default "30m".
 	MayorAlertAfter string `json:"mayor_alert_after,omitempty"`
 
+	// HumanGateChecks lists status-check context names that are human
+	// approval gates rather than CI (e.g. pullapprove) — excluded from the
+	// gate's green/pending evaluation, matched case-insensitively (AA-859).
+	// A human merge gate pends on every PR until a person acts; counting it
+	// would burn the full pending timeout on every completion. Approval
+	// enforcement stays with branch protection / require_review.
+	// Nil defaults to ["pullapprove"]; set to [] to exclude nothing.
+	HumanGateChecks []string `json:"human_gate_checks,omitempty"`
+
 	// EscalationCmd is run via `sh -c` when the gate needs a human: on CI
 	// status errors (fail-open) and pending-timeout aborts. It receives
 	// GT_CIGATE_EVENT, GT_CIGATE_TICKET, GT_CIGATE_DETAIL, GT_CIGATE_PR_URL,
@@ -1481,6 +1490,16 @@ func (c *CIGateConfig) MayorAlertAfterOrDefault() time.Duration {
 		return 30 * time.Minute
 	}
 	return ciGateDuration(c.MayorAlertAfter, 30*time.Minute)
+}
+
+// HumanGateChecksOrDefault returns the human-gate check names excluded from
+// CI evaluation. Nil-safe: nil (or missing block) defaults to
+// ["pullapprove"]; an explicitly empty list means exclude nothing.
+func (c *CIGateConfig) HumanGateChecksOrDefault() []string {
+	if c == nil || c.HumanGateChecks == nil {
+		return []string{"pullapprove"}
+	}
+	return c.HumanGateChecks
 }
 
 // EscalationCmdOrEmpty returns the configured escalation command. Nil-safe.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1445,6 +1445,39 @@ type CIGateConfig struct {
 	// your external tracker — e.g. a script that comments on the ticket and
 	// transitions it to a human-attention status.
 	EscalationCmd string `json:"escalation_cmd,omitempty"`
+
+	// MacroscopeSettle configures the Macroscope comment-settle phase of
+	// gt done's gate (op-sr9u): Macroscope posts inline review comments
+	// asynchronously AFTER its checks turn green, so once CI is green the
+	// gate additionally waits for Macroscope check contexts to reach a
+	// terminal state on the final head, then performs one review-comment
+	// fetch; unaddressed Macroscope threads block completion like CI red.
+	// Nil = enabled with defaults (a no-op on PRs with no Macroscope checks
+	// or comments, so the default is safe for rigs without Macroscope).
+	MacroscopeSettle *MacroscopeSettleConfig `json:"macroscope_settle,omitempty"`
+}
+
+// MacroscopeSettleConfig configures the Macroscope comment-settle phase of
+// the CI gate (op-sr9u).
+type MacroscopeSettleConfig struct {
+	// Enabled controls the settle phase. Nil defaults to true.
+	// Emergency process-level kill switch: GT_MACROSCOPE_SETTLE=off.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// CheckPatterns are case-insensitive substrings identifying Macroscope
+	// check contexts by display name. Nil defaults to ["macroscope"]
+	// (matches "Macroscope - Correctness Check" / "- Approvability Check").
+	CheckPatterns []string `json:"check_patterns,omitempty"`
+
+	// BotLogins are review-comment author logins that count as Macroscope
+	// ("[bot]" suffix ignored). Nil defaults to ["macroscopeapp"].
+	BotLogins []string `json:"bot_logins,omitempty"`
+
+	// SettleTimeout is how long gt done waits for Macroscope contexts to
+	// reach a terminal state before FAILING OPEN with a human escalation
+	// (a broken review bot must not brick completions). Empty defaults to
+	// the gate's pending_timeout (30m).
+	SettleTimeout string `json:"settle_timeout,omitempty"`
 }
 
 // IsEnabled returns whether the CI gate is on. Nil-safe, defaults to true.
@@ -1508,6 +1541,54 @@ func (c *CIGateConfig) EscalationCmdOrEmpty() string {
 		return ""
 	}
 	return c.EscalationCmd
+}
+
+// MacroscopeSettings returns the gate's Macroscope settle configuration,
+// never nil. A nil receiver or missing macroscope_settle block yields the
+// enabled defaults.
+func (c *CIGateConfig) MacroscopeSettings() *MacroscopeSettleConfig {
+	if c == nil || c.MacroscopeSettle == nil {
+		return &MacroscopeSettleConfig{}
+	}
+	return c.MacroscopeSettle
+}
+
+// IsEnabled returns whether the Macroscope settle phase is on. Nil-safe,
+// defaults to true.
+func (c *MacroscopeSettleConfig) IsEnabled() bool {
+	if c == nil || c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// CheckPatternsOrDefault returns the check-name patterns identifying
+// Macroscope contexts. Nil-safe: nil (or missing block) defaults to
+// ["macroscope"]; an explicitly empty list matches nothing.
+func (c *MacroscopeSettleConfig) CheckPatternsOrDefault() []string {
+	if c == nil || c.CheckPatterns == nil {
+		return []string{"macroscope"}
+	}
+	return c.CheckPatterns
+}
+
+// BotLoginsOrDefault returns the comment-author logins that count as
+// Macroscope. Nil-safe: nil (or missing block) defaults to
+// ["macroscopeapp"]; an explicitly empty list matches nothing.
+func (c *MacroscopeSettleConfig) BotLoginsOrDefault() []string {
+	if c == nil || c.BotLogins == nil {
+		return []string{"macroscopeapp"}
+	}
+	return c.BotLogins
+}
+
+// SettleTimeoutOrDefault returns the Macroscope settle wait budget, falling
+// back to the given duration (the gate's pending timeout) when unset.
+func (c *MacroscopeSettleConfig) SettleTimeoutOrDefault(fallback time.Duration) time.Duration {
+	if c == nil {
+		return fallback
+	}
+	return ciGateDuration(c.SettleTimeout, fallback)
 }
 
 // CIGateSettings returns the rig's CI gate configuration, never nil.

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -621,3 +621,35 @@ func TestParseDurationOrDefault_AllWebTimeoutDefaults(t *testing.T) {
 		})
 	}
 }
+
+// --- CIGateConfig.HumanGateChecksOrDefault (AA-859) ---
+
+func TestHumanGateChecksOrDefault(t *testing.T) {
+	t.Parallel()
+
+	var nilCfg *CIGateConfig
+	if got := nilCfg.HumanGateChecksOrDefault(); len(got) != 1 || got[0] != "pullapprove" {
+		t.Errorf("nil receiver = %v, want [pullapprove]", got)
+	}
+	if got := (&CIGateConfig{}).HumanGateChecksOrDefault(); len(got) != 1 || got[0] != "pullapprove" {
+		t.Errorf("unset field = %v, want [pullapprove]", got)
+	}
+	// Explicit empty list means "exclude nothing" — it must not be
+	// silently replaced by the default.
+	if got := (&CIGateConfig{HumanGateChecks: []string{}}).HumanGateChecksOrDefault(); len(got) != 0 {
+		t.Errorf("explicit empty list = %v, want []", got)
+	}
+	custom := &CIGateConfig{HumanGateChecks: []string{"pullapprove", "release-signoff"}}
+	if got := custom.HumanGateChecksOrDefault(); len(got) != 2 || got[1] != "release-signoff" {
+		t.Errorf("custom list = %v, want [pullapprove release-signoff]", got)
+	}
+
+	// The JSON wire format preserves the nil-vs-empty distinction.
+	var fromJSON CIGateConfig
+	if err := json.Unmarshal([]byte(`{"human_gate_checks": []}`), &fromJSON); err != nil {
+		t.Fatal(err)
+	}
+	if got := fromJSON.HumanGateChecksOrDefault(); len(got) != 0 {
+		t.Errorf(`{"human_gate_checks": []} = %v, want []`, got)
+	}
+}

--- a/internal/refinery/batch.go
+++ b/internal/refinery/batch.go
@@ -332,6 +332,10 @@ func (e *Engineer) processSingleMR(ctx context.Context, mr *MRInfo, target strin
 		// PR awaiting human approval — leave in queue for retry on next poll.
 		_, _ = fmt.Fprintf(e.output, "[Batch] MR %s: PR awaiting approval, will retry\n", mr.ID)
 		e.HandleMRInfoFailure(mr, processResult)
+	} else if processResult.NeedsCIGreen {
+		// AA-851: PR CI red/pending — leave in queue for retry on next poll.
+		_, _ = fmt.Fprintf(e.output, "[Batch] MR %s: PR CI not green, will retry\n", mr.ID)
+		e.HandleMRInfoFailure(mr, processResult)
 	} else {
 		result.Error = fmt.Errorf("merge failed: %s", processResult.Error)
 	}

--- a/internal/refinery/cigate_test.go
+++ b/internal/refinery/cigate_test.go
@@ -1,0 +1,46 @@
+package refinery
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/cigate"
+)
+
+func TestCIGateMergeDecision(t *testing.T) {
+	t.Run("red blocks with NeedsCIGreen", func(t *testing.T) {
+		res := cigate.CheckResult{Verdict: cigate.VerdictRed, PRNumber: 7, FailingChecks: []string{"jenkins/build"}}
+		blocked := ciGateMergeDecision(res)
+		if blocked == nil || !blocked.NeedsCIGreen || blocked.Success {
+			t.Fatalf("want NeedsCIGreen block, got %+v", blocked)
+		}
+		if !strings.Contains(blocked.Error, "jenkins/build") {
+			t.Errorf("block reason should name the failing check: %q", blocked.Error)
+		}
+	})
+
+	t.Run("pending blocks with NeedsCIGreen", func(t *testing.T) {
+		res := cigate.CheckResult{Verdict: cigate.VerdictPending, PRNumber: 7, PendingChecks: []string{"macroscope"}}
+		blocked := ciGateMergeDecision(res)
+		if blocked == nil || !blocked.NeedsCIGreen {
+			t.Fatalf("want NeedsCIGreen block, got %+v", blocked)
+		}
+	})
+
+	for _, tt := range []struct {
+		name string
+		res  cigate.CheckResult
+	}{
+		{"green proceeds", cigate.CheckResult{Verdict: cigate.VerdictGreen, PRNumber: 7}},
+		{"merged proceeds", cigate.CheckResult{Verdict: cigate.VerdictMerged, PRNumber: 7}},
+		{"no PR proceeds", cigate.CheckResult{Verdict: cigate.VerdictNoPR}},
+		{"error fails open", cigate.CheckResult{Verdict: cigate.VerdictError, Err: errors.New("gh down")}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if blocked := ciGateMergeDecision(tt.res); blocked != nil {
+				t.Errorf("want proceed (nil), got %+v", blocked)
+			}
+		})
+	}
+}

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/cigate"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/crew"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/git"
@@ -177,6 +179,12 @@ type MergeQueueConfig struct {
 	// Batch holds configuration for the batch-then-bisect merge queue.
 	// When nil or MaxBatchSize <= 1, batching is disabled and MRs process sequentially.
 	Batch *BatchConfig `json:"batch,omitempty"`
+
+	// CIGate mirrors the rig's merge_queue.ci_gate settings (AA-851). The
+	// refinery refuses to merge a PR whose checks are red or pending —
+	// belt-and-suspenders behind the gt done gate for merge_strategy=pr.
+	// Nil = enabled with defaults.
+	CIGate *config.CIGateConfig `json:"ci_gate,omitempty"`
 }
 
 // DefaultMergeQueueConfig returns sensible defaults for merge queue configuration.
@@ -269,6 +277,7 @@ type Engineer struct {
 	mergeSlotMaxRetries   int           // Max retries for slot acquisition (0 = no retry)
 	mergeSlotRetryBackoff time.Duration // Initial backoff between retries
 	testAllowSyntheticMRs bool          // Test-only: legacy merge-mechanics tests use synthetic MRs without beads.
+	ciGate                *cigate.Gate  // Test-injectable CI gate; nil = real gh-backed gate (AA-851)
 }
 
 // NewEngineer creates a new Engineer for the given rig.
@@ -355,6 +364,7 @@ func (e *Engineer) LoadConfig() error {
 		MergeStrategy        *string                   `json:"merge_strategy"`
 		VCSProvider          *string                   `json:"vcs_provider"`
 		RequireReview        *bool                     `json:"require_review"`
+		CIGate               *config.CIGateConfig      `json:"ci_gate"`
 	}
 
 	if err := json.Unmarshal(rawConfig.MergeQueue, &mqRaw); err != nil {
@@ -442,6 +452,9 @@ func (e *Engineer) LoadConfig() error {
 	if mqRaw.RequireReview != nil {
 		e.config.RequireReview = mqRaw.RequireReview
 	}
+	if mqRaw.CIGate != nil {
+		e.config.CIGate = mqRaw.CIGate
+	}
 
 	// Initialize the PR provider when merge_strategy=pr.
 	if e.config.MergeStrategy == "pr" {
@@ -495,6 +508,7 @@ type ProcessResult struct {
 	BranchNotFound bool // Source branch no longer exists (e.g. cleaned up after cherry-pick)
 	NoMerge        bool // MR/source is intentionally not merge-eligible, not a build failure
 	NeedsApproval  bool // PR exists but lacks required approving review (merge_strategy=pr)
+	NeedsCIGreen   bool // PR has red or pending CI checks (merge_strategy=pr); retried next poll (AA-851)
 }
 
 // doMerge performs the actual git merge operation.
@@ -759,6 +773,28 @@ func (e *Engineer) doMerge(ctx context.Context, mr *MRInfo, skipGates ...bool) P
 	}
 }
 
+// ciGateGate returns the CI gate, defaulting to the real gh-backed one.
+func (e *Engineer) ciGateGate() *cigate.Gate {
+	if e.ciGate != nil {
+		return e.ciGate
+	}
+	return cigate.New()
+}
+
+// ciGateMergeDecision maps a CI gate result to a merge-blocking ProcessResult,
+// or nil when the merge may proceed. Only RED and PENDING block; ERROR fails
+// open (callers log it loudly).
+func ciGateMergeDecision(res cigate.CheckResult) *ProcessResult {
+	if res.Verdict.Blocks() {
+		return &ProcessResult{
+			Success:      false,
+			NeedsCIGreen: true,
+			Error:        fmt.Sprintf("CI gate (AA-851): %s", res.Summary()),
+		}
+	}
+	return nil
+}
+
 // doMergePR handles merging via the VCS provider's PR merge API (merge_strategy=pr).
 // This respects branch protection/restriction rules including required reviews.
 // The VCS provider (GitHub, Bitbucket) is selected via vcs_provider config.
@@ -799,6 +835,20 @@ func (e *Engineer) doMergePR(ctx context.Context, mr *MRInfo) ProcessResult {
 		}
 	}
 	_, _ = fmt.Fprintf(e.output, "[Engineer] Found PR #%d for branch %s\n", prNumber, branch)
+
+	// Step PR.1.5 (AA-851): hard CI gate — never merge a PR with red or
+	// pending checks. Deferred like NeedsApproval: the MR stays queued and
+	// retries on the next poll. Belt-and-suspenders behind the gt done gate.
+	if e.config.CIGate.IsEnabled() && !cigate.EnvDisabled() {
+		res := e.ciGateGate().CheckBranch(e.workDir, branch)
+		if res.Verdict == cigate.VerdictError {
+			// Fail-open: unknown CI state must not wedge the queue, but log loudly.
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: CI gate could not determine CI status for PR #%d (%v) — failing open (AA-851)\n", prNumber, res.Err)
+		} else if blocked := ciGateMergeDecision(res); blocked != nil {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] PR #%d CI not green — deferring merge: %s\n", prNumber, res.Summary())
+			return *blocked
+		}
+	}
 
 	// Step PR.2: Check approval status if require_review is enabled
 	requireReview := e.config.RequireReview != nil && *e.config.RequireReview
@@ -1475,6 +1525,14 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 	// No polecat notification needed; the PR just needs a human review on GitHub.
 	if result.NeedsApproval {
 		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: PR awaiting human approval, will retry next poll\n", mr.ID)
+		return
+	}
+
+	// NeedsCIGreen (AA-851): the PR's checks are red or pending. Not a merge
+	// failure — the MR stays in queue and retries on the next poll, by which
+	// time the polecat should have fixed the failure or CI settled.
+	if result.NeedsCIGreen {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: PR CI not green, will retry next poll (%s)\n", mr.ID, result.Error)
 		return
 	}
 

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -778,7 +778,7 @@ func (e *Engineer) ciGateGate() *cigate.Gate {
 	if e.ciGate != nil {
 		return e.ciGate
 	}
-	return cigate.New()
+	return cigate.New(e.config.CIGate.HumanGateChecksOrDefault()...)
 }
 
 // ciGateMergeDecision maps a CI gate result to a merge-blocking ProcessResult,


### PR DESCRIPTION
## What

Adds a hard CI gate to the polecat lifecycle: a polecat cannot complete (`gt done`) and the refinery will not merge its MR while the PR's CI checks are red or pending. Prevents half-done work from reaching the merge queue and master from going red via the autonomous pipeline.

## Behavior

- Gate is ON by default, configurable per rig
- Polecat `done` flow polls CI status with a configurable timeout (default 30m) before submitting to the merge queue
- On timeout/undeterminable CI: fails open with an explanatory comment and routes the item to human attention rather than silently merging or silently dropping the work
- Refinery independently re-verifies CI green before merge (belt and suspenders)

## Why

Downstream deployments of gastown hit repeated incidents where polecats declared done with red CI, and merges landed while required checks were failing (merge gates configured as advisory). A pipeline-level hard gate makes green CI a precondition of the autonomous path regardless of repo-side branch-protection configuration.

## Testing

Built and unit-tested on this branch (commit 4f344d95); affected packages pass locally. Draft while we finish integration verification downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193nwJhFM7AFAzwkWXwKh6n