### PR TITLE
fix: guard non-force polecat nuke active MRs

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1864,6 +1864,12 @@ type nukePolecatOptions struct {
 }
 
 func nukePolecatFullWithOptions(polecatName, rigName string, mgr *polecat.Manager, r *rig.Rig, opts nukePolecatOptions) error {
+	if !opts.Force {
+		if activeMR, blocker := mgr.ActiveMRRemovalBlocker(polecatName); blocker != "" {
+			return fmt.Errorf("cannot nuke %s/%s: MR %s is still pending in merge queue (%s)\nRefinery will process the MR and clean up after merge\nUse --force to override (risks data loss)", rigName, polecatName, activeMR, blocker)
+		}
+	}
+
 	t := tmux.NewTmux()
 
 	// Step 1: Kill tmux session unconditionally to prevent ghost sessions

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1791,7 +1791,7 @@ func runPolecatNuke(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Nuking %s/%s...\n", p.rigName, p.polecatName)
 		}
 
-		if err := nukePolecatFullWithOptions(p.polecatName, p.rigName, p.mgr, p.r, nukePolecatOptions{PurgeClosedEphemerals: !batchPurge}); err != nil {
+		if err := nukePolecatFullWithOptions(p.polecatName, p.rigName, p.mgr, p.r, nukePolecatOptions{Force: polecatNukeForce, PurgeClosedEphemerals: !batchPurge}); err != nil {
 			nukeErrors = append(nukeErrors, fmt.Sprintf("%s/%s: %v", p.rigName, p.polecatName, err))
 			continue
 		}
@@ -1859,6 +1859,7 @@ func nukePolecatFull(polecatName, rigName string, mgr *polecat.Manager, r *rig.R
 }
 
 type nukePolecatOptions struct {
+	Force                 bool
 	PurgeClosedEphemerals bool
 }
 
@@ -1892,8 +1893,8 @@ func nukePolecatFullWithOptions(polecatName, rigName string, mgr *polecat.Manage
 	}
 
 	// Step 2.75: Best-effort push before nuke (gt-4vr guardrail).
-	// Try to preserve any unpushed commits on the branch. If push fails,
-	// proceed — --force already means "I accept data loss".
+	// Try to preserve any unpushed commits on the branch. Push failures are
+	// non-fatal because this cleanup path already passed its safety gates.
 	if branchToDelete != "" {
 		var pushGit *git.Git
 		// Try worktree first (may still exist), then bare repo fallback.
@@ -1921,7 +1922,7 @@ func nukePolecatFullWithOptions(polecatName, rigName string, mgr *polecat.Manage
 	}
 
 	// Step 3: Delete worktree (nuclear=true to bypass safety checks for stale polecats)
-	if err := mgr.RemoveWithOptions(polecatName, true, true, false); err != nil {
+	if err := mgr.RemoveWithOptions(polecatName, opts.Force, true, false); err != nil {
 		if errors.Is(err, polecat.ErrPolecatNotFound) {
 			fmt.Printf("  %s worktree already gone\n", style.Dim.Render("○"))
 			resetPolecatAgentBeadForReuse(r, rigName, polecatName)

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1864,10 +1864,8 @@ type nukePolecatOptions struct {
 }
 
 func nukePolecatFullWithOptions(polecatName, rigName string, mgr *polecat.Manager, r *rig.Rig, opts nukePolecatOptions) error {
-	if !opts.Force {
-		if activeMR, blocker := mgr.ActiveMRRemovalBlocker(polecatName); blocker != "" {
-			return fmt.Errorf("cannot nuke %s/%s: MR %s is still pending in merge queue (%s)\nRefinery will process the MR and clean up after merge\nUse --force to override (risks data loss)", rigName, polecatName, activeMR, blocker)
-		}
+	if err := checkNukeActiveMRSafety(mgr, polecatName, rigName, opts.Force); err != nil {
+		return err
 	}
 
 	t := tmux.NewTmux()
@@ -1962,6 +1960,20 @@ func nukePolecatFullWithOptions(polecatName, rigName string, mgr *polecat.Manage
 		purgeClosedEphemeralBeads(beads.New(r.Path))
 	}
 
+	return nil
+}
+
+type activeMRRemovalChecker interface {
+	ActiveMRRemovalBlocker(name string) (activeMR, blocker string)
+}
+
+func checkNukeActiveMRSafety(checker activeMRRemovalChecker, polecatName, rigName string, force bool) error {
+	if force || checker == nil {
+		return nil
+	}
+	if activeMR, blocker := checker.ActiveMRRemovalBlocker(polecatName); blocker != "" {
+		return fmt.Errorf("cannot nuke %s/%s: MR %s is still pending in merge queue (%s)\nRefinery will process the MR and clean up after merge\nUse --force to override (risks data loss)", rigName, polecatName, activeMR, blocker)
+	}
 	return nil
 }
 

--- a/internal/cmd/polecat_check_recovery_test.go
+++ b/internal/cmd/polecat_check_recovery_test.go
@@ -46,6 +46,19 @@ func (f *fakeCleanupUpdater) UpdateAgentCleanupStatus(id string, cleanupStatus s
 	return f.err
 }
 
+type fakeActiveMRRemovalChecker struct {
+	activeMR string
+	blocker  string
+	calls    int
+	name     string
+}
+
+func (f *fakeActiveMRRemovalChecker) ActiveMRRemovalBlocker(name string) (string, string) {
+	f.calls++
+	f.name = name
+	return f.activeMR, f.blocker
+}
+
 type fakeIssueMapShower struct {
 	issues map[string]*beads.Issue
 	errs   map[string]error
@@ -60,6 +73,36 @@ func (f fakeIssueMapShower) Show(issueID string) (*beads.Issue, error) {
 		return nil, beads.ErrNotFound
 	}
 	return issue, nil
+}
+
+func TestCheckNukeActiveMRSafety(t *testing.T) {
+	checker := &fakeActiveMRRemovalChecker{activeMR: "gt-mr", blocker: "active_mr=gt-mr status=in_progress"}
+	err := checkNukeActiveMRSafety(checker, "toast", "gastown", false)
+	if err == nil {
+		t.Fatal("checkNukeActiveMRSafety() error = nil, want pending MR blocker")
+	}
+	if checker.calls != 1 || checker.name != "toast" {
+		t.Fatalf("checker calls = %d name = %q, want one call for toast", checker.calls, checker.name)
+	}
+	for _, want := range []string{"gastown/toast", "gt-mr", "status=in_progress", "--force"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err, want)
+		}
+	}
+
+	checker.calls = 0
+	if err := checkNukeActiveMRSafety(checker, "toast", "gastown", true); err != nil {
+		t.Fatalf("forced checkNukeActiveMRSafety() error = %v, want nil", err)
+	}
+	if checker.calls != 0 {
+		t.Fatalf("forced check called blocker %d times, want 0", checker.calls)
+	}
+
+	lookupErrorChecker := &fakeActiveMRRemovalChecker{activeMR: "<unknown>", blocker: "agent_lookup_error: bd exploded"}
+	err = checkNukeActiveMRSafety(lookupErrorChecker, "toast", "gastown", false)
+	if err == nil || !strings.Contains(err.Error(), "agent_lookup_error") {
+		t.Fatalf("lookup-error check = %v, want fail-closed agent_lookup_error", err)
+	}
 }
 
 func TestApplyMQCheck(t *testing.T) {

--- a/internal/polecat/active_mr_test.go
+++ b/internal/polecat/active_mr_test.go
@@ -2,6 +2,7 @@ package polecat
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
@@ -77,5 +78,57 @@ func TestAssessActiveMRLookupErrorsFailClosed(t *testing.T) {
 	reader.issues["mr-closed"] = &beads.Issue{ID: "mr-closed", Status: "closed"}
 	if got := AssessActiveMR(reader, ActiveMRInput{ActiveMR: "mr-closed", SourceIssueHint: "gt-error"}); !got.Pending {
 		t.Fatalf("source lookup error Pending = false, want true")
+	}
+}
+
+func TestActiveMRRemovalBlockerUsesActiveMRPolicy(t *testing.T) {
+	reader := fakeActiveMRReader{issues: map[string]*beads.Issue{
+		"mr-open":     {ID: "mr-open", Status: "open"},
+		"mr-progress": {ID: "mr-progress", Status: "in_progress"},
+		"mr-closed":   {ID: "mr-closed", Status: "closed"},
+		"gt-closed":   {ID: "gt-closed", Status: "closed"},
+		"gt-open":     {ID: "gt-open", Status: "open"},
+	}}
+
+	tests := []struct {
+		name       string
+		fields     *beads.AgentFields
+		wantBlock  bool
+		wantReason string
+	}{
+		{name: "empty fields are safe"},
+		{name: "open MR blocks", fields: &beads.AgentFields{ActiveMR: "mr-open", LastSourceIssue: "gt-closed"}, wantBlock: true, wantReason: "status=open"},
+		{name: "in-progress MR blocks", fields: &beads.AgentFields{ActiveMR: "mr-progress", LastSourceIssue: "gt-closed"}, wantBlock: true, wantReason: "status=in_progress"},
+		{name: "closed MR with terminal source is safe", fields: &beads.AgentFields{ActiveMR: "mr-closed", LastSourceIssue: "gt-closed"}},
+		{name: "closed MR with open source blocks", fields: &beads.AgentFields{ActiveMR: "mr-closed", LastSourceIssue: "gt-open"}, wantBlock: true, wantReason: "source_status=open"},
+		{name: "closed MR uses hook as source hint", fields: &beads.AgentFields{ActiveMR: "mr-closed", HookBead: "gt-closed"}},
+		{name: "missing MR without terminal source blocks", fields: &beads.AgentFields{ActiveMR: "mr-missing"}, wantBlock: true, wantReason: "source_issue=<missing>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := activeMRRemovalBlocker(reader, tt.fields)
+			if tt.wantBlock && got == "" {
+				t.Fatal("activeMRRemovalBlocker() = empty, want blocker")
+			}
+			if !tt.wantBlock && got != "" {
+				t.Fatalf("activeMRRemovalBlocker() = %q, want empty", got)
+			}
+			if tt.wantReason != "" && !strings.Contains(got, tt.wantReason) {
+				t.Fatalf("blocker = %q, want contains %q", got, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestActiveMRRemovalBlockerLookupErrorsFailClosed(t *testing.T) {
+	reader := fakeActiveMRReader{
+		issues: map[string]*beads.Issue{"gt-closed": {ID: "gt-closed", Status: "closed"}},
+		errs:   map[string]error{"mr-error": errors.New("bd exploded")},
+	}
+
+	got := activeMRRemovalBlocker(reader, &beads.AgentFields{ActiveMR: "mr-error", LastSourceIssue: "gt-closed"})
+	if got == "" || !strings.Contains(got, "lookup_error") {
+		t.Fatalf("blocker = %q, want lookup_error fail-closed", got)
 	}
 }

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1178,12 +1178,8 @@ func (m *Manager) removeWithOptionsLocked(name string, force, nuclear, selfNuke 
 	// --force explicitly accepts that risk. Use the shared classifier so removal
 	// fails closed the same way recovery/listing do.
 	if !force {
-		agentID := m.agentBeadID(name)
-		_, fields, aErr := m.agentBeads().GetAgentBead(agentID)
-		if aErr == nil {
-			if blocker := activeMRRemovalBlocker(m.agentBeads(), fields); blocker != "" {
-				return fmt.Errorf("cannot remove polecat %s: MR %s is still pending in merge queue (%s)\nRefinery will process the MR and clean up after merge\nUse --force to override (risks data loss)", name, fields.ActiveMR, blocker)
-			}
+		if activeMR, blocker := m.ActiveMRRemovalBlocker(name); blocker != "" {
+			return fmt.Errorf("cannot remove polecat %s: MR %s is still pending in merge queue (%s)\nRefinery will process the MR and clean up after merge\nUse --force to override (risks data loss)", name, activeMR, blocker)
 		}
 	}
 
@@ -1306,6 +1302,22 @@ func (m *Manager) removeWithOptionsLocked(name string, force, nuclear, selfNuke 
 	_ = m.namePool.Save()
 
 	return nil
+}
+
+// ActiveMRRemovalBlocker returns the pending active-MR reason that should block
+// non-force polecat removal. It reads agent metadata from the town agent-bead
+// store, then classifies the MR/source through the normal rig beads reader.
+func (m *Manager) ActiveMRRemovalBlocker(name string) (string, string) {
+	agentID := m.agentBeadID(name)
+	_, fields, err := m.agentBeads().GetAgentBead(agentID)
+	if err != nil || fields == nil {
+		return "", ""
+	}
+	activeMR := strings.TrimSpace(fields.ActiveMR)
+	if activeMR == "" {
+		return "", ""
+	}
+	return activeMR, activeMRRemovalBlocker(m.beads, fields)
 }
 
 func activeMRRemovalBlocker(reader IssueReader, fields *beads.AgentFields) string {

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1174,16 +1174,15 @@ func (m *Manager) removeWithOptionsLocked(name string, force, nuclear, selfNuke 
 		}
 	}
 
-	// Even nuclear mode must not delete worktrees with unmerged MRs.
-	// The nuclear flag bypasses git-status checks (needed for self-nuke)
-	// but MR status is a higher-level concern that should always be checked.
+	// Even nuclear mode must not delete worktrees with pending MRs unless
+	// --force explicitly accepts that risk. Use the shared classifier so removal
+	// fails closed the same way recovery/listing do.
 	if !force {
 		agentID := m.agentBeadID(name)
 		_, fields, aErr := m.agentBeads().GetAgentBead(agentID)
-		if aErr == nil && fields != nil && fields.ActiveMR != "" {
-			mrBead, mrErr := m.beads.Show(fields.ActiveMR)
-			if mrErr == nil && mrBead != nil && beads.IssueStatus(mrBead.Status).BlocksRemoval() {
-				return fmt.Errorf("cannot remove polecat %s: MR %s is still open in merge queue\nRefinery will process the MR and clean up after merge\nUse --force to override (risks data loss)", name, fields.ActiveMR)
+		if aErr == nil {
+			if blocker := activeMRRemovalBlocker(m.agentBeads(), fields); blocker != "" {
+				return fmt.Errorf("cannot remove polecat %s: MR %s is still pending in merge queue (%s)\nRefinery will process the MR and clean up after merge\nUse --force to override (risks data loss)", name, fields.ActiveMR, blocker)
 			}
 		}
 	}
@@ -1307,6 +1306,24 @@ func (m *Manager) removeWithOptionsLocked(name string, force, nuclear, selfNuke 
 	_ = m.namePool.Save()
 
 	return nil
+}
+
+func activeMRRemovalBlocker(reader IssueReader, fields *beads.AgentFields) string {
+	if fields == nil || strings.TrimSpace(fields.ActiveMR) == "" {
+		return ""
+	}
+	sourceHint := strings.TrimSpace(fields.LastSourceIssue)
+	if sourceHint == "" {
+		sourceHint = strings.TrimSpace(fields.HookBead)
+	}
+	assessment := AssessActiveMR(reader, ActiveMRInput{ActiveMR: fields.ActiveMR, SourceIssueHint: sourceHint})
+	if !assessment.Pending {
+		return ""
+	}
+	if assessment.Reason != "" {
+		return assessment.Reason
+	}
+	return fmt.Sprintf("active_mr=%s status=pending", strings.TrimSpace(fields.ActiveMR))
 }
 
 // ReclaimBrokenIdlePolecat removes a structurally broken idle sandbox before any

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1310,7 +1310,10 @@ func (m *Manager) removeWithOptionsLocked(name string, force, nuclear, selfNuke 
 func (m *Manager) ActiveMRRemovalBlocker(name string) (string, string) {
 	agentID := m.agentBeadID(name)
 	_, fields, err := m.agentBeads().GetAgentBead(agentID)
-	if err != nil || fields == nil {
+	if err != nil {
+		return "<unknown>", fmt.Sprintf("agent_lookup_error: %v", err)
+	}
+	if fields == nil {
 		return "", ""
 	}
 	activeMR := strings.TrimSpace(fields.ActiveMR)


### PR DESCRIPTION
## Summary

- Supersedes #4127 with a current-main replacement for the same `gt polecat nuke --force` bug.
- Threads explicit force through `nukePolecatOptions` so only manual `gt polecat nuke --force` bypasses pending active-MR removal blockers.
- Keeps non-force nuke and `gt polecat stale --cleanup` fail-closed before session kill, molecule cleanup, branch push, or worktree removal.
- Converges removal safety on the shared `AssessActiveMR` classifier, including non-terminal MR statuses, lookup errors, missing sources, and terminal-source stale cases.

## Original PR Attribution

This carries forward the intent of #4127 by Athos/furiosa (`athosmartins`) with Claude Sonnet 4.6 co-authorship in the original commit `d9e3a6a165473f9f43f79a58e0810c5961269a4d`.

Original PR: https://github.com/gastownhall/gastown/pull/4127
Original author: Athos Bernardes / furiosa <athosmartins@gmail.com>
Original co-author: Claude Sonnet 4.6 <noreply@anthropic.com>

## Verification

- `CGO_ENABLED=0 go test ./internal/cmd`
- `CGO_ENABLED=0 go test ./internal/polecat -timeout=300s`

Default CGO local test runs fail on this host because `github.com/dolthub/go-icu-regex` cannot find `unicode/uregex.h`; this is the known local ICU-header issue and is unrelated to this change.

## PR Sheriff Evidence

- 15 independent research legs completed.
- 5 revised pre-implementation reviews approved the replacement plan.
- 5 final post-implementation reviews approved final head `e81c97fda0c57a4bb5b723b95e97ad9059bbb827`.
- Original #4127 remains blocked as-is: conflicting with current main, labeled `status/review-failed`, stale failing checks, and no approval.
- Merge path for this replacement remains pending until GitHub CI and review complete.
