### PR TITLE
fix: prune patch-equivalent remote polecat branches

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -2247,7 +2247,12 @@ func runPolecatPrune(cmd *cobra.Command, args []string) error {
 
 func pruneRemotePolecatBranches(repoGit *git.Git, dryRun bool) (int, error) {
 	defaultBranch := repoGit.RemoteDefaultBranch()
-	target := "origin/" + defaultBranch
+	target := repoGit.CleanDefaultBranchBaseRef("origin", defaultBranch)
+	if targetRemote := git.RemoteForRef(target); targetRemote != "" && targetRemote != "origin" {
+		if err := repoGit.FetchPrune(targetRemote); err != nil {
+			return 0, fmt.Errorf("refreshing %s before remote prune: %w", targetRemote, err)
+		}
+	}
 	remoteRefs, lsErr := repoGit.ListPushRemoteRefsWithHashes("origin", "refs/heads/polecat/")
 	if lsErr != nil {
 		return 0, fmt.Errorf("listing remote refs: %w", lsErr)

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -2196,6 +2196,9 @@ func runPolecatPrune(cmd *cobra.Command, args []string) error {
 
 	// First, prune stale remote-tracking refs so we detect deleted remote branches
 	if err := repoGit.FetchPrune("origin"); err != nil {
+		if polecatPruneRemote {
+			return fmt.Errorf("refreshing origin before remote prune: %w", err)
+		}
 		fmt.Printf("  %s fetch --prune: %v (continuing anyway)\n", style.Warning.Render("⚠"), err)
 	}
 
@@ -2223,38 +2226,9 @@ func runPolecatPrune(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 		fmt.Println("Pruning remote polecat branches...")
 
-		defaultBranch := repoGit.RemoteDefaultBranch()
-		remoteRefs, lsErr := repoGit.ListPushRemoteRefsWithHashes("origin", "refs/heads/polecat/")
-		if lsErr != nil {
-			return fmt.Errorf("listing remote refs: %w", lsErr)
-		}
-
-		remotePruned := 0
-		for _, ref := range remoteRefs {
-			if !strings.HasPrefix(ref.Name, "refs/heads/") {
-				continue
-			}
-			branch := strings.TrimPrefix(ref.Name, "refs/heads/")
-			// Use the listed remote tip, not the short branch name, so remote-only
-			// branches can be classified without a local branch.
-			merged, mergeErr := repoGit.IsAncestor(ref.Hash, "origin/"+defaultBranch)
-			if mergeErr != nil {
-				continue
-			}
-			if !merged {
-				continue
-			}
-
-			if polecatPruneDryRun {
-				fmt.Printf("  Would delete remote: %s\n", style.Dim.Render(branch))
-			} else {
-				if delErr := repoGit.DeleteRemoteBranchIfAt("origin", branch, ref.Hash); delErr != nil {
-					fmt.Printf("  %s remote %s: %v\n", style.Warning.Render("⚠"), branch, delErr)
-				} else {
-					fmt.Printf("  %s deleted remote %s\n", style.Success.Render("✓"), branch)
-				}
-			}
-			remotePruned++
+		remotePruned, remoteErr := pruneRemotePolecatBranches(repoGit, polecatPruneDryRun)
+		if remoteErr != nil {
+			return remoteErr
 		}
 
 		if remotePruned == 0 {
@@ -2269,6 +2243,41 @@ func runPolecatPrune(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func pruneRemotePolecatBranches(repoGit *git.Git, dryRun bool) (int, error) {
+	defaultBranch := repoGit.RemoteDefaultBranch()
+	target := "origin/" + defaultBranch
+	remoteRefs, lsErr := repoGit.ListPushRemoteRefsWithHashes("origin", "refs/heads/polecat/")
+	if lsErr != nil {
+		return 0, fmt.Errorf("listing remote refs: %w", lsErr)
+	}
+
+	remotePruned := 0
+	for _, ref := range remoteRefs {
+		if !strings.HasPrefix(ref.Name, "refs/heads/") {
+			continue
+		}
+		branch := strings.TrimPrefix(ref.Name, "refs/heads/")
+		status, statusErr := repoGit.PushRemoteRefTargetStatus("origin", ref, target)
+		if statusErr != nil || !status.Preserved {
+			continue
+		}
+
+		if dryRun {
+			fmt.Printf("  Would delete remote: %s\n", style.Dim.Render(branch))
+			remotePruned++
+			continue
+		}
+		if delErr := repoGit.DeleteRemoteBranchIfAt("origin", branch, ref.Hash); delErr != nil {
+			fmt.Printf("  %s remote %s: %v\n", style.Warning.Render("⚠"), branch, delErr)
+			continue
+		}
+		fmt.Printf("  %s deleted remote %s\n", style.Success.Render("✓"), branch)
+		remotePruned++
+	}
+
+	return remotePruned, nil
 }
 
 // runPolecatPoolInit creates a persistent polecat pool for a rig.

--- a/internal/cmd/polecat_prune_test.go
+++ b/internal/cmd/polecat_prune_test.go
@@ -54,6 +54,59 @@ func TestRunPolecatPruneRemoteDryRunIncludesPatchEquivalentBranch(t *testing.T) 
 	assertRemotePruneDryRunKeptBranch(t, repoGit, out, branch)
 }
 
+func TestPruneRemotePolecatBranchesUsesUpstreamBaseForOriginFork(t *testing.T) {
+	localDir, mainBranch := initPolecatPruneOriginForkRepo(t)
+	repoGit := git.NewGit(localDir)
+	branch := "polecat/fork-only-preserved"
+
+	runGit(t, localDir, "checkout", "-b", branch, "upstream/"+mainBranch)
+	writePolecatPruneTestFile(t, filepath.Join(localDir, "fork-only.txt"), "fork only\n")
+	runGit(t, localDir, "add", "fork-only.txt")
+	runGit(t, localDir, "commit", "-m", "fork-only branch work")
+	branchSHA, err := repoGit.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev branch: %v", err)
+	}
+	runGit(t, localDir, "push", "origin", branch)
+
+	runGit(t, localDir, "checkout", mainBranch)
+	runGit(t, localDir, "reset", "--hard", "origin/"+mainBranch)
+	writePolecatPruneTestFile(t, filepath.Join(localDir, "fork-advance.txt"), "fork advanced\n")
+	runGit(t, localDir, "add", "fork-advance.txt")
+	runGit(t, localDir, "commit", "-m", "advance fork target")
+	runGit(t, localDir, "cherry-pick", strings.TrimSpace(branchSHA))
+	runGit(t, localDir, "push", "origin", mainBranch)
+	if err := repoGit.FetchPrune("origin"); err != nil {
+		t.Fatalf("FetchPrune origin: %v", err)
+	}
+	if err := repoGit.FetchPrune("upstream"); err != nil {
+		t.Fatalf("FetchPrune upstream: %v", err)
+	}
+	if got := repoGit.CleanDefaultBranchBaseRef("origin", mainBranch); got != "upstream/"+mainBranch {
+		t.Fatalf("CleanDefaultBranchBaseRef = %q, want upstream/%s", got, mainBranch)
+	}
+
+	out := captureStdout(t, func() {
+		pruned, err := pruneRemotePolecatBranches(repoGit, true)
+		if err != nil {
+			t.Fatalf("pruneRemotePolecatBranches: %v", err)
+		}
+		if pruned != 0 {
+			t.Fatalf("pruned = %d, want 0 because branch is not preserved on upstream/%s", pruned, mainBranch)
+		}
+	})
+	if strings.Contains(out, branch) {
+		t.Fatalf("dry-run output %q should not include fork-only branch %s", out, branch)
+	}
+	exists, err := repoGit.RemoteBranchExists("origin", branch)
+	if err != nil {
+		t.Fatalf("RemoteBranchExists: %v", err)
+	}
+	if !exists {
+		t.Fatal("fork-only branch should remain on origin")
+	}
+}
+
 func createPatchEquivalentRemoteBranch(t *testing.T, repoGit *git.Git, localDir, mainBranch, branch string) {
 	t.Helper()
 	runGit(t, localDir, "checkout", "-b", branch, mainBranch)
@@ -114,6 +167,32 @@ func initPolecatPruneTestRepoAt(t *testing.T, localDir string) string {
 	runGit(t, localDir, "push", "-u", "origin", mainBranch)
 
 	return mainBranch
+}
+
+func initPolecatPruneOriginForkRepo(t *testing.T) (string, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	upstreamDir := filepath.Join(tmp, "upstream.git")
+	forkDir := filepath.Join(tmp, "fork.git")
+	localDir := filepath.Join(tmp, "local")
+	mainBranch := "main"
+
+	runGit(t, tmp, "init", "--bare", "--initial-branch", mainBranch, upstreamDir)
+	runGit(t, tmp, "init", "--bare", "--initial-branch", mainBranch, forkDir)
+	runGit(t, tmp, "clone", upstreamDir, localDir)
+	runGit(t, localDir, "config", "user.email", "test@test.com")
+	runGit(t, localDir, "config", "user.name", "Test User")
+	writePolecatPruneTestFile(t, filepath.Join(localDir, "README.md"), "test\n")
+	runGit(t, localDir, "add", "README.md")
+	runGit(t, localDir, "commit", "-m", "initial")
+	runGit(t, localDir, "push", "-u", "origin", mainBranch)
+	runGit(t, localDir, "push", forkDir, mainBranch)
+	runGit(t, localDir, "remote", "set-url", "origin", forkDir)
+	runGit(t, localDir, "remote", "add", "upstream", upstreamDir)
+	runGit(t, localDir, "fetch", "origin")
+	runGit(t, localDir, "fetch", "upstream")
+
+	return localDir, mainBranch
 }
 
 func writePolecatPruneTestFile(t *testing.T, path, data string) {

--- a/internal/cmd/polecat_prune_test.go
+++ b/internal/cmd/polecat_prune_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+func TestPruneRemotePolecatBranchesDryRunIncludesPatchEquivalentBranch(t *testing.T) {
+	localDir, mainBranch := initPolecatPruneTestRepo(t)
+	repoGit := git.NewGit(localDir)
+	branch := "polecat/prune-patch-equivalent"
+
+	runGit(t, localDir, "checkout", "-b", branch, mainBranch)
+	writePolecatPruneTestFile(t, filepath.Join(localDir, "feature.txt"), "feature\n")
+	runGit(t, localDir, "add", "feature.txt")
+	runGit(t, localDir, "commit", "-m", "feature work")
+	branchSHA, err := repoGit.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev branch: %v", err)
+	}
+	runGit(t, localDir, "push", "origin", branch)
+
+	runGit(t, localDir, "checkout", mainBranch)
+	writePolecatPruneTestFile(t, filepath.Join(localDir, "advance.txt"), "target advanced\n")
+	runGit(t, localDir, "add", "advance.txt")
+	runGit(t, localDir, "commit", "-m", "advance target")
+	runGit(t, localDir, "cherry-pick", strings.TrimSpace(branchSHA))
+	runGit(t, localDir, "push", "origin", mainBranch)
+	if err := repoGit.FetchPrune("origin"); err != nil {
+		t.Fatalf("FetchPrune: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		pruned, err := pruneRemotePolecatBranches(repoGit, true)
+		if err != nil {
+			t.Fatalf("pruneRemotePolecatBranches: %v", err)
+		}
+		if pruned != 1 {
+			t.Fatalf("pruned = %d, want 1", pruned)
+		}
+	})
+	if !strings.Contains(out, "Would delete remote") || !strings.Contains(out, branch) {
+		t.Fatalf("dry-run output %q, want branch %s", out, branch)
+	}
+	exists, err := repoGit.RemoteBranchExists("origin", branch)
+	if err != nil {
+		t.Fatalf("RemoteBranchExists: %v", err)
+	}
+	if !exists {
+		t.Fatal("dry-run should not delete the remote branch")
+	}
+}
+
+func initPolecatPruneTestRepo(t *testing.T) (string, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	remoteDir := filepath.Join(tmp, "remote.git")
+	localDir := filepath.Join(tmp, "local")
+	mainBranch := "main"
+
+	runGit(t, tmp, "init", "--bare", "--initial-branch", mainBranch, remoteDir)
+	runGit(t, tmp, "clone", remoteDir, localDir)
+	runGit(t, localDir, "config", "user.email", "test@test.com")
+	runGit(t, localDir, "config", "user.name", "Test User")
+	writePolecatPruneTestFile(t, filepath.Join(localDir, "README.md"), "test\n")
+	runGit(t, localDir, "add", "README.md")
+	runGit(t, localDir, "commit", "-m", "initial")
+	runGit(t, localDir, "push", "-u", "origin", mainBranch)
+
+	return localDir, mainBranch
+}
+
+func writePolecatPruneTestFile(t *testing.T, path, data string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/cmd/polecat_prune_test.go
+++ b/internal/cmd/polecat_prune_test.go
@@ -13,7 +13,49 @@ func TestPruneRemotePolecatBranchesDryRunIncludesPatchEquivalentBranch(t *testin
 	localDir, mainBranch := initPolecatPruneTestRepo(t)
 	repoGit := git.NewGit(localDir)
 	branch := "polecat/prune-patch-equivalent"
+	createPatchEquivalentRemoteBranch(t, repoGit, localDir, mainBranch, branch)
+	if err := repoGit.FetchPrune("origin"); err != nil {
+		t.Fatalf("FetchPrune: %v", err)
+	}
 
+	out := captureStdout(t, func() {
+		pruned, err := pruneRemotePolecatBranches(repoGit, true)
+		if err != nil {
+			t.Fatalf("pruneRemotePolecatBranches: %v", err)
+		}
+		if pruned != 1 {
+			t.Fatalf("pruned = %d, want 1", pruned)
+		}
+	})
+	assertRemotePruneDryRunKeptBranch(t, repoGit, out, branch)
+}
+
+func TestRunPolecatPruneRemoteDryRunIncludesPatchEquivalentBranch(t *testing.T) {
+	townRoot, rigName := setupTestRigForSettings(t)
+	localDir := filepath.Join(townRoot, rigName, "mayor", "rig")
+	mainBranch := initPolecatPruneTestRepoAt(t, localDir)
+	repoGit := git.NewGit(localDir)
+	branch := "polecat/prune-command-patch-equivalent"
+	createPatchEquivalentRemoteBranch(t, repoGit, localDir, mainBranch, branch)
+
+	oldRemote, oldDryRun := polecatPruneRemote, polecatPruneDryRun
+	polecatPruneRemote = true
+	polecatPruneDryRun = true
+	t.Cleanup(func() {
+		polecatPruneRemote = oldRemote
+		polecatPruneDryRun = oldDryRun
+	})
+
+	out := captureStdout(t, func() {
+		if err := runPolecatPrune(nil, []string{rigName}); err != nil {
+			t.Fatalf("runPolecatPrune: %v", err)
+		}
+	})
+	assertRemotePruneDryRunKeptBranch(t, repoGit, out, branch)
+}
+
+func createPatchEquivalentRemoteBranch(t *testing.T, repoGit *git.Git, localDir, mainBranch, branch string) {
+	t.Helper()
 	runGit(t, localDir, "checkout", "-b", branch, mainBranch)
 	writePolecatPruneTestFile(t, filepath.Join(localDir, "feature.txt"), "feature\n")
 	runGit(t, localDir, "add", "feature.txt")
@@ -30,19 +72,10 @@ func TestPruneRemotePolecatBranchesDryRunIncludesPatchEquivalentBranch(t *testin
 	runGit(t, localDir, "commit", "-m", "advance target")
 	runGit(t, localDir, "cherry-pick", strings.TrimSpace(branchSHA))
 	runGit(t, localDir, "push", "origin", mainBranch)
-	if err := repoGit.FetchPrune("origin"); err != nil {
-		t.Fatalf("FetchPrune: %v", err)
-	}
+}
 
-	out := captureStdout(t, func() {
-		pruned, err := pruneRemotePolecatBranches(repoGit, true)
-		if err != nil {
-			t.Fatalf("pruneRemotePolecatBranches: %v", err)
-		}
-		if pruned != 1 {
-			t.Fatalf("pruned = %d, want 1", pruned)
-		}
-	})
+func assertRemotePruneDryRunKeptBranch(t *testing.T, repoGit *git.Git, out, branch string) {
+	t.Helper()
 	if !strings.Contains(out, "Would delete remote") || !strings.Contains(out, branch) {
 		t.Fatalf("dry-run output %q, want branch %s", out, branch)
 	}
@@ -58,10 +91,19 @@ func TestPruneRemotePolecatBranchesDryRunIncludesPatchEquivalentBranch(t *testin
 func initPolecatPruneTestRepo(t *testing.T) (string, string) {
 	t.Helper()
 	tmp := t.TempDir()
-	remoteDir := filepath.Join(tmp, "remote.git")
 	localDir := filepath.Join(tmp, "local")
+	return localDir, initPolecatPruneTestRepoAt(t, localDir)
+}
+
+func initPolecatPruneTestRepoAt(t *testing.T, localDir string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	remoteDir := filepath.Join(tmp, "remote.git")
 	mainBranch := "main"
 
+	if err := os.MkdirAll(filepath.Dir(localDir), 0755); err != nil {
+		t.Fatalf("mkdir repo parent: %v", err)
+	}
 	runGit(t, tmp, "init", "--bare", "--initial-branch", mainBranch, remoteDir)
 	runGit(t, tmp, "clone", remoteDir, localDir)
 	runGit(t, localDir, "config", "user.email", "test@test.com")
@@ -71,7 +113,7 @@ func initPolecatPruneTestRepo(t *testing.T) (string, string) {
 	runGit(t, localDir, "commit", "-m", "initial")
 	runGit(t, localDir, "push", "-u", "origin", mainBranch)
 
-	return localDir, mainBranch
+	return mainBranch
 }
 
 func writePolecatPruneTestFile(t *testing.T, path, data string) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1800,13 +1800,7 @@ func (g *Git) ListPushRemoteRefs(remote, prefix string) ([]string, error) {
 
 // ListPushRemoteRefsWithHashes is ListPushRemoteRefs with commit hashes.
 func (g *Git) ListPushRemoteRefsWithHashes(remote, prefix string) ([]RemoteRef, error) {
-	fetchURL, fetchErr := g.RemoteURL(remote)
-	pushURL, pushErr := g.GetPushURL(remote)
-	if fetchErr != nil || pushErr != nil || pushURL == fetchURL {
-		return g.ListRemoteRefsWithHashes(remote, prefix)
-	}
-	// Query the push URL directly
-	return g.ListRemoteRefsWithHashes(pushURL, prefix)
+	return g.ListRemoteRefsWithHashes(g.pushTarget(remote), prefix)
 }
 
 // Rebase rebases the current branch onto the given ref.
@@ -2010,12 +2004,11 @@ func (g *Git) RemoteBranchTip(remote, branch string) (string, error) {
 // URL directly so verification matches where the branch was actually pushed.
 // Falls back to RemoteBranchExists when no custom push URL is configured.
 func (g *Git) PushRemoteBranchExists(remote, branch string) (bool, error) {
-	fetchURL, fetchErr := g.RemoteURL(remote)
-	pushURL, pushErr := g.GetPushURL(remote)
-	if fetchErr != nil || pushErr != nil || pushURL == fetchURL {
+	pushTarget := g.pushTarget(remote)
+	if pushTarget == remote {
 		return g.RemoteBranchExists(remote, branch)
 	}
-	out, err := g.run("ls-remote", "--heads", pushURL, branch)
+	out, err := g.run("ls-remote", "--heads", pushTarget, branch)
 	if err != nil {
 		return false, err
 	}
@@ -2027,12 +2020,20 @@ func (g *Git) PushRemoteBranchExists(remote, branch string) (bool, error) {
 // the fetch URL, verification must query the push URL because that is where the
 // preceding git push wrote.
 func (g *Git) PushRemoteBranchTip(remote, branch string) (string, error) {
+	pushTarget := g.pushTarget(remote)
+	if pushTarget == remote {
+		return g.RemoteBranchTip(remote, branch)
+	}
+	return g.RemoteBranchTip(pushTarget, branch)
+}
+
+func (g *Git) pushTarget(remote string) string {
 	fetchURL, fetchErr := g.RemoteURL(remote)
 	pushURL, pushErr := g.GetPushURL(remote)
 	if fetchErr != nil || pushErr != nil || pushURL == fetchURL {
-		return g.RemoteBranchTip(remote, branch)
+		return remote
 	}
-	return g.RemoteBranchTip(pushURL, branch)
+	return pushURL
 }
 
 // VerifyPushedCommit verifies that the push target branch tip is exactly commit.
@@ -2076,12 +2077,7 @@ func (g *Git) VerifyPushedCommitReachableFromPushTarget(remote, branch, commit s
 		return nil
 	}
 
-	fetchTarget := remote
-	fetchURL, fetchErr := g.RemoteURL(remote)
-	pushURL, pushErr := g.GetPushURL(remote)
-	if fetchErr == nil && pushErr == nil && pushURL != fetchURL {
-		fetchTarget = pushURL
-	}
+	fetchTarget := g.pushTarget(remote)
 	if _, err := g.run("fetch", "--no-tags", fetchTarget, "refs/heads/"+branch); err != nil {
 		return fmt.Errorf("verified_push_failed: unable to fetch %s/%s for ancestry check: %w", remote, branch, err)
 	}
@@ -2850,36 +2846,74 @@ func comparisonRefCandidates(ref, remote string) []string {
 }
 
 func (g *Git) preservationAgainstRef(ref string) (BranchPreservationStatus, error) {
+	return g.preservationOfRefAgainstRef("HEAD", ref)
+}
+
+func (g *Git) preservationOfRefAgainstRef(head, ref string) (BranchPreservationStatus, error) {
 	status := BranchPreservationStatus{ComparisonBase: ref}
-	if contains, err := g.refContainsHead(ref); err == nil && contains {
+	if contains, err := g.IsAncestor(head, ref); err == nil && contains {
 		status.Preserved = true
 		status.Evidence = "ancestor"
 		return status, nil
 	}
-	if preserved, err := g.mergeTreeNoopAgainstRef(ref); err == nil && preserved {
+	if preserved, err := g.mergeTreeNoopBetweenRefs(head, ref); err == nil && preserved {
 		status.Preserved = true
 		status.Evidence = "merge_tree_noop"
 		return status, nil
 	}
-	out, err := g.Cherry(ref, "HEAD")
+	out, err := g.Cherry(ref, head)
 	if err != nil {
 		return status, err
 	}
 	status.UnpreservedPatchCount = CountCherryUnmergedCommits(out)
 	status.Preserved = status.UnpreservedPatchCount == 0
+	if status.Preserved {
+		status.Evidence = "cherry"
+	}
 	return status, nil
 }
 
 func (g *Git) mergeTreeNoopAgainstRef(ref string) (bool, error) {
+	return g.mergeTreeNoopBetweenRefs("HEAD", ref)
+}
+
+func (g *Git) mergeTreeNoopBetweenRefs(head, ref string) (bool, error) {
 	refTree, err := g.run("rev-parse", ref+"^{tree}")
 	if err != nil {
 		return false, err
 	}
-	mergedTree, err := g.run("merge-tree", "--write-tree", ref, "HEAD")
+	mergedTree, err := g.run("merge-tree", "--write-tree", ref, head)
 	if err != nil {
 		return false, err
 	}
 	return strings.TrimSpace(mergedTree) == strings.TrimSpace(refTree), nil
+}
+
+// PushRemoteRefTargetStatus checks whether a push-remote ref is preserved on
+// target. It fetches the exact candidate ref first so remote-only tips and split
+// fetch/push remotes are classified against the listed hash, not stale tracking
+// refs.
+func (g *Git) PushRemoteRefTargetStatus(remote string, ref RemoteRef, target string) (BranchPreservationStatus, error) {
+	var status BranchPreservationStatus
+	refName := strings.TrimSpace(ref.Name)
+	expectedHash := strings.TrimSpace(ref.Hash)
+	if refName == "" || expectedHash == "" {
+		return status, fmt.Errorf("remote ref is missing name or hash")
+	}
+
+	if _, err := g.run("fetch", "--no-tags", g.pushTarget(remote), refName); err != nil {
+		return status, fmt.Errorf("fetching candidate %s: %w", refName, err)
+	}
+	fetchedHash, err := g.Rev("FETCH_HEAD")
+	if err != nil {
+		return status, fmt.Errorf("resolving fetched candidate %s: %w", refName, err)
+	}
+	fetchedHash = strings.TrimSpace(fetchedHash)
+	if fetchedHash != expectedHash {
+		return status, fmt.Errorf("candidate %s changed while pruning: expected %s, fetched %s", refName, shortSHA(expectedHash), shortSHA(fetchedHash))
+	}
+
+	return g.preservationOfRefAgainstRef("FETCH_HEAD", target)
 }
 
 // CountCherryUnmergedCommits counts `git cherry` lines whose patches are not

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3024,6 +3024,206 @@ func TestListPushRemoteRefsWithHashesUsesPushURLHash(t *testing.T) {
 	}
 }
 
+func TestPushRemoteRefTargetStatusPreservesRebasedRemoteBranch(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+	branch := "polecat/rebased-preserved"
+
+	if err := g.CreateBranch(branch); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if err := g.Checkout(branch); err != nil {
+		t.Fatalf("Checkout branch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "rebased.txt"), []byte("rebased\n"), 0644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+	if err := g.Add("rebased.txt"); err != nil {
+		t.Fatalf("Add feature: %v", err)
+	}
+	if err := g.Commit("rebased work"); err != nil {
+		t.Fatalf("Commit feature: %v", err)
+	}
+	branchSHA, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev branch: %v", err)
+	}
+	runGit(t, localDir, "push", "origin", branch)
+
+	if err := g.Checkout(mainBranch); err != nil {
+		t.Fatalf("Checkout main: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "advance.txt"), []byte("target advanced\n"), 0644); err != nil {
+		t.Fatalf("write advance: %v", err)
+	}
+	if err := g.Add("advance.txt"); err != nil {
+		t.Fatalf("Add advance: %v", err)
+	}
+	if err := g.Commit("advance target"); err != nil {
+		t.Fatalf("Commit advance: %v", err)
+	}
+	runGit(t, localDir, "cherry-pick", strings.TrimSpace(branchSHA))
+	runGit(t, localDir, "push", "origin", mainBranch)
+	if err := g.Fetch("origin"); err != nil {
+		t.Fatalf("Fetch origin: %v", err)
+	}
+
+	ref := mustPushRemoteRef(t, g, branch)
+	ancestor, err := g.IsAncestor(ref.Hash, "origin/"+mainBranch)
+	if err != nil {
+		t.Fatalf("IsAncestor remote hash: %v", err)
+	}
+	if ancestor {
+		t.Fatal("test setup invalid: remote hash should not be an ancestor of target")
+	}
+
+	status, err := g.PushRemoteRefTargetStatus("origin", ref, "origin/"+mainBranch)
+	if err != nil {
+		t.Fatalf("PushRemoteRefTargetStatus: %v", err)
+	}
+	if !status.Preserved || status.UnpreservedPatchCount != 0 {
+		t.Fatalf("PushRemoteRefTargetStatus = %+v, want preserved", status)
+	}
+	if status.Evidence == "" {
+		t.Fatalf("PushRemoteRefTargetStatus evidence should be set: %+v", status)
+	}
+}
+
+func TestPushRemoteRefTargetStatusPreservesMultiCommitSquashRemoteBranch(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	if err := exec.Command("git", "-C", localDir, "merge-tree", "--write-tree", "HEAD", "HEAD").Run(); err != nil {
+		t.Skipf("git merge-tree --write-tree unsupported: %v", err)
+	}
+	g := NewGit(localDir)
+	branch := "polecat/squash-remote-preserved"
+
+	if err := g.CreateBranch(branch); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if err := g.Checkout(branch); err != nil {
+		t.Fatalf("Checkout branch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "squash.txt"), []byte("one\n"), 0644); err != nil {
+		t.Fatalf("write one: %v", err)
+	}
+	if err := g.Add("squash.txt"); err != nil {
+		t.Fatalf("Add one: %v", err)
+	}
+	if err := g.Commit("checkpoint one"); err != nil {
+		t.Fatalf("Commit one: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "squash.txt"), []byte("one\ntwo\n"), 0644); err != nil {
+		t.Fatalf("write two: %v", err)
+	}
+	if err := g.Add("squash.txt"); err != nil {
+		t.Fatalf("Add two: %v", err)
+	}
+	if err := g.Commit("checkpoint two"); err != nil {
+		t.Fatalf("Commit two: %v", err)
+	}
+	runGit(t, localDir, "push", "origin", branch)
+
+	if err := g.Checkout(mainBranch); err != nil {
+		t.Fatalf("Checkout main: %v", err)
+	}
+	runGit(t, localDir, "merge", "--squash", branch)
+	runGit(t, localDir, "commit", "-m", "squash polecat work")
+	if err := os.WriteFile(filepath.Join(localDir, "advance.txt"), []byte("target advanced\n"), 0644); err != nil {
+		t.Fatalf("write advance: %v", err)
+	}
+	if err := g.Add("advance.txt"); err != nil {
+		t.Fatalf("Add advance: %v", err)
+	}
+	if err := g.Commit("advance target"); err != nil {
+		t.Fatalf("Commit advance: %v", err)
+	}
+	runGit(t, localDir, "push", "origin", mainBranch)
+	if err := g.Fetch("origin"); err != nil {
+		t.Fatalf("Fetch origin: %v", err)
+	}
+
+	ref := mustPushRemoteRef(t, g, branch)
+	status, err := g.PushRemoteRefTargetStatus("origin", ref, "origin/"+mainBranch)
+	if err != nil {
+		t.Fatalf("PushRemoteRefTargetStatus: %v", err)
+	}
+	if !status.Preserved || status.UnpreservedPatchCount != 0 {
+		t.Fatalf("PushRemoteRefTargetStatus = %+v, want squash-preserved", status)
+	}
+	if status.Evidence != "merge_tree_noop" {
+		t.Fatalf("Evidence = %q, want merge_tree_noop", status.Evidence)
+	}
+}
+
+func TestPushRemoteRefTargetStatusKeepsUnmergedSplitPushRemoteBranch(t *testing.T) {
+	localDir, upstream, _, mainBranch := initTestRepoWithSplitRemote(t)
+	g := NewGit(localDir)
+	branch := "polecat/split-unmerged"
+
+	if err := g.CreateBranch(branch); err != nil {
+		t.Fatalf("CreateBranch upstream branch: %v", err)
+	}
+	if err := g.Checkout(branch); err != nil {
+		t.Fatalf("Checkout upstream branch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "upstream-split.txt"), []byte("upstream\n"), 0644); err != nil {
+		t.Fatalf("write upstream: %v", err)
+	}
+	if err := g.Add("upstream-split.txt"); err != nil {
+		t.Fatalf("Add upstream: %v", err)
+	}
+	if err := g.Commit("upstream split work"); err != nil {
+		t.Fatalf("Commit upstream: %v", err)
+	}
+	runGit(t, localDir, "push", upstream, branch)
+	if err := g.Checkout(mainBranch); err != nil {
+		t.Fatalf("Checkout main: %v", err)
+	}
+	if err := g.Merge(branch); err != nil {
+		t.Fatalf("Merge upstream branch: %v", err)
+	}
+	runGit(t, localDir, "push", upstream, mainBranch)
+	if err := g.Fetch("origin"); err != nil {
+		t.Fatalf("Fetch origin: %v", err)
+	}
+
+	runGit(t, localDir, "checkout", "-B", branch, "origin/"+mainBranch)
+	if err := os.WriteFile(filepath.Join(localDir, "fork-split.txt"), []byte("fork-only\n"), 0644); err != nil {
+		t.Fatalf("write fork: %v", err)
+	}
+	if err := g.Add("fork-split.txt"); err != nil {
+		t.Fatalf("Add fork: %v", err)
+	}
+	if err := g.Commit("fork-only split work"); err != nil {
+		t.Fatalf("Commit fork: %v", err)
+	}
+	runGit(t, localDir, "push", "origin", branch)
+
+	ref := mustPushRemoteRef(t, g, branch)
+	status, err := g.PushRemoteRefTargetStatus("origin", ref, "origin/"+mainBranch)
+	if err != nil {
+		t.Fatalf("PushRemoteRefTargetStatus: %v", err)
+	}
+	if status.Preserved || status.UnpreservedPatchCount == 0 {
+		t.Fatalf("PushRemoteRefTargetStatus = %+v, want unpreserved split push branch", status)
+	}
+}
+
+func mustPushRemoteRef(t *testing.T, g *Git, branch string) RemoteRef {
+	t.Helper()
+	refs, err := g.ListPushRemoteRefsWithHashes("origin", "refs/heads/polecat/")
+	if err != nil {
+		t.Fatalf("ListPushRemoteRefsWithHashes: %v", err)
+	}
+	for _, ref := range refs {
+		if ref.Name == "refs/heads/"+branch {
+			return ref
+		}
+	}
+	t.Fatalf("remote ref %q not found in %#v", branch, refs)
+	return RemoteRef{}
+}
+
 func TestDeleteRemoteBranchIfAtRejectsChangedBranch(t *testing.T) {
 	localDir, _, mainBranch := initTestRepoWithRemote(t)
 	g := NewGit(localDir)


### PR DESCRIPTION
Replacement/fixup for #4061 by Emmanuel Sciara. Preserves attribution via commit trailer and PR reference.\n\nThis branch converges remote polecat prune classification through existing git preservation semantics: exact push-remote ref fetch/hash verification, ancestry, merge-tree no-op, and git cherry patch equivalence. Remote deletion remains leased with force-with-lease, remote prune fails closed on stale target refresh, and fork/upstream targets use the canonical clean base.\n\nFocused verification run locally with CGO disabled due host ICU headers: CGO_ENABLED=0 go test ./internal/git ./internal/cmd -run 'TestPushRemoteRefTargetStatus|TestListPushRemoteRefsWithHashesUsesPushURLHash|TestForkBackedDefaultPushGuard|Test.*PolecatPrune.*PatchEquivalentBranch|TestPruneRemotePolecatBranchesUsesUpstreamBaseForOriginFork|TestRunPolecatPruneRemoteDryRunIncludesPatchEquivalentBranch'.