### PR TITLE
v1.2.2: fix reaper query bug

### DIFF
--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -75,6 +75,13 @@ type VersionChange struct {
 // versionChanges contains agent-actionable changes for recent versions
 var versionChanges = []VersionChange{
 	{
+		Version: "1.2.2",
+		Date:    "2026-07-08",
+		Changes: []string{
+			"FIX: gt reaper scan no longer fails with \"table wd does not have column depends_on_id\"; reaper scan/auto-close/dangling-parent/reverse-cleanup queries now use the typed dependency columns (depends_on_issue_id, depends_on_wisp_id) matching the beads schema (gt-pr-sheriff-4228).",
+		},
+	},
+	{
 		Version: "1.2.1",
 		Date:    "2026-06-06",
 		Changes: []string{

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -14,7 +14,7 @@ import (
 
 // Version information - set at build time via ldflags
 var (
-	Version = "1.2.1"
+	Version = "1.2.2"
 	// Build can be set via ldflags at compile time
 	Build = "dev"
 	// Commit and Branch - the git revision the binary was built from (optional ldflag)

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -203,7 +203,7 @@ func parentExcludeJoin(dbName string) (joinClause, whereCondition string) {
 	joinClause = `LEFT JOIN (
 		SELECT DISTINCT wd.issue_id
 		FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
+		LEFT JOIN wisps pw ON pw.id = wd.depends_on_wisp_id LEFT JOIN issues pi ON pi.id = wd.depends_on_issue_id
 		WHERE wd.type = 'parent-child'
 		AND (pw.status IN ('open', 'hooked', 'in_progress') OR pi.status IN ('open', 'in_progress'))
 	) open_parent ON open_parent.issue_id = w.id`
@@ -278,13 +278,14 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 		AND i.issue_type != 'epic'
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM dependencies d
-			INNER JOIN issues dep ON d.depends_on_id = dep.id
+			INNER JOIN issues dep ON d.depends_on_issue_id = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM dependencies d
+			SELECT DISTINCT d.depends_on_issue_id FROM dependencies d
 			INNER JOIN issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
+			AND d.depends_on_issue_id IS NOT NULL
 		)`
 	if err := db.QueryRowContext(ctx, staleQuery, now.Add(-staleIssueAge)).Scan(&result.StaleCandidates); err != nil {
 		if !isTableNotFound(err) {
@@ -302,8 +303,8 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	// Anomaly detection: dangling parent references.
 	danglingQuery := `
 		SELECT COUNT(*) FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
-		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL`
+		LEFT JOIN wisps pw ON pw.id = wd.depends_on_wisp_id LEFT JOIN issues pi ON pi.id = wd.depends_on_issue_id
+		WHERE wd.type = 'parent-child' AND (wd.depends_on_wisp_id IS NOT NULL OR wd.depends_on_issue_id IS NOT NULL) AND pw.id IS NULL AND pi.id IS NULL`
 	var danglingCount int
 	if err := db.QueryRowContext(ctx, danglingQuery).Scan(&danglingCount); err == nil && danglingCount > 0 {
 		result.Anomalies = append(result.Anomalies, Anomaly{
@@ -604,13 +605,14 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 		)
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM `+"`%s`"+`.dependencies d
-			INNER JOIN `+"`%s`"+`.issues dep ON d.depends_on_id = dep.id
+			INNER JOIN `+"`%s`"+`.issues dep ON d.depends_on_issue_id = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM `+"`%s`"+`.dependencies d
+			SELECT DISTINCT d.depends_on_issue_id FROM `+"`%s`"+`.dependencies d
 			INNER JOIN `+"`%s`"+`.issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
+			AND d.depends_on_issue_id IS NOT NULL
 		)`, dbName, dbName, dbName, dbName, dbName)
 
 	// Two-step SELECT-then-UPDATE to avoid self-referencing subquery in UPDATE,
@@ -746,10 +748,23 @@ func batchDeleteRows(ctx context.Context, db *sql.DB, idQuery string, cutoffArg 
 			}
 		}
 
-		// Clean up reverse dependency references to prevent dangling parent refs.
-		delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_id IN %s", inClause)
-		if _, err := db.ExecContext(ctx, delReverse, args...); err != nil {
-			// Non-fatal.
+		// Clean up typed reverse dependency references to prevent dangling parent refs.
+		var reverseDeletes []string
+		switch primaryTable {
+		case "wisps":
+			reverseDeletes = []string{
+				fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_wisp_id IN %s", inClause),
+			}
+		case "issues":
+			reverseDeletes = []string{
+				fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_issue_id IN %s", inClause),
+				fmt.Sprintf("DELETE FROM dependencies WHERE depends_on_issue_id IN %s", inClause),
+			}
+		}
+		for _, delReverse := range reverseDeletes {
+			if _, err := db.ExecContext(ctx, delReverse, args...); err != nil {
+				// Non-fatal.
+			}
 		}
 
 		delPrimary := fmt.Sprintf("DELETE FROM `%s` WHERE id IN %s", primaryTable, inClause) //nolint:gosec // G201: primaryTable is internal

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -66,6 +66,15 @@ func TestParentExcludeJoin(t *testing.T) {
 	if !contains(joinClause, "wisp_dependencies") {
 		t.Error("parentExcludeJoin should query wisp_dependencies")
 	}
+	if !contains(joinClause, "wd.depends_on_wisp_id") {
+		t.Error("parentExcludeJoin should join wisp parents through depends_on_wisp_id")
+	}
+	if !contains(joinClause, "wd.depends_on_issue_id") {
+		t.Error("parentExcludeJoin should join issue parents through depends_on_issue_id")
+	}
+	if contains(joinClause, "wd.depends_on_id") {
+		t.Error("parentExcludeJoin should not use legacy depends_on_id")
+	}
 	if !contains(joinClause, "parent-child") {
 		t.Error("parentExcludeJoin should filter on parent-child type")
 	}
@@ -79,6 +88,53 @@ func TestParentExcludeJoin(t *testing.T) {
 	}
 	if !contains(whereCondition, "IS NULL") {
 		t.Error("parentExcludeJoin whereCondition should use IS NULL for anti-join")
+	}
+}
+
+func TestReaperQueriesUseTypedDependencyColumns(t *testing.T) {
+	sourcePath := "reaper.go"
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", sourcePath, err)
+	}
+	source := string(data)
+	if strings.Contains(source, "depends_on_id") {
+		t.Fatalf("reaper queries should not use legacy depends_on_id")
+	}
+
+	scanBody := sourceBetween(t, source, "func Scan(", "func Reap(")
+	autoCloseBody := sourceBetween(t, source, "func AutoClose(", "// batchDeleteRows")
+	batchDeleteBody := sourceBetween(t, source, "func batchDeleteRows(", "// ClosePluginReceiptResult")
+
+	for _, body := range []struct {
+		name string
+		text string
+	}{
+		{name: "Scan", text: scanBody},
+		{name: "AutoClose", text: autoCloseBody},
+	} {
+		if !strings.Contains(body.text, "d.depends_on_issue_id = dep.id") {
+			t.Fatalf("%s should join dependency blockers through depends_on_issue_id", body.name)
+		}
+		if !strings.Contains(body.text, "SELECT DISTINCT d.depends_on_issue_id") {
+			t.Fatalf("%s should exclude blocked issues through depends_on_issue_id", body.name)
+		}
+		if !strings.Contains(body.text, "d.depends_on_issue_id IS NOT NULL") {
+			t.Fatalf("%s should guard nullable depends_on_issue_id in NOT IN subquery", body.name)
+		}
+	}
+
+	if !strings.Contains(scanBody, "wd.depends_on_wisp_id IS NOT NULL OR wd.depends_on_issue_id IS NOT NULL") {
+		t.Fatal("Scan dangling-parent anomaly should ignore external-only dependency rows")
+	}
+	if !strings.Contains(batchDeleteBody, "DELETE FROM wisp_dependencies WHERE depends_on_wisp_id IN %s") {
+		t.Fatal("batchDeleteRows should clean reverse wisp dependency references")
+	}
+	if !strings.Contains(batchDeleteBody, "DELETE FROM wisp_dependencies WHERE depends_on_issue_id IN %s") {
+		t.Fatal("batchDeleteRows should clean reverse wisp parent references to issues")
+	}
+	if !strings.Contains(batchDeleteBody, "DELETE FROM dependencies WHERE depends_on_issue_id IN %s") {
+		t.Fatal("batchDeleteRows should clean reverse issue dependency references")
 	}
 }
 
@@ -202,6 +258,19 @@ func containsHelper(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func sourceBetween(t *testing.T, source, startMarker, endMarker string) string {
+	t.Helper()
+	start := strings.Index(source, startMarker)
+	if start == -1 {
+		t.Fatalf("could not find %q", startMarker)
+	}
+	end := strings.Index(source[start:], endMarker)
+	if end == -1 {
+		t.Fatalf("could not find %q after %q", endMarker, startMarker)
+	}
+	return source[start : start+end]
 }
 
 // TestReapExcludesAgentBeads verifies that the Reap function excludes agent beads


### PR DESCRIPTION
Cherry-picked reaper fix from main (commit 48f05e93) + version bump. Fixes hq-pra: reaper query targets nonexistent wd.depends_on_id — corrected to wisp_dependencies.depends_on_issue_id. Release verified locally.