### PR TITLE
fix(daemon): parse bd children schema envelope

### DIFF
--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -262,8 +262,8 @@ type childInfo struct {
 }
 
 // parseChildrenJSON parses the output of `bd show <id> --children --json`.
-// bd returns a map keyed by parent ID: {"hq-wisp-abc": [{...}, ...]}.
-// For forward compatibility, a bare array is also accepted.
+// bd returns a map keyed by parent ID, plus envelope metadata like
+// schema_version. For forward compatibility, a bare array is also accepted.
 func parseChildrenJSON(raw string) ([]childInfo, error) {
 	data := []byte(raw)
 
@@ -272,12 +272,34 @@ func parseChildrenJSON(raw string) ([]childInfo, error) {
 		return arr, nil
 	}
 
-	var wrapped map[string][]childInfo
+	var wrapped map[string]json.RawMessage
 	if err := json.Unmarshal(data, &wrapped); err == nil {
-		for _, children := range wrapped {
-			return children, nil
+		var found []childInfo
+		foundKey := ""
+
+		for key, payload := range wrapped {
+			if key == "schema_version" {
+				continue
+			}
+
+			trimmed := bytes.TrimSpace(payload)
+			if len(trimmed) == 0 || trimmed[0] != '[' {
+				return nil, fmt.Errorf("children for %q are not a JSON array", key)
+			}
+
+			var children []childInfo
+			if err := json.Unmarshal(payload, &children); err != nil {
+				return nil, fmt.Errorf("parse children array for %q: %w", key, err)
+			}
+			if foundKey != "" {
+				return nil, fmt.Errorf("multiple child arrays in children JSON: %q and %q", foundKey, key)
+			}
+
+			foundKey = key
+			found = children
 		}
-		return nil, nil
+
+		return found, nil
 	}
 
 	return nil, fmt.Errorf("unrecognized JSON shape: %.200s", raw)

--- a/internal/daemon/dog_molecule_test.go
+++ b/internal/daemon/dog_molecule_test.go
@@ -91,6 +91,16 @@ func TestParseChildrenJSON(t *testing.T) {
 			wantCount: 0,
 		},
 		{
+			name:      "schema version envelope",
+			input:     `{"hq-wisp-root":[{"id":"hq-wisp-a","title":"Probe","status":"open"}],"schema_version":1}`,
+			wantCount: 1,
+		},
+		{
+			name:      "schema version envelope with empty children",
+			input:     `{"hq-wisp-root":[],"schema_version":1}`,
+			wantCount: 0,
+		},
+		{
 			name:      "empty array",
 			input:     `[]`,
 			wantCount: 0,
@@ -98,6 +108,21 @@ func TestParseChildrenJSON(t *testing.T) {
 		{
 			name:    "invalid json",
 			input:   `not json`,
+			wantErr: true,
+		},
+		{
+			name:    "unexpected scalar child payload",
+			input:   `{"hq-wisp-root":1,"schema_version":1}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed child array",
+			input:   `{"hq-wisp-root":[{"id":1}],"schema_version":1}`,
+			wantErr: true,
+		},
+		{
+			name:    "ambiguous child arrays",
+			input:   `{"hq-wisp-root":[],"other-root":[]}`,
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
Replacement/fixup for #4327 by @antiwong.

This carries forward the `schema_version` children JSON envelope fix on current `upstream/main`, with a narrower parser boundary than the original patch:

- keep bare-array support
- skip only the shipped top-level `schema_version` envelope field
- preserve strict errors for malformed/non-array child payloads
- reject ambiguous multiple child arrays

Attribution is preserved publicly by crediting original PR #4327 / @antiwong in this replacement PR and by retaining the original PR/co-author references in the commit message. Do not close #4327 as superseded until this replacement has merge evidence.

Verification:
- `CGO_ENABLED=0 go test ./internal/daemon -run '^TestParseChildrenJSON$' -count=1`\n- `CGO_ENABLED=0 go test ./internal/daemon -count=1`