### PR TITLE
fix(doctor): accept deacon town DB in rig-config-sync

### DIFF
--- a/internal/doctor/rig_config_sync_check.go
+++ b/internal/doctor/rig_config_sync_check.go
@@ -87,6 +87,7 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 	c.dbNameMismatches = nil
 	c.dbCheckErrors = nil
 	var details []string
+	townDB := readDoltDatabase(filepath.Join(ctx.TownRoot, ".beads"))
 
 	for rigName, entry := range rigsConfig.Rigs {
 		rigPath := filepath.Join(ctx.TownRoot, rigName)
@@ -188,11 +189,16 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 
 		// Check if Dolt database exists (only for server mode)
 		if metadata.DoltMode == "server" {
-			// Database name should match the rig directory name (rigName), not the beads
-			// prefix. This is the convention established by doltserver.EnsureMetadata:
-			// the Dolt database identifier is the rig's directory name so that rigs
-			// with short prefixes (e.g. "ts" for trading_scripts) don't collide and
-			// bd can always locate the right database without extra config.
+			// Database name should normally match the rig directory name (rigName),
+			// not the beads prefix. This is the convention established by
+			// doltserver.EnsureMetadata: the Dolt database identifier is the rig's
+			// directory name so that rigs with short prefixes (e.g. "ts" for
+			// trading_scripts) don't collide and bd can always locate the right
+			// database without extra config.
+			//
+			// Exception: deacon shares the town-wide beads DB after the HQ storage
+			// migration. Keep that invariant aligned with UnregisteredBeadsDirsCheck
+			// instead of rewriting deacon back to a separate database.
 			//
 			// Exception: some rigs' Dolt data physically lives in a PREFIX-named
 			// directory (e.g. .dolt-data/bd, .dolt-data/gt) from a directory rename
@@ -203,11 +209,15 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 			// a false mismatch and --fix reverts metadata to the non-existent rig-name
 			// DB. (gt-5hd2)
 			expectedDBName := rigName
-			doltDataDir := filepath.Join(ctx.TownRoot, ".dolt-data")
-			if _, err := os.Stat(filepath.Join(doltDataDir, rigName)); os.IsNotExist(err) {
-				if prefix := config.GetRigPrefix(ctx.TownRoot, rigName); prefix != "" {
-					if _, err := os.Stat(filepath.Join(doltDataDir, prefix)); err == nil {
-						expectedDBName = prefix
+			if rigName == "deacon" && townDB != "" {
+				expectedDBName = townDB
+			} else {
+				doltDataDir := filepath.Join(ctx.TownRoot, ".dolt-data")
+				if _, err := os.Stat(filepath.Join(doltDataDir, rigName)); os.IsNotExist(err) {
+					if prefix := config.GetRigPrefix(ctx.TownRoot, rigName); prefix != "" {
+						if _, err := os.Stat(filepath.Join(doltDataDir, prefix)); err == nil {
+							expectedDBName = prefix
+						}
 					}
 				}
 			}

--- a/internal/doctor/rig_config_sync_check_test.go
+++ b/internal/doctor/rig_config_sync_check_test.go
@@ -617,6 +617,171 @@ func TestRigConfigSyncCheck_PrefixNamedDoltDBNoMismatch(t *testing.T) {
 	}
 }
 
+func TestRigConfigSyncCheck_DeaconTownDoltDBNoMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake bd stub is shell-specific")
+	}
+
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigsJSON := `{
+		"version": 1,
+		"rigs": {
+			"deacon": {
+				"git_url": "https://github.com/test/deacon.git",
+				"beads": {"prefix": "dc"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	townBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townBeadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestDoltDatabase(t, tmpDir, "hq")
+
+	rigDir := filepath.Join(tmpDir, "deacon")
+	beadsDir := filepath.Join(rigDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configJSON := `{"type":"rig","version":1,"name":"deacon","git_url":"https://github.com/test/deacon.git","beads":{"prefix":"dc"}}`
+	if err := os.WriteFile(filepath.Join(rigDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("prefix: dc\nissue-prefix: dc\nexport.auto: \"false\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+	metadata := `{"backend":"dolt","database":"dolt","dolt_mode":"server","dolt_database":"hq"}`
+	if err := os.WriteFile(metadataPath, []byte(metadata), 0644); err != nil {
+		t.Fatal(err)
+	}
+	setFakeBDShow(t)
+
+	ctx := &CheckContext{TownRoot: tmpDir}
+	check := NewRigConfigSyncCheck()
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Fatalf("Status = %v, want StatusOK: %s %#v", result.Status, result.Message, result.Details)
+	}
+	if len(check.dbNameMismatches) != 0 {
+		t.Fatalf("dbNameMismatches = %#v, want none for deacon town DB", check.dbNameMismatches)
+	}
+	if len(check.missingDoltDB) != 0 {
+		t.Fatalf("missingDoltDB = %#v, want none", check.missingDoltDB)
+	}
+
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+	after, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("read metadata.json: %v", err)
+	}
+	if !strings.Contains(string(after), `"dolt_database":"hq"`) {
+		t.Fatalf("Fix rewrote deacon away from town DB: %s", string(after))
+	}
+}
+
+func TestRigConfigSyncCheck_OrdinaryRigTownDoltDBMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake bd stub is shell-specific")
+	}
+
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigsJSON := `{
+		"version": 1,
+		"rigs": {
+			"testrig": {
+				"git_url": "https://github.com/test/test.git",
+				"beads": {"prefix": "tr"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	townBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townBeadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestDoltDatabase(t, tmpDir, "hq")
+	writeTestDoltDatabase(t, tmpDir, "testrig")
+
+	rigDir := filepath.Join(tmpDir, "testrig")
+	beadsDir := filepath.Join(rigDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configJSON := `{"type":"rig","version":1,"name":"testrig","git_url":"https://github.com/test/test.git","beads":{"prefix":"tr"}}`
+	if err := os.WriteFile(filepath.Join(rigDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("prefix: tr\nissue-prefix: tr\nexport.auto: \"false\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	metadata := `{"backend":"dolt","database":"dolt","dolt_mode":"server","dolt_database":"hq"}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(metadata), 0644); err != nil {
+		t.Fatal(err)
+	}
+	setFakeBDShow(t)
+
+	ctx := &CheckContext{TownRoot: tmpDir}
+	check := NewRigConfigSyncCheck()
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Fatalf("Status = %v, want StatusWarning", result.Status)
+	}
+	if len(check.dbNameMismatches) != 1 {
+		t.Fatalf("dbNameMismatches = %#v, want one mismatch", check.dbNameMismatches)
+	}
+	mismatch := check.dbNameMismatches[0]
+	if mismatch.rigName != "testrig" || mismatch.currentDB != "hq" || mismatch.expectedDB != "testrig" {
+		t.Fatalf("dbNameMismatch = %#v, want testrig hq -> testrig", mismatch)
+	}
+}
+
+func writeTestDoltDatabase(t *testing.T, townRoot, dbName string) {
+	t.Helper()
+	manifestDir := filepath.Join(townRoot, ".dolt-data", dbName, ".dolt", "noms")
+	if err := os.MkdirAll(manifestDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(manifestDir, "manifest"), []byte("0"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setFakeBDShow(t *testing.T) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := "#!/usr/bin/env bash\nif [ \"$1\" = show ]; then echo \"[{\\\"id\\\":\\\"$2\\\"}]\"; fi\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 func TestStaleRuntimeFilesCheck_StalePIDFiles(t *testing.T) {
 	// Create temp town root
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Replacement for #4122 on current upstream/main.

Carries forward the valid bug-fix intent from #4122 by athosmartins/rictus while narrowing the acceptance rule to the deacon/HQ shared-storage invariant. Attribution is preserved in the commit body with `Co-authored-by: rictus <athosmartins@gmail.com>`.

Changes:
- Treat deacon's expected Dolt database as the town `.beads` database when town metadata defines one.
- Preserve the existing rig-name default and prefix-DB fallback for all other rigs.
- Add regression coverage proving deacon `dolt_database == hq` is valid and `Fix` does not rewrite it.
- Add negative coverage proving an ordinary rig pointing at the town DB still reports a DB mismatch.

Verification:
- `CGO_ENABLED=0 go test ./internal/doctor -run 'TestRigConfigSyncCheck_(DeaconTownDoltDBNoMismatch|OrdinaryRigTownDoltDBMismatch|PrefixNamedDoltDBNoMismatch)' -count=1`
- `env -u GT_DOLT_PORT -u GT_DOLT_HOST CGO_ENABLED=0 go test ./internal/doctor -count=1`

PR Sheriff:
- 15 independent research legs completed.
- 5 pre-implementation reviews approved `action-plan-pr4122-deacon-town-db-replacement`.
- 5 post-implementation reviews approved head `d0b0e435c2616325d22d9a2cfd82321cee631faa`.
