### PR TITLE
fix(done): squash WIP checkpoint commits before push — keep crash-recovery checkpoints sandbox-local

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -84,7 +84,14 @@ town-level Gas Town beads.
     "integration_branch_polecat_enabled": true,
     "integration_branch_refinery_enabled": true,
     "integration_branch_template": "integration/{title}",
-    "integration_branch_auto_land": false
+    "integration_branch_auto_land": false,
+    "ci_gate": {
+      "enabled": true,
+      "pending_timeout": "30m",
+      "poll_interval": "30s",
+      "mayor_alert_after": "30m",
+      "escalation_cmd": ""
+    }
   }
 }
 ```
@@ -149,8 +156,29 @@ Town-level role defaults live in `mayor/config.json` under:
 | `integration_branch_refinery_enabled` | `*bool` | `true` | `gt done` / `gt mq submit` auto-target integration branches |
 | `integration_branch_template` | `string` | `"integration/{title}"` | Branch name template (`{title}`, `{epic}`, `{prefix}`, `{user}`) |
 | `integration_branch_auto_land` | `*bool` | `false` | Refinery patrol auto-lands when all children closed |
+| `ci_gate` | `object` | enabled | Hard CI gate (AA-851) — see below |
 
 See [Integration Branches](concepts/integration-branches.md) for integration branch details.
+
+**CI gate fields (`merge_queue.ci_gate`):**
+
+The hard CI gate blocks a polecat from completing (`gt done`) and from being
+nuked while its branch's PR has any CI check red or pending, and stops the
+refinery from merging such a PR (merge_strategy=pr). The gate only applies
+when a PR exists — no-PR branches and merged PRs pass through — so it is safe
+to leave enabled on direct-merge rigs. When CI state cannot be determined the
+gate FAILS OPEN but runs `escalation_cmd` so a human verifies.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `*bool` | `true` | Enable the gate. Process-level kill switch: `GT_CI_GATE=off` |
+| `pending_timeout` | `string` | `"30m"` | How long `gt done` waits for pending checks before aborting with a human escalation (sized for slow Jenkins pipelines) |
+| `poll_interval` | `string` | `"30s"` | Initial poll interval while waiting; backs off to 4x |
+| `mayor_alert_after` | `string` | `"30m"` | How long a nuke can stay CI-blocked before the mayor is nudged |
+| `escalation_cmd` | `string` | `""` | Command run via `sh -c` on CI-status errors and pending timeouts. Receives `GT_CIGATE_EVENT`, `GT_CIGATE_TICKET` (from the bead's `Jira:`/`Ticket:` line), `GT_CIGATE_DETAIL`, `GT_CIGATE_PR_URL`, `GT_CIGATE_BRANCH`, `GT_CIGATE_AGENT` in the environment. Wire it to your tracker, e.g. a script that comments on the ticket and transitions it to a human-attention status |
+
+Overrides: `gt polecat nuke --ignore-ci` bypasses the nuke gate for one
+invocation; `GT_CI_GATE=off` disables the gate process-wide (emergencies only).
 
 ### Runtime (`.runtime/` - gitignored)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -195,6 +195,24 @@ When `polecat_branch_template` is empty or not set:
 - With issue: `polecat/{name}/{issue}+{timestamp}`
 - Without issue: `polecat/{name}-{timestamp}`
 
+**Issue/timestamp delimiter (`polecat_branch_delimiter`):**
+
+Some CI systems constrain the branch-name charset — e.g. docker-compose
+project names derived from branch names allow only `[a-z0-9_-]`, rejecting
+the default `+`. Rigs whose CI needs this can pick a different delimiter for
+the default (non-template) branch format:
+
+```bash
+gt rig config set myrig polecat_branch_delimiter _
+# → polecat/{name}/{issue}_{timestamp}
+```
+
+Valid delimiters are `+` (default), `_`, and `@` (legacy) — characters that
+can never appear in issue IDs or polecat names, so branches always parse
+back to the right issue. Invalid values fall back to `+`. Parsing accepts
+all valid delimiters regardless of configuration, so branches created under
+a previous delimiter keep working after a config change.
+
 **Example Configurations:**
 
 ```bash

--- a/internal/cigate/cigate.go
+++ b/internal/cigate/cigate.go
@@ -1,0 +1,314 @@
+// Package cigate implements the hard CI gate (AA-851): a polecat cannot
+// complete (gt done) and cannot be reaped while its branch's pull request
+// has any CI check red or pending, and the refinery will not merge such a
+// PR. The gate applies only when a PR exists — branches with no PR and
+// already-merged PRs pass through.
+//
+// CI state is read via the gh CLI (`gh pr list ... --json statusCheckRollup`),
+// matching the existing PR-state precedents in internal/git (HasOpenPR,
+// FindPRNumber). The rollup evaluation is a port of the display-layer
+// determineCIStatus (internal/web/fetcher.go): it handles both GitHub check
+// runs (Status/Conclusion) and commit statuses (State — how Jenkins contexts
+// report), so GitHub Actions, Jenkins, and other status providers are all
+// covered by one rollup.
+//
+// Failure semantics: when CI state cannot be determined (gh missing, rate
+// limit, network), the verdict is ERROR and callers FAIL OPEN — a GitHub
+// outage must not brick every completion town-wide — but must escalate
+// loudly (see RunEscalationCmd) so a silently-disabled gate is visible.
+package cigate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Verdict classifies the CI state of a branch's pull request.
+type Verdict string
+
+const (
+	// VerdictGreen means all reported checks passed.
+	VerdictGreen Verdict = "GREEN"
+	// VerdictRed means at least one check failed.
+	VerdictRed Verdict = "RED"
+	// VerdictPending means no failures but at least one check is still
+	// running (or the PR has no checks reported yet).
+	VerdictPending Verdict = "PENDING"
+	// VerdictNoPR means the branch has no pull request — the gate does not apply.
+	VerdictNoPR Verdict = "NO_PR"
+	// VerdictMerged means the branch's PR is already merged.
+	VerdictMerged Verdict = "MERGED"
+	// VerdictClosedUnmerged means the PR was closed without merging
+	// (a deliberate human action; callers pass through with a warning).
+	VerdictClosedUnmerged Verdict = "CLOSED_UNMERGED"
+	// VerdictError means CI state could not be determined; callers fail open.
+	VerdictError Verdict = "ERROR"
+)
+
+// Blocks reports whether the verdict blocks completion/reaping.
+// Only RED and PENDING block; ERROR fails open (callers escalate it loudly).
+func (v Verdict) Blocks() bool {
+	return v == VerdictRed || v == VerdictPending
+}
+
+// CheckResult is the outcome of one CI gate evaluation for a branch.
+type CheckResult struct {
+	Verdict       Verdict
+	PRNumber      int
+	PRURL         string
+	FailingChecks []string
+	PendingChecks []string
+	Err           error // set when Verdict == VerdictError
+}
+
+// Summary renders a one-line human-readable description of the result.
+func (r CheckResult) Summary() string {
+	switch r.Verdict {
+	case VerdictRed:
+		return fmt.Sprintf("PR #%d has failing checks [%s]", r.PRNumber, strings.Join(r.FailingChecks, ", "))
+	case VerdictPending:
+		return fmt.Sprintf("PR #%d has pending checks [%s]", r.PRNumber, strings.Join(r.PendingChecks, ", "))
+	case VerdictGreen:
+		return fmt.Sprintf("PR #%d all checks green", r.PRNumber)
+	case VerdictMerged:
+		return fmt.Sprintf("PR #%d already merged", r.PRNumber)
+	case VerdictClosedUnmerged:
+		return fmt.Sprintf("PR #%d closed without merging", r.PRNumber)
+	case VerdictNoPR:
+		return "no PR for branch"
+	case VerdictError:
+		return fmt.Sprintf("CI status unknown: %v", r.Err)
+	}
+	return string(r.Verdict)
+}
+
+// EnvDisabled reports whether the gate is force-disabled process-wide via
+// GT_CI_GATE=off (emergency kill switch that needs no config edit or redeploy).
+func EnvDisabled() bool {
+	switch strings.ToLower(os.Getenv("GT_CI_GATE")) {
+	case "off", "0", "false", "disabled":
+		return true
+	}
+	return false
+}
+
+// Runner executes a command in dir and returns its stdout. Swappable in tests.
+type Runner func(dir, name string, args ...string) ([]byte, error)
+
+func defaultRunner(dir, name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return nil, fmt.Errorf("%s: %w (%s)", name, err, msg)
+		}
+		return nil, fmt.Errorf("%s: %w", name, err)
+	}
+	return out, nil
+}
+
+// Gate evaluates PR CI status for branches.
+type Gate struct {
+	// Run executes external commands (gh). Defaults to a real exec runner.
+	Run Runner
+}
+
+// New returns a Gate backed by the real gh CLI.
+func New() *Gate { return &Gate{Run: defaultRunner} }
+
+// prInfo mirrors the fields requested from `gh pr list --json`.
+type prInfo struct {
+	Number            int           `json:"number"`
+	State             string        `json:"state"` // OPEN | MERGED | CLOSED
+	URL               string        `json:"url"`
+	StatusCheckRollup []rollupEntry `json:"statusCheckRollup"`
+}
+
+// rollupEntry covers both rollup shapes GitHub returns: check runs
+// (name/status/conclusion) and commit statuses (context/state).
+type rollupEntry struct {
+	Name       string `json:"name"`    // check runs
+	Context    string `json:"context"` // commit statuses (Jenkins-style)
+	State      string `json:"state"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+func (e rollupEntry) displayName() string {
+	if e.Name != "" {
+		return e.Name
+	}
+	if e.Context != "" {
+		return e.Context
+	}
+	return "unnamed-check"
+}
+
+// CheckBranch resolves the branch's PR via gh and evaluates its check rollup.
+// PR resolution: newest OPEN PR wins; with no open PR, a merged PR yields
+// MERGED, a closed-unmerged PR yields CLOSED_UNMERGED, and none yields NO_PR.
+// dir must be inside a clone whose origin is the repo to query (gh resolves
+// the repo from git remotes).
+func (g *Gate) CheckBranch(dir, branch string) CheckResult {
+	run := g.Run
+	if run == nil {
+		run = defaultRunner
+	}
+	out, err := run(dir, "gh", "pr", "list", "--head", branch, "--state", "all",
+		"--json", "number,state,url,statusCheckRollup", "--limit", "20")
+	if err != nil {
+		return CheckResult{Verdict: VerdictError, Err: err}
+	}
+	var prs []prInfo
+	if err := json.Unmarshal(bytes.TrimSpace(out), &prs); err != nil {
+		return CheckResult{Verdict: VerdictError, Err: fmt.Errorf("parsing gh pr list output: %w", err)}
+	}
+	// gh returns newest-first; keep the first PR seen in each state.
+	var open, merged, closed *prInfo
+	for i := range prs {
+		switch prs[i].State {
+		case "OPEN":
+			if open == nil {
+				open = &prs[i]
+			}
+		case "MERGED":
+			if merged == nil {
+				merged = &prs[i]
+			}
+		case "CLOSED":
+			if closed == nil {
+				closed = &prs[i]
+			}
+		}
+	}
+	switch {
+	case open != nil:
+		res := evaluateRollup(open.StatusCheckRollup)
+		res.PRNumber = open.Number
+		res.PRURL = open.URL
+		return res
+	case merged != nil:
+		return CheckResult{Verdict: VerdictMerged, PRNumber: merged.Number, PRURL: merged.URL}
+	case closed != nil:
+		return CheckResult{Verdict: VerdictClosedUnmerged, PRNumber: closed.Number, PRURL: closed.URL}
+	}
+	return CheckResult{Verdict: VerdictNoPR}
+}
+
+// evaluateRollup ports determineCIStatus (internal/web/fetcher.go) semantics
+// to a gate verdict, additionally collecting failing/pending check names.
+//
+// Case note: gh renders the GraphQL rollup enums in UPPERCASE for check runs
+// ("conclusion":"SUCCESS", "status":"COMPLETED" — verified live against
+// gh 2.45), while older code paths compared lowercase. Normalize both ways
+// so the gate works across gh versions.
+func evaluateRollup(checks []rollupEntry) CheckResult {
+	if len(checks) == 0 {
+		// Open PR with no checks reported yet — treat as pending so a
+		// just-pushed PR isn't waved through before CI registers. The
+		// pending wait window absorbs webhook lag.
+		return CheckResult{Verdict: VerdictPending, PendingChecks: []string{"checks not yet reported"}}
+	}
+	var failing, pending []string
+	for _, check := range checks {
+		// Conclusion first (completed check runs).
+		switch strings.ToLower(check.Conclusion) {
+		case "failure", "cancelled", "timed_out", "action_required", "startup_failure": //nolint:misspell // GitHub API returns "cancelled" (British spelling)
+			failing = append(failing, check.displayName())
+		case "success", "skipped", "neutral":
+			// Pass.
+		case "stale":
+			// Marked stale by a newer commit — results no longer trustworthy.
+			pending = append(pending, check.displayName())
+		default:
+			// In-progress check runs report via Status.
+			switch strings.ToLower(check.Status) {
+			case "queued", "in_progress", "waiting", "pending", "requested":
+				pending = append(pending, check.displayName())
+			}
+			// Commit statuses (Jenkins contexts) report via State.
+			switch strings.ToUpper(check.State) {
+			case "FAILURE", "ERROR":
+				failing = append(failing, check.displayName())
+			case "PENDING", "EXPECTED":
+				pending = append(pending, check.displayName())
+			}
+		}
+	}
+	switch {
+	case len(failing) > 0:
+		return CheckResult{Verdict: VerdictRed, FailingChecks: failing, PendingChecks: pending}
+	case len(pending) > 0:
+		return CheckResult{Verdict: VerdictPending, PendingChecks: pending}
+	}
+	return CheckResult{Verdict: VerdictGreen}
+}
+
+// WaitOptions configures WaitForGreen.
+type WaitOptions struct {
+	// Timeout is the total time to wait for pending checks to settle.
+	Timeout time.Duration
+	// PollInterval is the initial poll interval; it doubles per poll up to
+	// 4x (30s → 60s → 120s with the 30s default).
+	PollInterval time.Duration
+	// Progress, when set, receives one line per poll.
+	Progress io.Writer
+	// Sleep is a test hook; nil means time.Sleep.
+	Sleep func(time.Duration)
+	// Now is a test hook; nil means time.Now.
+	Now func() time.Time
+}
+
+// WaitForGreen polls CheckBranch while the verdict is PENDING, with backoff,
+// until the checks settle or the timeout elapses. It returns the last result
+// and whether the wait timed out with checks still pending.
+func (g *Gate) WaitForGreen(dir, branch string, opts WaitOptions) (CheckResult, bool) {
+	sleep := opts.Sleep
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	interval := opts.PollInterval
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	maxInterval := interval * 4
+	deadline := now().Add(opts.Timeout)
+
+	res := g.CheckBranch(dir, branch)
+	for res.Verdict == VerdictPending {
+		remaining := deadline.Sub(now())
+		if remaining <= 0 {
+			return res, true
+		}
+		if interval > remaining {
+			interval = remaining
+		}
+		if opts.Progress != nil {
+			fmt.Fprintf(opts.Progress, "  CI pending (%s) — next poll in %s, %s remaining\n",
+				strings.Join(res.PendingChecks, ", "), interval.Round(time.Second), remaining.Round(time.Second))
+		}
+		sleep(interval)
+		if interval < maxInterval {
+			interval *= 2
+			if interval > maxInterval {
+				interval = maxInterval
+			}
+		}
+		res = g.CheckBranch(dir, branch)
+	}
+	return res, false
+}

--- a/internal/cigate/cigate_test.go
+++ b/internal/cigate/cigate_test.go
@@ -1,0 +1,364 @@
+package cigate
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func stubRunner(out string, err error) Runner {
+	return func(dir, name string, args ...string) ([]byte, error) {
+		if err != nil {
+			return nil, err
+		}
+		return []byte(out), nil
+	}
+}
+
+func TestEvaluateRollup(t *testing.T) {
+	tests := []struct {
+		name    string
+		checks  []rollupEntry
+		verdict Verdict
+		failing []string
+		pending []string
+	}{
+		{
+			name:    "empty rollup is pending (checks not registered yet)",
+			checks:  nil,
+			verdict: VerdictPending,
+			pending: []string{"checks not yet reported"},
+		},
+		{
+			name: "all check runs green",
+			checks: []rollupEntry{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "lint", Status: "completed", Conclusion: "skipped"},
+				{Name: "note", Status: "completed", Conclusion: "neutral"},
+			},
+			verdict: VerdictGreen,
+		},
+		{
+			name: "one failing check run is red",
+			checks: []rollupEntry{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "test", Status: "completed", Conclusion: "failure"},
+			},
+			verdict: VerdictRed,
+			failing: []string{"test"},
+		},
+		{
+			name: "cancelled and timed_out are red",
+			checks: []rollupEntry{
+				{Name: "a", Conclusion: "cancelled"},
+				{Name: "b", Conclusion: "timed_out"},
+				{Name: "c", Conclusion: "action_required"},
+			},
+			verdict: VerdictRed,
+			failing: []string{"a", "b", "c"},
+		},
+		{
+			name: "in-progress check run is pending",
+			checks: []rollupEntry{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "test", Status: "in_progress"},
+			},
+			verdict: VerdictPending,
+			pending: []string{"test"},
+		},
+		{
+			name: "jenkins commit status failure is red",
+			checks: []rollupEntry{
+				{Context: "continuous-integration/jenkins/branch", State: "FAILURE"},
+			},
+			verdict: VerdictRed,
+			failing: []string{"continuous-integration/jenkins/branch"},
+		},
+		{
+			name: "jenkins commit status pending is pending",
+			checks: []rollupEntry{
+				{Context: "continuous-integration/jenkins/pr-merge", State: "PENDING"},
+				{Name: "gha", Status: "completed", Conclusion: "success"},
+			},
+			verdict: VerdictPending,
+			pending: []string{"continuous-integration/jenkins/pr-merge"},
+		},
+		{
+			name: "jenkins success plus gha success is green",
+			checks: []rollupEntry{
+				{Context: "jenkins/build", State: "SUCCESS"},
+				{Name: "gha", Status: "completed", Conclusion: "success"},
+			},
+			verdict: VerdictGreen,
+		},
+		{
+			name: "red wins over pending",
+			checks: []rollupEntry{
+				{Name: "test", Conclusion: "failure"},
+				{Name: "deploy", Status: "queued"},
+			},
+			verdict: VerdictRed,
+			failing: []string{"test"},
+			pending: []string{"deploy"},
+		},
+		{
+			name: "expected commit status is pending",
+			checks: []rollupEntry{
+				{Context: "macroscope", State: "EXPECTED"},
+			},
+			verdict: VerdictPending,
+			pending: []string{"macroscope"},
+		},
+		{
+			// Real gh 2.45 output uses UPPERCASE GraphQL enums (verified live).
+			name: "uppercase enums from modern gh: green",
+			checks: []rollupEntry{
+				{Name: "API & Page Tests", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "Mergify Merge Queue", Status: "COMPLETED", Conclusion: "NEUTRAL"},
+			},
+			verdict: VerdictGreen,
+		},
+		{
+			name: "uppercase enums from modern gh: red",
+			checks: []rollupEntry{
+				{Name: "API & Page Tests", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			verdict: VerdictRed,
+			failing: []string{"API & Page Tests"},
+		},
+		{
+			name: "uppercase enums from modern gh: pending",
+			checks: []rollupEntry{
+				{Name: "build", Status: "IN_PROGRESS", Conclusion: ""},
+			},
+			verdict: VerdictPending,
+			pending: []string{"build"},
+		},
+		{
+			name: "startup_failure is red, stale is pending",
+			checks: []rollupEntry{
+				{Name: "a", Conclusion: "STARTUP_FAILURE"},
+				{Name: "b", Conclusion: "STALE"},
+			},
+			verdict: VerdictRed,
+			failing: []string{"a"},
+			pending: []string{"b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := evaluateRollup(tt.checks)
+			if res.Verdict != tt.verdict {
+				t.Fatalf("verdict = %s, want %s", res.Verdict, tt.verdict)
+			}
+			if got, want := strings.Join(res.FailingChecks, ","), strings.Join(tt.failing, ","); got != want {
+				t.Errorf("failing = %q, want %q", got, want)
+			}
+			if got, want := strings.Join(res.PendingChecks, ","), strings.Join(tt.pending, ","); got != want {
+				t.Errorf("pending = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestVerdictBlocks(t *testing.T) {
+	blocking := map[Verdict]bool{
+		VerdictRed:            true,
+		VerdictPending:        true,
+		VerdictGreen:          false,
+		VerdictNoPR:           false,
+		VerdictMerged:         false,
+		VerdictClosedUnmerged: false,
+		VerdictError:          false, // fail-open
+	}
+	for v, want := range blocking {
+		if v.Blocks() != want {
+			t.Errorf("%s.Blocks() = %v, want %v", v, v.Blocks(), want)
+		}
+	}
+}
+
+func TestCheckBranch(t *testing.T) {
+	tests := []struct {
+		name     string
+		ghOutput string
+		ghErr    error
+		verdict  Verdict
+		prNumber int
+	}{
+		{
+			name:     "no PR",
+			ghOutput: `[]`,
+			verdict:  VerdictNoPR,
+		},
+		{
+			name: "open PR green",
+			ghOutput: `[{"number":42,"state":"OPEN","url":"https://github.com/x/y/pull/42",
+				"statusCheckRollup":[{"name":"build","status":"completed","conclusion":"success"}]}]`,
+			verdict:  VerdictGreen,
+			prNumber: 42,
+		},
+		{
+			name: "open PR red",
+			ghOutput: `[{"number":7,"state":"OPEN","url":"u",
+				"statusCheckRollup":[{"name":"test","status":"completed","conclusion":"failure"}]}]`,
+			verdict:  VerdictRed,
+			prNumber: 7,
+		},
+		{
+			name: "open PR pending",
+			ghOutput: `[{"number":8,"state":"OPEN","url":"u",
+				"statusCheckRollup":[{"context":"jenkins/pr","state":"PENDING"}]}]`,
+			verdict:  VerdictPending,
+			prNumber: 8,
+		},
+		{
+			name:     "merged PR only",
+			ghOutput: `[{"number":9,"state":"MERGED","url":"u","statusCheckRollup":[]}]`,
+			verdict:  VerdictMerged,
+			prNumber: 9,
+		},
+		{
+			name:     "closed unmerged PR only",
+			ghOutput: `[{"number":10,"state":"CLOSED","url":"u","statusCheckRollup":[]}]`,
+			verdict:  VerdictClosedUnmerged,
+			prNumber: 10,
+		},
+		{
+			name: "open PR preferred over merged",
+			ghOutput: `[{"number":12,"state":"OPEN","url":"u",
+				"statusCheckRollup":[{"name":"b","conclusion":"success"}]},
+				{"number":11,"state":"MERGED","url":"u","statusCheckRollup":[]}]`,
+			verdict:  VerdictGreen,
+			prNumber: 12,
+		},
+		{
+			name:    "gh error fails open as ERROR",
+			ghErr:   errors.New("gh: rate limited"),
+			verdict: VerdictError,
+		},
+		{
+			name:     "garbage output is ERROR",
+			ghOutput: `not json`,
+			verdict:  VerdictError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &Gate{Run: stubRunner(tt.ghOutput, tt.ghErr)}
+			res := g.CheckBranch("/tmp", "polecat/test")
+			if res.Verdict != tt.verdict {
+				t.Fatalf("verdict = %s, want %s (err=%v)", res.Verdict, tt.verdict, res.Err)
+			}
+			if tt.prNumber != 0 && res.PRNumber != tt.prNumber {
+				t.Errorf("prNumber = %d, want %d", res.PRNumber, tt.prNumber)
+			}
+			if tt.verdict == VerdictError && res.Err == nil {
+				t.Errorf("VerdictError should carry Err")
+			}
+		})
+	}
+}
+
+// sequenceGate returns a Gate whose CheckBranch yields canned outputs in order,
+// repeating the last one.
+func sequenceGate(outputs ...string) *Gate {
+	i := 0
+	return &Gate{Run: func(dir, name string, args ...string) ([]byte, error) {
+		out := outputs[i]
+		if i < len(outputs)-1 {
+			i++
+		}
+		return []byte(out), nil
+	}}
+}
+
+const (
+	prPending = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"context":"jenkins","state":"PENDING"}]}]`
+	prGreen   = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"context":"jenkins","state":"SUCCESS"}]}]`
+	prRed     = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"context":"jenkins","state":"FAILURE"}]}]`
+)
+
+// fakeClock drives WaitForGreen without real sleeping.
+type fakeClock struct{ now time.Time }
+
+func (c *fakeClock) Now() time.Time        { return c.now }
+func (c *fakeClock) Sleep(d time.Duration) { c.now = c.now.Add(d) }
+
+func TestWaitForGreen(t *testing.T) {
+	t.Run("pending then green", func(t *testing.T) {
+		clock := &fakeClock{now: time.Unix(0, 0)}
+		g := sequenceGate(prPending, prPending, prGreen)
+		res, timedOut := g.WaitForGreen("/tmp", "b", WaitOptions{
+			Timeout: 30 * time.Minute, PollInterval: 30 * time.Second,
+			Sleep: clock.Sleep, Now: clock.Now,
+		})
+		if timedOut || res.Verdict != VerdictGreen {
+			t.Fatalf("got %s timedOut=%v, want GREEN", res.Verdict, timedOut)
+		}
+	})
+
+	t.Run("pending then red", func(t *testing.T) {
+		clock := &fakeClock{now: time.Unix(0, 0)}
+		g := sequenceGate(prPending, prRed)
+		res, timedOut := g.WaitForGreen("/tmp", "b", WaitOptions{
+			Timeout: 30 * time.Minute, PollInterval: 30 * time.Second,
+			Sleep: clock.Sleep, Now: clock.Now,
+		})
+		if timedOut || res.Verdict != VerdictRed {
+			t.Fatalf("got %s timedOut=%v, want RED", res.Verdict, timedOut)
+		}
+	})
+
+	t.Run("stuck pending times out", func(t *testing.T) {
+		clock := &fakeClock{now: time.Unix(0, 0)}
+		g := sequenceGate(prPending)
+		start := clock.now
+		res, timedOut := g.WaitForGreen("/tmp", "b", WaitOptions{
+			Timeout: 10 * time.Minute, PollInterval: 30 * time.Second,
+			Sleep: clock.Sleep, Now: clock.Now,
+		})
+		if !timedOut || res.Verdict != VerdictPending {
+			t.Fatalf("got %s timedOut=%v, want PENDING + timeout", res.Verdict, timedOut)
+		}
+		if waited := clock.now.Sub(start); waited < 10*time.Minute || waited > 12*time.Minute {
+			t.Errorf("waited %s, want ~10m", waited)
+		}
+	})
+
+	t.Run("backoff caps at 4x", func(t *testing.T) {
+		clock := &fakeClock{now: time.Unix(0, 0)}
+		var sleeps []time.Duration
+		g := sequenceGate(prPending)
+		_, _ = g.WaitForGreen("/tmp", "b", WaitOptions{
+			Timeout: 20 * time.Minute, PollInterval: 30 * time.Second,
+			Sleep: func(d time.Duration) { sleeps = append(sleeps, d); clock.Sleep(d) },
+			Now:   clock.Now,
+		})
+		if len(sleeps) < 4 {
+			t.Fatalf("expected several polls, got %d", len(sleeps))
+		}
+		want := []time.Duration{30 * time.Second, 60 * time.Second, 120 * time.Second, 120 * time.Second}
+		for i, w := range want {
+			if sleeps[i] != w {
+				t.Errorf("sleep[%d] = %s, want %s (all: %v)", i, sleeps[i], w, sleeps)
+			}
+		}
+	})
+}
+
+func TestSummary(t *testing.T) {
+	res := CheckResult{Verdict: VerdictRed, PRNumber: 3, FailingChecks: []string{"jenkins/build", "macroscope"}}
+	want := "PR #3 has failing checks [jenkins/build, macroscope]"
+	if got := res.Summary(); got != want {
+		t.Errorf("Summary() = %q, want %q", got, want)
+	}
+	errRes := CheckResult{Verdict: VerdictError, Err: fmt.Errorf("boom")}
+	if !strings.Contains(errRes.Summary(), "boom") {
+		t.Errorf("error summary should include cause: %q", errRes.Summary())
+	}
+}

--- a/internal/cigate/escalate.go
+++ b/internal/cigate/escalate.go
@@ -1,0 +1,94 @@
+package cigate
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// EscalationEvent identifies why the gate needs a human.
+type EscalationEvent string
+
+const (
+	// EventCIStatusError: the gate could not determine CI state and failed
+	// open. A human must confirm the completion was actually green.
+	EventCIStatusError EscalationEvent = "ci_status_error"
+	// EventPendingTimeout: checks were still pending when the configured
+	// pending_timeout elapsed and the completion was aborted.
+	EventPendingTimeout EscalationEvent = "pending_timeout"
+)
+
+// Escalation carries the context handed to the configured escalation command.
+type Escalation struct {
+	Event  EscalationEvent
+	Ticket string // external ticket key (e.g. Jira "AA-851"); may be empty
+	Detail string // human-readable description of what happened
+	PRURL  string
+	Branch string
+	Agent  string // e.g. "openclaw/polecats/furiosa"
+}
+
+// ticketLineRe matches the `Jira: AA-123 ...` (or `Ticket: AA-123 ...`)
+// convention used in bead descriptions to link Gas Town work to an external
+// tracker. The key may be followed by a title (`Jira: AA-851 — Implement …`).
+var ticketLineRe = regexp.MustCompile(`(?mi)^\s*(?:jira|ticket):\s*([A-Za-z][A-Za-z0-9]*-\d+)\b`)
+
+// ExtractTicket returns the external ticket key referenced by a bead
+// description, or "" when the bead carries no ticket line.
+func ExtractTicket(description string) string {
+	m := ticketLineRe.FindStringSubmatch(description)
+	if m == nil {
+		return ""
+	}
+	return strings.ToUpper(m[1])
+}
+
+// escalationTimeout bounds the external escalation command so a hung tracker
+// integration cannot wedge gt done / the refinery.
+const escalationTimeout = 60 * time.Second
+
+// RunEscalationCmd runs the rig-configured ci_gate.escalation_cmd via
+// `sh -c` with GT_CIGATE_* environment variables describing the event.
+// The command is the rig's bridge to its external tracker — e.g. a script
+// that comments on the ticket and transitions it to a human-attention
+// status. Errors are returned for logging but must never block completion:
+// escalation paths are fail-open by design.
+func RunEscalationCmd(cmdStr, dir string, esc Escalation) error {
+	if strings.TrimSpace(cmdStr) == "" {
+		return fmt.Errorf("no ci_gate.escalation_cmd configured")
+	}
+	cmd := exec.Command("sh", "-c", cmdStr)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GT_CIGATE_EVENT="+string(esc.Event),
+		"GT_CIGATE_TICKET="+esc.Ticket,
+		"GT_CIGATE_DETAIL="+esc.Detail,
+		"GT_CIGATE_PR_URL="+esc.PRURL,
+		"GT_CIGATE_BRANCH="+esc.Branch,
+		"GT_CIGATE_AGENT="+esc.Agent,
+	)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("escalation_cmd failed to start: %w", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			return fmt.Errorf("escalation_cmd failed: %w (%s)", err, strings.TrimSpace(out.String()))
+		}
+		return nil
+	case <-time.After(escalationTimeout):
+		_ = cmd.Process.Kill()
+		<-done
+		return fmt.Errorf("escalation_cmd timed out after %s", escalationTimeout)
+	}
+}

--- a/internal/cigate/escalate_test.go
+++ b/internal/cigate/escalate_test.go
@@ -1,0 +1,70 @@
+package cigate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtractTicket(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+		want string
+	}{
+		{"jira line with title", "attached_molecule: x\n\nJira: AA-851 — Implement the HARD GATE", "AA-851"},
+		{"jira line bare", "some text\nJira: AA-851\nmore", "AA-851"},
+		{"ticket alias", "Ticket: proj-42", "PROJ-42"},
+		{"lowercase key", "jira: aa-99", "AA-99"},
+		{"no line", "just a description", ""},
+		{"empty", "", ""},
+		{"key not on own line", "fixes Jira: AA-1 inline", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractTicket(tt.desc); got != tt.want {
+				t.Errorf("ExtractTicket(%q) = %q, want %q", tt.desc, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunEscalationCmd(t *testing.T) {
+	t.Run("passes context via environment", func(t *testing.T) {
+		outFile := filepath.Join(t.TempDir(), "esc.txt")
+		cmd := `echo "$GT_CIGATE_EVENT|$GT_CIGATE_TICKET|$GT_CIGATE_BRANCH|$GT_CIGATE_AGENT" > ` + outFile
+		err := RunEscalationCmd(cmd, t.TempDir(), Escalation{
+			Event:  EventPendingTimeout,
+			Ticket: "AA-851",
+			Branch: "polecat/furiosa",
+			Agent:  "openclaw/polecats/furiosa",
+			Detail: "CI pending too long",
+		})
+		if err != nil {
+			t.Fatalf("RunEscalationCmd: %v", err)
+		}
+		data, err := os.ReadFile(outFile)
+		if err != nil {
+			t.Fatalf("reading output: %v", err)
+		}
+		got := strings.TrimSpace(string(data))
+		want := "pending_timeout|AA-851|polecat/furiosa|openclaw/polecats/furiosa"
+		if got != want {
+			t.Errorf("escalation env = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty command errors", func(t *testing.T) {
+		if err := RunEscalationCmd("  ", ".", Escalation{}); err == nil {
+			t.Error("want error for empty escalation_cmd")
+		}
+	})
+
+	t.Run("failing command returns error with output", func(t *testing.T) {
+		err := RunEscalationCmd("echo tracker down >&2; exit 3", ".", Escalation{Event: EventCIStatusError})
+		if err == nil || !strings.Contains(err.Error(), "tracker down") {
+			t.Errorf("want failure containing command output, got %v", err)
+		}
+	})
+}

--- a/internal/cigate/execpath_test.go
+++ b/internal/cigate/execpath_test.go
@@ -1,0 +1,43 @@
+package cigate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCheckBranchRealExecPath exercises the default (non-stubbed) runner by
+// putting a fake gh binary on PATH, proving the exec wiring end to end:
+// argument passing, stdout capture, JSON decode, and stderr propagation on
+// failure. This is the "fake gh shim" simulation from the AA-851 test plan.
+func TestCheckBranchRealExecPath(t *testing.T) {
+	writeFakeGh := func(t *testing.T, script string) string {
+		t.Helper()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "gh")
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+
+	t.Run("green PR via real exec", func(t *testing.T) {
+		shim := writeFakeGh(t, fmt.Sprintf(`echo '%s'`,
+			`[{"number":21,"state":"OPEN","url":"u","statusCheckRollup":[{"__typename":"CheckRun","name":"CI","status":"COMPLETED","conclusion":"SUCCESS"}]}]`))
+		t.Setenv("PATH", shim+string(os.PathListSeparator)+os.Getenv("PATH"))
+		res := New().CheckBranch(t.TempDir(), "polecat/shim-test")
+		if res.Verdict != VerdictGreen || res.PRNumber != 21 {
+			t.Fatalf("got %s pr=%d err=%v, want GREEN pr=21", res.Verdict, res.PRNumber, res.Err)
+		}
+	})
+
+	t.Run("gh failure yields ERROR with stderr detail", func(t *testing.T) {
+		shim := writeFakeGh(t, `echo "gh: Bad credentials" >&2; exit 1`)
+		t.Setenv("PATH", shim+string(os.PathListSeparator)+os.Getenv("PATH"))
+		res := New().CheckBranch(t.TempDir(), "polecat/shim-test")
+		if res.Verdict != VerdictError || res.Err == nil {
+			t.Fatalf("got %s err=%v, want ERROR", res.Verdict, res.Err)
+		}
+	})
+}

--- a/internal/cigate/live_test.go
+++ b/internal/cigate/live_test.go
@@ -1,0 +1,26 @@
+package cigate
+
+import (
+	"os"
+	"testing"
+)
+
+// TestCheckBranchLive runs the gate against real GitHub. Opt-in:
+//
+//	GT_CIGATE_LIVE_TEST_DIR=<repo clone> \
+//	GT_CIGATE_LIVE_TEST_BRANCH=<branch> \
+//	GT_CIGATE_LIVE_TEST_WANT=<verdict> go test ./internal/cigate -run Live
+func TestCheckBranchLive(t *testing.T) {
+	dir := os.Getenv("GT_CIGATE_LIVE_TEST_DIR")
+	branch := os.Getenv("GT_CIGATE_LIVE_TEST_BRANCH")
+	want := os.Getenv("GT_CIGATE_LIVE_TEST_WANT")
+	if dir == "" || branch == "" {
+		t.Skip("set GT_CIGATE_LIVE_TEST_DIR and GT_CIGATE_LIVE_TEST_BRANCH to run")
+	}
+	res := New().CheckBranch(dir, branch)
+	t.Logf("live verdict=%s pr=%d url=%s failing=%v pending=%v err=%v",
+		res.Verdict, res.PRNumber, res.PRURL, res.FailingChecks, res.PendingChecks, res.Err)
+	if want != "" && string(res.Verdict) != want {
+		t.Fatalf("verdict = %s, want %s", res.Verdict, want)
+	}
+}

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1029,7 +1029,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		if convoyInfo != nil && convoyInfo.MergeStrategy == "direct" {
 			fmt.Printf("%s Direct merge strategy: pushing to %s\n", style.Bold.Render("→"), defaultBranch)
 			// Keep crash-recovery WIP checkpoints sandbox-local (gastownhall/gastown#4440).
-			squashWIPCheckpointCommits(cwd, baseRef)
+			squashWIPCheckpointCommits(g.WorkDir(), baseRef)
 			// Push submodule changes before direct push (gt-dzs)
 			pushSubmoduleChanges(g, baseRef)
 			directRefspec := branch + ":" + defaultBranch
@@ -1116,7 +1116,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// checkpoint_dog's "WIP: checkpoint (auto)" commits are a local crash-safety
 		// net and must never reach the remote. Runs after the resume check above so
 		// an already-pushed branch is never rewritten.
-		squashWIPCheckpointCommits(cwd, baseRef)
+		squashWIPCheckpointCommits(g.WorkDir(), baseRef)
 
 		// Auto-push submodule changes BEFORE parent push (gt-dzs).
 		// If the parent repo's submodule pointer references commits that don't

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/checkpoint"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/git"
@@ -1027,6 +1028,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// Handle "direct" strategy: push to target branch, skip MR
 		if convoyInfo != nil && convoyInfo.MergeStrategy == "direct" {
 			fmt.Printf("%s Direct merge strategy: pushing to %s\n", style.Bold.Render("→"), defaultBranch)
+			// Keep crash-recovery WIP checkpoints sandbox-local (gastownhall/gastown#4440).
+			squashWIPCheckpointCommits(cwd, baseRef)
 			// Push submodule changes before direct push (gt-dzs)
 			pushSubmoduleChanges(g, baseRef)
 			directRefspec := branch + ":" + defaultBranch
@@ -1109,6 +1112,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// isn't pushed yet, Refinery finds nothing to merge. The worktree gets
 		// nuked at the end of gt done, so the commits are lost forever.
 		//
+		// Keep crash-recovery WIP checkpoints sandbox-local (gastownhall/gastown#4440).
+		// checkpoint_dog's "WIP: checkpoint (auto)" commits are a local crash-safety
+		// net and must never reach the remote. Runs after the resume check above so
+		// an already-pushed branch is never rewritten.
+		squashWIPCheckpointCommits(cwd, baseRef)
+
 		// Auto-push submodule changes BEFORE parent push (gt-dzs).
 		// If the parent repo's submodule pointer references commits that don't
 		// exist on the submodule's remote, the Refinery MR will be broken.
@@ -1860,6 +1869,23 @@ notifyWitness:
 	}
 
 	return nil
+}
+
+// squashWIPCheckpointCommits collapses checkpoint_dog's "WIP: checkpoint (auto)"
+// commits into a single commit before a push, so crash-recovery checkpoints stay
+// sandbox-local instead of landing on the remote branch (gastownhall/gastown#4440).
+// Safe because the refinery squash-merges polecat branches anyway. Failures are
+// warnings, not errors: pushing WIP junk is bad, but blocking gt done on a squash
+// failure would strand the work entirely.
+func squashWIPCheckpointCommits(workDir, baseRef string) {
+	n, err := checkpoint.SquashWIPCommits(workDir, baseRef)
+	if err != nil {
+		style.PrintWarning("could not squash WIP checkpoint commits: %v", err)
+		return
+	}
+	if n > 0 {
+		fmt.Printf("%s Squashed %d WIP checkpoint commit(s) before push\n", style.Bold.Render("✓"), n)
+	}
 }
 
 // pushSubmoduleChanges detects submodules modified between baseRef

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1207,6 +1207,15 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		}
 		bd := beads.NewWithBeadsDir(cwd, resolvedBeads)
 
+		// AA-851 hard CI gate: block COMPLETED while this branch's PR has any
+		// check red or pending. Runs after push verification and BEFORE any
+		// issue close or MR-bead creation, so an abort leaves the polecat
+		// assigned with its hook bead open. No-PR and merged-PR pass through;
+		// CI-status errors fail open with a loud human escalation.
+		if gateErr := runDoneCIGate(bd, townRoot, rigName, cwd, branch, issueID, agentBeadID, sender); gateErr != nil {
+			return gateErr
+		}
+
 		// Check for no_merge flag - if set, skip merge queue and notify for review
 		sourceIssueForNoMerge, err := bd.Show(issueID)
 		if err == nil {
@@ -1257,19 +1266,33 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 					prBodyBuilder.WriteString("---\n")
 					prBodyBuilder.WriteString(fmt.Sprintf("*Polecat: %s | Issue: %s*\n", worker, issueID))
 					prBody := prBodyBuilder.String()
-					ghCmd := exec.CommandContext(context.Background(), "gh", "pr", "create",
-						"--base", defaultBranch,
-						"--head", branch,
-						"--title", prTitle,
-						"--body", prBody,
-					)
-					ghCmd.Dir = cwd
-					prOutput, prErr := ghCmd.Output()
-					if prErr != nil {
-						style.PrintWarning("could not create GitHub PR: %v", prErr)
-					} else {
-						prURL = strings.TrimSpace(string(prOutput))
-						fmt.Printf("%s GitHub PR created: %s\n", style.Bold.Render("✓"), prURL)
+					// Re-run idempotency (AA-851): a gt done that was aborted by
+					// the CI gate after creating the PR would otherwise fail here
+					// on a duplicate `gh pr create`. Reuse the existing open PR.
+					if existingNum, findErr := g.FindPRNumber(branch); findErr == nil && existingNum > 0 {
+						viewCmd := exec.CommandContext(context.Background(), "gh", "pr", "view",
+							fmt.Sprintf("%d", existingNum), "--json", "url", "--jq", ".url")
+						viewCmd.Dir = cwd
+						if viewOut, viewErr := viewCmd.Output(); viewErr == nil && len(strings.TrimSpace(string(viewOut))) > 0 {
+							prURL = strings.TrimSpace(string(viewOut))
+							fmt.Printf("%s Reusing existing GitHub PR: %s\n", style.Bold.Render("✓"), prURL)
+						}
+					}
+					if prURL == "" {
+						ghCmd := exec.CommandContext(context.Background(), "gh", "pr", "create",
+							"--base", defaultBranch,
+							"--head", branch,
+							"--title", prTitle,
+							"--body", prBody,
+						)
+						ghCmd.Dir = cwd
+						prOutput, prErr := ghCmd.Output()
+						if prErr != nil {
+							style.PrintWarning("could not create GitHub PR: %v", prErr)
+						} else {
+							prURL = strings.TrimSpace(string(prOutput))
+							fmt.Printf("%s GitHub PR created: %s\n", style.Bold.Render("✓"), prURL)
+						}
 					}
 				} else {
 					fmt.Printf("%s\n", style.Dim.Render("Work stays on feature branch for human review."))

--- a/internal/cmd/done_cigate.go
+++ b/internal/cmd/done_cigate.go
@@ -1,0 +1,270 @@
+package cmd
+
+// AA-851 hard CI gate for gt done: a polecat cannot transition to COMPLETED
+// while its branch's PR has any CI check red or pending. The gate runs after
+// the branch push is verified and BEFORE any issue close or MR-bead creation,
+// so an abort leaves the polecat assigned with its hook bead open — it keeps
+// iterating until the PR is green.
+//
+// Pass-through verdicts: no PR (merge-strategy=direct rigs), PR already
+// merged, PR closed-unmerged (deliberate human action, warn only).
+// Fail-open verdict: ERROR (CI state unknown) — completion proceeds, but the
+// event escalates to a human via ci_gate.escalation_cmd so a silently
+// broken gate is loudly visible.
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/cigate"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/style"
+)
+
+// needsCIGreenLabelPrefix marks an agent bead whose last gt done was blocked
+// by the CI gate: needs-ci-green:<pr>:<unix-ts>. Cleared on the next gt done
+// that passes the gate.
+const needsCIGreenLabelPrefix = "needs-ci-green:"
+
+// loadCIGateConfig reads the rig's merge_queue.ci_gate settings.
+// Missing settings file or block yields the enabled defaults.
+func loadCIGateConfig(rigPath string) *config.CIGateConfig {
+	settingsPath := filepath.Join(rigPath, "settings", "config.json")
+	if settings, err := config.LoadRigSettings(settingsPath); err == nil && settings.MergeQueue != nil {
+		return settings.MergeQueue.CIGateSettings()
+	}
+	return &config.CIGateConfig{}
+}
+
+// doneCIGateDeps carries the gate inputs plus injectable side effects so the
+// decision logic is unit-testable without beads/tmux/gh.
+type doneCIGateDeps struct {
+	gate   *cigate.Gate
+	cfg    *config.CIGateConfig
+	dir    string
+	branch string
+	agent  string
+	out    io.Writer
+
+	setNeedsCIGreen   func(prNumber int)
+	clearNeedsCIGreen func()
+	clearDoneIntent   func()
+	escalate          func(esc cigate.Escalation)
+	nudgeMayor        func(msg string)
+	// wait overrides gate.WaitForGreen in tests; nil = real wait.
+	wait func(timeout, poll time.Duration) (cigate.CheckResult, bool)
+}
+
+// enforce runs the gate. A nil return means gt done may proceed; a non-nil
+// error aborts gt done with the polecat still assigned.
+func (d *doneCIGateDeps) enforce() error {
+	res := d.gate.CheckBranch(d.dir, d.branch)
+
+	if res.Verdict == cigate.VerdictPending {
+		timeout := d.cfg.PendingTimeoutOrDefault()
+		poll := d.cfg.PollIntervalOrDefault()
+		fmt.Fprintf(d.out, "%s CI gate: %s — waiting up to %s for checks to settle\n",
+			style.Bold.Render("→"), res.Summary(), timeout)
+		var timedOut bool
+		if d.wait != nil {
+			res, timedOut = d.wait(timeout, poll)
+		} else {
+			res, timedOut = d.gate.WaitForGreen(d.dir, d.branch, cigate.WaitOptions{
+				Timeout:      timeout,
+				PollInterval: poll,
+				Progress:     d.out,
+			})
+		}
+		if timedOut {
+			detail := fmt.Sprintf("CI gate (AA-851): gt done aborted — %s after waiting %s. "+
+				"Agent %s on branch %s stays assigned and must re-run gt done once CI completes.",
+				res.Summary(), timeout, d.agent, d.branch)
+			d.escalate(cigate.Escalation{
+				Event:  cigate.EventPendingTimeout,
+				Detail: detail,
+				PRURL:  res.PRURL,
+				Branch: d.branch,
+				Agent:  d.agent,
+			})
+			d.nudgeMayor(fmt.Sprintf("NEEDS_CI_GREEN: %s stuck pending >%s for %s (branch %s)",
+				res.Summary(), timeout, d.agent, d.branch))
+			d.setNeedsCIGreen(res.PRNumber)
+			d.clearDoneIntent()
+			return fmt.Errorf("NEEDS_CI_GREEN: %s — still pending after %s.\n"+
+				"Poll `gh pr checks %d` and re-run `gt done` when CI completes.\n"+
+				"(Escalated for human attention; override: GT_CI_GATE=off)",
+				res.Summary(), timeout, res.PRNumber)
+		}
+	}
+
+	switch res.Verdict {
+	case cigate.VerdictNoPR:
+		// No PR for this branch — the gate only applies when a PR exists.
+		d.clearNeedsCIGreen()
+		return nil
+	case cigate.VerdictMerged:
+		fmt.Fprintf(d.out, "%s CI gate: %s\n", style.Bold.Render("✓"), res.Summary())
+		d.clearNeedsCIGreen()
+		return nil
+	case cigate.VerdictClosedUnmerged:
+		fmt.Fprintf(d.out, "%s CI gate: %s — passing through (deliberate close?)\n",
+			style.Warning.Render("⚠"), res.Summary())
+		d.clearNeedsCIGreen()
+		return nil
+	case cigate.VerdictGreen:
+		fmt.Fprintf(d.out, "%s CI gate: %s\n", style.Bold.Render("✓"), res.Summary())
+		d.clearNeedsCIGreen()
+		return nil
+	case cigate.VerdictError:
+		// Fail-open: a GitHub outage must not brick every completion, but a
+		// human must verify — escalate via the rig's tracker integration.
+		fmt.Fprintf(d.out, "%s CI gate: could not determine CI status (%v) — FAILING OPEN (AA-851)\n",
+			style.Warning.Render("⚠"), res.Err)
+		d.escalate(cigate.Escalation{
+			Event: cigate.EventCIStatusError,
+			Detail: fmt.Sprintf("CI gate (AA-851): could not determine CI status for branch %s (%v). "+
+				"gt done by %s proceeded FAIL-OPEN — a human must verify the PR's checks were green.",
+				d.branch, res.Err, d.agent),
+			Branch: d.branch,
+			Agent:  d.agent,
+		})
+		return nil
+	case cigate.VerdictRed:
+		d.setNeedsCIGreen(res.PRNumber)
+		d.clearDoneIntent()
+		return fmt.Errorf("NEEDS_CI_GREEN: %s.\n"+
+			"Fix the failures, push, and re-run `gt done`. You stay assigned to this work.\n"+
+			"(Inspect: `gh pr checks %d`; override: GT_CI_GATE=off)",
+			res.Summary(), res.PRNumber)
+	}
+	// Unknown verdict — treat like fail-open but warn.
+	fmt.Fprintf(d.out, "%s CI gate: unexpected verdict %s — failing open\n",
+		style.Warning.Render("⚠"), res.Verdict)
+	return nil
+}
+
+// runDoneCIGate wires the gate with real side effects and enforces it.
+// Called from the COMPLETED path of runDone after push verification.
+func runDoneCIGate(bd *beads.Beads, townRoot, rigName, cwd, branch, issueID, agentBeadID, sender string) error {
+	cfg := loadCIGateConfig(filepath.Join(townRoot, rigName))
+	if !cfg.IsEnabled() || cigate.EnvDisabled() {
+		return nil
+	}
+
+	agentBd := beads.New(cwd).ForAgentBead()
+	deps := &doneCIGateDeps{
+		gate:   cigate.New(),
+		cfg:    cfg,
+		dir:    cwd,
+		branch: branch,
+		agent:  sender,
+		out:    os.Stdout,
+		setNeedsCIGreen: func(prNumber int) {
+			setNeedsCIGreenLabel(agentBd, agentBeadID, prNumber)
+		},
+		clearNeedsCIGreen: func() {
+			clearNeedsCIGreenLabel(agentBd, agentBeadID)
+		},
+		clearDoneIntent: func() {
+			clearDoneIntentLabel(agentBd, agentBeadID)
+		},
+		escalate: func(esc cigate.Escalation) {
+			esc.Ticket = ticketForIssue(bd, issueID)
+			escalateCIGate(cfg, cwd, esc)
+		},
+		nudgeMayor: nudgeMayorBestEffort,
+	}
+	return deps.enforce()
+}
+
+// ticketForIssue extracts the external tracker key (`Jira: AA-123` line)
+// from the worked issue's description. Best-effort: "" when unavailable.
+func ticketForIssue(bd *beads.Beads, issueID string) string {
+	if bd == nil || issueID == "" {
+		return ""
+	}
+	issue, err := bd.Show(issueID)
+	if err != nil || issue == nil {
+		return ""
+	}
+	return cigate.ExtractTicket(issue.Description)
+}
+
+// escalateCIGate runs the rig's ci_gate.escalation_cmd (tracker integration:
+// comment on the ticket + move it to a human-attention status). Best-effort —
+// escalation failures are logged, never fatal.
+func escalateCIGate(cfg *config.CIGateConfig, dir string, esc cigate.Escalation) {
+	cmdStr := cfg.EscalationCmdOrEmpty()
+	if cmdStr == "" {
+		fmt.Fprintf(os.Stderr, "Warning: CI gate %s event but no ci_gate.escalation_cmd configured (ticket=%s): %s\n",
+			esc.Event, esc.Ticket, esc.Detail)
+		return
+	}
+	if err := cigate.RunEscalationCmd(cmdStr, dir, esc); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: CI gate escalation failed: %v\n", err)
+		return
+	}
+	fmt.Printf("%s CI gate: escalated %s to human attention (ticket %s)\n",
+		style.Bold.Render("→"), esc.Event, esc.Ticket)
+}
+
+// nudgeMayorBestEffort sends a gt nudge to the mayor, mirroring the
+// refinery's BRANCH_MISSING escalation precedent. Best-effort.
+func nudgeMayorBestEffort(msg string) {
+	cmd := exec.Command("gt", "nudge", "mayor/", msg)
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to nudge mayor: %v\n", err)
+	}
+}
+
+// setNeedsCIGreenLabel marks the agent bead as CI-gate-blocked:
+// needs-ci-green:<pr>:<unix-ts>. Replaces any prior needs-ci-green label.
+func setNeedsCIGreenLabel(bd *beads.Beads, agentBeadID string, prNumber int) {
+	if agentBeadID == "" {
+		return
+	}
+	label := fmt.Sprintf("%s%d:%d", needsCIGreenLabelPrefix, prNumber, time.Now().Unix())
+	toRemove := needsCIGreenLabels(bd, agentBeadID)
+	if err := bd.Update(agentBeadID, beads.UpdateOptions{
+		AddLabels:    []string{label},
+		RemoveLabels: toRemove,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: couldn't set needs-ci-green label on %s: %v\n", agentBeadID, err)
+	}
+}
+
+// clearNeedsCIGreenLabel removes any needs-ci-green:* label from the agent
+// bead (called when a later gt done passes the gate).
+func clearNeedsCIGreenLabel(bd *beads.Beads, agentBeadID string) {
+	if agentBeadID == "" {
+		return
+	}
+	toRemove := needsCIGreenLabels(bd, agentBeadID)
+	if len(toRemove) == 0 {
+		return
+	}
+	if err := bd.Update(agentBeadID, beads.UpdateOptions{RemoveLabels: toRemove}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: couldn't clear needs-ci-green label on %s: %v\n", agentBeadID, err)
+	}
+}
+
+// needsCIGreenLabels lists the agent bead's needs-ci-green:* labels.
+func needsCIGreenLabels(bd *beads.Beads, agentBeadID string) []string {
+	issue, err := bd.Show(agentBeadID)
+	if err != nil || issue == nil {
+		return nil
+	}
+	var labels []string
+	for _, label := range issue.Labels {
+		if strings.HasPrefix(label, needsCIGreenLabelPrefix) {
+			labels = append(labels, label)
+		}
+	}
+	return labels
+}

--- a/internal/cmd/done_cigate_test.go
+++ b/internal/cmd/done_cigate_test.go
@@ -1,0 +1,207 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/cigate"
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+// gateRecorder captures the side effects of a doneCIGateDeps.enforce run.
+type gateRecorder struct {
+	needsSetPR    int
+	needsSet      bool
+	needsCleared  bool
+	intentCleared bool
+	escalations   []cigate.Escalation
+	mayorNudges   []string
+}
+
+func gateDeps(ghOutput string, rec *gateRecorder) *doneCIGateDeps {
+	return &doneCIGateDeps{
+		gate: &cigate.Gate{Run: func(dir, name string, args ...string) ([]byte, error) {
+			return []byte(ghOutput), nil
+		}},
+		cfg:    &config.CIGateConfig{},
+		dir:    "/tmp",
+		branch: "polecat/test",
+		agent:  "rig/polecats/test",
+		out:    &bytes.Buffer{},
+		setNeedsCIGreen: func(pr int) {
+			rec.needsSet = true
+			rec.needsSetPR = pr
+		},
+		clearNeedsCIGreen: func() { rec.needsCleared = true },
+		clearDoneIntent:   func() { rec.intentCleared = true },
+		escalate:          func(esc cigate.Escalation) { rec.escalations = append(rec.escalations, esc) },
+		nudgeMayor:        func(msg string) { rec.mayorNudges = append(rec.mayorNudges, msg) },
+	}
+}
+
+const (
+	ghNoPR        = `[]`
+	ghGreen       = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"context":"jenkins","state":"SUCCESS"}]}]`
+	ghRed         = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"name":"test","conclusion":"failure"}]}]`
+	ghPending     = `[{"number":5,"state":"OPEN","url":"u","statusCheckRollup":[{"context":"jenkins","state":"PENDING"}]}]`
+	ghMerged      = `[{"number":5,"state":"MERGED","url":"u","statusCheckRollup":[]}]`
+	ghClosed      = `[{"number":5,"state":"CLOSED","url":"u","statusCheckRollup":[]}]`
+	ghUnparseable = `oops`
+)
+
+func TestDoneCIGateAllows(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		ghOutput string
+	}{
+		{"no PR passes through", ghNoPR},
+		{"green PR allowed", ghGreen},
+		{"merged PR allowed", ghMerged},
+		{"closed-unmerged PR allowed with warning", ghClosed},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &gateRecorder{}
+			if err := gateDeps(tt.ghOutput, rec).enforce(); err != nil {
+				t.Fatalf("enforce() = %v, want nil", err)
+			}
+			if !rec.needsCleared {
+				t.Error("expected stale needs-ci-green label cleared on pass")
+			}
+			if rec.needsSet || rec.intentCleared || len(rec.escalations) != 0 {
+				t.Errorf("unexpected side effects: %+v", rec)
+			}
+		})
+	}
+}
+
+func TestDoneCIGateBlocksRed(t *testing.T) {
+	rec := &gateRecorder{}
+	err := gateDeps(ghRed, rec).enforce()
+	if err == nil {
+		t.Fatal("enforce() = nil, want NEEDS_CI_GREEN error")
+	}
+	if !strings.Contains(err.Error(), "NEEDS_CI_GREEN") || !strings.Contains(err.Error(), "test") {
+		t.Errorf("error should name the gate and failing check: %v", err)
+	}
+	if !rec.needsSet || rec.needsSetPR != 5 {
+		t.Errorf("needs-ci-green label not set for PR 5: %+v", rec)
+	}
+	if !rec.intentCleared {
+		t.Error("done-intent label must be cleared so witness doesn't treat abort as crash-mid-done")
+	}
+	if len(rec.escalations) != 0 {
+		t.Errorf("red is the polecat's job, not a human escalation: %+v", rec.escalations)
+	}
+}
+
+func TestDoneCIGateErrorFailsOpenAndEscalates(t *testing.T) {
+	rec := &gateRecorder{}
+	if err := gateDeps(ghUnparseable, rec).enforce(); err != nil {
+		t.Fatalf("enforce() = %v, want nil (fail-open)", err)
+	}
+	if len(rec.escalations) != 1 || rec.escalations[0].Event != cigate.EventCIStatusError {
+		t.Fatalf("want one ci_status_error escalation, got %+v", rec.escalations)
+	}
+	if rec.needsSet || rec.intentCleared {
+		t.Errorf("fail-open must not block: %+v", rec)
+	}
+}
+
+func TestDoneCIGatePendingResolvesGreen(t *testing.T) {
+	rec := &gateRecorder{}
+	deps := gateDeps(ghPending, rec)
+	deps.wait = func(timeout, poll time.Duration) (cigate.CheckResult, bool) {
+		return cigate.CheckResult{Verdict: cigate.VerdictGreen, PRNumber: 5}, false
+	}
+	if err := deps.enforce(); err != nil {
+		t.Fatalf("enforce() = %v, want nil after pending→green", err)
+	}
+	if !rec.needsCleared || len(rec.escalations) != 0 {
+		t.Errorf("unexpected side effects: %+v", rec)
+	}
+}
+
+func TestDoneCIGatePendingResolvesRed(t *testing.T) {
+	rec := &gateRecorder{}
+	deps := gateDeps(ghPending, rec)
+	deps.wait = func(timeout, poll time.Duration) (cigate.CheckResult, bool) {
+		return cigate.CheckResult{Verdict: cigate.VerdictRed, PRNumber: 5, FailingChecks: []string{"jenkins"}}, false
+	}
+	err := deps.enforce()
+	if err == nil || !strings.Contains(err.Error(), "NEEDS_CI_GREEN") {
+		t.Fatalf("enforce() = %v, want NEEDS_CI_GREEN block after pending→red", err)
+	}
+	if !rec.needsSet || !rec.intentCleared {
+		t.Errorf("expected block side effects: %+v", rec)
+	}
+}
+
+func TestDoneCIGatePendingTimeoutEscalatesAndBlocks(t *testing.T) {
+	rec := &gateRecorder{}
+	deps := gateDeps(ghPending, rec)
+	deps.cfg = &config.CIGateConfig{PendingTimeout: "30m"}
+	deps.wait = func(timeout, poll time.Duration) (cigate.CheckResult, bool) {
+		if timeout != 30*time.Minute {
+			t.Errorf("timeout = %s, want 30m", timeout)
+		}
+		return cigate.CheckResult{Verdict: cigate.VerdictPending, PRNumber: 5, PendingChecks: []string{"jenkins"}}, true
+	}
+	err := deps.enforce()
+	if err == nil || !strings.Contains(err.Error(), "NEEDS_CI_GREEN") {
+		t.Fatalf("enforce() = %v, want NEEDS_CI_GREEN block on timeout", err)
+	}
+	if len(rec.escalations) != 1 || rec.escalations[0].Event != cigate.EventPendingTimeout {
+		t.Fatalf("want one pending_timeout escalation (Blair: comment + Requires Human Input), got %+v", rec.escalations)
+	}
+	if len(rec.mayorNudges) != 1 {
+		t.Errorf("want mayor nudge on pending timeout, got %v", rec.mayorNudges)
+	}
+	if !rec.needsSet || !rec.intentCleared {
+		t.Errorf("expected block side effects: %+v", rec)
+	}
+}
+
+func TestCIGateConfigDefaults(t *testing.T) {
+	var nilCfg *config.CIGateConfig
+	if !nilCfg.IsEnabled() {
+		t.Error("nil ci_gate config must default to enabled")
+	}
+	if got := nilCfg.PendingTimeoutOrDefault(); got != 30*time.Minute {
+		t.Errorf("default pending_timeout = %s, want 30m (Blair: capital Jenkins green runs take ~18m)", got)
+	}
+	if got := nilCfg.PollIntervalOrDefault(); got != 30*time.Second {
+		t.Errorf("default poll_interval = %s, want 30s", got)
+	}
+	if got := nilCfg.MayorAlertAfterOrDefault(); got != 30*time.Minute {
+		t.Errorf("default mayor_alert_after = %s, want 30m", got)
+	}
+
+	off := false
+	cfg := &config.CIGateConfig{Enabled: &off, PendingTimeout: "10m"}
+	if cfg.IsEnabled() {
+		t.Error("enabled=false must disable")
+	}
+	if got := cfg.PendingTimeoutOrDefault(); got != 10*time.Minute {
+		t.Errorf("configured pending_timeout = %s, want 10m", got)
+	}
+	if got := (&config.CIGateConfig{PendingTimeout: "garbage"}).PendingTimeoutOrDefault(); got != 30*time.Minute {
+		t.Errorf("invalid pending_timeout should fall back to 30m, got %s", got)
+	}
+}
+
+func TestCIGateEnvKillSwitch(t *testing.T) {
+	for _, v := range []string{"off", "0", "false", "disabled", "OFF"} {
+		t.Setenv("GT_CI_GATE", v)
+		if !cigate.EnvDisabled() {
+			t.Errorf("GT_CI_GATE=%s should disable the gate", v)
+		}
+	}
+	for _, v := range []string{"", "on", "1", "true"} {
+		t.Setenv("GT_CI_GATE", v)
+		if cigate.EnvDisabled() {
+			t.Errorf("GT_CI_GATE=%s should NOT disable the gate", v)
+		}
+	}
+}

--- a/internal/cmd/done_squash_wip_test.go
+++ b/internal/cmd/done_squash_wip_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// wipTestRepo creates a git repo with a main branch, a feature branch, and the
+// given sequence of commit subjects on the feature branch. Returns the repo dir.
+func wipTestRepo(t *testing.T, subjects ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run("git", "init", "-b", "main")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("git", "add", "-A")
+	run("git", "commit", "-m", "initial commit")
+	run("git", "checkout", "-b", "feature")
+
+	for i, subj := range subjects {
+		name := "file" + strings.Repeat("x", i) + ".txt"
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(subj+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		run("git", "add", name)
+		run("git", "commit", "-m", subj)
+	}
+	return dir
+}
+
+func featureSubjects(t *testing.T, dir string) []string {
+	t.Helper()
+	cmd := exec.Command("git", "log", "--format=%s", "main..HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git log failed: %v", err)
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return nil
+	}
+	return strings.Split(raw, "\n")
+}
+
+// TestSquashWIPCheckpointCommits_StripsWIPBeforePush verifies the gt done
+// pre-push hook squashes checkpoint_dog's "WIP: checkpoint (auto)" commits so
+// they never reach the remote (gastownhall/gastown#4440).
+func TestSquashWIPCheckpointCommits_StripsWIPBeforePush(t *testing.T) {
+	dir := wipTestRepo(t,
+		"feat: real work",
+		"WIP: checkpoint (auto)",
+		"fix: more real work",
+		"WIP: checkpoint (auto)",
+	)
+
+	squashWIPCheckpointCommits(dir, "main")
+
+	subjects := featureSubjects(t, dir)
+	if len(subjects) != 1 {
+		t.Fatalf("expected 1 squashed commit, got %d: %v", len(subjects), subjects)
+	}
+	for _, s := range subjects {
+		if strings.HasPrefix(s, "WIP: checkpoint (auto)") {
+			t.Errorf("WIP checkpoint commit survived squash: %q", s)
+		}
+	}
+	// The most recent non-WIP subject is preserved as the squash-commit title
+	// (git log order: newest first).
+	if subjects[0] != "fix: more real work" {
+		t.Errorf("squash title = %q, want %q", subjects[0], "fix: more real work")
+	}
+}
+
+// TestSquashWIPCheckpointCommits_NoWIPIsNoOp verifies branches without WIP
+// checkpoint commits keep their history untouched.
+func TestSquashWIPCheckpointCommits_NoWIPIsNoOp(t *testing.T) {
+	dir := wipTestRepo(t, "feat: one", "fix: two")
+
+	squashWIPCheckpointCommits(dir, "main")
+
+	subjects := featureSubjects(t, dir)
+	if len(subjects) != 2 {
+		t.Fatalf("expected history untouched (2 commits), got %d: %v", len(subjects), subjects)
+	}
+}

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -142,6 +142,7 @@ var (
 	polecatNukeAll                       bool
 	polecatNukeDryRun                    bool
 	polecatNukeForce                     bool
+	polecatNukeIgnoreCI                  bool
 	polecatCheckRecoveryJSON             bool
 	polecatCheckRecoveryReconcileCleanup bool
 	polecatPoolInitDryRun                bool
@@ -346,6 +347,7 @@ func init() {
 	polecatNukeCmd.Flags().BoolVar(&polecatNukeAll, "all", false, "Nuke all polecats in the rig")
 	polecatNukeCmd.Flags().BoolVar(&polecatNukeDryRun, "dry-run", false, "Show what would be nuked without doing it")
 	polecatNukeCmd.Flags().BoolVarP(&polecatNukeForce, "force", "f", false, "Force nuke, bypassing all safety checks (LOSES WORK)")
+	polecatNukeCmd.Flags().BoolVar(&polecatNukeIgnoreCI, "ignore-ci", false, "Bypass the AA-851 CI gate (nuke even when the branch's PR has red/pending checks)")
 
 	// Check-recovery flags
 	polecatCheckRecoveryCmd.Flags().BoolVar(&polecatCheckRecoveryJSON, "json", false, "Output as JSON")
@@ -1791,7 +1793,7 @@ func runPolecatNuke(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Nuking %s/%s...\n", p.rigName, p.polecatName)
 		}
 
-		if err := nukePolecatFullWithOptions(p.polecatName, p.rigName, p.mgr, p.r, nukePolecatOptions{PurgeClosedEphemerals: !batchPurge}); err != nil {
+		if err := nukePolecatFullWithOptions(p.polecatName, p.rigName, p.mgr, p.r, nukePolecatOptions{PurgeClosedEphemerals: !batchPurge, IgnoreCIGate: polecatNukeIgnoreCI}); err != nil {
 			nukeErrors = append(nukeErrors, fmt.Sprintf("%s/%s: %v", p.rigName, p.polecatName, err))
 			continue
 		}
@@ -1860,9 +1862,23 @@ func nukePolecatFull(polecatName, rigName string, mgr *polecat.Manager, r *rig.R
 
 type nukePolecatOptions struct {
 	PurgeClosedEphemerals bool
+	// IgnoreCIGate bypasses the AA-851 CI gate (nuke even when the branch's
+	// PR has red/pending checks). Set only by explicit --ignore-ci.
+	IgnoreCIGate bool
 }
 
 func nukePolecatFullWithOptions(polecatName, rigName string, mgr *polecat.Manager, r *rig.Rig, opts nukePolecatOptions) error {
+	// Step 0: AA-851 hard CI gate — refuse to reap a polecat whose branch has
+	// an open PR with red or pending checks. Runs before the tmux kill so a
+	// refused nuke leaves the session intact. Covers nuke (incl. --force),
+	// stale --cleanup, and the witness auto-nuke. Override: --ignore-ci or
+	// GT_CI_GATE=off.
+	if !opts.IgnoreCIGate {
+		if err := checkNukeCIGate(polecatName, rigName, mgr, r); err != nil {
+			return err
+		}
+	}
+
 	t := tmux.NewTmux()
 
 	// Step 1: Kill tmux session unconditionally to prevent ghost sessions

--- a/internal/cmd/polecat_cigate.go
+++ b/internal/cmd/polecat_cigate.go
@@ -1,0 +1,145 @@
+package cmd
+
+// AA-851 hard CI gate for the reap funnel: a polecat cannot be nuked while
+// its branch's PR has any CI check red or pending. This single hook at the
+// top of nukePolecatFullWithOptions covers every deliberate destroy path —
+// `gt polecat nuke` (including --force), `gt polecat stale --cleanup`, and
+// the witness's auto-nuke (which shells out to `gt polecat nuke`).
+//
+// Unlike the gt done gate, the nuke gate never waits: it refuses immediately
+// and lets the caller retry later. Repeated refusals past
+// ci_gate.mayor_alert_after nudge the mayor. Explicit overrides:
+// `gt polecat nuke --ignore-ci` or GT_CI_GATE=off.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/cigate"
+	"github.com/steveyegge/gastown/internal/polecat"
+	"github.com/steveyegge/gastown/internal/rig"
+)
+
+// ciGateBlockedLabelPrefix marks an agent bead whose nuke was refused by the
+// CI gate: ci-gate-blocked:<unix-ts-of-first-refusal>. Cleared when the gate
+// passes; used to alert the mayor when a nuke stays blocked too long.
+const ciGateBlockedLabelPrefix = "ci-gate-blocked:"
+
+// checkNukeCIGate refuses the nuke (returns an error) when the polecat's
+// branch has an open PR with red or pending checks. Pass-through: no PR,
+// merged PR, closed-unmerged PR, CI-status errors (fail-open with warning),
+// no resolvable branch, gate disabled.
+func checkNukeCIGate(polecatName, rigName string, mgr *polecat.Manager, r *rig.Rig) error {
+	cfg := loadCIGateConfig(r.Path)
+	if !cfg.IsEnabled() || cigate.EnvDisabled() {
+		return nil
+	}
+
+	info, err := mgr.Get(polecatName)
+	if err != nil || info == nil || info.Branch == "" {
+		return nil // no branch to check — nothing to gate
+	}
+
+	res := cigate.New().CheckBranch(ciGateDirForPolecat(info.ClonePath, r.Path), info.Branch)
+	agentBd := beads.New(r.Path).ForAgentBead()
+	agentBeadID := polecatBeadIDForRig(r, rigName, polecatName)
+
+	if res.Verdict == cigate.VerdictError {
+		fmt.Fprintf(os.Stderr, "Warning: CI gate could not determine CI status for %s/%s branch %s (%v) — failing open (AA-851)\n",
+			rigName, polecatName, info.Branch, res.Err)
+		return nil
+	}
+	if !res.Verdict.Blocks() {
+		clearCIGateBlockedLabel(agentBd, agentBeadID)
+		return nil
+	}
+
+	// Blocked. Track the first refusal so long-standing blocks alert the mayor.
+	firstBlocked := markCIGateBlocked(agentBd, agentBeadID)
+	if !firstBlocked.IsZero() && time.Since(firstBlocked) > cfg.MayorAlertAfterOrDefault() {
+		nudgeMayorBestEffort(fmt.Sprintf("CI_GATE_BLOCKED: nuke of %s/%s blocked >%s — %s (branch %s). Investigate the PR or override with --ignore-ci.",
+			rigName, polecatName, cfg.MayorAlertAfterOrDefault(), res.Summary(), info.Branch))
+	}
+	return fmt.Errorf("CI gate (AA-851): refusing to nuke %s/%s — %s.\n"+
+		"The polecat's work is not landed; nuking would strand a red/pending PR.\n"+
+		"Wait for CI (or fix the PR), or override with --ignore-ci / GT_CI_GATE=off",
+		rigName, polecatName, res.Summary())
+}
+
+// ciGateDirForPolecat picks the directory for gh invocations: gh resolves
+// the repo from the git remotes of its working directory, so prefer the
+// polecat worktree and fall back to the rig's mayor clone when it's gone.
+func ciGateDirForPolecat(clonePath, rigPath string) string {
+	if clonePath != "" {
+		if _, err := os.Stat(clonePath); err == nil {
+			return clonePath
+		}
+	}
+	return filepath.Join(rigPath, "mayor", "rig")
+}
+
+// markCIGateBlocked records the first CI-gate refusal timestamp on the agent
+// bead and returns it (zero time when the bead is unavailable). Subsequent
+// refusals reuse the existing timestamp so the mayor-alert threshold measures
+// total blocked time, not time since the latest attempt.
+func markCIGateBlocked(bd *beads.Beads, agentBeadID string) time.Time {
+	if agentBeadID == "" {
+		return time.Time{}
+	}
+	issue, err := bd.Show(agentBeadID)
+	if err != nil || issue == nil {
+		return time.Time{}
+	}
+	for _, label := range issue.Labels {
+		if ts, ok := parseCIGateBlockedLabel(label); ok {
+			return ts
+		}
+	}
+	now := time.Now()
+	label := fmt.Sprintf("%s%d", ciGateBlockedLabelPrefix, now.Unix())
+	if err := bd.Update(agentBeadID, beads.UpdateOptions{AddLabels: []string{label}}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: couldn't set ci-gate-blocked label on %s: %v\n", agentBeadID, err)
+	}
+	return now
+}
+
+// clearCIGateBlockedLabel removes any ci-gate-blocked:* label (gate passed).
+func clearCIGateBlockedLabel(bd *beads.Beads, agentBeadID string) {
+	if agentBeadID == "" {
+		return
+	}
+	issue, err := bd.Show(agentBeadID)
+	if err != nil || issue == nil {
+		return
+	}
+	var toRemove []string
+	for _, label := range issue.Labels {
+		if strings.HasPrefix(label, ciGateBlockedLabelPrefix) {
+			toRemove = append(toRemove, label)
+		}
+	}
+	if len(toRemove) == 0 {
+		return
+	}
+	if err := bd.Update(agentBeadID, beads.UpdateOptions{RemoveLabels: toRemove}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: couldn't clear ci-gate-blocked label on %s: %v\n", agentBeadID, err)
+	}
+}
+
+// parseCIGateBlockedLabel extracts the first-refusal time from a
+// ci-gate-blocked:<unix> label.
+func parseCIGateBlockedLabel(label string) (time.Time, bool) {
+	if !strings.HasPrefix(label, ciGateBlockedLabelPrefix) {
+		return time.Time{}, false
+	}
+	ts, err := strconv.ParseInt(strings.TrimPrefix(label, ciGateBlockedLabelPrefix), 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return time.Unix(ts, 0), true
+}

--- a/internal/cmd/polecat_cigate_test.go
+++ b/internal/cmd/polecat_cigate_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseCIGateBlockedLabel(t *testing.T) {
+	ts, ok := parseCIGateBlockedLabel("ci-gate-blocked:1720000000")
+	if !ok {
+		t.Fatal("want ok for valid label")
+	}
+	if want := time.Unix(1720000000, 0); !ts.Equal(want) {
+		t.Errorf("ts = %v, want %v", ts, want)
+	}
+	for _, bad := range []string{"ci-gate-blocked:", "ci-gate-blocked:abc", "needs-ci-green:5:1", "other"} {
+		if _, ok := parseCIGateBlockedLabel(bad); ok {
+			t.Errorf("parseCIGateBlockedLabel(%q) = ok, want !ok", bad)
+		}
+	}
+}
+
+func TestCIGateDirForPolecat(t *testing.T) {
+	rigPath := t.TempDir()
+	mayorClone := filepath.Join(rigPath, "mayor", "rig")
+
+	t.Run("missing clone falls back to mayor clone", func(t *testing.T) {
+		if got := ciGateDirForPolecat(filepath.Join(rigPath, "gone"), rigPath); got != mayorClone {
+			t.Errorf("dir = %q, want %q", got, mayorClone)
+		}
+	})
+	t.Run("empty clone falls back to mayor clone", func(t *testing.T) {
+		if got := ciGateDirForPolecat("", rigPath); got != mayorClone {
+			t.Errorf("dir = %q, want %q", got, mayorClone)
+		}
+	})
+	t.Run("existing clone preferred", func(t *testing.T) {
+		clone := filepath.Join(rigPath, "polecats", "x", "rig")
+		if err := os.MkdirAll(clone, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if got := ciGateDirForPolecat(clone, rigPath); got != clone {
+			t.Errorf("dir = %q, want %q", got, clone)
+		}
+	})
+}

--- a/internal/cmd/polecat_helpers.go
+++ b/internal/cmd/polecat_helpers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/cigate"
 	"github.com/steveyegge/gastown/internal/polecat"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
@@ -213,6 +214,19 @@ func checkPolecatSafety(target polecatTarget) *SafetyCheckResult {
 		} else if mr != nil {
 			result.OpenMR = mr.ID
 			result.Reasons = append(result.Reasons, fmt.Sprintf("has open MR (%s)", mr.ID))
+		}
+	}
+
+	// Check 4 (AA-851): PR CI not green — friendly early error surfaced by
+	// safety checks/dry-run. The nuke funnel (checkNukeCIGate) enforces the
+	// same gate even under --force.
+	if infoErr == nil && polecatInfo != nil && polecatInfo.Branch != "" {
+		cfg := loadCIGateConfig(target.r.Path)
+		if cfg.IsEnabled() && !cigate.EnvDisabled() {
+			res := cigate.New().CheckBranch(ciGateDirForPolecat(polecatInfo.ClonePath, target.r.Path), polecatInfo.Branch)
+			if res.Verdict.Blocks() {
+				result.Reasons = append(result.Reasons, fmt.Sprintf("PR CI not green: %s", res.Summary()))
+			}
 		}
 	}
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1400,6 +1400,104 @@ type MergeQueueConfig struct {
 	// is enabled. Valid values: "quick", "standard", "deep".
 	// Nil defaults to "standard".
 	ReviewDepth string `json:"review_depth,omitempty"`
+
+	// CIGate configures the hard CI gate (AA-851): a polecat cannot complete
+	// (gt done) and cannot be nuked while its branch's PR has failing or
+	// pending CI checks, and the refinery will not merge such a PR.
+	// Nil = enabled with defaults; the gate only applies when a PR exists
+	// for the branch (no-PR and merged-PR pass through), which makes the
+	// default safe for direct-merge rigs.
+	CIGate *CIGateConfig `json:"ci_gate,omitempty"`
+}
+
+// CIGateConfig configures the hard CI gate (AA-851).
+type CIGateConfig struct {
+	// Enabled controls the gate. Nil defaults to true.
+	// Emergency process-level kill switch (no config edit): GT_CI_GATE=off.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// PendingTimeout is how long gt done waits for pending checks to settle
+	// before aborting with a human escalation. Default "30m" — sized for
+	// slow Jenkins pipelines (capital green runs take ~18m).
+	PendingTimeout string `json:"pending_timeout,omitempty"`
+
+	// PollInterval is the initial poll interval while waiting on pending
+	// checks; it backs off to 4x. Default "30s".
+	PollInterval string `json:"poll_interval,omitempty"`
+
+	// MayorAlertAfter is how long a polecat nuke can stay CI-blocked before
+	// the gate nudges the mayor. Default "30m".
+	MayorAlertAfter string `json:"mayor_alert_after,omitempty"`
+
+	// EscalationCmd is run via `sh -c` when the gate needs a human: on CI
+	// status errors (fail-open) and pending-timeout aborts. It receives
+	// GT_CIGATE_EVENT, GT_CIGATE_TICKET, GT_CIGATE_DETAIL, GT_CIGATE_PR_URL,
+	// GT_CIGATE_BRANCH and GT_CIGATE_AGENT in the environment. Wire it to
+	// your external tracker — e.g. a script that comments on the ticket and
+	// transitions it to a human-attention status.
+	EscalationCmd string `json:"escalation_cmd,omitempty"`
+}
+
+// IsEnabled returns whether the CI gate is on. Nil-safe, defaults to true.
+func (c *CIGateConfig) IsEnabled() bool {
+	if c == nil || c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// ciGateDuration parses s, falling back to def on empty or invalid values.
+func ciGateDuration(s string, def time.Duration) time.Duration {
+	if s == "" {
+		return def
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return def
+	}
+	return d
+}
+
+// PendingTimeoutOrDefault returns the pending-check wait budget (default 30m).
+func (c *CIGateConfig) PendingTimeoutOrDefault() time.Duration {
+	if c == nil {
+		return 30 * time.Minute
+	}
+	return ciGateDuration(c.PendingTimeout, 30*time.Minute)
+}
+
+// PollIntervalOrDefault returns the initial poll interval (default 30s).
+func (c *CIGateConfig) PollIntervalOrDefault() time.Duration {
+	if c == nil {
+		return 30 * time.Second
+	}
+	return ciGateDuration(c.PollInterval, 30*time.Second)
+}
+
+// MayorAlertAfterOrDefault returns the CI-blocked-nuke mayor alert threshold
+// (default 30m).
+func (c *CIGateConfig) MayorAlertAfterOrDefault() time.Duration {
+	if c == nil {
+		return 30 * time.Minute
+	}
+	return ciGateDuration(c.MayorAlertAfter, 30*time.Minute)
+}
+
+// EscalationCmdOrEmpty returns the configured escalation command. Nil-safe.
+func (c *CIGateConfig) EscalationCmdOrEmpty() string {
+	if c == nil {
+		return ""
+	}
+	return c.EscalationCmd
+}
+
+// CIGateSettings returns the rig's CI gate configuration, never nil.
+// A nil receiver or missing ci_gate block yields the enabled defaults.
+func (c *MergeQueueConfig) CIGateSettings() *CIGateConfig {
+	if c == nil || c.CIGate == nil {
+		return &CIGateConfig{}
+	}
+	return c.CIGate
 }
 
 // OnConflict strategy constants.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2228,6 +2228,14 @@ func (d *Daemon) isRigOperational(rigName string) (bool, string) {
 				return false, "rig is parked (global)"
 			}
 		}
+	} else if isRigBeadNotFound(err) {
+		// Not-found is a DEFINITIVE answer, not an outage: the rig has no rig
+		// bead, so nothing has ever docked/parked it globally. Treat it like a
+		// rig bead without status labels and continue. Conflating this with
+		// "Dolt unavailable" excluded rigs with missing rig beads (e.g.
+		// cap-rig-capital, 2026-07-08) from witness/refinery patrol
+		// indefinitely and spammed ~18k warnings/day.
+		d.logger.Printf("Rig bead %s not found — no global docked/parked state, treating rig as not docked", rigBeadID)
 	} else {
 		// Log when rig bead lookup fails - this helps debug transient Dolt issues
 		// FAIL-SAFE: When we can't verify docked status (Dolt down, network issue, etc.),
@@ -2253,6 +2261,21 @@ func (d *Daemon) isRigOperational(rigName string) (bool, string) {
 	}
 
 	return true, ""
+}
+
+// isRigBeadNotFound reports whether a rig-bead lookup error means the bead
+// definitively does not exist (as opposed to a transport/Dolt failure where
+// existence is unknown). Matches beads.ErrNotFound plus the "not found" /
+// "no issue found" strings the bd CLI path surfaces instead of the sentinel.
+func isRigBeadNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, beads.ErrNotFound) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "not found") || strings.Contains(msg, "no issue found") || strings.Contains(msg, "no issues found")
 }
 
 // processLifecycleRequests checks for and processes lifecycle requests.
@@ -2820,9 +2843,17 @@ func (d *Daemon) isBeadClosed(beadID string) bool {
 // assignee on the work bead, but no longer maintains the agent bead's hook_bead
 // field (updateAgentHookBead is a no-op). Without this fallback, the idle reaper
 // kills working polecats whose agent bead hook_bead is stale.
-func (d *Daemon) hasAssignedOpenWork(rigName, assignee string) bool {
+//
+// Returns (true, nil) when open work is found. Returns (false, nil) only when
+// EVERY status query succeeded and none returned work — a verified negative.
+// Returns (false, err) when any status query failed and no work was seen: the
+// work-state is UNKNOWN, and callers MUST NOT treat it as "no work" (2026-07-08
+// incidents: bd failures during Dolt degradation read as idle → healthy
+// mid-work polecats killed).
+func (d *Daemon) hasAssignedOpenWork(rigName, assignee string) (bool, error) {
 	rigDir := beads.GetRigDirForName(d.config.TownRoot, rigName)
 
+	var lookupErr error
 	for _, status := range []string{"hooked", "in_progress", "open"} {
 		args := beads.InjectFlatForListJSON([]string{"list", "--assignee=" + assignee, "--status=" + status, "--json"})
 		cmd := exec.Command(d.bdPath, args...) //nolint:gosec // G204: args are constructed internally
@@ -2834,14 +2865,19 @@ func (d *Daemon) hasAssignedOpenWork(rigName, assignee string) bool {
 		}
 		output, err := cmd.Output()
 		if err != nil {
+			lookupErr = fmt.Errorf("bd list --assignee=%s --status=%s: %w", assignee, status, err)
 			continue
 		}
 		var issues []json.RawMessage
-		if json.Unmarshal(output, &issues) == nil && len(issues) > 0 {
-			return true
+		if err := json.Unmarshal(output, &issues); err != nil {
+			lookupErr = fmt.Errorf("parsing bd list --status=%s output: %w", status, err)
+			continue
+		}
+		if len(issues) > 0 {
+			return true, nil
 		}
 	}
-	return false
+	return false, lookupErr
 }
 
 // notifyWitnessOfCrashedPolecat notifies the witness when a polecat crash is detected.
@@ -2941,14 +2977,28 @@ func (d *Daemon) reapIdlePolecat(rigName, polecatName string, timeout time.Durat
 			// Bead infrastructure failures (Dolt issues, version mismatches) cause
 			// spurious lookup errors while the polecat is actively working (GH#3342).
 			assignee := fmt.Sprintf("%s/polecats/%s", rigName, polecatName)
-			if d.hasAssignedOpenWork(rigName, assignee) {
+			hasWork, verifyErr := d.hasAssignedOpenWork(rigName, assignee)
+			if verifyErr != nil {
+				// FAIL-SAFE (2026-07-08 incidents): both the agent bead lookup AND
+				// the work-bead verification failed — the polecat's work-state is
+				// UNKNOWN. Never kill on an unknown work-state, no matter how stale
+				// the heartbeat; a Dolt outage must not read as "idle". The reap is
+				// merely deferred until beads answer again.
+				d.logger.Printf("Skipping idle-reap for %s/%s: work-state unknown (agent bead: %v; work-bead check: %v) — failing safe",
+					rigName, polecatName, err, verifyErr)
 				return
 			}
-			// No assigned work and agent not running — safe to reap.
-			// Use 3x threshold (not 2x) to avoid killing polecats during transient
-			// infrastructure degradation when the agent process is alive but not
-			// detectable (e.g. long thinking sessions, slow process inspection).
-			if staleDuration >= timeout*3 || !d.tmux.IsAgentAlive(sessionName) && staleDuration >= timeout*2 {
+			if hasWork {
+				return
+			}
+			// Verified no assigned work — but never kill while the agent process is
+			// still running: an alive agent with a failed bead lookup can be a
+			// mid-sling race or bd/Dolt inconsistency, not an idle session.
+			if d.tmux.IsAgentAlive(sessionName) {
+				return
+			}
+			// No assigned work and agent not running — safe to reap at 2x threshold.
+			if staleDuration >= timeout*2 {
 				d.killIdlePolecat(rigName, polecatName, sessionName, staleDuration, timeout, "working-bead-lookup-failed")
 			}
 			return
@@ -2969,7 +3019,14 @@ func (d *Daemon) reapIdlePolecat(rigName, polecatName string, timeout time.Durat
 		// whose agent bead hook_bead points to a closed bead from a previous swarm
 		// while the polecat is actively working on a newly-slung bead.
 		assignee := fmt.Sprintf("%s/polecats/%s", rigName, polecatName)
-		if d.hasAssignedOpenWork(rigName, assignee) {
+		hasWork, verifyErr := d.hasAssignedOpenWork(rigName, assignee)
+		if verifyErr != nil {
+			// FAIL-SAFE: cannot verify the absence of assigned work — do not kill.
+			d.logger.Printf("Skipping idle-reap for %s/%s: work-bead check failed (%v) — failing safe",
+				rigName, polecatName, verifyErr)
+			return
+		}
+		if hasWork {
 			return
 		}
 

--- a/internal/daemon/has_assigned_work_test.go
+++ b/internal/daemon/has_assigned_work_test.go
@@ -58,7 +58,11 @@ printf '[{"id":"gt-123"}]\n'
 		bdPath: bdPath,
 	}
 
-	if !d.hasAssignedOpenWork("gastown", "polecats/rust") {
+	hasWork, workErr := d.hasAssignedOpenWork("gastown", "polecats/rust")
+	if workErr != nil {
+		t.Fatalf("expected assigned work lookup to succeed, got error: %v", workErr)
+	}
+	if !hasWork {
 		t.Fatal("expected assigned work lookup to succeed")
 	}
 

--- a/internal/daemon/polecat_health_failsafe_test.go
+++ b/internal/daemon/polecat_health_failsafe_test.go
@@ -1,0 +1,161 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/polecat"
+	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// writeFakeBDAllFail creates a "bd" script where EVERY invocation fails,
+// simulating a full Dolt outage (both agent-bead show and work-bead list).
+func writeFakeBDAllFail(t *testing.T, dir string) string {
+	t.Helper()
+	script := "#!/bin/sh\nexit 1\n"
+	path := filepath.Join(dir, "bd")
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatalf("writing fake bd: %v", err)
+	}
+	return path
+}
+
+func writeStaleWorkingHeartbeat(t *testing.T, townRoot, sessionName string, age time.Duration) {
+	t.Helper()
+	hbPath := filepath.Join(townRoot, ".runtime", "heartbeats", sessionName+".json")
+	if err := os.MkdirAll(filepath.Dir(hbPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	hb := polecat.SessionHeartbeat{
+		Timestamp: time.Now().UTC().Add(-age),
+		State:     polecat.HeartbeatWorking,
+	}
+	data, err := json.Marshal(hb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hbPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestReapIdlePolecat_SkipsWhenAllBeadLookupsFail verifies the fail-safe rule
+// from the 2026-07-08 incidents: when BOTH the agent-bead lookup and the
+// work-bead verification fail (full Dolt outage), the polecat's work-state is
+// UNKNOWN and the reaper must NOT kill — no matter how stale the heartbeat is,
+// and even when the agent process is not detectable.
+func TestReapIdlePolecat_SkipsWhenAllBeadLookupsFail(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for tmux and bd")
+	}
+	old := session.DefaultRegistry()
+	reg := session.NewPrefixRegistry()
+	reg.Register("myr", "myr")
+	session.SetDefaultRegistry(reg)
+	defer session.SetDefaultRegistry(old)
+
+	binDir := t.TempDir()
+	writeFakeTmuxIdleSession(t, binDir) // session alive, agent NOT detectable
+	bdPath := writeFakeBDAllFail(t, binDir)
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	townRoot := t.TempDir()
+	var logBuf strings.Builder
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		logger: log.New(&logBuf, "", 0),
+		tmux:   tmux.NewTmuxWithSocket(""),
+		bdPath: bdPath,
+	}
+
+	// 10x the timeout — extreme staleness must still not override the fail-safe.
+	writeStaleWorkingHeartbeat(t, townRoot, "myr-mycat", 150*time.Minute)
+
+	d.reapIdlePolecat("myr", "mycat", 15*time.Minute)
+
+	got := logBuf.String()
+	if strings.Contains(got, "Reaping idle polecat") {
+		t.Errorf("must NOT reap when work-state is unknown (all bead lookups failed), got: %q", got)
+	}
+	if !strings.Contains(got, "failing safe") {
+		t.Errorf("expected a fail-safe skip log line, got: %q", got)
+	}
+}
+
+// TestReapIdlePolecat_SkipsAliveAgentWhenBeadLookupFails verifies that a
+// session with a live agent process is never reaped in the bead-lookup-failed
+// path, even when the work-bead check verifies no assigned work and the
+// heartbeat is past every staleness multiple. (Before this fix, the 3x-threshold
+// arm killed regardless of agent liveness.)
+func TestReapIdlePolecat_SkipsAliveAgentWhenBeadLookupFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for tmux and bd")
+	}
+	old := session.DefaultRegistry()
+	reg := session.NewPrefixRegistry()
+	reg.Register("myr", "myr")
+	session.SetDefaultRegistry(reg)
+	defer session.SetDefaultRegistry(old)
+
+	binDir := t.TempDir()
+	writeFakeTmuxWithAgent(t, binDir, "claude") // agent process IS running
+	bdPath := writeFakeBDLookupFail(t, binDir, false /* verified: no work */)
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	townRoot := t.TempDir()
+	var logBuf strings.Builder
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		logger: log.New(&logBuf, "", 0),
+		tmux:   tmux.NewTmuxWithSocket(""),
+		bdPath: bdPath,
+	}
+
+	writeStaleWorkingHeartbeat(t, townRoot, "myr-mycat", 60*time.Minute) // 4x threshold
+
+	d.reapIdlePolecat("myr", "mycat", 15*time.Minute)
+
+	if strings.Contains(logBuf.String(), "Reaping idle polecat") {
+		t.Errorf("must NOT reap a session with a live agent process on bead-lookup failure, got: %q", logBuf.String())
+	}
+}
+
+// TestIsRigBeadNotFound verifies the classification that keeps isRigOperational
+// from conflating a definitively-missing rig bead with a Dolt outage (2026-07-08:
+// missing cap-rig-capital excluded the rig from witness patrol indefinitely).
+func TestIsRigBeadNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"sentinel", beads.ErrNotFound, true},
+		{"wrapped sentinel", fmt.Errorf("show cap-rig-capital: %w", beads.ErrNotFound), true},
+		{"cli not found text", errors.New(`no issue found matching "cap-rig-capital"`), true},
+		{"cli plural text", errors.New("no issues found matching the provided IDs"), true},
+		{"transport timeout", errors.New("read tcp 127.0.0.1:37204->127.0.0.1:3307: i/o timeout"), false},
+		{"connection refused", errors.New("dial tcp 127.0.0.1:3307: connect: connection refused"), false},
+		{"eof", io.EOF, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRigBeadNotFound(tc.err); got != tc.want {
+				t.Errorf("isRigBeadNotFound(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/polecat/branch_name.go
+++ b/internal/polecat/branch_name.go
@@ -9,7 +9,39 @@ const (
 	polecatBranchPrefix           = "polecat/"
 	generatedIssueBranchSeparator = "+"
 	legacyIssueBranchSeparator    = "@"
+
+	// BranchDelimiterConfigKey is the rig config key that selects which
+	// delimiter FormatGeneratedBranchName places between the issue ID and the
+	// generated suffix. Some CI systems constrain the branch-name charset
+	// (e.g. docker-compose project names allow only [a-z0-9_-]), so rigs whose
+	// CI rejects "+" can pick "_" instead.
+	BranchDelimiterConfigKey = "polecat_branch_delimiter"
 )
+
+// issueBranchSeparators lists every delimiter ParseBranchName recognizes
+// between the issue ID and the generated suffix. Parsing accepts all of them
+// regardless of the rig's configured delimiter, so branches created under a
+// previous delimiter configuration keep resolving to the right issue. None of
+// these characters can appear in issue IDs ([a-z0-9-] plus "." for subtasks)
+// or polecat names, so the split is unambiguous.
+var issueBranchSeparators = []string{
+	generatedIssueBranchSeparator,
+	legacyIssueBranchSeparator,
+	"_",
+}
+
+// ValidBranchDelimiter reports whether s may be used as the configured
+// branch delimiter. Only delimiters the parser recognizes are valid;
+// anything else would produce branches that no longer round-trip to an
+// issue ID.
+func ValidBranchDelimiter(s string) bool {
+	for _, sep := range issueBranchSeparators {
+		if s == sep {
+			return true
+		}
+	}
+	return false
+}
 
 // BranchNameMeta is the structured identity encoded in a polecat branch name.
 type BranchNameMeta struct {
@@ -18,10 +50,21 @@ type BranchNameMeta struct {
 	Generated bool
 }
 
-// FormatGeneratedBranchName returns the canonical generated polecat branch.
+// FormatGeneratedBranchName returns the canonical generated polecat branch
+// using the default "+" delimiter.
 func FormatGeneratedBranchName(polecatName, issue, suffix string) string {
+	return FormatGeneratedBranchNameWithDelimiter(polecatName, issue, suffix, generatedIssueBranchSeparator)
+}
+
+// FormatGeneratedBranchNameWithDelimiter returns the generated polecat branch
+// with the given issue/suffix delimiter. Invalid delimiters fall back to the
+// default "+" so a bad config value can never produce an unparseable branch.
+func FormatGeneratedBranchNameWithDelimiter(polecatName, issue, suffix, delimiter string) string {
+	if !ValidBranchDelimiter(delimiter) {
+		delimiter = generatedIssueBranchSeparator
+	}
 	if issue != "" {
-		return fmt.Sprintf("%s%s/%s%s%s", polecatBranchPrefix, polecatName, issue, generatedIssueBranchSeparator, suffix)
+		return fmt.Sprintf("%s%s/%s%s%s", polecatBranchPrefix, polecatName, issue, delimiter, suffix)
 	}
 	return fmt.Sprintf("%s%s-%s", polecatBranchPrefix, polecatName, suffix)
 }
@@ -60,8 +103,9 @@ func ParseBranchName(branch string) (BranchNameMeta, bool) {
 	return BranchNameMeta{Polecat: rest[:dash], Generated: true}, true
 }
 
-// ParseGeneratedBranchName decodes only branch names emitted by FormatGeneratedBranchName
-// and the legacy @ issue-suffix form kept for in-flight branches.
+// ParseGeneratedBranchName decodes only branch names emitted by
+// FormatGeneratedBranchName / FormatGeneratedBranchNameWithDelimiter and the
+// legacy @ issue-suffix form kept for in-flight branches.
 func ParseGeneratedBranchName(branch string) (BranchNameMeta, bool) {
 	meta, ok := ParseBranchName(branch)
 	if !ok || !meta.Generated {
@@ -72,7 +116,7 @@ func ParseGeneratedBranchName(branch string) (BranchNameMeta, bool) {
 
 func parseIssueTail(issueTail string) (issue string, generated bool, ok bool) {
 	delim := -1
-	for _, sep := range []string{generatedIssueBranchSeparator, legacyIssueBranchSeparator} {
+	for _, sep := range issueBranchSeparators {
 		if idx := strings.Index(issueTail, sep); idx >= 0 && (delim == -1 || idx < delim) {
 			delim = idx
 		}

--- a/internal/polecat/branch_name_test.go
+++ b/internal/polecat/branch_name_test.go
@@ -70,12 +70,44 @@ func TestParseBranchName(t *testing.T) {
 			wantPolecat:   "alpha",
 		},
 		{
+			name:          "generated issue with underscore suffix",
+			branch:        "polecat/alpha/cap-5gw_mrb05j24",
+			wantOk:        true,
+			wantGenerated: true,
+			wantPolecat:   "alpha",
+			wantIssue:     "cap-5gw",
+		},
+		{
+			name:          "generated dashed issue with underscore suffix",
+			branch:        "polecat/alpha/gt-pin-bd-metadata_mk123456",
+			wantOk:        true,
+			wantGenerated: true,
+			wantPolecat:   "alpha",
+			wantIssue:     "gt-pin-bd-metadata",
+		},
+		{
+			name:          "generated dotted subtask with underscore suffix",
+			branch:        "polecat/alpha/gt-4kp9.5.5.1_mk123456",
+			wantOk:        true,
+			wantGenerated: true,
+			wantPolecat:   "alpha",
+			wantIssue:     "gt-4kp9.5.5.1",
+		},
+		{
 			name:   "empty generated suffix is invalid",
 			branch: "polecat/alpha/gt-abc+",
 		},
 		{
+			name:   "empty underscore suffix is invalid",
+			branch: "polecat/alpha/gt-abc_",
+		},
+		{
 			name:   "empty generated issue is invalid",
 			branch: "polecat/alpha/+mk123456",
+		},
+		{
+			name:   "empty underscore issue is invalid",
+			branch: "polecat/alpha/_mk123456",
 		},
 	}
 
@@ -98,6 +130,62 @@ func TestParseBranchName(t *testing.T) {
 				t.Errorf("Issue = %q, want %q", got.Issue, tt.wantIssue)
 			}
 		})
+	}
+}
+
+func TestFormatGeneratedBranchNameWithDelimiter(t *testing.T) {
+	tests := []struct {
+		name      string
+		issue     string
+		delimiter string
+		want      string
+	}{
+		{name: "underscore delimiter", issue: "cap-5gw", delimiter: "_", want: "polecat/alpha/cap-5gw_mk123456"},
+		{name: "plus delimiter", issue: "cap-5gw", delimiter: "+", want: "polecat/alpha/cap-5gw+mk123456"},
+		{name: "invalid delimiter falls back to plus", issue: "cap-5gw", delimiter: "!", want: "polecat/alpha/cap-5gw+mk123456"},
+		{name: "empty delimiter falls back to plus", issue: "cap-5gw", delimiter: "", want: "polecat/alpha/cap-5gw+mk123456"},
+		{name: "multi-char delimiter falls back to plus", issue: "cap-5gw", delimiter: "__", want: "polecat/alpha/cap-5gw+mk123456"},
+		{name: "no issue ignores delimiter", issue: "", delimiter: "_", want: "polecat/alpha-mk123456"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatGeneratedBranchNameWithDelimiter("alpha", tt.issue, "mk123456", tt.delimiter)
+			if got != tt.want {
+				t.Errorf("FormatGeneratedBranchNameWithDelimiter() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnderscoreBranchRoundTrip(t *testing.T) {
+	// The docker-compose-safe delimiter must round-trip: format with "_" and
+	// parse back to the same issue (AA-849).
+	branch := FormatGeneratedBranchNameWithDelimiter("nux", "cap-5gw", "mrb05j24", "_")
+	if branch != "polecat/nux/cap-5gw_mrb05j24" {
+		t.Fatalf("format = %q, want polecat/nux/cap-5gw_mrb05j24", branch)
+	}
+	meta, ok := ParseGeneratedBranchName(branch)
+	if !ok {
+		t.Fatalf("ParseGeneratedBranchName(%q) not ok", branch)
+	}
+	if meta.Polecat != "nux" || meta.Issue != "cap-5gw" {
+		t.Fatalf("round-trip = %+v, want polecat nux issue cap-5gw", meta)
+	}
+	if err := exec.Command("git", "check-ref-format", "--branch", branch).Run(); err != nil {
+		t.Fatalf("branch %q rejected by git check-ref-format: %v", branch, err)
+	}
+}
+
+func TestValidBranchDelimiter(t *testing.T) {
+	for _, valid := range []string{"+", "@", "_"} {
+		if !ValidBranchDelimiter(valid) {
+			t.Errorf("ValidBranchDelimiter(%q) = false, want true", valid)
+		}
+	}
+	for _, invalid := range []string{"", "-", ".", "/", "!", "__", "+@", "a"} {
+		if ValidBranchDelimiter(invalid) {
+			t.Errorf("ValidBranchDelimiter(%q) = true, want false", invalid)
+		}
 	}
 }
 

--- a/internal/polecat/heartbeat.go
+++ b/internal/polecat/heartbeat.go
@@ -5,12 +5,26 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/config"
 )
 
-// SessionHeartbeatStaleThreshold is the age at which a polecat session heartbeat
-// is considered stale, indicating the agent process is likely dead.
-// Configurable via operational.polecat.heartbeat_stale_threshold in settings/config.json.
+// SessionHeartbeatStaleThreshold is the default age at which a polecat session
+// heartbeat is considered stale, indicating the agent process is likely dead.
+// Configurable via operational.polecat.heartbeat_stale_threshold in
+// settings/config.json — use SessionHeartbeatStaleThresholdFor to honor the
+// configured value; this constant is only the compiled-in default.
 const SessionHeartbeatStaleThreshold = 3 * time.Minute
+
+// SessionHeartbeatStaleThresholdFor returns the heartbeat stale threshold for a
+// town, honoring operational.polecat.heartbeat_stale_threshold in
+// settings/config.json and falling back to SessionHeartbeatStaleThreshold.
+func SessionHeartbeatStaleThresholdFor(townRoot string) time.Duration {
+	if townRoot == "" {
+		return SessionHeartbeatStaleThreshold
+	}
+	return config.LoadOperationalConfig(townRoot).GetPolecatConfig().HeartbeatStaleThresholdD()
+}
 
 // HeartbeatState represents the agent-reported state in a heartbeat v2 (gt-3vr5).
 // Agents report their own state; the witness makes exactly one inference:
@@ -123,7 +137,7 @@ func IsSessionHeartbeatStale(townRoot, sessionName string) (stale bool, exists b
 	if hb == nil {
 		return false, false
 	}
-	return time.Since(hb.Timestamp) >= SessionHeartbeatStaleThreshold, true
+	return time.Since(hb.Timestamp) >= SessionHeartbeatStaleThresholdFor(townRoot), true
 }
 
 // RemoveSessionHeartbeat removes the heartbeat file for a session.

--- a/internal/polecat/heartbeat_config_test.go
+++ b/internal/polecat/heartbeat_config_test.go
@@ -1,0 +1,86 @@
+package polecat
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeTownHeartbeatConfig writes a settings/config.json with the given
+// operational.polecat.heartbeat_stale_threshold value.
+func writeTownHeartbeatConfig(t *testing.T, townRoot, threshold string) {
+	t.Helper()
+	settingsDir := filepath.Join(townRoot, "settings")
+	if err := os.MkdirAll(settingsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := `{"type":"town-settings","version":1,"operational":{"polecat":{"heartbeat_stale_threshold":"` + threshold + `"}}}`
+	if err := os.WriteFile(filepath.Join(settingsDir, "config.json"), []byte(cfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeBackdatedHeartbeat writes a heartbeat file whose timestamp is `age` in the past.
+func writeBackdatedHeartbeat(t *testing.T, townRoot, sessionName string, age time.Duration) {
+	t.Helper()
+	dir := filepath.Join(townRoot, ".runtime", "heartbeats")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	hb := SessionHeartbeat{Timestamp: time.Now().UTC().Add(-age), State: HeartbeatWorking}
+	data, err := json.Marshal(hb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, sessionName+".json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestIsSessionHeartbeatStale_HonorsConfiguredThreshold verifies that
+// operational.polecat.heartbeat_stale_threshold in settings/config.json is
+// actually read (regression fixed 2026-07-08: the accessor existed but was
+// never called, so the compiled-in 3m constant always won).
+func TestIsSessionHeartbeatStale_HonorsConfiguredThreshold(t *testing.T) {
+	townRoot := t.TempDir()
+	writeTownHeartbeatConfig(t, townRoot, "10m")
+	sessionName := "gt-test-hb-config"
+
+	if got := SessionHeartbeatStaleThresholdFor(townRoot); got != 10*time.Minute {
+		t.Fatalf("SessionHeartbeatStaleThresholdFor = %v, want 10m", got)
+	}
+
+	// 5 minutes old: stale under the 3m compiled default, fresh under the
+	// configured 10m threshold.
+	writeBackdatedHeartbeat(t, townRoot, sessionName, 5*time.Minute)
+	stale, exists := IsSessionHeartbeatStale(townRoot, sessionName)
+	if !exists {
+		t.Fatal("expected heartbeat to exist")
+	}
+	if stale {
+		t.Error("5m-old heartbeat must be fresh under configured 10m threshold")
+	}
+
+	// 15 minutes old: stale even under the configured threshold.
+	writeBackdatedHeartbeat(t, townRoot, sessionName, 15*time.Minute)
+	stale, exists = IsSessionHeartbeatStale(townRoot, sessionName)
+	if !exists {
+		t.Fatal("expected heartbeat to exist")
+	}
+	if !stale {
+		t.Error("15m-old heartbeat must be stale under configured 10m threshold")
+	}
+}
+
+// TestSessionHeartbeatStaleThresholdFor_Defaults verifies fallback behavior
+// when no config is present or townRoot is unknown.
+func TestSessionHeartbeatStaleThresholdFor_Defaults(t *testing.T) {
+	if got := SessionHeartbeatStaleThresholdFor(""); got != SessionHeartbeatStaleThreshold {
+		t.Errorf("empty townRoot: got %v, want compiled default %v", got, SessionHeartbeatStaleThreshold)
+	}
+	if got := SessionHeartbeatStaleThresholdFor(t.TempDir()); got != SessionHeartbeatStaleThreshold {
+		t.Errorf("no config file: got %v, want compiled default %v", got, SessionHeartbeatStaleThreshold)
+	}
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -555,25 +555,46 @@ type AddOptions struct {
 // - {timestamp}: unique timestamp
 //
 // If no template is configured or template is empty, uses default format:
-// - polecat/{name}/{issue}+{timestamp} when issue is available
-// - polecat/{name}-{timestamp} otherwise
+//   - polecat/{name}/{issue}<delimiter>{timestamp} when issue is available,
+//     where <delimiter> comes from the polecat_branch_delimiter rig config
+//     (default "+")
+//   - polecat/{name}-{timestamp} otherwise
 func (m *Manager) buildBranchName(name, issue string) string {
-	template := m.rig.GetStringConfig("polecat_branch_template")
+	return buildBranchNameFor(m.rig, m.git, m.beads, name, issue)
+}
+
+// buildBranchNameFor is the shared implementation behind Manager.buildBranchName
+// and SessionManager.freshBranchName, so polecat creation and session-restart
+// branch creation always agree on naming. r, g, and b may each be nil: a nil
+// rig means no template/delimiter config, a nil git skips the {user} lookup,
+// and nil beads skips the {description} lookup.
+func buildBranchNameFor(r *rig.Rig, g *git.Git, b *beads.Beads, name, issue string) string {
+	template := ""
+	if r != nil {
+		template = r.GetStringConfig("polecat_branch_template")
+	}
 
 	// No template configured - use default behavior for backward compatibility
 	if template == "" {
+		delimiter := generatedIssueBranchSeparator
+		if r != nil {
+			if d := r.GetStringConfig(BranchDelimiterConfigKey); d != "" {
+				delimiter = d
+			}
+		}
 		timestamp := strconv.FormatInt(time.Now().UnixMilli(), 36)
-		return FormatGeneratedBranchName(name, issue, timestamp)
+		return FormatGeneratedBranchNameWithDelimiter(name, issue, timestamp, delimiter)
 	}
 
 	// Build template variables
 	vars := make(map[string]string)
 
 	// {user} - from git config user.name
-	if userName, err := m.git.ConfigGet("user.name"); err == nil && userName != "" {
-		vars["{user}"] = userName
-	} else {
-		vars["{user}"] = "unknown"
+	vars["{user}"] = "unknown"
+	if g != nil {
+		if userName, err := g.ConfigGet("user.name"); err == nil && userName != "" {
+			vars["{user}"] = userName
+		}
 	}
 
 	// {year} and {month}
@@ -600,8 +621,9 @@ func (m *Manager) buildBranchName(name, issue string) string {
 	}
 
 	// {description} - try to get from beads if issue is set
-	if issue != "" {
-		if issueData, err := m.beads.Show(issue); err == nil && issueData.Title != "" {
+	vars["{description}"] = ""
+	if issue != "" && b != nil {
+		if issueData, err := b.Show(issue); err == nil && issueData.Title != "" {
 			// Sanitize title for branch name: lowercase, replace spaces/special chars with hyphens
 			desc := strings.ToLower(issueData.Title)
 			desc = strings.Map(func(r rune) rune {
@@ -620,11 +642,7 @@ func (m *Manager) buildBranchName(name, issue string) string {
 				desc = desc[:40]
 			}
 			vars["{description}"] = desc
-		} else {
-			vars["{description}"] = ""
 		}
-	} else {
-		vars["{description}"] = ""
 	}
 
 	// Replace all variables in template

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -688,7 +688,7 @@ func (m *Manager) AllocateAndAdd(opts AddOptions) (string, *Polecat, error) {
 
 	m.reconcilePoolInternal()
 
-	name, err := m.namePool.Allocate()
+	name, err := m.allocateNameSkippingLiveSessions()
 	if err != nil {
 		_ = poolLock.Unlock()
 		return "", nil, err
@@ -714,7 +714,9 @@ func (m *Manager) AllocateAndAdd(opts AddOptions) (string, *Polecat, error) {
 		return "", nil, fmt.Errorf("creating polecat dir: %w", err)
 	}
 
-	// Kill any lingering tmux session for this name (gt-pqf9x)
+	// Kill any lingering tmux session for this name (gt-pqf9x).
+	// allocateNameSkippingLiveSessions guarantees no live agent owns this
+	// session — anything still here is a dead shell left by a crashed startup.
 	if m.tmux != nil {
 		sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
 		if alive, _ := m.tmux.HasSession(sessionName); alive {
@@ -1397,7 +1399,7 @@ func (m *Manager) AllocateName() (string, error) {
 	// Reconcile without re-acquiring the pool lock
 	m.reconcilePoolInternal()
 
-	name, err := m.namePool.Allocate()
+	name, err := m.allocateNameSkippingLiveSessions()
 	if err != nil {
 		return "", err
 	}
@@ -1427,6 +1429,8 @@ func (m *Manager) AllocateName() (string, error) {
 	// can be allocated after its directory was cleaned up while the tmux session
 	// lingers (race between cleanup and allocation). This extra check ensures
 	// no stale session blocks the new polecat's session creation.
+	// allocateNameSkippingLiveSessions guarantees no live agent owns this
+	// session — anything still here is a dead shell left by a crashed startup.
 	if m.tmux != nil {
 		sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
 		if alive, _ := m.tmux.HasSession(sessionName); alive {
@@ -1435,6 +1439,33 @@ func (m *Manager) AllocateName() (string, error) {
 	}
 
 	return name, nil
+}
+
+// allocateNameSkippingLiveSessions allocates a name from the pool, refusing any
+// name whose tmux session still hosts a live agent process. Such a session means
+// the pool's view of the name is wrong (bead/fs state diverged, mid-nuke race,
+// Dolt degradation) — reclaiming it would kill a working agent, which is exactly
+// what happened in the 2026-07-08 incidents. The live name is marked in-use and
+// a different name is allocated instead. Caller must hold the pool lock.
+func (m *Manager) allocateNameSkippingLiveSessions() (string, error) {
+	const maxAttempts = 8
+	var skipped []string
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		name, err := m.namePool.Allocate()
+		if err != nil {
+			return "", err
+		}
+		if m.tmux != nil {
+			sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
+			if alive, _ := m.tmux.HasSession(sessionName); alive && m.tmux.IsAgentAlive(sessionName) {
+				m.namePool.MarkInUse(name)
+				skipped = append(skipped, name)
+				continue
+			}
+		}
+		return name, nil
+	}
+	return "", fmt.Errorf("no allocatable polecat name after %d attempts: names %v have sessions with live agent processes", maxAttempts, skipped)
 }
 
 // ReleaseName releases a name back to the pool.
@@ -1697,6 +1728,16 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 		}
 	}
 	if current.State == StateIdle {
+		// FAIL-SAFE (2026-07-08 incidents): "Issue == \"\"" can mean the bead
+		// lookup failed or raced, not that the polecat is done. If the session
+		// still hosts a live agent process, its work-state is unverifiable —
+		// refuse destructive reuse and let the allocator pick a different name.
+		if m.tmux != nil {
+			sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
+			if alive, _ := m.tmux.HasSession(sessionName); alive && m.tmux.IsAgentAlive(sessionName) {
+				return nil, fmt.Errorf("%w: session %s has a live agent process but no verifiable work-state — refusing destructive reuse", ErrPolecatNeedsRecovery, sessionName)
+			}
+		}
 		// A live session with no active work is a dead prompt, not preserved work.
 		// Clear it before evaluating reuse so recovery-blocked idle slots don't
 		// continue consuming capacity.
@@ -1908,27 +1949,34 @@ func (m *Manager) ReconcilePool() {
 // reconcilePoolInternal performs pool reconciliation without acquiring the pool lock.
 // Called by ReconcilePool (which holds the lock) and AllocateName (which also holds it).
 func (m *Manager) reconcilePoolInternal() {
-	// Get polecats with existing directories
-	polecats, err := m.List()
-	if err != nil {
+	// Get polecats with existing directories — straight from the filesystem.
+	// Deliberately NOT via m.List(): List() loads each polecat from beads and
+	// silently drops any whose bead lookup fails, so under Dolt degradation a
+	// live mid-work polecat would vanish from namesWithDirs and its session
+	// would be killed below as a directory-less "orphan" (2026-07-08 incidents:
+	// healthy sessions killed seconds before a spawn at full capacity).
+	// Directory existence is the ZFC source of truth for name reservation and
+	// needs no bead lookup.
+	var namesWithDirs []string
+	polecatsDir := filepath.Join(m.rig.Path, "polecats")
+	entries, err := os.ReadDir(polecatsDir)
+	if err != nil && !os.IsNotExist(err) {
+		// Cannot enumerate directories — state unknown. Do NOT reconcile with an
+		// empty list: that would mark every name available and kill every session.
 		return
 	}
-
-	var namesWithDirs []string
-	for _, p := range polecats {
-		namesWithDirs = append(namesWithDirs, p.Name)
-	}
-
-	// Include names with pending reservation markers.
-	// A .pending file means AllocateName has claimed the name but AddWithOptions
-	// hasn't created the directory yet. Without this, Reconcile would see no
-	// directory and treat the name as available, causing a duplicate allocation.
-	polecatsDir := filepath.Join(m.rig.Path, "polecats")
-	if entries, err := os.ReadDir(polecatsDir); err == nil {
-		for _, e := range entries {
-			if !e.IsDir() && strings.HasSuffix(e.Name(), ".pending") {
-				namesWithDirs = append(namesWithDirs, strings.TrimSuffix(e.Name(), ".pending"))
-			}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() && !strings.HasPrefix(name, ".") {
+			namesWithDirs = append(namesWithDirs, name)
+			continue
+		}
+		// Include names with pending reservation markers.
+		// A .pending file means AllocateName has claimed the name but AddWithOptions
+		// hasn't created the directory yet. Without this, Reconcile would see no
+		// directory and treat the name as available, causing a duplicate allocation.
+		if !e.IsDir() && strings.HasSuffix(name, ".pending") {
+			namesWithDirs = append(namesWithDirs, strings.TrimSuffix(name, ".pending"))
 		}
 	}
 
@@ -1959,8 +2007,11 @@ func (m *Manager) reconcilePoolInternal() {
 // - namesWithDirs: names that have existing worktree directories (in use)
 // - namesWithSessions: names that have tmux sessions
 //
-// Names with sessions but no directories are orphans and their sessions are killed.
-// Only namesWithDirs are marked as in-use for allocation.
+// Names with sessions but no directories are orphans and their sessions are killed —
+// unless the session still has a live agent process, in which case it is skipped and
+// its name kept in-use (fail-safe: never reclaim a session whose work-state can't be
+// verified as dead; the allocator picks a different name instead).
+// Only namesWithDirs (plus protected live sessions) are marked as in-use for allocation.
 func (m *Manager) ReconcilePoolWith(namesWithDirs, namesWithSessions []string) {
 	dirSet := make(map[string]bool)
 	for _, name := range namesWithDirs {
@@ -1969,21 +2020,30 @@ func (m *Manager) ReconcilePoolWith(namesWithDirs, namesWithSessions []string) {
 
 	// Kill orphaned sessions only. Directory-backed sessions are lifecycle-owned by
 	// their polecat/witness paths; allocation must never reap unrelated workers.
-	// - No directory: orphan session, always kill (worktree was removed but tmux lingered)
+	// - No directory: orphan session, kill ONLY if the agent process is verifiably
+	//   not running. A live agent in a directory-less session means our view of
+	//   the polecat state is inconsistent (mid-nuke race, transient fs/bead
+	//   failure) — killing it destroys work, so protect the name instead.
 	// Use KillSessionWithProcesses to ensure all descendant processes are killed.
+	inUse := namesWithDirs
 	if m.tmux != nil {
 		townRoot := filepath.Dir(m.rig.Path)
 		for _, name := range namesWithSessions {
 			sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
 			if !dirSet[name] {
-				// Orphan: session exists but no directory
+				if m.tmux.IsAgentAlive(sessionName) {
+					// Live agent — never reclaim; keep the name out of the pool.
+					inUse = append(inUse, name)
+					continue
+				}
+				// Orphan: session exists but no directory and no live agent
 				_ = m.tmux.KillSessionWithProcesses(sessionName)
 				RemoveSessionHeartbeat(townRoot, sessionName)
 			}
 		}
 	}
 
-	m.namePool.Reconcile(namesWithDirs)
+	m.namePool.Reconcile(inUse)
 	// Note: No Save() needed - InUse is transient state, only OverflowNext is persisted
 
 	// Clean up orphaned polecat state (fixes #698)
@@ -2007,7 +2067,17 @@ func isSessionProcessDead(t *tmux.Tmux, sessionName string, townRoot string) boo
 	if townRoot != "" {
 		stale, exists := IsSessionHeartbeatStale(townRoot, sessionName)
 		if exists {
-			return stale
+			if !stale {
+				return false
+			}
+			// Heartbeat is stale — but heartbeats are only touched by gt commands,
+			// so an agent deep in a long turn goes stale while very much alive
+			// (2026-07-08 incidents: mid-work sessions killed on this verdict).
+			// Confirm with a direct process probe before declaring death.
+			if t != nil && t.IsAgentAlive(sessionName) {
+				return false
+			}
+			return true
 		}
 		// No heartbeat file — fall through to PID-based check for backward compatibility.
 	}
@@ -2039,11 +2109,13 @@ func isSessionProcessDead(t *tmux.Tmux, sessionName string, townRoot string) boo
 	return false
 }
 
-// pendingMaxAge is how long a .pending reservation marker may exist before
-// it is considered stale. gt sling completes in seconds, so 5 minutes is
-// a conservative bound that avoids false positives on slow machines.
+// pendingMaxAge returns how long a .pending reservation marker may exist before
+// it is considered stale. gt sling completes in seconds, so the 5-minute default
+// is a conservative bound that avoids false positives on slow machines.
 // Configurable via operational.polecat.pending_max_age in settings/config.json.
-const pendingMaxAge = 5 * time.Minute
+func (m *Manager) pendingMaxAge() time.Duration {
+	return config.LoadOperationalConfig(filepath.Dir(m.rig.Path)).GetPolecatConfig().PendingMaxAgeD()
+}
 
 // cleanupOrphanPolecatState removes partial/broken polecat state during allocation.
 // This handles the race condition where worktree creation fails mid-way, leaving:
@@ -2066,7 +2138,7 @@ func (m *Manager) cleanupOrphanPolecatState() {
 		// so the name can be reallocated on the next reconcile.
 		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".pending") {
 			info, err := entry.Info()
-			if err == nil && time.Since(info.ModTime()) > pendingMaxAge {
+			if err == nil && time.Since(info.ModTime()) > m.pendingMaxAge() {
 				_ = os.Remove(filepath.Join(polecatsDir, entry.Name()))
 			}
 			continue
@@ -2712,6 +2784,12 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 		if sessionDead {
 			state = StateStalled
 		}
+	} else if sessionRunning && hookedErr != nil {
+		// The hooked-work query failed, so "no active issue" is unverified — the
+		// polecat may be mid-work with its bead unreadable (Dolt degradation).
+		// Never classify a live session as idle (= destructively reusable) on an
+		// unverifiable work-state; keep it out of the reuse pool instead.
+		state = StateReviewNeeded
 	} else if sessionRunning && !sessionStale && !m.getCleanupStatusFromBead(name).IsSafe() {
 		state = StateReviewNeeded
 	}

--- a/internal/polecat/manager_failsafe_test.go
+++ b/internal/polecat/manager_failsafe_test.go
@@ -1,0 +1,133 @@
+package polecat
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/rig"
+	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// writeFakeTmuxSessionFor creates a fake tmux binary where exactly one session
+// exists. paneCommand controls what display-message/list-panes report for that
+// session ("claude" simulates a live agent, "bash" an idle shell). Every
+// kill-session invocation is appended to killLog.
+func writeFakeTmuxSessionFor(t *testing.T, dir, liveSession, paneCommand, killLog string) {
+	t.Helper()
+	script := fmt.Sprintf("#!/bin/sh\n"+
+		"case \"$*\" in\n"+
+		"  *kill-session*) echo \"$*\" >> %s; exit 0;;\n"+
+		"  *has-session*%s*) exit 0;;\n"+
+		"  *has-session*) exit 1;;\n"+
+		"  *%s*) echo '%s';;\n"+
+		"  *) exit 1;;\n"+
+		"esac\n", killLog, liveSession, liveSession, paneCommand)
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0755); err != nil {
+		t.Fatalf("writing fake tmux: %v", err)
+	}
+}
+
+func newFailsafeTestManager(t *testing.T, paneCommand string) (m *Manager, firstName, sessionName, killLog string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for tmux")
+	}
+
+	rigDir := t.TempDir()
+	r := &rig.Rig{Name: "myrig", Path: rigDir}
+
+	// Learn the first pool name deterministically (Allocate returns the first
+	// available themed name) without touching tmux.
+	probe := NewManager(r, nil, nil)
+	names := probe.namePool.getNames()
+	if len(names) < 2 {
+		t.Fatalf("expected at least 2 pool names, got %d", len(names))
+	}
+	firstName = names[0]
+	sessionName = session.PolecatSessionName(session.PrefixFor(r.Name), firstName)
+
+	binDir := t.TempDir()
+	killLog = filepath.Join(binDir, "kills.log")
+	writeFakeTmuxSessionFor(t, binDir, sessionName, paneCommand, killLog)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	m = NewManager(r, nil, tmux.NewTmuxWithSocket(""))
+	return m, firstName, sessionName, killLog
+}
+
+// TestAllocateNameSkipsLiveAgentSession verifies the fail-safe allocator: a
+// name whose tmux session still hosts a live agent process must be skipped
+// (marked in-use), never killed, and a different name allocated (2026-07-08
+// incidents: allocation reclaimed live sessions).
+func TestAllocateNameSkipsLiveAgentSession(t *testing.T) {
+	m, firstName, _, killLog := newFailsafeTestManager(t, "claude")
+
+	got, err := m.allocateNameSkippingLiveSessions()
+	if err != nil {
+		t.Fatalf("allocateNameSkippingLiveSessions: %v", err)
+	}
+	if got == firstName {
+		t.Errorf("allocated %q, the name of a session with a live agent — must pick a different name", firstName)
+	}
+
+	// The live session must not have been killed.
+	if _, err := os.Stat(killLog); err == nil {
+		data, _ := os.ReadFile(killLog)
+		t.Errorf("live agent session was killed during allocation: %s", data)
+	}
+
+	// The skipped name must be marked in-use so subsequent allocations skip it too.
+	inUse := false
+	for _, n := range m.namePool.ActiveNames() {
+		if n == firstName {
+			inUse = true
+		}
+	}
+	if !inUse {
+		t.Errorf("expected %q to be marked in-use after skip", firstName)
+	}
+}
+
+// TestReconcilePoolWithProtectsLiveAgentOrphan verifies that a directory-less
+// session with a live agent process is protected: not killed, and its name is
+// kept in-use so the allocator cannot hand it out.
+func TestReconcilePoolWithProtectsLiveAgentOrphan(t *testing.T) {
+	m, firstName, _, killLog := newFailsafeTestManager(t, "claude")
+
+	m.ReconcilePoolWith(nil, []string{firstName})
+
+	if _, err := os.Stat(killLog); err == nil {
+		data, _ := os.ReadFile(killLog)
+		t.Errorf("live agent orphan session was killed by ReconcilePoolWith: %s", data)
+	}
+
+	inUse := strings.Join(m.namePool.ActiveNames(), ",")
+	if !strings.Contains(inUse, firstName) {
+		t.Errorf("expected %q to be kept in-use (protected), got in-use: %s", firstName, inUse)
+	}
+}
+
+// TestReconcilePoolWithStillKillsDeadOrphan verifies the fail-safe does not
+// over-protect: a directory-less session with NO live agent (idle shell) is
+// still reaped and its name returned to the pool.
+func TestReconcilePoolWithStillKillsDeadOrphan(t *testing.T) {
+	m, firstName, _, killLog := newFailsafeTestManager(t, "bash")
+
+	m.ReconcilePoolWith(nil, []string{firstName})
+
+	data, err := os.ReadFile(killLog)
+	if err != nil || !strings.Contains(string(data), "kill-session") {
+		t.Errorf("expected dead orphan session to be killed, kill log: %q (err %v)", data, err)
+	}
+
+	for _, n := range m.namePool.ActiveNames() {
+		if n == firstName {
+			t.Errorf("expected %q to be available after dead-orphan reap, but it is in-use", firstName)
+		}
+	}
+}

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1247,6 +1247,53 @@ func TestBuildBranchName(t *testing.T) {
 	}
 }
 
+func TestBuildBranchName_ConfiguredDelimiter(t *testing.T) {
+	tmpDir := t.TempDir()
+	gitCmd := exec.Command("git", "init")
+	gitCmd.Dir = tmpDir
+	if err := gitCmd.Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		delimiter  string
+		issue      string
+		wantPrefix string
+	}{
+		{name: "underscore delimiter", delimiter: "_", issue: "cap-5gw", wantPrefix: "polecat/alpha/cap-5gw_"},
+		{name: "unset delimiter keeps plus", delimiter: "", issue: "cap-5gw", wantPrefix: "polecat/alpha/cap-5gw+"},
+		{name: "invalid delimiter falls back to plus", delimiter: "!", issue: "cap-5gw", wantPrefix: "polecat/alpha/cap-5gw+"},
+		{name: "no issue unaffected", delimiter: "_", issue: "", wantPrefix: "polecat/alpha-"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origDefault := rig.SystemDefaults[BranchDelimiterConfigKey]
+			rig.SystemDefaults[BranchDelimiterConfigKey] = tt.delimiter
+			defer func() {
+				rig.SystemDefaults[BranchDelimiterConfigKey] = origDefault
+			}()
+
+			r := &rig.Rig{Name: "test-rig", Path: tmpDir}
+			g := git.NewGit(tmpDir)
+			m := NewManager(r, g, nil)
+
+			got := m.buildBranchName("alpha", tt.issue)
+			if !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Errorf("buildBranchName() = %q, want prefix %q", got, tt.wantPrefix)
+			}
+			// A delimited branch must round-trip back to its issue.
+			if tt.issue != "" {
+				meta, ok := ParseBranchName(got)
+				if !ok || meta.Issue != tt.issue {
+					t.Errorf("ParseBranchName(%q) = %+v ok=%v, want issue %q", got, meta, ok, tt.issue)
+				}
+			}
+		})
+	}
+}
+
 func TestBuildBranchName_ClaudeActionCompatible(t *testing.T) {
 	tmpDir := t.TempDir()
 	gitCmd := exec.Command("git", "init")

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -2071,7 +2071,7 @@ func TestStalePendingMarkerIsCleanedUp(t *testing.T) {
 	}
 
 	// Backdate the file to simulate a stale marker (older than pendingMaxAge).
-	staleTime := time.Now().Add(-(pendingMaxAge + time.Minute))
+	staleTime := time.Now().Add(-(m.pendingMaxAge() + time.Minute))
 	if err := os.Chtimes(pendingPath, staleTime, staleTime); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -175,14 +174,22 @@ func (m *SessionManager) clonePath(polecat string) string {
 }
 
 // freshBranchName returns a unique branch name for a new polecat session.
-// Mirrors the naming convention in Manager.buildBranchName:
+// It shares Manager.buildBranchName's implementation, so session restarts
+// honor the rig's polecat_branch_template and polecat_branch_delimiter config
+// instead of leaking the default separator. Without any config:
 //   - polecat/<name>/<issue>+<timestamp> when an issue is known
 //   - polecat/<name>-<timestamp> otherwise
 //
-// parseFreshBranchName is the structural inverse.
-func (m *SessionManager) freshBranchName(polecatName, issue string) string {
-	ts := strconv.FormatInt(time.Now().UnixMilli(), 36)
-	return FormatGeneratedBranchName(polecatName, issue, ts)
+// g is the polecat worktree's git handle ({user} template variable); it may
+// be nil. parseFreshBranchName is the structural inverse for the default
+// (non-template) forms.
+func (m *SessionManager) freshBranchName(g *git.Git, polecatName, issue string) string {
+	var b *beads.Beads
+	if m.rig != nil {
+		resolvedBeads := beads.ResolveBeadsDir(m.rig.Path)
+		b = beads.NewWithBeadsDir(filepath.Dir(resolvedBeads), resolvedBeads)
+	}
+	return buildBranchNameFor(m.rig, g, b, polecatName, issue)
 }
 
 // freshBranchMeta holds the identity decoded from a branch produced by
@@ -275,7 +282,7 @@ func (m *SessionManager) ensureCanonicalSessionBranch(g *git.Git, polecat string
 		return currentBranch
 	}
 
-	newBranch := m.freshBranchName(polecat, opts.Issue)
+	newBranch := m.freshBranchName(g, polecat, opts.Issue)
 	if err := g.CheckoutNewBranch(newBranch, startPoint); err != nil {
 		debugSession("auto-checkout fresh branch on canonical base", err)
 		return currentBranch

--- a/internal/polecat/session_manager_test.go
+++ b/internal/polecat/session_manager_test.go
@@ -877,7 +877,7 @@ func TestParseFreshBranchName_RoundTrip(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			branch := sm.freshBranchName(c.polecat, c.issue)
+			branch := sm.freshBranchName(nil, c.polecat, c.issue)
 			meta := parseFreshBranchName(branch)
 			if !meta.ok {
 				t.Fatalf("parseFreshBranchName(%q) not ok", branch)
@@ -890,6 +890,47 @@ func TestParseFreshBranchName_RoundTrip(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFreshBranchName_HonorsRigConfig(t *testing.T) {
+	// Session restarts must produce the same branch shape as polecat creation:
+	// both the configured delimiter and the branch template apply (AA-849).
+	tmpDir := t.TempDir()
+
+	t.Run("configured delimiter", func(t *testing.T) {
+		origDefault := rig.SystemDefaults[BranchDelimiterConfigKey]
+		rig.SystemDefaults[BranchDelimiterConfigKey] = "_"
+		defer func() {
+			rig.SystemDefaults[BranchDelimiterConfigKey] = origDefault
+		}()
+
+		sm := &SessionManager{rig: &rig.Rig{Name: "test-rig", Path: tmpDir}}
+		branch := sm.freshBranchName(nil, "nux", "cap-5gw")
+		if !strings.HasPrefix(branch, "polecat/nux/cap-5gw_") {
+			t.Fatalf("freshBranchName() = %q, want prefix polecat/nux/cap-5gw_", branch)
+		}
+		meta := parseFreshBranchName(branch)
+		if !meta.ok || meta.issue != "cap-5gw" || meta.polecat != "nux" {
+			t.Fatalf("parseFreshBranchName(%q) = %+v, want ok polecat nux issue cap-5gw", branch, meta)
+		}
+	})
+
+	t.Run("configured template", func(t *testing.T) {
+		origDefault := rig.SystemDefaults["polecat_branch_template"]
+		rig.SystemDefaults["polecat_branch_template"] = "polecat/{name}/cap-{issue}_{timestamp}"
+		defer func() {
+			rig.SystemDefaults["polecat_branch_template"] = origDefault
+		}()
+
+		sm := &SessionManager{rig: &rig.Rig{Name: "test-rig", Path: tmpDir}}
+		branch := sm.freshBranchName(nil, "nux", "cap-5gw")
+		if !strings.HasPrefix(branch, "polecat/nux/cap-5gw_") {
+			t.Fatalf("freshBranchName() = %q, want prefix polecat/nux/cap-5gw_ (template ignored?)", branch)
+		}
+		if strings.ContainsAny(branch, "@+") {
+			t.Fatalf("freshBranchName() = %q, must not contain @ or +", branch)
+		}
+	})
 }
 
 func TestParseFreshBranchName_IssueTimestampSeparators(t *testing.T) {

--- a/internal/refinery/batch.go
+++ b/internal/refinery/batch.go
@@ -332,6 +332,10 @@ func (e *Engineer) processSingleMR(ctx context.Context, mr *MRInfo, target strin
 		// PR awaiting human approval — leave in queue for retry on next poll.
 		_, _ = fmt.Fprintf(e.output, "[Batch] MR %s: PR awaiting approval, will retry\n", mr.ID)
 		e.HandleMRInfoFailure(mr, processResult)
+	} else if processResult.NeedsCIGreen {
+		// AA-851: PR CI red/pending — leave in queue for retry on next poll.
+		_, _ = fmt.Fprintf(e.output, "[Batch] MR %s: PR CI not green, will retry\n", mr.ID)
+		e.HandleMRInfoFailure(mr, processResult)
 	} else {
 		result.Error = fmt.Errorf("merge failed: %s", processResult.Error)
 	}

--- a/internal/refinery/cigate_test.go
+++ b/internal/refinery/cigate_test.go
@@ -1,0 +1,46 @@
+package refinery
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/cigate"
+)
+
+func TestCIGateMergeDecision(t *testing.T) {
+	t.Run("red blocks with NeedsCIGreen", func(t *testing.T) {
+		res := cigate.CheckResult{Verdict: cigate.VerdictRed, PRNumber: 7, FailingChecks: []string{"jenkins/build"}}
+		blocked := ciGateMergeDecision(res)
+		if blocked == nil || !blocked.NeedsCIGreen || blocked.Success {
+			t.Fatalf("want NeedsCIGreen block, got %+v", blocked)
+		}
+		if !strings.Contains(blocked.Error, "jenkins/build") {
+			t.Errorf("block reason should name the failing check: %q", blocked.Error)
+		}
+	})
+
+	t.Run("pending blocks with NeedsCIGreen", func(t *testing.T) {
+		res := cigate.CheckResult{Verdict: cigate.VerdictPending, PRNumber: 7, PendingChecks: []string{"macroscope"}}
+		blocked := ciGateMergeDecision(res)
+		if blocked == nil || !blocked.NeedsCIGreen {
+			t.Fatalf("want NeedsCIGreen block, got %+v", blocked)
+		}
+	})
+
+	for _, tt := range []struct {
+		name string
+		res  cigate.CheckResult
+	}{
+		{"green proceeds", cigate.CheckResult{Verdict: cigate.VerdictGreen, PRNumber: 7}},
+		{"merged proceeds", cigate.CheckResult{Verdict: cigate.VerdictMerged, PRNumber: 7}},
+		{"no PR proceeds", cigate.CheckResult{Verdict: cigate.VerdictNoPR}},
+		{"error fails open", cigate.CheckResult{Verdict: cigate.VerdictError, Err: errors.New("gh down")}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if blocked := ciGateMergeDecision(tt.res); blocked != nil {
+				t.Errorf("want proceed (nil), got %+v", blocked)
+			}
+		})
+	}
+}

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/cigate"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/crew"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/git"
@@ -177,6 +179,12 @@ type MergeQueueConfig struct {
 	// Batch holds configuration for the batch-then-bisect merge queue.
 	// When nil or MaxBatchSize <= 1, batching is disabled and MRs process sequentially.
 	Batch *BatchConfig `json:"batch,omitempty"`
+
+	// CIGate mirrors the rig's merge_queue.ci_gate settings (AA-851). The
+	// refinery refuses to merge a PR whose checks are red or pending —
+	// belt-and-suspenders behind the gt done gate for merge_strategy=pr.
+	// Nil = enabled with defaults.
+	CIGate *config.CIGateConfig `json:"ci_gate,omitempty"`
 }
 
 // DefaultMergeQueueConfig returns sensible defaults for merge queue configuration.
@@ -269,6 +277,7 @@ type Engineer struct {
 	mergeSlotMaxRetries   int           // Max retries for slot acquisition (0 = no retry)
 	mergeSlotRetryBackoff time.Duration // Initial backoff between retries
 	testAllowSyntheticMRs bool          // Test-only: legacy merge-mechanics tests use synthetic MRs without beads.
+	ciGate                *cigate.Gate  // Test-injectable CI gate; nil = real gh-backed gate (AA-851)
 }
 
 // NewEngineer creates a new Engineer for the given rig.
@@ -355,6 +364,7 @@ func (e *Engineer) LoadConfig() error {
 		MergeStrategy        *string                   `json:"merge_strategy"`
 		VCSProvider          *string                   `json:"vcs_provider"`
 		RequireReview        *bool                     `json:"require_review"`
+		CIGate               *config.CIGateConfig      `json:"ci_gate"`
 	}
 
 	if err := json.Unmarshal(rawConfig.MergeQueue, &mqRaw); err != nil {
@@ -442,6 +452,9 @@ func (e *Engineer) LoadConfig() error {
 	if mqRaw.RequireReview != nil {
 		e.config.RequireReview = mqRaw.RequireReview
 	}
+	if mqRaw.CIGate != nil {
+		e.config.CIGate = mqRaw.CIGate
+	}
 
 	// Initialize the PR provider when merge_strategy=pr.
 	if e.config.MergeStrategy == "pr" {
@@ -495,6 +508,7 @@ type ProcessResult struct {
 	BranchNotFound bool // Source branch no longer exists (e.g. cleaned up after cherry-pick)
 	NoMerge        bool // MR/source is intentionally not merge-eligible, not a build failure
 	NeedsApproval  bool // PR exists but lacks required approving review (merge_strategy=pr)
+	NeedsCIGreen   bool // PR has red or pending CI checks (merge_strategy=pr); retried next poll (AA-851)
 }
 
 // doMerge performs the actual git merge operation.
@@ -759,6 +773,28 @@ func (e *Engineer) doMerge(ctx context.Context, mr *MRInfo, skipGates ...bool) P
 	}
 }
 
+// ciGateGate returns the CI gate, defaulting to the real gh-backed one.
+func (e *Engineer) ciGateGate() *cigate.Gate {
+	if e.ciGate != nil {
+		return e.ciGate
+	}
+	return cigate.New()
+}
+
+// ciGateMergeDecision maps a CI gate result to a merge-blocking ProcessResult,
+// or nil when the merge may proceed. Only RED and PENDING block; ERROR fails
+// open (callers log it loudly).
+func ciGateMergeDecision(res cigate.CheckResult) *ProcessResult {
+	if res.Verdict.Blocks() {
+		return &ProcessResult{
+			Success:      false,
+			NeedsCIGreen: true,
+			Error:        fmt.Sprintf("CI gate (AA-851): %s", res.Summary()),
+		}
+	}
+	return nil
+}
+
 // doMergePR handles merging via the VCS provider's PR merge API (merge_strategy=pr).
 // This respects branch protection/restriction rules including required reviews.
 // The VCS provider (GitHub, Bitbucket) is selected via vcs_provider config.
@@ -799,6 +835,20 @@ func (e *Engineer) doMergePR(ctx context.Context, mr *MRInfo) ProcessResult {
 		}
 	}
 	_, _ = fmt.Fprintf(e.output, "[Engineer] Found PR #%d for branch %s\n", prNumber, branch)
+
+	// Step PR.1.5 (AA-851): hard CI gate — never merge a PR with red or
+	// pending checks. Deferred like NeedsApproval: the MR stays queued and
+	// retries on the next poll. Belt-and-suspenders behind the gt done gate.
+	if e.config.CIGate.IsEnabled() && !cigate.EnvDisabled() {
+		res := e.ciGateGate().CheckBranch(e.workDir, branch)
+		if res.Verdict == cigate.VerdictError {
+			// Fail-open: unknown CI state must not wedge the queue, but log loudly.
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: CI gate could not determine CI status for PR #%d (%v) — failing open (AA-851)\n", prNumber, res.Err)
+		} else if blocked := ciGateMergeDecision(res); blocked != nil {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] PR #%d CI not green — deferring merge: %s\n", prNumber, res.Summary())
+			return *blocked
+		}
+	}
 
 	// Step PR.2: Check approval status if require_review is enabled
 	requireReview := e.config.RequireReview != nil && *e.config.RequireReview
@@ -1475,6 +1525,14 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 	// No polecat notification needed; the PR just needs a human review on GitHub.
 	if result.NeedsApproval {
 		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: PR awaiting human approval, will retry next poll\n", mr.ID)
+		return
+	}
+
+	// NeedsCIGreen (AA-851): the PR's checks are red or pending. Not a merge
+	// failure — the MR stays in queue and retries on the next poll, by which
+	// time the polecat should have fixed the failure or CI settled.
+	if result.NeedsCIGreen {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: PR CI not green, will retry next poll (%s)\n", mr.ID, result.Error)
 		return
 	}
 

--- a/internal/rig/config.go
+++ b/internal/rig/config.go
@@ -31,14 +31,15 @@ type ConfigResult struct {
 // SystemDefaults contains compiled-in default values.
 // These are the fallback when no other layer provides a value.
 var SystemDefaults = map[string]interface{}{
-	"status":                  "operational",
-	"auto_restart":            true,
-	"auto_start_on_up":        false, // If true, rig agents start on gt up even when docked
-	"max_polecats":            10,
-	"priority_adjustment":     0,
-	"dnd":                     false,
-	"polecat_branch_template": "", // Empty = use default behavior (polecat/{name}/...)
-	"default_formula":         "mol-polecat-work",
+	"status":                   "operational",
+	"auto_restart":             true,
+	"auto_start_on_up":         false, // If true, rig agents start on gt up even when docked
+	"max_polecats":             10,
+	"priority_adjustment":      0,
+	"dnd":                      false,
+	"polecat_branch_template":  "", // Empty = use default behavior (polecat/{name}/...)
+	"polecat_branch_delimiter": "", // Empty = default "+"; rigs whose CI rejects "+" can set "_"
+	"default_formula":          "mol-polecat-work",
 }
 
 // StackingKeys defines which keys use stacking semantics (values add up).


### PR DESCRIPTION
## Summary

Fixes #4440.

`checkpoint_dog` auto-commits `WIP: checkpoint (auto)` in dirty live polecat worktrees as a crash-safety net. `checkpoint.SquashWIPCommits` (`internal/checkpoint/squash.go`) was written to collapse those commits before publishing — but nothing ever called it, so `gt done` pushed WIP checkpoint junk verbatim to the remote. In the same-PR handoff pattern that landed raw WIP commits on a PR a successor polecat was actively working (observed in production 2026-07-08; a refinery also had to strip a WIP commit from another branch the same night).

## Change

`gt done` now calls a small `squashWIPCheckpointCommits(workDir, baseRef)` wrapper immediately before both push paths:

- the `direct` merge-strategy push (feature branch → default branch), and
- the MR feature-branch push (`branch:branch`).

The MR-path call sits **after** the push-checkpoint resume check, so a branch already pushed by a previous interrupted `gt done` run is never rewritten. The `local` strategy path (human review / upstream PRs, no push) is deliberately untouched — intentional commit structure is preserved there.

Squash failures are warnings, not errors: pushing WIP junk is bad, but blocking `gt done` and stranding the work is worse. Squashing is safe by the helper's own contract — the refinery squash-merges polecat branches anyway.

The nuke work-preservation push (`Manager.NukePolecat`) can still publish WIP checkpoints onto a shared branch; that's the remaining part of #4440 (rescue-ref design), intentionally out of scope here.

## Tests

- `TestSquashWIPCheckpointCommits_StripsWIPBeforePush` — mixed real/WIP history collapses to one commit, WIP subjects gone, newest non-WIP subject kept as title.
- `TestSquashWIPCheckpointCommits_NoWIPIsNoOp` — WIP-free branches keep their history untouched.
- Existing `internal/checkpoint` squash tests and `internal/cmd` done/rebase tests pass.

## Notes

Stacked on #4436 — the first commits are #4430/#4431/#4436; review the last commit here.
