### PR TITLE
fix: retire polecats after gt done

### DIFF
--- a/docs/CLEANUP.md
+++ b/docs/CLEANUP.md
@@ -25,7 +25,7 @@ A comprehensive catalog of all cleanup-related commands in the gastown/beads eco
 | `gt polecat stale <rig>` | Detects stale polecats; `--cleanup` auto-nukes them |
 | `gt polecat check-recovery` | Pre-nuke safety check (SAFE_TO_NUKE vs NEEDS_RECOVERY) |
 | `gt polecat identity remove <rig> <name>` | Removes a polecat identity |
-| `gt done` | Polecat self-cleaning: pushes branch, submits MR (by default), self-nukes worktree, kills own session. MR skipped for `--status ESCALATED\|DEFERRED` or `no_merge` paths |
+| `gt done` | Polecat self-cleaning: pushes branch, submits MR/PR path as configured, preserves handoff metadata, kills own session. MR skipped for `--status ESCALATED\|DEFERRED` or `no_merge` paths |
 
 ## Git Artifact Cleanup
 
@@ -147,8 +147,7 @@ A comprehensive catalog of all cleanup-related commands in the gastown/beads eco
 | Function | Where | What it does |
 |----------|-------|-------------|
 | `cleanupOrphanedProcesses()` | `polecat.go` | Auto-runs after nuke/stale cleanup |
-| `selfNukePolecat()` | `done.go` | Self-destructs worktree during `gt done` |
-| `selfKillSession()` | `done.go` | Self-terminates tmux session |
+| `retirePolecatSessionAfterDone()` | `done.go` | Self-terminates tmux session with PID exclusion after durable handoff |
 | `rollbackSlingArtifacts()` | `sling.go` | Cleans up partial sling failures |
 | `cleanStaleHookedBeads()` | `unsling.go` | Repairs beads stuck in "hooked" state |
 | `gt signal stop` | `signal_stop.go` | Clears stop-state temp files at turn boundaries |

--- a/docs/concepts/molecules.md
+++ b/docs/concepts/molecules.md
@@ -97,7 +97,7 @@ through each step in order.
 2. gt prime               # Shows formula checklist inline
 3. Work through each step
 4. Persist findings: bd update <issue> --notes "..."
-5. gt done                # Submit, nuke sandbox, exit
+5. gt done                # Submit, preserve handoff metadata, exit
 ```
 
 ### Molecule Types
@@ -127,6 +127,6 @@ a new one for the next cycle.
 ## Best Practices
 
 1. **Persist findings early** — `bd update <issue> --notes "..."` before session death
-2. **Run `gt done` when complete** — mandatory for polecats (pushes, submits to MQ, nukes)
+2. **Run `gt done` when complete** — mandatory for polecats (pushes, submits to MQ/PR path, exits)
 3. **Use `gt patrol report`** — for patrol agents to cycle (replaces squash+new pattern)
 4. **File discovered work** — `bd create` for bugs found, don't fix them yourself

--- a/docs/concepts/polecat-lifecycle.md
+++ b/docs/concepts/polecat-lifecycle.md
@@ -5,17 +5,19 @@
 ## Overview
 
 Polecats have three distinct lifecycle layers that operate independently. The
-key design principle: **polecats are persistent**. They survive work completion
-and can be reused across assignments.
+key design principle: **clean completion retires the live polecat session**.
+The agent identity and merge evidence persist, but completed sessions do not
+return to the idle reuse pool.
 
-## The Four Operating States
+## Operating States
 
-Polecats have four operating states:
+Polecats use these primary operating states:
 
 | State | Description | How it happens |
 |-------|-------------|----------------|
 | **Working** | Actively doing assigned work | Normal operation after `gt sling` |
-| **Idle** | Work completed, sandbox preserved for reuse | After `gt done` completes successfully |
+| **Idle** | Available before assignment | Spawned or explicitly prepared for work |
+| **Done** | Work completed and session retired | After `gt done` completes successfully |
 | **Stalled** | Session stopped mid-work | Interrupted, crashed, or timed out without being nudged |
 | **Zombie** | Completed work but failed to exit | `gt done` failed during cleanup |
 
@@ -23,49 +25,49 @@ Polecats have four operating states:
 
 ```
          ┌──────────┐
-    ┌───>│  IDLE    │<──── sync sandbox to main, clear hook
-    │    └────┬─────┘
-    │         │ gt sling
-    │         v
-    │    ┌──────────┐
-    │    │ WORKING  │<──── session active, hook set
-    │    └────┬─────┘
-    │         │ gt done
-    │         v
-    │    ┌──────────┐
-    └────┤  IDLE    │──── push branch, submit MR, go idle
+         │  IDLE    │──── gt sling
+         └────┬─────┘
+              v
+         ┌──────────┐
+         │ WORKING  │<──── session active, hook set
+         └────┬─────┘
+              │ gt done
+              v
+         ┌──────────┐
+         │  DONE    │──── branch/MR evidence preserved, session exits
          └──────────┘
 ```
 
-No `nuke` in the happy path. Polecats cycle: IDLE -> WORKING -> IDLE.
+No idle reuse in the happy path. Polecats move: IDLE -> WORKING -> DONE.
 
 **Key distinctions:**
 
 - **Working** = actively executing. Session alive, hook set, doing work.
-- **Idle** = work done, session killed, sandbox preserved. Ready for next `gt sling`.
+- **Idle** = not yet assigned and safe to use.
+- **Done** = work done, session killed, waiting for cleanup/refinery outcome.
 - **Stalled** = supposed to be working, but stopped. Needs Witness intervention.
 - **Zombie** = finished work, tried to exit, but cleanup failed. Stuck in limbo.
 
-## The Persistent Polecat Model (gt-4ac)
+## The Retired Completion Model
 
-**Polecats persist after completing work.** When a polecat finishes its assignment:
+**Polecat identity persists after completing work, but the live session does not.**
+When a polecat finishes its assignment:
 
 1. Signals completion via `gt done`
 2. Pushes branch, submits MR to merge queue
 3. Clears its hook (work is done)
-4. Sets agent state to "idle"
-5. Kills its own session
-6. **Sandbox (worktree) is preserved for reuse**
+4. Sets agent state to "done"
+5. Kills its own session using PID-excluding cleanup
+6. Leaves branch/MR metadata for Witness/refinery cleanup
 
-The next `gt sling` reuses idle polecats before allocating new ones, avoiding
-the overhead of creating fresh worktrees.
+The next `gt sling` allocates available capacity without reusing a completed
+session that still has branch/MR or cleanup state attached.
 
-### Why Persistent?
+### Why Retire Sessions?
 
-- **Faster turnaround** — Reusing an existing worktree is faster than creating one
 - **Preserved identity** — The polecat's agent bead, CV chain, and work history persist
-- **Simpler lifecycle** — No nuke/respawn cycle between assignments
-- **Done means idle** — Session dies, sandbox lives, polecat awaits next assignment
+- **Simpler lifecycle** — Clean completion has one terminal session path
+- **Done means retired** — Session dies, cleanup/refinery owns remaining state
 
 ### What About Pending Merges?
 
@@ -73,7 +75,7 @@ The Refinery owns the merge queue. Once `gt done` submits work:
 - The branch is pushed to origin
 - Work exists in the MQ, not in the polecat
 - If rebase fails, Refinery creates a conflict-resolution task
-- The idle polecat can be reused for the conflict resolution work
+- The completed polecat is not reused while pending MR or cleanup state remains
 
 ## The Three Layers
 
@@ -87,16 +89,16 @@ Early designs treated polecats as monolithic. This caused recurring issues:
 | **Sandbox** | Per-assignment (worktree, branch) | Destroyed on nuke |
 | **Session** | Ephemeral (Claude context window) | = polecat lifetime |
 
-Separating these three layers means idle polecats are a healthy state (not waste),
-eliminates unnecessary worktree creation overhead, and preserves capability
-records (CV, completion history) across assignments.
+Separating these three layers keeps completed sessions out of the idle reuse pool,
+preserves capability records (CV, completion history), and lets cleanup/refinery
+own branch and worktree state after handoff.
 
 ### Layer Summary
 
 | Layer | Component | Lifecycle | Persistence |
 |-------|-----------|-----------|-------------|
 | **Identity** | Agent bead, CV chain, work history | Permanent | Never dies |
-| **Sandbox** | Git worktree, branch | Persistent across assignments | Created on first sling, reused thereafter |
+| **Sandbox** | Git worktree, branch | Per active assignment/cleanup window | Created for work, retired after cleanup |
 | **Session** | Claude (tmux pane), context window | Ephemeral per step | Cycles per step/handoff |
 
 ### Identity Layer
@@ -140,23 +142,22 @@ The sandbox is the **git worktree**—the polecat's working directory:
 ```
 
 This worktree:
-- Exists from first `gt sling` and persists across assignments
-- Survives all session cycles
-- Is repaired (reset to fresh branch from main) when reused by `gt sling`
+- Exists while the polecat is active or awaiting cleanup
+- Survives handoff/session cycles during an assignment
+- Is not synced to main or branch-deleted by `gt done`
 - Contains uncommitted work, staged changes, branch state during active work
 
-The Witness never destroys sandboxes. Only explicit `gt polecat nuke` removes them.
+Witness/refinery cleanup owns sandbox retirement after durable handoff. Explicit
+`gt polecat nuke` remains the manual destructive path.
 
-#### Sandbox Sync (Between Assignments)
+#### Branch Preservation (After Completion)
 
-When work completes and the polecat goes idle, the sandbox is synced to main:
+When work completes, `gt done` leaves the feature branch and MR metadata intact:
 
 ```bash
-# In the polecat's worktree (done automatically by gt done / gt sling)
-git checkout main
-git pull origin main
-git branch -D polecat/<name>/<old-issue>+<timestamp>
-# Worktree is now clean, on main, ready for next assignment
+# Handled by gt done
+git push origin polecat/<name>/<issue>@<suffix>
+# Branch and metadata remain available for refinery/review/cleanup
 ```
 
 When new work is slung:
@@ -166,8 +167,8 @@ git checkout -b polecat/<name>/<new-issue>+<timestamp>
 # Start working
 ```
 
-No worktree add/remove between assignments. Just branch operations on an
-existing worktree. This avoids the ~5s overhead of creating fresh worktrees.
+Completed sandboxes are not treated as reusable idle worktrees while branch,
+MR, or cleanup state remains attached.
 
 ### Slot Layer
 
@@ -209,14 +210,14 @@ The slot:
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                  gt done (persistent model)                  │
+│                  gt done (retired model)                     │
 │  → Push branch to origin                                   │
 │  → Submit work to merge queue (MR bead)                    │
-│  → Set agent state to "idle"                               │
+│  → Set agent state to "done"                               │
 │  → Kill session                                            │
 │                                                             │
-│  Work now lives in MQ. Polecat is IDLE, not gone.          │
-│  Sandbox preserved for reuse by next gt sling.             │
+│  Work now lives in MQ. Polecat session is retired.         │
+│  Branch/MR metadata remains for refinery and cleanup.       │
 └─────────────────────────────────────────────────────────────┘
                               │
                               ▼
@@ -241,13 +242,13 @@ The slot:
 gt handoff  # Session cycles, polecat continues
 ```
 
-**Sandbox repair**: On reuse. `gt sling` resets the worktree to a fresh branch.
+**Sandbox setup**: For active work. `gt sling` prepares a fresh branch for the assignment.
 
 ```bash
-gt sling gt-xyz gastown  # Reuses idle Toast, repairs worktree
+gt sling gt-xyz gastown  # Allocates capacity and prepares branch
 ```
 
-Session cycling happens constantly. Sandbox repair happens between assignments.
+Session cycling happens constantly. Sandbox setup/cleanup is tied to assignments.
 
 ## Anti-Patterns
 
@@ -270,10 +271,13 @@ gt polecat nuke Toast  # (destroys sandbox, identity persists)
 
 Polecats manage their own session lifecycle. External manipulation bypasses verification.
 
-### Sandboxes Without Work (Idle vs Stalled)
+### Sandboxes Without Work (Idle vs Done vs Stalled)
 
-An idle polecat has no hook and no session — this is **normal**. It completed
-its work and is waiting for the next `gt sling`.
+An idle polecat has no hook, no session, and no completion/MR cleanup state —
+this is **available capacity**.
+
+A **done** polecat has completed work and exited, but branch/MR or cleanup state
+may still be attached. It is not reusable until cleanup resolves that state.
 
 A **stalled** polecat has a hook but no session — this is a **failure**:
 - The session crashed and wasn't nudged back to life
@@ -312,17 +316,17 @@ Sessions cycle for these reasons:
 | `gt handoff` | Voluntary | Clean cycle to fresh context |
 | Context compaction | Automatic | Forced by Claude Code |
 | Crash/timeout | Failure | Witness respawns |
-| `gt done` | Completion | Session exits, polecat goes idle |
+| `gt done` | Completion | Session exits, polecat goes done |
 
 All except `gt done` result in continued work. Only `gt done` signals completion
-and transitions the polecat to idle.
+and retires the completed polecat session.
 
 ## Witness Responsibilities
 
 The Witness monitors polecats but does NOT:
 - Force session cycles (polecats self-manage via handoff)
 - Interrupt mid-step (unless truly stuck)
-- Nuke polecats after completion (persistent model)
+- Reuse polecats after completion while cleanup/MR state remains
 
 The Witness DOES:
 - Detect and nudge stalled polecats (sessions that stopped unexpectedly)
@@ -345,10 +349,10 @@ explicit nuke. The *agent identity* that executes as that polecat accumulates a
 work history across all assignments.
 
 ```
-POLECAT IDENTITY (permanent)      SESSION (ephemeral)     SANDBOX (persistent)
+POLECAT IDENTITY (permanent)      SESSION (ephemeral)     SANDBOX (assignment-scoped)
 ├── CV chain                      ├── Claude instance     ├── Git worktree
 ├── Work history                  ├── Context window      ├── Branch
-├── Skills demonstrated           └── Dies on handoff     └── Repaired on reuse
+├── Skills demonstrated           └── Dies on handoff     └── Retired after cleanup
 └── Credit for work                   or gt done              by gt sling
 ```
 
@@ -366,11 +370,11 @@ for the full implementation matrix and [design/persistent-polecat-pool.md](../de
 for phase-by-phase shipping status.
 
 Key files:
-- `internal/cmd/done.go` — work submission, sandbox sync, idle transition
-- `internal/cmd/sling.go` + `polecat_spawn.go` — idle reuse, branch-only repair
+- `internal/cmd/done.go` — work submission, done-state handoff, session retirement
+- `internal/cmd/sling.go` + `polecat_spawn.go` — capacity allocation, branch setup
 - `internal/cmd/handoff.go` — session cycling for all roles
 - `internal/witness/handlers.go` — cleanup pipeline, POLECAT_DONE routing, zombie/orphan detection
-- `internal/polecat/manager.go` — stale detection, idle reuse (`FindIdlePolecat`, `ReuseIdlePolecat`), pool management
+- `internal/polecat/manager.go` — stale detection, done-state projection, pool management
 
 ## Related Documentation
 

--- a/docs/design/agent-api-inventory.md
+++ b/docs/design/agent-api-inventory.md
@@ -656,8 +656,8 @@ structured data; no need to scrape terminal
 **What**: Agent signals work completion through GT commands and intent files.
 
 **Code**:
-- `internal/cmd/done.go` — `runDone()` (line ~81): persistent polecat model,
-  transitions to IDLE with sandbox preserved; exit constants: `ExitCompleted`,
+- `internal/cmd/done.go` — `runDone()` (line ~81): retired completion model,
+  transitions clean completions to DONE and exits the session; exit constants: `ExitCompleted`,
   `ExitEscalated`, `ExitDeferred` (line ~65)
 - `internal/cmd/signal_stop.go` — `runSignalStop()` (line ~47): Stop hook handler,
   checks unread mail and hooked work, returns JSON

--- a/docs/design/persistent-polecat-pool.md
+++ b/docs/design/persistent-polecat-pool.md
@@ -61,7 +61,8 @@ SESSION (ephemeral)
          └──────────┘
 ```
 
-No `nuke` in the happy path. Polecats cycle: IDLE → WORKING → DONE → IDLE.
+This historical design described IDLE reuse after DONE. Current behavior retires
+clean completed sessions instead of returning them to the idle reuse pool.
 
 ### Pool Management
 
@@ -76,27 +77,24 @@ No `nuke` in the happy path. Polecats cycle: IDLE → WORKING → DONE → IDLE.
 **Initialization:** `gt rig add` or `gt polecat pool init <rig>` creates N polecats
 with identities and worktrees. They start in IDLE state.
 
-**Dispatch:** `gt sling <bead> <rig>` finds an IDLE polecat (already does this via
-`FindIdlePolecat()`), attaches work, starts session. No worktree creation needed.
+**Dispatch:** `gt sling <bead> <rig>` allocates capacity, attaches work, and starts
+a session on a fresh work branch.
 
 **Completion:** When a polecat finishes work:
 1. Push branch to origin
 2. Submit MR (if code changes)
 3. Clear hook_bead
-4. Sync worktree: `git checkout main && git pull`
-5. Set state to IDLE
-6. Session stays alive or cycles — doesn't matter, identity persists
+4. Set state to DONE
+5. Preserve branch/MR metadata for refinery/review
+6. Retire the live session
 
-### Sandbox Sync (DONE → IDLE transition)
+### Sandbox Retirement (DONE transition)
 
-When work completes and MR is merged (or no code changes):
+When work completes, `gt done` preserves the branch and handoff metadata:
 
 ```bash
-# In the polecat's worktree
-git checkout main
-git pull origin main
-git branch -D polecat/furiosa/<old-issue>+<timestamp>
-# Worktree is now clean, on main, ready for next assignment
+git push origin polecat/furiosa/<issue>@<suffix>
+# Refinery/review and cleanup own the remaining branch/worktree state
 ```
 
 When new work is slung:
@@ -115,7 +113,8 @@ No changes to refinery. Refinery still:
 2. Reviews and merges to main
 3. Deletes remote polecat branch (NEW: add this step)
 
-The polecat doesn't care — it already moved to main locally during DONE → IDLE.
+The polecat does not move to main locally during `gt done`; branch/MR metadata
+remains available for refinery/review and cleanup.
 
 ### Witness Integration
 
@@ -135,13 +134,13 @@ It should be rare and manual, not part of normal workflow.
 
 ### Branch Pollution Solution
 
-With persistent polecats, branches have clear owners:
+With retired completion, branches have clear owners:
 - Active branches: polecat is WORKING on them
 - Merged branches: refinery deletes after merge
-- Abandoned branches: polecat syncs to main on DONE → IDLE, old branch deleted locally
+- Abandoned branches: cleanup/recovery decides after durable handoff evidence
 
-The 219 stale branches came from nuked polecats that never cleaned up. With persistent
-polecats, branch lifecycle is managed by the polecat itself.
+The 219 stale branches came from nuked polecats that never cleaned up. Current
+branch lifecycle is managed by refinery/recovery, not local branch deletion in `gt done`.
 
 ### One-time Cleanup
 
@@ -156,23 +155,21 @@ git branch -r | grep 'origin/polecat/' | grep -v 'furiosa/gt-ziiu' | grep -v 'nu
 
 ### Phase 1: Stop the bleeding — SHIPPED
 - Witness no longer nukes idle polecats
-- `gt polecat done` transitions to IDLE instead of triggering nuke
+- `gt done` transitions to DONE and retires the session instead of local sync/reuse
 - Refinery deletes remote branch after merge
 
 ### Phase 2: Pool initialization — DEFERRED
 - `gt polecat pool init <rig>` creates N persistent polecats
 - Pool size configured in rig.config.json
-- Worktrees created once, reused across assignments
+- Worktrees are created for active work and retired after cleanup
 
-**Status:** Polecats are allocated on-demand by `gt sling` via `FindIdlePolecat()`
-and `AllocateAndAdd()`. Pre-allocation is unnecessary because idle polecats are
-reused automatically. Pool size enforcement is a future optimization, not a blocker.
+**Status:** Polecats are allocated on-demand by `gt sling` via capacity allocation.
+Pool size enforcement is a future optimization, not a blocker.
 
-### Phase 3: Sandbox sync — SHIPPED
-- DONE → IDLE transition syncs worktree to main (`done.go`)
-- IDLE → WORKING creates fresh branch (no worktree add) via `ReuseIdlePolecat()`
-- `gt sling` prefers idle polecats via `FindIdlePolecat()`
-- Branch-only reuse eliminates ~5s worktree creation overhead
+### Phase 3: Sandbox sync — SUPERSEDED
+- DONE no longer syncs the worktree to main in `gt done`
+- Clean completion sets done-state handoff and retires the session
+- Branch/MR metadata remains for refinery/review and cleanup
 
 ### Phase 4: Session independence — SHIPPED
 - Session cycling doesn't affect polecat state
@@ -189,8 +186,8 @@ reused automatically. Pool size enforcement is a future optimization, not a bloc
 
 | Component | Status | Key Files |
 |-----------|--------|-----------|
-| `gt done` (push, MR, idle, sandbox sync) | SHIPPED | `internal/cmd/done.go` |
-| `gt sling` (idle reuse, branch-only repair) | SHIPPED | `internal/cmd/sling.go`, `polecat_spawn.go` |
+| `gt done` (push, MR/PR handoff, done-state session retirement) | SHIPPED | `internal/cmd/done.go` |
+| `gt sling` (capacity allocation, branch setup) | SHIPPED | `internal/cmd/sling.go`, `polecat_spawn.go` |
 | `gt handoff` (session cycle, all roles) | SHIPPED | `internal/cmd/handoff.go` |
 | Witness patrol (zombie, stale, orphan detection) | SHIPPED | `internal/witness/handlers.go`, `internal/polecat/manager.go` |
 | Cleanup pipeline (POLECAT_DONE → MERGE_READY → MERGED) | SHIPPED | `internal/witness/handlers.go`, `internal/refinery/engineer.go` |

--- a/docs/design/polecat-lifecycle-patrol.md
+++ b/docs/design/polecat-lifecycle-patrol.md
@@ -448,7 +448,7 @@ safety net.
 
 ```
 AGENT-DRIVEN (preferred)              MECHANICAL (safety net)
-├── gt done (polecat goes idle)       ├── Daemon detects dead session
+├── gt done (polecat retires session) ├── Daemon detects dead session
 ├── gt handoff (polecat self-cycles)  ├── Daemon detects GUPP violation
 ├── gt escalate (polecat asks help)   ├── Witness zombie sweep
 └── HELP mail (polecat signals)       └── Deacon restart on stale heartbeat
@@ -632,8 +632,8 @@ All core lifecycle operations are implemented and running in production:
 | Work execution | `gt prime --hook` | Session discovers hook via `bd mol current`, GUPP fires |
 | Session cycling | `gt handoff` | `handoff.go` — all roles, preserves sandbox and identity |
 | Step completion | `bd close` + `gt handoff` | Step cleanup: session dies, sandbox lives |
-| Work submission | `gt done` | `done.go` — push, MR, sandbox sync, set idle |
-| Idle polecat reuse | `gt sling` | `polecat/manager.go`: `FindIdlePolecat()` + `ReuseIdlePolecat()` — branch-only repair |
+| Work submission | `gt done` | `done.go` — push, MR/PR handoff, set done, retire session |
+| Polecat allocation | `gt sling` | `polecat/manager.go` + `polecat_spawn.go` — capacity allocation and branch setup |
 | Zombie detection | Witness patrol | `witness/handlers.go`: `DetectZombiePolecats()` — restart-first, no auto-nuke |
 | Stale detection | Witness patrol | `polecat/manager.go`: `DetectStalePolecats()` — tmux-based, protects paused states |
 | Orphan recovery | Witness patrol | `witness/handlers.go`: `DetectOrphanedBeads()` — reset and re-dispatch |

--- a/docs/design/polecat-self-managed-completion.md
+++ b/docs/design/polecat-self-managed-completion.md
@@ -65,14 +65,14 @@ Polecat runs gt done
     ├── 5. Set agent_state = "done" (NOT idle)
     ├── 6. Clear hook_bead
     ├── 7. Nudge witness via tmux
-    ├── 8. Sync worktree to main, delete old branch
-    └── 9. Session goes idle (sandbox preserved)
+    ├── 8. Preserve branch/MR metadata for cleanup
+    └── 9. Session retires
          │
          ▼
     ┌─── WAIT ──────────────────────────────────────────┐
     │ Polecat is in "done" state.                       │
     │ Cannot accept new work until witness processes.    │
-    │ If witness is busy: polecat sits idle for minutes. │
+    │ If witness is busy: cleanup/refinery state remains.│
     └───────────────────────────────────────────────────┘
          │
          ▼ (next witness patrol cycle)
@@ -84,8 +84,8 @@ Witness survey-workers step
     │   ├── Create cleanup wisp (merge-requested state)
     │   ├── Send MERGE_READY to refinery
     │   └── Clear completion metadata
-    ├── Transition agent_state: done → idle
-    └── Polecat is now available for new work
+    ├── Resolve cleanup/refinery state
+    └── Completed polecat remains non-reusable until cleanup clears it
 ```
 
 **Time in "done" state:** 30s to several minutes, depending on witness patrol
@@ -103,12 +103,12 @@ Polecat runs gt done
     ├── 3. Create MR bead (type: merge-request, label: gt:merge-request)
     ├── 4. Write completion metadata to agent bead (for audit)
     ├── 5. Nudge refinery directly: "MERGE_READY <mr-id>"     ← NEW
-    ├── 6. Set agent_state = "idle"                           ← CHANGED
-    ├── 7. Clear hook_bead
-    ├── 8. Sync worktree to main, delete old branch
-    └── 9. Session goes idle (sandbox preserved)
-              │
-              └── Polecat is IMMEDIATELY available for new work
+    ├── 6. Set agent_state = "done"                           ← CURRENT
+	├── 7. Clear hook_bead
+	├── 8. Preserve branch/MR metadata
+	└── 9. Session retires
+	          │
+	          └── Cleanup/refinery owns remaining state
 ```
 
 **Key changes:**

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -260,8 +260,8 @@ with = "macro-formula"
 ```
 1. Work through formula checklist (shown inline by gt prime)
 2. Submit to merge queue via gt done
-3. gt done nukes sandbox and exits
-4. Witness removes worktree + branch
+3. gt done preserves branch/MR metadata and exits the session
+4. Witness/refinery cleanup handles any retired sandbox state
 ```
 
 ### Session Cycling

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -39,8 +39,8 @@ This is a convenience command for polecats that:
 1. Submits the current branch to the merge queue
 2. Auto-detects issue ID from branch name
 3. Notifies the Witness with the exit outcome
-4. Syncs worktree to main and transitions polecat to IDLE
-   (sandbox preserved, session stays alive for reuse)
+4. Exits the polecat session after durable handoff
+   (Witness/refinery cleanup owns the retired sandbox)
 
 Exit statuses:
   COMPLETED      - Work done, MR submitted (default)
@@ -48,7 +48,7 @@ Exit statuses:
   DEFERRED       - Work paused, issue still open
 
 Examples:
-  gt done                              # Submit branch, notify COMPLETED, transition to IDLE
+  gt done                              # Submit branch, notify COMPLETED, exit session
   gt done --pre-verified               # Submit with pre-verification fast-path
   gt done --target feat/my-branch      # Explicit MR target branch
   gt done --pre-verified --target feat/contract-review  # Pre-verified with explicit target
@@ -90,11 +90,48 @@ func doneContaminationBaseRef(defaultBranch, explicitTarget string) string {
 	return "origin/" + targetBranch
 }
 
-func shouldSyncIdlePolecatWorktree(exitType, mergeStrategy string, pushFailed, mrFailed, syncSafe bool) bool {
-	if exitType != ExitCompleted || pushFailed || mrFailed || !syncSafe {
+func shouldUpdateAgentStateOnDone(pushFailed, mrFailed bool) bool {
+	return !pushFailed && !mrFailed
+}
+
+func shouldRetirePolecatSessionAfterDone(exitType, mergeStrategy string, pushFailed, mrFailed bool) bool {
+	if exitType != ExitCompleted || pushFailed || mrFailed {
 		return false
 	}
 	return mergeStrategy != "local"
+}
+
+type doneSessionKiller interface {
+	KillSessionWithProcessesExcluding(name string, excludePIDs []string) error
+}
+
+var newDoneSessionKiller = func() doneSessionKiller {
+	return tmux.NewTmux()
+}
+
+var updateAgentStateOnDoneFn = updateAgentStateOnDone
+
+func updateAgentStateAfterSubmission(cwd, townRoot, exitType, issueID string, pushFailed, mrFailed bool) error {
+	if !shouldUpdateAgentStateOnDone(pushFailed, mrFailed) {
+		style.PrintWarning("skipping agent cleanup because push or MR submission failed")
+		return nil
+	}
+	return updateAgentStateOnDoneFn(cwd, townRoot, exitType, issueID)
+}
+
+func polecatSessionRetirementTarget(rigName, polecatName string, pid int) (string, []string, bool) {
+	if rigName == "" || polecatName == "" || pid <= 0 {
+		return "", nil, false
+	}
+	return session.PolecatSessionName(session.PrefixFor(rigName), polecatName), []string{fmt.Sprintf("%d", pid)}, true
+}
+
+func retirePolecatSessionAfterDone(rigName, polecatName string, pid int) error {
+	sessionName, excludePIDs, ok := polecatSessionRetirementTarget(rigName, polecatName, pid)
+	if !ok {
+		return nil
+	}
+	return newDoneSessionKiller().KillSessionWithProcessesExcluding(sessionName, excludePIDs)
 }
 
 func cleanupStatusAfterSuccessfulPush(status string) string {
@@ -366,9 +403,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		return fmt.Errorf("invalid exit status '%s': must be COMPLETED, ESCALATED, or DEFERRED", doneStatus)
 	}
 
-	// Persistent polecat model (gt-hdf8): sessions stay alive after gt done.
-	// No deferred session kill — the polecat transitions to IDLE with sandbox
-	// preserved. The Witness handles any cleanup if the polecat gets stuck.
+	// Clean completions retire the live polecat session after durable handoff.
+	// Failed, deferred, escalated, and local-review paths preserve the session for recovery.
 
 	// Find workspace with fallback for deleted worktrees (hq-3xaxy)
 	// If the polecat's worktree was deleted by Witness before gt done finishes,
@@ -687,8 +723,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// leaves the existing warnings.
 		ensureAgentBeadExists(beads.New(cwd).ForAgentBead(), agentBeadID, ctx)
 
-		// Persistent polecat model (gt-hdf8): no deferred session kill.
-		// Sessions stay alive after gt done — polecat transitions to IDLE.
+		// Completion now exits the live polecat session after durable handoff.
+		// The agent bead keeps lifecycle metadata for witness/refinery cleanup.
 	}
 	polecatName := ""
 	if parts := strings.Split(sender, "/"); len(parts) >= 2 {
@@ -1721,8 +1757,9 @@ notifyWitness:
 		style.PrintWarning("could not log feed event: %v", err)
 	}
 
-	// Update agent bead state (ZFC: self-report completion)
-	if err := updateAgentStateOnDone(cwd, townRoot, exitType, issueID); err != nil {
+	// Update agent bead state (ZFC: self-report completion). If push/MR failed,
+	// keep the hook intact so Witness can recover the still-open work.
+	if err := updateAgentStateAfterSubmission(cwd, townRoot, exitType, issueID, pushFailed, mrFailed); err != nil {
 		return err
 	}
 
@@ -1732,38 +1769,15 @@ notifyWitness:
 	nudgeWitness(rigName, fmt.Sprintf("POLECAT_DONE %s exit=%s", polecatName, exitType))
 	fmt.Printf("%s Witness notified of %s (via nudge)\n", style.Bold.Render("✓"), exitType)
 
-	// Persistent polecat model (gt-hdf8): polecats transition to IDLE after completion.
-	// Session stays alive, sandbox preserved, worktree synced to main for reuse.
-	// "done means idle" - not "done means dead".
+	// Clean successful polecats are retired after durable handoff. Preserve the
+	// feature branch and metadata; Witness/refinery cleanup owns the sandbox.
 	isPolecat := false
+	retirePolecat := false
 	if roleInfo, err := GetRoleWithContext(cwd, townRoot); err == nil && roleInfo.Role == RolePolecat {
 		isPolecat = true
 
-		fmt.Printf("%s Sandbox preserved for reuse (persistent polecat)\n", style.Bold.Render("✓"))
-
 		if pushFailed || mrFailed {
 			fmt.Printf("%s Work needs recovery (push or MR failed) — session preserved\n", style.Bold.Render("⚠"))
-		}
-
-		// Sync worktree to main so the polecat is ready for new assignments.
-		// Phase 3 of persistent-polecat-pool: DONE→IDLE syncs to main and deletes old branch.
-		// Non-fatal: if sync fails, the polecat is still IDLE and the Witness
-		// or next gt sling can handle the branch state.
-		//
-		// GUARD (gt-pvx): Refuse to sync if uncommitted changes remain.
-		// If the auto-commit safety net above failed (git add/commit error),
-		// switching branches would discard the work. Better to leave the worktree
-		// dirty on the feature branch so work can be recovered.
-		syncSafe := true
-		if cwdAvailable {
-			if ws, wsErr := g.CheckUncommittedWork(); wsErr != nil {
-				syncSafe = false
-				style.PrintWarning("could not inspect worktree before idle sync: %v — skipping sync to preserve work", wsErr)
-			} else if ws.HasUncommittedChanges && !ws.CleanExcludingRuntime() {
-				syncSafe = false
-				style.PrintWarning("uncommitted changes still present — skipping worktree sync to preserve work")
-				fmt.Printf("  Files: %s\n", ws.String())
-			}
 		}
 		if exitType == ExitCompleted && issueID != "" && convoyInfo == nil {
 			convoyInfo = getConvoyInfoFromIssue(issueID, cwd)
@@ -1775,41 +1789,12 @@ notifyWitness:
 		if convoyInfo != nil {
 			mergeStrategy = convoyInfo.MergeStrategy
 		}
-		if cwdAvailable && shouldSyncIdlePolecatWorktree(exitType, mergeStrategy, pushFailed, mrFailed, syncSafe) {
-			// Remember the old branch so we can delete it after switching
-			oldBranch := branch
-
-			fmt.Printf("%s Syncing worktree to %s...\n", style.Bold.Render("→"), defaultBranch)
-			syncRef := g.CleanDefaultBranchBaseRef("origin", defaultBranch)
-			fetchRemote := git.RemoteForRef(syncRef)
-			if fetchRemote == "" {
-				fetchRemote = "origin"
-			}
-			if err := g.Fetch(fetchRemote); err != nil {
-				style.PrintWarning("could not fetch %s before idle sync: %v (using local refs)", fetchRemote, err)
-			}
-			if err := g.CheckoutDetach(syncRef); err != nil {
-				if fallbackErr := g.CheckoutDetach(defaultBranch); fallbackErr != nil {
-					style.PrintWarning("could not detach checkout %s: %v; fallback %s also failed: %v (worktree stays on feature branch)", syncRef, err, defaultBranch, fallbackErr)
-				} else {
-					fmt.Printf("%s Worktree synced to %s (detached fallback)\n", style.Bold.Render("✓"), defaultBranch)
-				}
-			} else {
-				fmt.Printf("%s Worktree synced to %s (detached)\n", style.Bold.Render("✓"), syncRef)
-			}
-
-			// Delete the old polecat branch (non-fatal: cleanup only).
-			// This prevents stale branch accumulation from persistent polecats.
-			if oldBranch != "" && oldBranch != defaultBranch && oldBranch != "master" {
-				if err := g.DeleteBranch(oldBranch, true); err != nil {
-					style.PrintWarning("could not delete old branch %s: %v", oldBranch, err)
-				} else {
-					fmt.Printf("%s Deleted old branch %s\n", style.Bold.Render("✓"), oldBranch)
-				}
-			}
+		retirePolecat = shouldRetirePolecatSessionAfterDone(exitType, mergeStrategy, pushFailed, mrFailed)
+		if retirePolecat {
+			fmt.Printf("%s Polecat session retiring after durable handoff\n", style.Bold.Render("✓"))
+		} else {
+			fmt.Printf("%s Session preserved for recovery or local review\n", style.Bold.Render("→"))
 		}
-
-		fmt.Printf("%s Polecat transitioned to IDLE — ready for new work\n", style.Bold.Render("✓"))
 	}
 
 	fmt.Println()
@@ -1818,21 +1803,12 @@ notifyWitness:
 		fmt.Printf("  Witness will handle cleanup.\n")
 	}
 
-	// Self-terminate AFTER all cleanup is complete (opt-in via config).
-	// When enabled, polecats kill their session after gt done finishes
-	// instead of transitioning to IDLE. This gives fresh context windows
-	// per task, reduces token waste, and eliminates stale state bugs.
-	// Must be the LAST thing gt done does — everything above must complete first.
-	if isPolecat {
-		daemonCfg := config.LoadOperationalConfig(townRoot).GetDaemonConfig()
-		if daemonCfg.PolecatSelfTerminate != nil && *daemonCfg.PolecatSelfTerminate {
-			fmt.Printf("%s Self-terminating session (polecat_self_terminate=true)\n", style.Bold.Render("✓"))
-			sessionName := session.PolecatSessionName(session.PrefixFor(rigName), polecatName)
-			go func() {
-				time.Sleep(3 * time.Second)
-				t := tmux.NewTmux()
-				_ = t.KillSessionWithProcesses(sessionName)
-			}()
+	// Retire the live session as the final action. The PID exclusion prevents
+	// killing gt done before all metadata and notifications above are written.
+	if retirePolecat {
+		fmt.Printf("%s Terminating polecat session\n", style.Bold.Render("→"))
+		if err := retirePolecatSessionAfterDone(rigName, polecatName, os.Getpid()); err != nil {
+			style.PrintWarning("could not terminate polecat session: %v", err)
 		}
 	}
 
@@ -2089,9 +2065,9 @@ func clearDoneCheckpoints(bd *beads.Beads, agentBeadID string) {
 // Uses issueID directly to find the hooked bead instead of reading the agent bead's
 // hook_bead slot (hq-l6mm5: direct bead tracking).
 //
-// Per gt-zecmc: observable states ("done", "idle") removed - use tmux to discover.
-// Non-observable states ("stuck", "awaiting-gate") are still set since they represent
-// intentional agent decisions that can't be observed from tmux.
+// Clean completions use "done" to prevent dead completed sessions from
+// re-entering the idle reuse pool before witness/refinery cleanup finishes.
+// Escalated/deferred exits use "stuck" because they need recovery.
 //
 // Also self-reports cleanup_status for ZFC compliance (#10).
 //
@@ -2262,14 +2238,10 @@ doneStateUpdate:
 	// Best-effort: failures are non-fatal since the work is already done.
 	purgeClosedEphemeralBeads(bd)
 
-	// Self-managed completion (gt-1qlg, polecat-self-managed-completion.md Phase 2):
-	// Polecat sets agent_state=idle directly, skipping the intermediate "done" state.
-	// The witness is no longer in the critical path for routine completions.
 	// Completion metadata (exit_type, MR ID, branch) remains on the agent bead
 	// for audit purposes and anomaly detection by witness patrol.
-	// Exception: ESCALATED exits use "stuck" — the polecat needs help.
-	doneState := "idle"
-	if exitType == ExitEscalated {
+	doneState := string(beads.AgentStateDone)
+	if exitType != ExitCompleted {
 		doneState = "stuck"
 	}
 	// Use UpdateAgentState to sync both column and description (gt-ulom).

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	gitpkg "github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/session"
 )
 
 // TestDoneUsesResolveBeadsDir verifies that the done command correctly uses
@@ -776,35 +777,144 @@ func TestShouldNudgeRefinery(t *testing.T) {
 	}
 }
 
-func TestShouldSyncIdlePolecatWorktree(t *testing.T) {
+func TestShouldUpdateAgentStateOnDone(t *testing.T) {
+	tests := []struct {
+		name       string
+		pushFailed bool
+		mrFailed   bool
+		want       bool
+	}{
+		{"clean submission updates state", false, false, true},
+		{"push failure preserves hook", true, false, false},
+		{"mr failure preserves hook", false, true, false},
+		{"both failures preserve hook", true, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldUpdateAgentStateOnDone(tt.pushFailed, tt.mrFailed)
+			if got != tt.want {
+				t.Errorf("shouldUpdateAgentStateOnDone(%v, %v) = %v, want %v", tt.pushFailed, tt.mrFailed, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateAgentStateAfterSubmissionSkipsFailedSubmissions(t *testing.T) {
+	calls := 0
+	old := updateAgentStateOnDoneFn
+	updateAgentStateOnDoneFn = func(cwd, townRoot, exitType, issueID string) error {
+		calls++
+		return nil
+	}
+	t.Cleanup(func() { updateAgentStateOnDoneFn = old })
+
+	if err := updateAgentStateAfterSubmission("/work", "/town", ExitCompleted, "gt-abc", true, false); err != nil {
+		t.Fatalf("updateAgentStateAfterSubmission push failure: %v", err)
+	}
+	if err := updateAgentStateAfterSubmission("/work", "/town", ExitCompleted, "gt-abc", false, true); err != nil {
+		t.Fatalf("updateAgentStateAfterSubmission mr failure: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("state update calls after failed submissions = %d, want 0", calls)
+	}
+
+	if err := updateAgentStateAfterSubmission("/work", "/town", ExitCompleted, "gt-abc", false, false); err != nil {
+		t.Fatalf("updateAgentStateAfterSubmission clean submission: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("state update calls after clean submission = %d, want 1", calls)
+	}
+}
+
+func TestShouldRetirePolecatSessionAfterDone(t *testing.T) {
 	tests := []struct {
 		name          string
 		exitType      string
 		mergeStrategy string
 		pushFailed    bool
 		mrFailed      bool
-		syncSafe      bool
 		want          bool
 	}{
-		{"completed default strategy syncs", ExitCompleted, "", false, false, true, true},
-		{"completed direct strategy syncs", ExitCompleted, "direct", false, false, true, true},
-		{"completed mr strategy syncs", ExitCompleted, "mr", false, false, true, true},
-		{"local strategy keeps branch", ExitCompleted, "local", false, false, true, false},
-		{"deferred keeps branch", ExitDeferred, "", false, false, true, false},
-		{"escalated keeps branch", ExitEscalated, "", false, false, true, false},
-		{"push failure keeps branch", ExitCompleted, "", true, false, true, false},
-		{"mr failure keeps branch", ExitCompleted, "", false, true, true, false},
-		{"unsafe sync keeps branch", ExitCompleted, "", false, false, false, false},
+		{"completed default strategy retires", ExitCompleted, "", false, false, true},
+		{"completed direct strategy retires", ExitCompleted, "direct", false, false, true},
+		{"completed mr strategy retires", ExitCompleted, "mr", false, false, true},
+		{"local strategy preserves session", ExitCompleted, "local", false, false, false},
+		{"deferred preserves session", ExitDeferred, "", false, false, false},
+		{"escalated preserves session", ExitEscalated, "", false, false, false},
+		{"push failure preserves session", ExitCompleted, "", true, false, false},
+		{"mr failure preserves session", ExitCompleted, "", false, true, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shouldSyncIdlePolecatWorktree(tt.exitType, tt.mergeStrategy, tt.pushFailed, tt.mrFailed, tt.syncSafe)
+			got := shouldRetirePolecatSessionAfterDone(tt.exitType, tt.mergeStrategy, tt.pushFailed, tt.mrFailed)
 			if got != tt.want {
-				t.Errorf("shouldSyncIdlePolecatWorktree(%q, %q, %v, %v, %v) = %v, want %v",
-					tt.exitType, tt.mergeStrategy, tt.pushFailed, tt.mrFailed, tt.syncSafe, got, tt.want)
+				t.Errorf("shouldRetirePolecatSessionAfterDone(%q, %q, %v, %v) = %v, want %v",
+					tt.exitType, tt.mergeStrategy, tt.pushFailed, tt.mrFailed, got, tt.want)
 			}
 		})
+	}
+}
+
+type fakeDoneSessionKiller struct {
+	name        string
+	excludePIDs []string
+	calls       int
+}
+
+func (f *fakeDoneSessionKiller) KillSessionWithProcessesExcluding(name string, excludePIDs []string) error {
+	f.calls++
+	f.name = name
+	f.excludePIDs = append([]string(nil), excludePIDs...)
+	return nil
+}
+
+func TestRetirePolecatSessionAfterDoneUsesPIDExclusion(t *testing.T) {
+	fake := &fakeDoneSessionKiller{}
+	old := newDoneSessionKiller
+	newDoneSessionKiller = func() doneSessionKiller { return fake }
+	t.Cleanup(func() { newDoneSessionKiller = old })
+
+	if err := retirePolecatSessionAfterDone("gastown", "nitro", 12345); err != nil {
+		t.Fatalf("retirePolecatSessionAfterDone: %v", err)
+	}
+	if fake.calls != 1 {
+		t.Fatalf("killer calls = %d, want 1", fake.calls)
+	}
+	wantSession := session.PolecatSessionName(session.PrefixFor("gastown"), "nitro")
+	if fake.name != wantSession {
+		t.Fatalf("session name = %q, want %q", fake.name, wantSession)
+	}
+	if len(fake.excludePIDs) != 1 || fake.excludePIDs[0] != "12345" {
+		t.Fatalf("excludePIDs = %#v, want [12345]", fake.excludePIDs)
+	}
+}
+
+func TestRetirePolecatSessionAfterDoneNoopsWithoutIdentity(t *testing.T) {
+	fake := &fakeDoneSessionKiller{}
+	old := newDoneSessionKiller
+	newDoneSessionKiller = func() doneSessionKiller { return fake }
+	t.Cleanup(func() { newDoneSessionKiller = old })
+
+	for _, tt := range []struct {
+		name        string
+		rigName     string
+		polecatName string
+		pid         int
+	}{
+		{"missing rig", "", "nitro", 12345},
+		{"missing polecat", "gastown", "", 12345},
+		{"missing pid", "gastown", "nitro", 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := retirePolecatSessionAfterDone(tt.rigName, tt.polecatName, tt.pid); err != nil {
+				t.Fatalf("retirePolecatSessionAfterDone: %v", err)
+			}
+		})
+	}
+	if fake.calls != 0 {
+		t.Fatalf("killer calls = %d, want 0", fake.calls)
 	}
 }
 

--- a/internal/cmd/polecat_inventory.go
+++ b/internal/cmd/polecat_inventory.go
@@ -92,6 +92,10 @@ func buildPolecatInventoryItemFromEvidence(rigName, polecatName string, fields *
 		item.CleanupStatus = strings.TrimSpace(fields.CleanupStatus)
 		item.ActiveMR = strings.TrimSpace(fields.ActiveMR)
 		item.Branch = strings.TrimSpace(fields.Branch)
+		switch beads.AgentState(strings.TrimSpace(fields.AgentState)) {
+		case beads.AgentStateDone:
+			item.State = polecat.StateDone
+		}
 		input.CleanupStatus = polecat.CleanupStatus(item.CleanupStatus)
 		input.PushFailed = fields.PushFailed
 		input.MRFailed = fields.MRFailed
@@ -116,7 +120,7 @@ func buildPolecatInventoryItemFromEvidence(rigName, polecatName string, fields *
 		}
 		input.ActiveWorkBlocker = activeWorkEvidence.Blocker
 		input.ActiveWorkCountsTowardCapacity = activeWorkEvidence.CountsTowardCapacity
-	} else if running && !polecat.CleanupStatus(item.CleanupStatus).IsSafe() {
+	} else if item.State == polecat.StateIdle && running && !polecat.CleanupStatus(item.CleanupStatus).IsSafe() {
 		item.State = polecat.StateReviewNeeded
 	}
 

--- a/internal/cmd/polecat_inventory_test.go
+++ b/internal/cmd/polecat_inventory_test.go
@@ -106,6 +106,22 @@ func TestBuildPolecatInventoryItem(t *testing.T) {
 			wantState:   polecat.StateIdle,
 			wantVerdict: polecat.WorkstateVerdictPendingMR,
 		},
+		{
+			name:         "done without active mr is not reusable",
+			polecatName:  "done",
+			fields:       &beads.AgentFields{AgentState: string(beads.AgentStateDone), CleanupStatus: string(polecat.CleanupClean)},
+			wantState:    polecat.StateDone,
+			wantVerdict:  polecat.WorkstateVerdictNeedsRecovery,
+			wantRecovery: true,
+			wantCapacity: true,
+		},
+		{
+			name:        "done with active mr remains pending",
+			polecatName: "donepending",
+			fields:      &beads.AgentFields{AgentState: string(beads.AgentStateDone), CleanupStatus: string(polecat.CleanupClean), ActiveMR: "gt-mr"},
+			wantState:   polecat.StateDone,
+			wantVerdict: polecat.WorkstateVerdictPendingMR,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2232,9 +2232,7 @@ func (m *Manager) List() ([]*Polecat, error) {
 }
 
 // FindIdlePolecat returns the first idle polecat in the rig, or nil if none.
-// Idle polecats have completed their work and have a preserved sandbox (worktree)
-// that can be reused by gt sling without creating a new worktree.
-// Persistent polecat model (gt-4ac).
+// Idle means no hook, no active session, and no pending completion/MR cleanup state.
 func (m *Manager) FindIdlePolecat() (*Polecat, error) {
 	polecats, err := m.List()
 	if err != nil {
@@ -2780,13 +2778,21 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 		issueID = issue.ID
 	}
 
-	state := StateIdle
+	agentState := StateIdle
+	if agentErr == nil && fields != nil {
+		switch beads.AgentState(strings.TrimSpace(fields.AgentState)) {
+		case beads.AgentStateDone:
+			agentState = StateDone
+		}
+	}
+
+	state := agentState
 	if issueID != "" {
 		state = StateWorking
 		if sessionDead {
 			state = StateStalled
 		}
-	} else if sessionRunning && !sessionStale && !m.getCleanupStatusFromBead(name).IsSafe() {
+	} else if agentState == StateIdle && sessionRunning && !sessionStale && !m.getCleanupStatusFromBead(name).IsSafe() {
 		state = StateReviewNeeded
 	}
 

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -303,6 +303,56 @@ func createStalePolecatCommit(t *testing.T, repoPath, startPoint, branchName str
 	return sha
 }
 
+func TestManagerGetMapsDoneAgentStateFromBead(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script bd stub not supported on Windows")
+	}
+
+	binDir := t.TempDir()
+	bdScript := `#!/bin/sh
+cmd=""
+for arg in "$@"; do
+  case "$arg" in --*) ;; *) cmd="$arg"; break ;; esac
+done
+case "$cmd" in
+  list)
+    echo '[]'
+    ;;
+  show)
+    echo '[{"id":"gt-testrig-polecat-toast","title":"agent","issue_type":"agent","status":"open","description":"agent\n\nrole_type: polecat\nrig: testrig\nagent_state: done\nhook_bead: null\ncleanup_status: clean"}]'
+    ;;
+  config|update|slot)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "testrig")
+	if err := os.MkdirAll(filepath.Join(rigPath, "polecats", "toast", "testrig"), 0755); err != nil {
+		t.Fatalf("mkdir polecat path: %v", err)
+	}
+
+	mgr := NewManager(&rig.Rig{Name: "testrig", Path: rigPath}, git.NewGit(rigPath), nil)
+	p, err := mgr.Get("toast")
+	if err != nil {
+		t.Fatalf("mgr.Get(toast): %v", err)
+	}
+	if p.State != StateDone {
+		t.Fatalf("polecat state = %q, want %q", p.State, StateDone)
+	}
+	if p.Issue != "" {
+		t.Fatalf("polecat issue = %q, want empty", p.Issue)
+	}
+}
+
 func TestStateIsWorking(t *testing.T) {
 	tests := []struct {
 		state   State

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -319,7 +319,7 @@ case "$cmd" in
     echo '[]'
     ;;
   show)
-    echo '[{"id":"gt-testrig-polecat-toast","title":"agent","issue_type":"agent","status":"open","description":"agent\n\nrole_type: polecat\nrig: testrig\nagent_state: done\nhook_bead: null\ncleanup_status: clean"}]'
+    printf '%s\n' '[{"id":"gt-testrig-polecat-toast","title":"agent","issue_type":"agent","status":"open","description":"agent\n\nrole_type: polecat\nrig: testrig\nagent_state: done\nhook_bead: null\ncleanup_status: clean"}]'
     ;;
   config|update|slot)
     exit 0

--- a/internal/polecat/namepool.go
+++ b/internal/polecat/namepool.go
@@ -18,9 +18,8 @@ import (
 
 const (
 	// DefaultPoolSize is the number of name slots in the pool.
-	// Names are allocated when a polecat is first created. In the persistent
-	// polecat model (gt-4ac), polecats cycle IDLE → WORKING → DONE → IDLE,
-	// keeping their name, identity, and sandbox across assignments.
+	// Names are allocated when a polecat is first created. Polecat identity persists,
+	// while clean completion retires the live session and cleanup owns remaining state.
 	DefaultPoolSize = 50
 
 	// DefaultTheme is the default theme for new rigs.

--- a/internal/polecat/types.go
+++ b/internal/polecat/types.go
@@ -5,22 +5,23 @@ import "time"
 
 // State represents the current lifecycle state of a polecat.
 //
-// Polecats are PERSISTENT: they survive work completion and can be reused.
-// The four operating states are:
+// Polecat identity is persistent, but clean completion retires the live session.
+// The primary operating states are:
 //
 //   - Working: Session active, doing assigned work (normal operation)
-//   - Idle: Work completed, session killed, sandbox preserved for reuse
+//   - Idle: Available before assignment, with no pending completion cleanup
+//   - Done: Work completed, session retired, cleanup/refinery still owns state
 //   - ReviewNeeded: Session is live but no active work bead is attached
 //   - Stalled: Session stopped unexpectedly, was never nudged back to life
 //   - Zombie: Session called 'gt done' but cleanup failed - tried to die but couldn't
 //
-// The distinction matters: idle polecats completed their work successfully and
-// are ready for new assignments. Stalled polecats failed mid-work. Zombies
-// tried to exit but couldn't complete cleanup.
+// The distinction matters: idle polecats are available capacity. Done polecats
+// completed work and are waiting for cleanup/refinery state to clear. Stalled
+// polecats failed mid-work. Zombies tried to exit but couldn't complete cleanup.
 //
-// Note: These are LIFECYCLE states. The polecat IDENTITY (CV chain, mailbox, work
-// history) and SANDBOX (worktree) persist across sessions. An idle polecat keeps
-// its worktree so it can be quickly reassigned without creating a new one.
+// Note: These are LIFECYCLE states. The polecat IDENTITY (CV chain, mailbox,
+// work history) persists across sessions. Worktrees persist only while active
+// or awaiting cleanup; they are not reused after clean completion with pending state.
 //
 // "Stalled", "zombie", and related conditions are detected at query time by
 // cross-checking tmux session liveness against beads state. The Witness also
@@ -32,10 +33,8 @@ const (
 	// This is the initial and primary state after sling.
 	StateWorking State = "working"
 
-	// StateIdle means the polecat completed its work and the session was killed,
-	// but the sandbox (worktree) is preserved for reuse. An idle polecat has no
-	// hook_bead and no active session. It can be reassigned via gt sling without
-	// creating a new worktree.
+	// StateIdle means the polecat is available before assignment. It has no
+	// hook_bead, no active session, and no pending completion/MR cleanup state.
 	StateIdle State = "idle"
 
 	// StateDone means the polecat has completed its assigned work and called

--- a/internal/polecat/workstate.go
+++ b/internal/polecat/workstate.go
@@ -57,7 +57,7 @@ type WorkstateDisposition struct {
 
 // DecideWorkstate returns the canonical disposition for a polecat.
 func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
-	if in.ActiveMRBlocker != "" && !in.PushFailed && !in.MRFailed && (in.State == StateIdle || in.State == StateDone) {
+	if in.ActiveMRBlocker != "" && !in.PushFailed && !in.MRFailed && in.State == StateDone {
 		return WorkstateDisposition{
 			Verdict:     WorkstateVerdictPendingMR,
 			Reason:      "active-mr-open",

--- a/internal/polecat/workstate.go
+++ b/internal/polecat/workstate.go
@@ -57,6 +57,15 @@ type WorkstateDisposition struct {
 
 // DecideWorkstate returns the canonical disposition for a polecat.
 func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
+	if in.ActiveMRBlocker != "" && !in.PushFailed && !in.MRFailed && (in.State == StateIdle || in.State == StateDone) {
+		return WorkstateDisposition{
+			Verdict:     WorkstateVerdictPendingMR,
+			Reason:      "active-mr-open",
+			ReuseStatus: "idle-pr-open",
+			Blockers:    []string{in.ActiveMRBlocker},
+		}
+	}
+
 	if in.State != StateIdle {
 		verdict := WorkstateVerdictNeedsRecovery
 		needsRecovery := true

--- a/internal/polecat/workstate_test.go
+++ b/internal/polecat/workstate_test.go
@@ -94,6 +94,11 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 			want: WorkstateDisposition{Verdict: WorkstateVerdictPendingMR, Reason: "active-mr-open", ReuseStatus: "idle-pr-open"},
 		},
 		{
+			name: "open active mr does not hide cleanup blocker",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupUnpushed, ActiveMR: "gt-mr-open", ActiveMRBlocker: "active_mr=gt-mr-open status=open"},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "cleanup-has_unpushed", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed", Blockers: []string{"cleanup_status=has_unpushed", "active_mr=gt-mr-open status=open"}},
+		},
+		{
 			name: "done active mr remains pending mr",
 			in:   WorkstateInput{State: StateDone, CleanupStatus: CleanupClean, ActiveMR: "gt-mr-open", ActiveMRBlocker: "active_mr=gt-mr-open status=open"},
 			want: WorkstateDisposition{Verdict: WorkstateVerdictPendingMR, Reason: "active-mr-open", ReuseStatus: "idle-pr-open", Blockers: []string{"active_mr=gt-mr-open status=open"}},

--- a/internal/polecat/workstate_test.go
+++ b/internal/polecat/workstate_test.go
@@ -94,6 +94,16 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 			want: WorkstateDisposition{Verdict: WorkstateVerdictPendingMR, Reason: "active-mr-open", ReuseStatus: "idle-pr-open"},
 		},
 		{
+			name: "done active mr remains pending mr",
+			in:   WorkstateInput{State: StateDone, CleanupStatus: CleanupClean, ActiveMR: "gt-mr-open", ActiveMRBlocker: "active_mr=gt-mr-open status=open"},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictPendingMR, Reason: "active-mr-open", ReuseStatus: "idle-pr-open", Blockers: []string{"active_mr=gt-mr-open status=open"}},
+		},
+		{
+			name: "done without mr blocks reuse until cleanup",
+			in:   WorkstateInput{State: StateDone, CleanupStatus: CleanupClean},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "not-idle", NeedsRecovery: true, CountsTowardCapacity: true},
+		},
+		{
 			name: "working counts as working capacity",
 			in:   WorkstateInput{State: StateWorking, CleanupStatus: CleanupClean},
 			want: WorkstateDisposition{Verdict: WorkstateVerdictWorking, Reason: "not-idle", NeedsRecovery: false, CountsTowardCapacity: true},

--- a/internal/templates/commands/bodies/done.md
+++ b/internal/templates/commands/bodies/done.md
@@ -39,5 +39,5 @@ bd close <issue-id> --reason="no-changes: <brief explanation>"
 gt done
 ```
 
-This command pushes your branch, submits an MR to the merge queue, and transitions
-you to IDLE. The Refinery handles the actual merge. You are done after this.
+This command pushes your branch, submits an MR to the merge queue, and exits the
+polecat session after durable handoff. The Refinery/Witness handle merge and cleanup.


### PR DESCRIPTION
## Summary
- Supersedes #4222 with a clean current-main replacement.
- Retires clean `gt done` polecat sessions after durable handoff instead of returning them to idle reuse.
- Preserves branch/MR metadata and failed-submission recovery state; avoids local branch deletion and sandbox self-nuke behavior.
- Updates lifecycle docs and focused tests for done-state non-reuse, pending-MR visibility, and PID-excluding session termination.

## Attribution
This replacement carries forward the bugfix intent from #4222 by @adamziel / Adam Zieliński (`0d8d46e4a74e75a85115e5c4743b1e852ea0cfc2`). It is a clean reimplementation from current `main`, not a merge of the original conflicting branch.

## Verification
- `CGO_ENABLED=0 go test ./internal/cmd -run 'TestShouldUpdateAgentStateOnDone|TestUpdateAgentStateAfterSubmissionSkipsFailedSubmissions|TestShouldRetirePolecatSessionAfterDone|TestRetirePolecatSessionAfterDoneUsesPIDExclusion|TestRetirePolecatSessionAfterDoneNoopsWithoutIdentity|TestBuildPolecatInventoryItem|TestApplyAgentFieldsToCapacitySnapshot|TestWorkstateDispositionProjectionAgreement|TestPolecatReuseStatus' -count=1`\n- `CGO_ENABLED=0 go test ./internal/polecat -run 'TestManagerGetMapsDoneAgentStateFromBead|TestDecideWorkstateCanonicalFields|TestReuseIdlePolecat_KillsLiveSession|TestRepairWorktreeWithOptions_KillsLiveSession' -count=1`\n- `CGO_ENABLED=0 go build ./cmd/gt`\n\n## Notes\n- Plain `go test` on this host requires ICU headers for `github.com/dolthub/go-icu-regex`; local verification used `CGO_ENABLED=0`, matching the Gastown dogfood workaround.\n- Keep #4222 open until this replacement lands; then close #4222 as superseded with a link to this PR.