### PR TITLE
ci: converge bd setup for workflows

### DIFF
--- a/.github/actions/setup-bd/action.yml
+++ b/.github/actions/setup-bd/action.yml
@@ -1,0 +1,35 @@
+name: Set up beads (bd)
+description: Resolve, cache, install, and expose the bd CLI used by Gastown tests.
+
+inputs:
+  cache-prefix:
+    description: Prefix for the actions/cache key.
+    required: false
+    default: beads
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve beads version
+      id: beads-version
+      shell: bash
+      run: |
+        version="$(go list -mod=readonly -m -f '{{.Version}}' github.com/steveyegge/beads)"
+        test -n "$version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Cache beads (bd)
+      id: cache-beads
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ~/go/bin/bd
+        key: ${{ inputs.cache-prefix }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.beads-version.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}
+
+    - name: Install beads (bd)
+      if: steps.cache-beads.outputs.cache-hit != 'true'
+      shell: bash
+      run: CGO_ENABLED=0 go install "github.com/steveyegge/beads/cmd/bd@${{ steps.beads-version.outputs.version }}"
+
+    - name: Add Go bin to PATH
+      shell: bash
+      run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
         run: |
           curl -L https://github.com/dolthub/dolt/releases/download/v2.0.7/install.sh | sudo bash
 
+      - name: Set up beads (bd)
+        uses: ./.github/actions/setup-bd
+
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
@@ -169,23 +172,8 @@ jobs:
       - name: Pre-pull Dolt Docker image
         run: docker pull dolthub/dolt-sql-server:2.0.7
 
-      - name: Resolve beads version
-        id: beads-version
-        run: |
-          version="$(go list -mod=readonly -m -f '{{.Version}}' github.com/steveyegge/beads)"
-          test -n "$version"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Cache beads (bd)
-        id: cache-beads-int
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/go/bin/bd
-          key: beads-${{ runner.os }}-${{ runner.arch }}-${{ steps.beads-version.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}
-
-      - name: Install beads (bd)
-        if: steps.cache-beads-int.outputs.cache-hit != 'true'
-        run: CGO_ENABLED=0 go install "github.com/steveyegge/beads/cmd/bd@${{ steps.beads-version.outputs.version }}"
+      - name: Set up beads (bd)
+        uses: ./.github/actions/setup-bd
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
@@ -194,9 +182,6 @@ jobs:
         run: |
           make build
           cp gt "$(go env GOPATH)/bin/"
-
-      - name: Add to PATH
-        run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Integration Tests
         run: |

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -27,23 +27,10 @@ jobs:
           git config --global user.name "CI Bot"
           git config --global user.email "ci@gastown.test"
 
-      - name: Resolve beads version
-        id: beads-version
-        run: |
-          version="$(go list -mod=readonly -m -f '{{.Version}}' github.com/steveyegge/beads)"
-          test -n "$version"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Cache beads (bd)
-        id: cache-beads
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Set up beads (bd)
+        uses: ./.github/actions/setup-bd
         with:
-          path: ~/go/bin/bd
-          key: beads-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.beads-version.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}
-
-      - name: Install beads (bd)
-        if: steps.cache-beads.outputs.cache-hit != 'true'
-        run: CGO_ENABLED=0 go install "github.com/steveyegge/beads/cmd/bd@${{ steps.beads-version.outputs.version }}"
+          cache-prefix: beads-nightly
 
       - name: Install Dolt
         run: |
@@ -52,9 +39,6 @@ jobs:
 
       - name: Pre-pull Dolt Docker image
         run: docker pull dolthub/dolt-sql-server:2.0.7
-
-      - name: Add to PATH
-        run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Configure Dolt
         run: |


### PR DESCRIPTION
Carries forward #4318 by @rbriski with a current-main cleanup-first replacement.

Summary:
- Adds a shared local setup-bd action that resolves github.com/steveyegge/beads from go.mod, caches bd by OS/arch/version/go.mod/go.sum, installs bd with CGO_ENABLED=0, and exposes GOPATH/bin.
- Uses that shared action from Test, Integration Tests, and Nightly Integration instead of hardcoding bd versions or keeping duplicated workflow-local cache/install blocks.
- Keeps CI permissions unchanged and does not skip tests, add retries, broaden secrets, or introduce compatibility shims.

Verification:
- git diff --check upstream/main...HEAD
- go list -mod=readonly -m -f {{.Version}} github.com/steveyegge/beads => v1.0.5
- CGO_ENABLED=0 go test ./internal/doctor -run ^TestAgentBeadsExistCheck -short -count=1
- CGO_ENABLED=0 go test ./internal/cmd -run ^TestJSONOutput_ -short -count=1
- CGO_ENABLED=0 go test ./cmd/gt -run ^$ -count=1
- ruby YAML parse for the new action and touched workflows

Attribution:
- Supersedes/carries forward #4318 by @rbriski.
- Commit includes Co-authored-by: mayor <bbriski@raybeam.com>.
- Do not close #4318 as superseded until this replacement merges.

PR Sheriff:
- 15 independent research legs completed.
- 5 pre-implementation reviews approved this cleanup-first replacement plan.
- 5 post-implementation reviews approved final head 8df00cca2304242353d9964b9523f0a7fa01da53.