### PR TITLE
fix: route compact wisp promotion through SDK

### DIFF
--- a/internal/beads/promote_wisp_test.go
+++ b/internal/beads/promote_wisp_test.go
@@ -1,0 +1,147 @@
+package beads
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	beadsdk "github.com/steveyegge/beads"
+)
+
+func TestPromoteWispUsesSDKPromotion(t *testing.T) {
+	data, err := os.ReadFile("store.go")
+	if err != nil {
+		t.Fatalf("read store.go: %v", err)
+	}
+	source := string(data)
+	body := sourceBetween(t, source, "func (b *Beads) PromoteWisp(", "// storeAddLabel")
+
+	for _, want := range []string{
+		"type wispPromoter interface",
+		"PromoteFromEphemeral(context.Context, string, string) error",
+		"type commentEventStore interface",
+		"AddComment(context.Context, string, string, string) error",
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("store.go missing %q", want)
+		}
+	}
+
+	for _, want := range []string{
+		"OpenStore(ctx)",
+		"store.(wispPromoter)",
+		"promoter.PromoteFromEphemeral(ctx, id, actor)",
+		"store.(commentEventStore)",
+		"commenter.AddComment(ctx, id, actor, comment)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("PromoteWisp missing %q:\n%s", want, body)
+		}
+	}
+
+	for _, forbidden := range []string{
+		`Run("update"`,
+		`Run("promote"`,
+		`Run("comments"`,
+		`--persistent`,
+		`depends_on_id`,
+		`RunInTransaction`,
+		`ImportIssueComment`,
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("PromoteWisp should not use %q:\n%s", forbidden, body)
+		}
+	}
+}
+
+func TestPromoteWispCallsSDKPromotionAndComments(t *testing.T) {
+	store := &promoteWispStore{}
+	bd := NewWithStore(t.TempDir(), store)
+	t.Setenv("BD_ACTOR", "tester")
+
+	if err := bd.PromoteWisp("gt-wisp-alpha", "has comments"); err != nil {
+		t.Fatalf("PromoteWisp: %v", err)
+	}
+
+	if store.promotedID != "gt-wisp-alpha" {
+		t.Fatalf("promoted ID = %q, want gt-wisp-alpha", store.promotedID)
+	}
+	if store.promotedActor != "tester" {
+		t.Fatalf("promoted actor = %q, want tester", store.promotedActor)
+	}
+	if store.commentID != "gt-wisp-alpha" || store.commentActor != "tester" {
+		t.Fatalf("comment target = %q/%q, want gt-wisp-alpha/tester", store.commentID, store.commentActor)
+	}
+	if store.commentText != "Promoted from Level 0: has comments" {
+		t.Fatalf("comment text = %q", store.commentText)
+	}
+}
+
+func TestPromoteWispTreatsCommentFailureAsBestEffort(t *testing.T) {
+	wantErr := errors.New("comment failed")
+	store := &promoteWispStore{commentErr: wantErr}
+	bd := NewWithStore(t.TempDir(), store)
+	t.Setenv("BD_ACTOR", "tester")
+
+	if err := bd.PromoteWisp("gt-wisp-beta", "comment may fail"); err != nil {
+		t.Fatalf("PromoteWisp should not fail when promotion comment fails: %v", err)
+	}
+	if store.promotedID != "gt-wisp-beta" {
+		t.Fatalf("promoted ID = %q, want gt-wisp-beta", store.promotedID)
+	}
+}
+
+func TestPromoteWispRequiresPromotionCapability(t *testing.T) {
+	bd := NewWithStore(t.TempDir(), &commentOnlyStore{})
+
+	err := bd.PromoteWisp("gt-wisp-gamma", "no promoter")
+	if err == nil || !strings.Contains(err.Error(), "does not support wisp promotion") {
+		t.Fatalf("PromoteWisp error = %v, want unsupported promotion", err)
+	}
+}
+
+type promoteWispStore struct {
+	beadsdk.Storage
+	promotedID    string
+	promotedActor string
+	commentID     string
+	commentActor  string
+	commentText   string
+	commentErr    error
+}
+
+func (s *promoteWispStore) PromoteFromEphemeral(_ context.Context, id, actor string) error {
+	s.promotedID = id
+	s.promotedActor = actor
+	return nil
+}
+
+func (s *promoteWispStore) AddComment(_ context.Context, issueID, actor, comment string) error {
+	s.commentID = issueID
+	s.commentActor = actor
+	s.commentText = comment
+	return s.commentErr
+}
+
+type commentOnlyStore struct {
+	beadsdk.Storage
+}
+
+func (s *commentOnlyStore) AddComment(context.Context, string, string, string) error {
+	return nil
+}
+
+func sourceBetween(t *testing.T, source, startMarker, endMarker string) string {
+	t.Helper()
+	start := strings.Index(source, startMarker)
+	if start == -1 {
+		t.Fatalf("could not find %q", startMarker)
+	}
+	end := strings.Index(source[start:], endMarker)
+	if end == -1 {
+		t.Fatalf("could not find %q after %q", endMarker, startMarker)
+	}
+	return source[start : start+end]
+}

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -573,6 +574,63 @@ func (b *Beads) storeRemoveDependency(issue, dependsOn string) error {
 	defer cancel()
 
 	return b.store.RemoveDependency(ctx, issue, dependsOn, b.getActor())
+}
+
+type wispPromoter interface {
+	PromoteFromEphemeral(context.Context, string, string) error
+}
+
+type commentEventStore interface {
+	AddComment(context.Context, string, string, string) error
+}
+
+// PromoteWisp promotes an ephemeral wisp through the in-process Beads storage
+// path. This keeps gt compact on the SDK's typed dependency promotion logic
+// instead of shelling out to whichever bd binary is on PATH.
+func (b *Beads) PromoteWisp(id, reason string) error {
+	ctx, cancel := storeCtx()
+	defer cancel()
+
+	store := b.store
+	cleanup := func() {}
+	if store == nil {
+		var err error
+		store, cleanup, err = b.OpenStore(ctx)
+		if err != nil {
+			return fmt.Errorf("open store for wisp promotion: %w", err)
+		}
+	}
+	defer cleanup()
+
+	promoter, ok := store.(wispPromoter)
+	if !ok {
+		return fmt.Errorf("beads store does not support wisp promotion")
+	}
+
+	actor := b.getActor()
+	if actor == "" {
+		actor = "unknown"
+	}
+
+	if err := promoter.PromoteFromEphemeral(ctx, id, actor); err != nil {
+		return fmt.Errorf("promote wisp %s: %w", id, err)
+	}
+
+	commenter, ok := store.(commentEventStore)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Warning: beads store does not support promotion comments for %s\n", id)
+		return nil
+	}
+
+	comment := "Promoted from Level 0"
+	if reason != "" {
+		comment += ": " + reason
+	}
+	if err := commenter.AddComment(ctx, id, actor, comment); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to add promotion comment to %s: %v\n", id, err)
+	}
+
+	return nil
 }
 
 // storeAddLabel implements AddLabel using the in-process store.

--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -345,7 +345,7 @@ func extractJSONArray(data []byte) []byte {
 	return data[idx:]
 }
 
-// promoteWisp makes a wisp permanent by setting --persistent and adding a comment.
+// promoteWisp makes a wisp permanent through Beads' canonical promotion path.
 func promoteWisp(bd *beads.Beads, w *compactIssue, reason string, result *compactResult) {
 	action := compactAction{ID: w.ID, Title: w.Title, Reason: reason, WispType: w.WispType}
 
@@ -358,15 +358,10 @@ func promoteWisp(bd *beads.Beads, w *compactIssue, reason string, result *compac
 		return
 	}
 
-	// bd update --persistent sets ephemeral=false
-	_, err := bd.Run("update", w.ID, "--persistent")
-	if err != nil {
+	if err := bd.PromoteWisp(w.ID, reason); err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("promote %s: %v", w.ID, err))
 		return
 	}
-
-	// Add comment noting the promotion
-	_, _ = bd.Run("comments", "add", w.ID, fmt.Sprintf("Promoted from Level 0: %s", reason))
 
 	result.Promoted = append(result.Promoted, action)
 

--- a/internal/cmd/compact_test.go
+++ b/internal/cmd/compact_test.go
@@ -290,6 +290,30 @@ func TestCleanOrphanedWispDepsUsesTypedTargets(t *testing.T) {
 	}
 }
 
+func TestPromoteWispUsesCanonicalSDKPromotion(t *testing.T) {
+	data, err := os.ReadFile("compact.go")
+	if err != nil {
+		t.Fatalf("read compact.go: %v", err)
+	}
+	body := compactSourceBetween(t, string(data), "func promoteWisp(", "// deleteWisp")
+
+	for _, forbidden := range []string{
+		`bd.Run("update"`,
+		`bd.Run("promote"`,
+		`bd.Run("comments"`,
+		`--persistent`,
+		`depends_on_id`,
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("promoteWisp should not use %q:\n%s", forbidden, body)
+		}
+	}
+
+	if !strings.Contains(body, `bd.PromoteWisp(w.ID, reason)`) {
+		t.Fatalf("promoteWisp should delegate to Beads SDK promotion:\n%s", body)
+	}
+}
+
 func compactSourceBetween(t *testing.T, source, startMarker, endMarker string) string {
 	t.Helper()
 	start := strings.Index(source, startMarker)


### PR DESCRIPTION
## Summary
- Carries forward the bug-fix intent from PR #4414 and source commit `4843d0c8947860bfde30e3cbc38a6cf8a3f1a25d` onto current `upstream/main`.
- Routes `gt compact` wisp promotion through the Beads SDK `PromoteFromEphemeral` path instead of subprocess `bd update --persistent` / `bd comments add`.
- Sheriff fixup: uses the canonical store-level `AddComment` path for the promotion note instead of `RunInTransaction` + `ImportIssueComment`, which embedded transactions do not implement.

## Attribution
- Commit author preserved as `radrat <thalia.geraghty@fiserv.com>` from PR #4414.
- Source PR: https://github.com/gastownhall/gastown/pull/4414

## Verification
- `git diff --check upstream/main...HEAD`
- `CGO_ENABLED=0 go test ./internal/beads ./internal/cmd -run 'TestPromoteWisp' -count=1 -v`
- `CGO_ENABLED=0 go test ./internal/beads ./internal/cmd -count=1`
- `CGO_ENABLED=0 go build -o /tmp/opencode/gt-build-gt-xiif ./cmd/gt`

## PR Sheriff Evidence
- 15 independent research legs completed for PR #4414.
- 5 approving pre-implementation reviews completed for the corrected capability-assertion plan.
- 5 approving post-implementation reviews completed against final head `a8007bc98030ac264225c82037797a1bd7749a65`.
- Cleanup-first verdict: convergent/acceptable minimal; no raw DB hacks, retry layers, compatibility shims, or broad unrelated rewrites.
