### PR TITLE
fix(refinery): route source issue closes and surface malformed MRs

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -2014,6 +2014,32 @@ func (b *Beads) ForceCloseWithReason(reason string, ids ...string) error {
 		return b.storeClose(reason, runtime.SessionIDFromEnv(), ids...)
 	}
 
+	type closeGroup struct {
+		target *Beads
+		ids    []string
+	}
+	groups := make([]closeGroup, 0, len(ids))
+	groupByDir := make(map[string]int, len(ids))
+	for _, id := range ids {
+		target := b.forIssueID(id)
+		targetDir := target.getResolvedBeadsDir()
+		if idx, ok := groupByDir[targetDir]; ok {
+			groups[idx].ids = append(groups[idx].ids, id)
+			continue
+		}
+		groupByDir[targetDir] = len(groups)
+		groups = append(groups, closeGroup{target: target, ids: []string{id}})
+	}
+
+	for _, group := range groups {
+		if err := group.target.forceCloseWithReasonInCurrentDB(reason, group.ids...); err != nil {
+			return fmt.Errorf("force closing %s in %s: %w", strings.Join(group.ids, ","), group.target.getResolvedBeadsDir(), err)
+		}
+	}
+	return nil
+}
+
+func (b *Beads) forceCloseWithReasonInCurrentDB(reason string, ids ...string) error {
 	args := append([]string{"close"}, ids...)
 	args = append(args, "--reason="+reason, "--force")
 

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -591,6 +591,62 @@ func TestBuildMutationBDEnvForcesWritableCommit(t *testing.T) {
 	}
 }
 
+func TestForceCloseWithReasonRoutesIDsByResolvedBeadsDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+	ResetBdAllowStaleCacheForTest()
+	t.Cleanup(ResetBdAllowStaleCacheForTest)
+	t.Setenv("GT_SESSION_ID_ENV", "")
+	t.Setenv("GT_AGENT", "")
+	t.Setenv("CLAUDE_SESSION_ID", "")
+
+	workDir, townBeadsDir, rigBeadsDir := setupForceCloseRoutingTown(t)
+	logPath := installMockBDCloseRecorder(t)
+
+	b := NewWithBeadsDir(workDir, townBeadsDir)
+	if err := b.ForceCloseWithReason("merged", "gt-src", "hq-src", "gt-other"); err != nil {
+		t.Fatalf("ForceCloseWithReason: %v", err)
+	}
+
+	lines := closeRecorderLines(readMockBDLog(t, logPath))
+	want := []string{
+		fmt.Sprintf("beads_dir=%s args=close gt-src gt-other --reason=merged --force", rigBeadsDir),
+		fmt.Sprintf("beads_dir=%s args=close hq-src --reason=merged --force", townBeadsDir),
+	}
+	if !reflect.DeepEqual(lines, want) {
+		t.Fatalf("force-close routing log mismatch\ngot:  %#v\nwant: %#v", lines, want)
+	}
+}
+
+func TestForceCloseWithReasonNoRouteStaysOnCurrentBeadsDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+	ResetBdAllowStaleCacheForTest()
+	t.Cleanup(ResetBdAllowStaleCacheForTest)
+	t.Setenv("GT_SESSION_ID_ENV", "")
+	t.Setenv("GT_AGENT", "")
+	t.Setenv("CLAUDE_SESSION_ID", "")
+
+	workDir, townBeadsDir, rigBeadsDir := setupForceCloseRoutingTown(t)
+	logPath := installMockBDCloseRecorder(t)
+
+	b := NewWithBeadsDir(workDir, townBeadsDir).ForAgentBead()
+	if err := b.ForceCloseWithReason("done", "gt-agent"); err != nil {
+		t.Fatalf("ForceCloseWithReason: %v", err)
+	}
+
+	lines := closeRecorderLines(readMockBDLog(t, logPath))
+	want := []string{fmt.Sprintf("beads_dir=%s args=close gt-agent --reason=done --force", townBeadsDir)}
+	if !reflect.DeepEqual(lines, want) {
+		t.Fatalf("force-close noRoute log mismatch\ngot:  %#v\nwant: %#v", lines, want)
+	}
+	if strings.Contains(strings.Join(lines, "\n"), "beads_dir="+rigBeadsDir) {
+		t.Fatalf("noRoute force-close unexpectedly used routed rig beads dir: %#v", lines)
+	}
+}
+
 func TestDeleteBeadsUseSupportedBdDeleteFlags(t *testing.T) {
 	ResetBdAllowStaleCacheForTest()
 	t.Cleanup(ResetBdAllowStaleCacheForTest)
@@ -717,6 +773,69 @@ func envMap(env []string) map[string]string {
 		if len(parts) == 2 {
 			out[parts[0]] = parts[1]
 		}
+	}
+	return out
+}
+
+func installMockBDCloseRecorder(t *testing.T) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "bd.log")
+	quotedLogPath := strings.ReplaceAll(logPath, "'", "'\\''")
+	script := `#!/bin/sh
+if [ "$1" = "--allow-stale" ] && [ "$2" = "version" ]; then
+  exit 1
+fi
+LOG_FILE='` + quotedLogPath + `'
+target="${BEADS_DIR:-$(pwd)/.beads}"
+printf 'beads_dir=%s args=%s\n' "$target" "$*" >> "$LOG_FILE"
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write mock bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}
+
+func setupForceCloseRoutingTown(t *testing.T) (workDir, townBeadsDir, rigBeadsDir string) {
+	t.Helper()
+
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+
+	townBeadsDir = filepath.Join(townRoot, ".beads")
+	rigBeadsDir = filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir town beads: %v", err)
+	}
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+
+	routes := `{"prefix":"gt-","path":"gastown/mayor/rig"}
+{"prefix":"hq-","path":"."}
+`
+	if err := os.WriteFile(filepath.Join(townBeadsDir, "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+	return townRoot, townBeadsDir, rigBeadsDir
+}
+
+func closeRecorderLines(log string) []string {
+	lines := strings.Split(strings.TrimSpace(log), "\n")
+	out := lines[:0]
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		out = append(out, line)
 	}
 	return out
 }

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -2134,7 +2134,20 @@ func detectQueueAnomalies(
 			continue
 		}
 		fields := beads.ParseMRFields(issue)
-		if fields == nil || fields.Branch == "" {
+		if fields == nil {
+			anomalies = append(anomalies, &MRAnomaly{
+				ID:     issue.ID,
+				Type:   "malformed-mr",
+				Detail: "MR bead has no parseable merge-request fields",
+			})
+			continue
+		}
+		if strings.TrimSpace(fields.Branch) == "" {
+			anomalies = append(anomalies, &MRAnomaly{
+				ID:     issue.ID,
+				Type:   "malformed-mr",
+				Detail: "MR bead is missing branch",
+			})
 			continue
 		}
 

--- a/internal/refinery/engineer_anomalies_test.go
+++ b/internal/refinery/engineer_anomalies_test.go
@@ -1,6 +1,7 @@
 package refinery
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -92,5 +93,39 @@ worker: nux`,
 	// ZFC: no severity field — agent classifies from type + context.
 	if anomalies[0].ID != "gt-orphan" {
 		t.Fatalf("anomaly ID = %q, want gt-orphan", anomalies[0].ID)
+	}
+}
+
+func TestDetectQueueAnomalies_MalformedMRFields(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	issues := []*beads.Issue{
+		{
+			ID:          "gt-missing-fields",
+			Status:      "open",
+			Description: "created by older tooling before MR fields existed",
+		},
+		{
+			ID:     "gt-missing-branch",
+			Status: "open",
+			Description: `target: main
+source_issue: gt-src`,
+		},
+	}
+
+	anomalies := detectQueueAnomalies(issues, now, 2*time.Hour, func(branch string) (bool, bool, error) {
+		t.Fatalf("branch existence should not be checked for malformed MR fields, got %q", branch)
+		return false, false, nil
+	})
+
+	if len(anomalies) != 2 {
+		t.Fatalf("expected 2 anomalies, got %d (%+v)", len(anomalies), anomalies)
+	}
+	for _, anomaly := range anomalies {
+		if anomaly.Type != "malformed-mr" {
+			t.Fatalf("anomaly type = %q, want malformed-mr", anomaly.Type)
+		}
+		if !strings.Contains(anomaly.Detail, "MR bead") {
+			t.Fatalf("anomaly detail missing MR context: %+v", anomaly)
+		}
 	}
 }


### PR DESCRIPTION
Replacement for #4187.

This carries forward the accepted bug-fix intent from #4187 on top of current `main`, without the stale/unrelated commits from the original branch.

What changed:
- Routes `ForceCloseWithReason` by issue ID through the existing Beads routing boundary so cross-rig source issues close in their owning DB.
- Keeps refinery call sites unchanged, so both normal refinery success and manual post-merge paths use the same routed force-close behavior.
- Surfaces malformed merge-request beads as structured queue anomalies instead of stdout warnings.
- Adds focused regression tests for routed force-close grouping, no-route agent-bead behavior, and malformed MR anomaly reporting.

Attribution:
- Original PR: #4187 by @Cdfghglz.
- Carried-forward final fix intent from commit `7fa884a995d6581fa2a9c349076cfea4eb67ae5e`, authored by shiny <rastislav.marko@panzarobotics.com> with `Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>`.

Verification:
- `CGO_ENABLED=0 go test ./internal/beads ./internal/refinery -count=1`

PR Sheriff:
- Original #4187 is not mergeable as-is: `status/review-failed`, conflicting/dirty branch, stale unrelated commits, no approvals, and no substantive CI beyond label automation.
