### PR TITLE
fix(tmux): fall back safely for stale nudge pane IDs

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1658,23 +1658,51 @@ type NudgeOpts struct {
 	TownRoot string
 }
 
-// canonicalPaneTarget converts a pane identifier like "%23" into a tmux target
-// that send-keys can resolve reliably. Bare pane IDs work for display-message,
-// but for send-keys we prefer an explicit session:window.pane target.
+// canonicalPaneTarget converts a pane identifier like "%23" into an explicit
+// tmux session:window.pane target. If the pane is stale or resolves outside the
+// expected session, fall back to the session's first pane instead of the active
+// pane that a bare session target would select.
 func (t *Tmux) canonicalPaneTarget(session, pane string) string {
+	fallback := session + ":0.0"
 	if pane == "" {
-		return session
+		return fallback
 	}
 
-	out, err := t.run("display-message", "-t", pane, "-p", "#{session_name}:#{window_index}.#{pane_index}")
-	if err == nil {
-		target := strings.TrimSpace(out)
-		if target != "" {
-			return target
+	expectedSession := session
+	if out, err := t.run("display-message", "-t", session, "-p", "#{session_name}"); err == nil {
+		if resolved := strings.TrimSpace(out); resolved != "" {
+			expectedSession = resolved
 		}
 	}
 
-	return pane
+	out, err := t.run("display-message", "-t", pane, "-p", "#{session_name}\t#{window_index}\t#{pane_index}")
+	if err != nil {
+		return fallback
+	}
+	if target, ok := canonicalPaneTargetFromDisplay(expectedSession, out); ok {
+		return target
+	}
+	return fallback
+}
+
+func canonicalPaneTargetFromDisplay(expectedSession, out string) (string, bool) {
+	parts := strings.Split(strings.TrimSpace(out), "\t")
+	if len(parts) != 3 {
+		return "", false
+	}
+
+	session := strings.TrimSpace(parts[0])
+	window := strings.TrimSpace(parts[1])
+	pane := strings.TrimSpace(parts[2])
+	if session != expectedSession || !isTmuxIndex(window) || !isTmuxIndex(pane) {
+		return "", false
+	}
+	return fmt.Sprintf("%s:%s.%s", session, window, pane), true
+}
+
+func isTmuxIndex(value string) bool {
+	n, err := strconv.Atoi(value)
+	return err == nil && n >= 0
 }
 
 // NudgeSessionWithOpts is like NudgeSession but accepts delivery options.
@@ -1702,7 +1730,7 @@ func (t *Tmux) NudgeSessionWithOpts(session, message string, opts NudgeOpts) err
 
 	// Resolve the correct target: in multi-pane sessions, find the pane
 	// running the agent rather than sending to the focused pane.
-	target := session
+	target := session + ":0.0"
 	if agentPane, err := t.FindAgentPane(session); err == nil && agentPane != "" {
 		target = t.canonicalPaneTarget(session, agentPane)
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1701,6 +1701,14 @@ func canonicalPaneTargetFromDisplay(expectedSession, out string) (string, bool) 
 }
 
 func isTmuxIndex(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
 	n, err := strconv.Atoi(value)
 	return err == nil && n >= 0
 }

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1920,6 +1920,12 @@ func TestCanonicalPaneTargetFromDisplay(t *testing.T) {
 			out:             "gt-alpha\t0\t-1",
 			wantOK:          false,
 		},
+		{
+			name:            "signed index",
+			expectedSession: "gt-alpha",
+			out:             "gt-alpha\t+1\t0",
+			wantOK:          false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1860,6 +1860,177 @@ func TestNudgeSession_WakesAgentWindowNotActiveWindow(t *testing.T) {
 	}
 }
 
+func TestCanonicalPaneTargetFromDisplay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		expectedSession string
+		out             string
+		want            string
+		wantOK          bool
+	}{
+		{
+			name:            "valid target",
+			expectedSession: "gt-alpha",
+			out:             "gt-alpha\t0\t0",
+			want:            "gt-alpha:0.0",
+			wantOK:          true,
+		},
+		{
+			name:            "valid multi window",
+			expectedSession: "gt-alpha",
+			out:             "gt-alpha\t12\t3",
+			want:            "gt-alpha:12.3",
+			wantOK:          true,
+		},
+		{
+			name:            "wrong session",
+			expectedSession: "gt-alpha",
+			out:             "gt-beta\t0\t0",
+			wantOK:          false,
+		},
+		{
+			name:            "malformed combined target",
+			expectedSession: "gt-alpha",
+			out:             "gt-alpha:0.0",
+			wantOK:          false,
+		},
+		{
+			name:            "empty output",
+			expectedSession: "gt-alpha",
+			out:             "",
+			wantOK:          false,
+		},
+		{
+			name:            "non numeric window",
+			expectedSession: "gt-alpha",
+			out:             "gt-alpha\tactive\t0",
+			wantOK:          false,
+		},
+		{
+			name:            "non numeric pane",
+			expectedSession: "gt-alpha",
+			out:             "gt-alpha\t0\tactive",
+			wantOK:          false,
+		},
+		{
+			name:            "negative index",
+			expectedSession: "gt-alpha",
+			out:             "gt-alpha\t0\t-1",
+			wantOK:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := canonicalPaneTargetFromDisplay(tt.expectedSession, tt.out)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("target = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalPaneTargetResolvesAndFallsBack(t *testing.T) {
+	tm := newTestTmux(t)
+	sessionName := "gt-test-canonical-pane-" + fmt.Sprintf("%d", time.Now().UnixNano()%100000)
+	otherSession := "gt-test-canonical-other-" + fmt.Sprintf("%d", time.Now().UnixNano()%100000)
+
+	if err := tm.NewSession(sessionName, os.TempDir()); err != nil {
+		t.Fatalf("NewSession target: %v", err)
+	}
+	defer func() { _ = tm.KillSession(sessionName) }()
+	if err := tm.NewSession(otherSession, os.TempDir()); err != nil {
+		t.Fatalf("NewSession other: %v", err)
+	}
+	defer func() { _ = tm.KillSession(otherSession) }()
+
+	time.Sleep(200 * time.Millisecond)
+	fallback := sessionName + ":0.0"
+	if got := tm.canonicalPaneTarget(sessionName, ""); got != fallback {
+		t.Errorf("empty pane target = %q, want %q", got, fallback)
+	}
+	if got := tm.canonicalPaneTarget(sessionName, "%999999"); got != fallback {
+		t.Errorf("missing pane target = %q, want %q", got, fallback)
+	}
+
+	paneID, err := tm.GetPaneID(sessionName)
+	if err != nil {
+		t.Fatalf("GetPaneID target: %v", err)
+	}
+	if got := tm.canonicalPaneTarget(sessionName, paneID); got != fallback {
+		t.Errorf("live pane target = %q, want %q", got, fallback)
+	}
+
+	otherPane, err := tm.GetPaneID(otherSession)
+	if err != nil {
+		t.Fatalf("GetPaneID other: %v", err)
+	}
+	if got := tm.canonicalPaneTarget(sessionName, otherPane); got != fallback {
+		t.Errorf("cross-session pane target = %q, want %q", got, fallback)
+	}
+}
+
+func TestNudgeSession_StalePaneIDFallsBackToFirstPane(t *testing.T) {
+	tm := newTestTmux(t)
+	sessionName := "gt-test-nudge-stale-pane-" + fmt.Sprintf("%d", time.Now().UnixNano()%100000)
+	otherSession := "gt-test-nudge-other-pane-" + fmt.Sprintf("%d", time.Now().UnixNano()%100000)
+
+	if err := tm.NewSession(sessionName, os.TempDir()); err != nil {
+		t.Fatalf("NewSession target: %v", err)
+	}
+	defer func() { _ = tm.KillSession(sessionName) }()
+	if err := tm.NewSession(otherSession, os.TempDir()); err != nil {
+		t.Fatalf("NewSession other: %v", err)
+	}
+	defer func() { _ = tm.KillSession(otherSession) }()
+
+	time.Sleep(200 * time.Millisecond)
+	otherPane, err := tm.GetPaneID(otherSession)
+	if err != nil {
+		t.Fatalf("GetPaneID other: %v", err)
+	}
+	if err := tm.SetEnvironment(sessionName, "GT_PANE_ID", otherPane); err != nil {
+		t.Fatalf("SetEnvironment GT_PANE_ID: %v", err)
+	}
+	if _, err := tm.run("new-window", "-t", sessionName, "-n", "active"); err != nil {
+		t.Fatalf("new-window: %v", err)
+	}
+
+	marker := "GT_NUDGE_STALE_PANE_FALLBACK_" + fmt.Sprintf("%d", time.Now().UnixNano()%100000)
+	if err := tm.NudgeSession(sessionName, "echo "+marker); err != nil {
+		t.Fatalf("NudgeSession: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	firstPane, err := tm.CapturePane(sessionName+":0.0", 80)
+	if err != nil {
+		t.Fatalf("CapturePane first: %v", err)
+	}
+	activePane, err := tm.CapturePane(sessionName+":1.0", 80)
+	if err != nil {
+		t.Fatalf("CapturePane active: %v", err)
+	}
+	otherPaneContent, err := tm.CapturePane(otherSession+":0.0", 80)
+	if err != nil {
+		t.Fatalf("CapturePane other: %v", err)
+	}
+
+	if !strings.Contains(firstPane, marker) {
+		t.Fatalf("first pane did not receive nudge marker %q; content:\n%s", marker, firstPane)
+	}
+	if strings.Contains(activePane, marker) {
+		t.Fatalf("active fallback pane received stale-pane nudge marker %q; content:\n%s", marker, activePane)
+	}
+	if strings.Contains(otherPaneContent, marker) {
+		t.Fatalf("cross-session stale pane received nudge marker %q; content:\n%s", marker, otherPaneContent)
+	}
+}
+
 // TestAdaptiveTextDelay verifies the delay scaling logic for post-text delivery.
 func TestAdaptiveTextDelay(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- Replace stale tmux pane fallback with an explicit `session:0.0` target instead of raw `%pane` or bare session targeting.
- Validate `display-message` target output against the expected session and digit-only window/pane indexes before using `session:window.pane`.
- Add focused regression coverage for malformed output, missing/cross-session pane IDs, live pane canonicalization, and stale `GT_PANE_ID` with an active non-agent window.

## Attribution

Replacement for #4342 by @kaushikNaarayan / Kanaba.

Original PR head: `c9aac99bdcb93c6e6d1bf40671b4ee421cb058bb`.

This carries forward only the accepted stale-pane fallback intent. The original PR should remain open until this replacement lands.

## PR Sheriff Evidence

- Bead: `gt-1w1a`
- Final head: `cc71495cf875294e5a89d09011b6f79ae892f3cc`
- 15 independent research legs and 5 pre-implementation reviews were persisted on the bead before code changes.
- 5 final post-implementation reviews passed on the clean upstream-based head.
- Cleanup-first verdict: acceptable minimal/convergent; no broad tmux rewrite, no queue/retry shim, no `GT_PANE_ID` mutation.

## Verification

- `git diff --check upstream/main...HEAD`
- `go test ./internal/tmux -run 'TestCanonicalPaneTarget|TestNudgeSession_(WithStoredPaneID|WakesAgentWindowNotActiveWindow|StalePaneIDFallsBackToFirstPane)$' -v`
- `go test ./internal/tmux -count=1` currently fails in unrelated environment-sensitive tests: `TestNewSessionWithCommand_ExecEnvSuccess` and `TestGetPaneCommand_MultiPane` expect `sleep` but tmux reports `coreutils`.

Refs #4342.
