### PR TITLE
fix: reclaim agent-dead dogs

### DIFF
--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -79,8 +79,8 @@ func (d *Daemon) handleDogsCleanupOnly() {
 	// Skip dispatchPlugins — under pressure
 }
 
-// cleanupStuckDogs finds dogs in state=working whose tmux session is dead and
-// clears their work so they return to idle.
+// cleanupStuckDogs finds dogs in state=working whose tmux session or agent
+// process is dead and clears their work so they return to idle.
 func (d *Daemon) cleanupStuckDogs(mgr *dog.Manager, sm *dog.SessionManager) {
 	dogs, err := mgr.List()
 	if err != nil {
@@ -88,27 +88,50 @@ func (d *Daemon) cleanupStuckDogs(mgr *dog.Manager, sm *dog.SessionManager) {
 		return
 	}
 
+	t := tmux.NewTmux()
 	for _, dg := range dogs {
 		if dg.State != dog.StateWorking {
 			continue
 		}
 
+		sessionID := sm.SessionName(dg.Name)
 		running, err := sm.IsRunning(dg.Name)
 		if err != nil {
 			d.logger.Printf("Handler: error checking session for dog %s: %v", dg.Name, err)
 			continue
 		}
 
-		if running {
+		if !running {
+			d.logger.Printf("Handler: dog %s is working but session is dead, clearing work", dg.Name)
+			d.clearDogWorkIfMatches(mgr, dg, "dead session")
 			continue
 		}
 
-		// Dog is marked working but session is dead — clean it up.
-		d.logger.Printf("Handler: dog %s is working but session is dead, clearing work", dg.Name)
-		if err := mgr.ClearWork(dg.Name); err != nil {
-			d.logger.Printf("Handler: failed to clear work for dog %s: %v", dg.Name, err)
+		status := t.CheckSessionHealth(sessionID, 0)
+		if status != tmux.AgentDead {
+			continue
 		}
+
+		d.logger.Printf("Handler: dog %s (%s) is working but agent is dead, killing session and clearing work", dg.Name, sessionID)
+		if err := t.KillSessionWithProcesses(sessionID); err != nil {
+			d.logger.Printf("Handler: failed to kill agent-dead session for dog %s (%s): %v", dg.Name, sessionID, err)
+			continue
+		}
+		d.clearDogWorkIfMatches(mgr, dg, "dead agent")
 	}
+}
+
+func (d *Daemon) clearDogWorkIfMatches(mgr *dog.Manager, dg *dog.Dog, reason string) bool {
+	cleared, err := mgr.ClearWorkIfMatches(dg.Name, dg.Work, dg.WorkStartedAt)
+	if err != nil {
+		d.logger.Printf("Handler: failed to clear work for dog %s (%s): %v", dg.Name, reason, err)
+		return false
+	}
+	if !cleared {
+		d.logger.Printf("Handler: skipped clearing dog %s (%s): work assignment changed", dg.Name, reason)
+		return false
+	}
+	return true
 }
 
 // detectStaleWorkingDogs finds dogs in state=working whose last_active exceeds
@@ -124,6 +147,7 @@ func (d *Daemon) detectStaleWorkingDogs(mgr *dog.Manager, sm *dog.SessionManager
 
 	threshold := daemonCfg.StaleWorkingTimeoutD()
 	now := time.Now()
+	t := tmux.NewTmux()
 	for _, dg := range dogs {
 		if dg.State != dog.StateWorking {
 			continue
@@ -137,22 +161,21 @@ func (d *Daemon) detectStaleWorkingDogs(mgr *dog.Manager, sm *dog.SessionManager
 		d.logger.Printf("Handler: dog %s stuck in working state (inactive %v, work: %s), clearing",
 			dg.Name, staleDuration.Truncate(time.Minute), dg.Work)
 
-		if err := mgr.ClearWork(dg.Name); err != nil {
-			d.logger.Printf("Handler: failed to clear work for stale dog %s: %v", dg.Name, err)
-			continue
-		}
-
-		// Kill the tmux session — it's not doing anything useful.
 		running, err := sm.IsRunning(dg.Name)
 		if err != nil {
 			d.logger.Printf("Handler: error checking session for stale dog %s: %v", dg.Name, err)
 			continue
 		}
 		if running {
-			if err := sm.Stop(dg.Name, true); err != nil {
+			// Kill the tmux session before clearing state so a failed kill does not
+			// return the dog to the idle pool with stale work still running.
+			if err := t.KillSessionWithProcesses(sm.SessionName(dg.Name)); err != nil {
 				d.logger.Printf("Handler: failed to stop session for stale dog %s: %v", dg.Name, err)
+				continue
 			}
 		}
+
+		d.clearDogWorkIfMatches(mgr, dg, "stale working")
 	}
 }
 

--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -121,17 +121,15 @@ func (d *Daemon) cleanupStuckDogs(mgr *dog.Manager, sm *dog.SessionManager) {
 	}
 }
 
-func (d *Daemon) clearDogWorkIfMatches(mgr *dog.Manager, dg *dog.Dog, reason string) bool {
+func (d *Daemon) clearDogWorkIfMatches(mgr *dog.Manager, dg *dog.Dog, reason string) {
 	cleared, err := mgr.ClearWorkIfMatches(dg.Name, dg.Work, dg.WorkStartedAt)
 	if err != nil {
 		d.logger.Printf("Handler: failed to clear work for dog %s (%s): %v", dg.Name, reason, err)
-		return false
+		return
 	}
 	if !cleared {
 		d.logger.Printf("Handler: skipped clearing dog %s (%s): work assignment changed", dg.Name, reason)
-		return false
 	}
-	return true
 }
 
 // detectStaleWorkingDogs finds dogs in state=working whose last_active exceeds

--- a/internal/daemon/handler_test.go
+++ b/internal/daemon/handler_test.go
@@ -2,8 +2,10 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -21,6 +23,13 @@ func testHandlerDaemon(t *testing.T, townRoot string) *Daemon {
 	return &Daemon{
 		config: &Config{TownRoot: townRoot},
 		logger: log.New(os.Stderr, "test: ", log.LstdFlags),
+	}
+}
+
+func requireTmux(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
 	}
 }
 
@@ -86,6 +95,8 @@ func testSetupWorkingDogState(t *testing.T, townRoot, name, work string, lastAct
 }
 
 func TestDetectStaleWorkingDogs_ClearsStaleWorkers(t *testing.T) {
+	requireTmux(t)
+
 	townRoot := t.TempDir()
 	d := testHandlerDaemon(t, townRoot)
 
@@ -108,6 +119,49 @@ func TestDetectStaleWorkingDogs_ClearsStaleWorkers(t *testing.T) {
 	}
 	if dg.Work != "" {
 		t.Errorf("stale dog work = %q, want empty", dg.Work)
+	}
+}
+
+func TestDetectStaleWorkingDogs_KillsSessionBeforeClearing(t *testing.T) {
+	requireTmux(t)
+
+	oldSocket := tmux.GetDefaultSocket()
+	socketName := fmt.Sprintf("gt-test-dog-stale-%d", time.Now().UnixNano())
+	tmux.SetDefaultSocket(socketName)
+	t.Cleanup(func() { tmux.SetDefaultSocket(oldSocket) })
+
+	townRoot := t.TempDir()
+	d := testHandlerDaemon(t, townRoot)
+
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	tm := tmux.NewTmux()
+	sm := dog.NewSessionManager(tm, townRoot, mgr)
+
+	testSetupWorkingDogState(t, townRoot, "stale", constants.MolConvoyFeed, time.Now().Add(-3*time.Hour))
+
+	sessionName := sm.SessionName("stale")
+	if err := tm.NewSession(sessionName, ""); err != nil {
+		t.Fatalf("NewSession(%q): %v", sessionName, err)
+	}
+	t.Cleanup(func() { _ = tm.KillSession(sessionName) })
+
+	d.detectStaleWorkingDogs(mgr, sm, &config.DaemonThresholds{})
+
+	dg, err := mgr.Get("stale")
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if dg.State != dog.StateIdle {
+		t.Errorf("stale dog state = %q, want idle", dg.State)
+	}
+	if dg.Work != "" {
+		t.Errorf("stale dog work = %q, want empty", dg.Work)
+	}
+	if has, err := tm.HasSession(sessionName); err != nil {
+		t.Fatalf("HasSession(%q): %v", sessionName, err)
+	} else if has {
+		t.Errorf("stale dog session %q still exists after cleanup", sessionName)
 	}
 }
 
@@ -445,5 +499,96 @@ func TestFindDispatchableDog_PicksFirstIdleWhenNoSessionsLive(t *testing.T) {
 	}
 	if got.Name != "alpha" && got.Name != "bravo" {
 		t.Errorf("findDispatchableDog = %q, want alpha or bravo", got.Name)
+	}
+}
+
+func TestCleanupStuckDogs_ClearsDeadSessionWorker(t *testing.T) {
+	requireTmux(t)
+
+	townRoot := t.TempDir()
+	d := testHandlerDaemon(t, townRoot)
+
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	sm := dog.NewSessionManager(tmux.NewTmux(), townRoot, mgr)
+
+	testSetupWorkingDogState(t, townRoot, "alpha", constants.MolDogReaper, time.Now())
+
+	d.cleanupStuckDogs(mgr, sm)
+
+	dg, err := mgr.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if dg.State != dog.StateIdle {
+		t.Errorf("stuck dog state = %q, want idle", dg.State)
+	}
+	if dg.Work != "" {
+		t.Errorf("stuck dog work = %q, want empty", dg.Work)
+	}
+}
+
+func TestCleanupStuckDogs_ClearsAgentDeadWorker(t *testing.T) {
+	requireTmux(t)
+
+	oldSocket := tmux.GetDefaultSocket()
+	socketName := fmt.Sprintf("gt-test-dog-cleanup-%d", time.Now().UnixNano())
+	tmux.SetDefaultSocket(socketName)
+	t.Cleanup(func() { tmux.SetDefaultSocket(oldSocket) })
+
+	townRoot := t.TempDir()
+	d := testHandlerDaemon(t, townRoot)
+
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	tm := tmux.NewTmux()
+	sm := dog.NewSessionManager(tm, townRoot, mgr)
+
+	testSetupWorkingDogState(t, townRoot, "alpha", constants.MolDogReaper, time.Now())
+
+	sessionName := sm.SessionName("alpha")
+	if err := tm.NewSession(sessionName, ""); err != nil {
+		t.Fatalf("NewSession(%q): %v", sessionName, err)
+	}
+	t.Cleanup(func() { _ = tm.KillSession(sessionName) })
+	time.Sleep(200 * time.Millisecond)
+
+	d.cleanupStuckDogs(mgr, sm)
+
+	dg, err := mgr.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if dg.State != dog.StateIdle {
+		t.Errorf("agent-dead dog state = %q, want idle", dg.State)
+	}
+	if dg.Work != "" {
+		t.Errorf("agent-dead dog work = %q, want empty", dg.Work)
+	}
+	if has, err := tm.HasSession(sessionName); err != nil {
+		t.Fatalf("HasSession(%q): %v", sessionName, err)
+	} else if has {
+		t.Errorf("agent-dead session %q still exists after cleanup", sessionName)
+	}
+}
+
+func TestCleanupStuckDogs_SkipsIdleDogs(t *testing.T) {
+	townRoot := t.TempDir()
+	d := testHandlerDaemon(t, townRoot)
+
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	sm := dog.NewSessionManager(tmux.NewTmux(), townRoot, mgr)
+
+	testSetupDogState(t, townRoot, "alpha", dog.StateIdle, time.Now())
+
+	d.cleanupStuckDogs(mgr, sm)
+
+	dg, err := mgr.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if dg.State != dog.StateIdle {
+		t.Errorf("idle dog state = %q, want idle", dg.State)
 	}
 }


### PR DESCRIPTION
Replacement/fixup for draft PR #4310.

Carries forward the original bugfix intent from #4310 on current upstream/main while tightening cleanup semantics.

Changes:
- detect working dogs whose tmux session exists but agent process is dead with CheckSessionHealth(..., 0)
- kill agent-dead session process trees before returning dogs to idle
- compare-clear the exact dog work assignment with ClearWorkIfMatches
- make stale-working cleanup kill live sessions before clearing state
- add focused daemon regression tests

Verification:
- CGO_ENABLED=0 go test -v ./internal/daemon -run '^(TestCleanupStuckDogs_(ClearsDeadSessionWorker|ClearsAgentDeadWorker|SkipsIdleDogs)|TestDetectStaleWorkingDogs_(ClearsStaleWorkers|KillsSessionBeforeClearing|SkipsRecentWorkers|SkipsIdleDogs))$' -count=1\n- CGO_ENABLED=0 go test -v ./internal/dog -run '^(TestHealth_(Zombie|AutoClear|Hung|Orphan|CheckAll|WorkDuration)|TestNeedsAttentionCount)' -count=1\n- CGO_ENABLED=0 go test -v ./internal/tmux -run '^(TestZombieStatusString|TestCheckSessionHealth_(NonexistentSession|ZombieSession|ActivityCheck))$' -count=1\n- CGO_ENABLED=0 go vet ./internal/daemon ./internal/dog ./internal/tmux\n- CGO_ENABLED=0 go build ./internal/daemon ./internal/dog ./internal/tmux\n\nAttribution:\n- Original PR: #4310 by @munizr13\n- Original commit: 9fa47da1e0e36d5efc718bb12d4bb49011c394d9\n- Commit author preserved as Rodrigo Muñiz <munizr@renascentia.ai>\n- Co-authored-by: Paperclip <noreply@paperclip.ing>\n\nPR Sheriff evidence is tracked under bead gt-8rv7.