### PR TITLE
feat: add minimal Kiro runtime preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,11 @@ gt feed                     # Real-time activity feed (TUI)
 gt feed --problems          # Start in problems view (stuck agent detection)
 ```
 
-**Built-in agent presets**: `claude`, `gemini`, `codex`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`, `pi`, `omp`
+**Built-in agent presets**: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`, `pi`, `omp`
+
+The `kiro` preset launches `kiro-cli chat --trust-all-tools`, supports Kiro's
+documented `--resume` / `--resume-id` session flags, and does not install Kiro
+hooks or `.kiro` project files.
 
 ### Convoy (Work Tracking)
 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -195,7 +195,7 @@ gt status              # Show workspace status
 
 ### Step 5: Configure Agents (Optional)
 
-Gas Town supports built-in runtimes (`claude`, `gemini`, `codex`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`) plus custom agent aliases.
+Gas Town supports built-in runtimes (`claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`) plus custom agent aliases.
 
 ```bash
 # List available agents

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -461,7 +461,11 @@ gt config agent remove <name>     # Remove custom agent (built-ins protected)
 gt config default-agent [name]    # Get or set town default agent
 ```
 
-**Built-in agents**: `claude`, `gemini`, `codex`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`
+**Built-in agents**: `claude`, `gemini`, `codex`, `kiro`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`
+
+The `kiro` preset launches `kiro-cli chat --trust-all-tools` and uses Kiro's
+documented `--resume` / `--resume-id` session flags. Gas Town does not install
+Kiro hooks or `.kiro` project files for this preset.
 
 > **Note on GitHub Copilot**: The `copilot` preset uses executable lifecycle hooks in
 > `.github/hooks/gastown.json` (`sessionStart`, `userPromptSubmitted`, `preToolUse`,

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -27,6 +27,8 @@ const (
 	AgentGemini AgentPreset = "gemini"
 	// AgentCodex is OpenAI Codex.
 	AgentCodex AgentPreset = "codex"
+	// AgentKiro is Kiro CLI.
+	AgentKiro AgentPreset = "kiro"
 	// AgentCursor is Cursor Agent.
 	AgentCursor AgentPreset = "cursor"
 	// AgentAuggie is Auggie CLI.
@@ -295,6 +297,24 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		ReadyPromptPrefix: "› ",
 		ReadyDelayMs:      3000,
 		InstructionsFile:  "AGENTS.md",
+	},
+	AgentKiro: {
+		Name:         AgentKiro,
+		Command:      "kiro-cli",
+		Args:         []string{"chat", "--trust-all-tools"},
+		ProcessNames: []string{"kiro-cli"},
+		// Kiro sessions are stored per directory; the CLI resumes by flag, not
+		// by an environment variable that Gas Town needs to manage.
+		SessionIDEnv:        "",
+		ResumeFlag:          "--resume-id",
+		ContinueFlag:        "--resume",
+		ResumeStyle:         "flag",
+		SupportsHooks:       false, // Kiro has hooks, but Gas Town has no Kiro hook adapter yet.
+		SupportsForkSession: false,
+		NonInteractive:      nil, // Kiro's --no-interactive shape is not modeled by NonInteractiveConfig yet.
+		PromptMode:          "arg",
+		ReadyDelayMs:        5000,
+		InstructionsFile:    "AGENTS.md",
 	},
 	AgentCursor: {
 		Name:    AgentCursor,

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -32,7 +32,7 @@ func TestBuiltInAgentPresetSummary(t *testing.T) {
 func TestBuiltinPresets(t *testing.T) {
 	t.Parallel()
 	// Ensure all built-in presets are accessible
-	presets := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentCopilot, AgentPi, AgentOmp}
+	presets := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentKiro, AgentCursor, AgentAuggie, AgentAmp, AgentOpenCode, AgentCopilot, AgentPi, AgentOmp}
 
 	for _, preset := range presets {
 		info := GetAgentPreset(preset)
@@ -62,6 +62,7 @@ func TestGetAgentPresetByName(t *testing.T) {
 		{"claude", AgentClaude, false},
 		{"gemini", AgentGemini, false},
 		{"codex", AgentCodex, false},
+		{"kiro", AgentKiro, false},
 		{"cursor", AgentCursor, false},
 		{"auggie", AgentAuggie, false},
 		{"amp", AgentAmp, false},
@@ -98,6 +99,7 @@ func TestRuntimeConfigFromPreset(t *testing.T) {
 		{AgentClaude, "claude"}, // Note: claude may resolve to full path
 		{AgentGemini, "gemini"},
 		{AgentCodex, "codex"},
+		{AgentKiro, "kiro-cli"},
 		{AgentCursor, "cursor-agent"},
 		{AgentAuggie, "auggie"},
 		{AgentAmp, "amp"},
@@ -634,6 +636,13 @@ func TestBuildResumeCommand(t *testing.T) {
 			contains:  []string{"codex", "resume", "codex-sess-789", "--dangerously-bypass-approvals-and-sandbox"},
 		},
 		{
+			name:      "kiro flag style",
+			agentName: "kiro",
+			sessionID: "f2946a26-3735-4b08-8d05-c928010302d5",
+			wantEmpty: false,
+			contains:  []string{"kiro-cli", "chat", "--trust-all-tools", "--resume-id", "f2946a26-3735-4b08-8d05-c928010302d5"},
+		},
+		{
 			name:      "empty session ID",
 			agentName: "claude",
 			sessionID: "",
@@ -683,6 +692,7 @@ func TestSupportsSessionResume(t *testing.T) {
 		{"claude", true},
 		{"gemini", true},
 		{"codex", true},
+		{"kiro", true},
 		{"cursor", true},
 		{"auggie", true},
 		{"amp", true},
@@ -708,6 +718,7 @@ func TestGetSessionIDEnvVar(t *testing.T) {
 		{"claude", "CLAUDE_SESSION_ID"},
 		{"gemini", "GEMINI_SESSION_ID"},
 		{"codex", ""},   // Codex uses JSONL output instead
+		{"kiro", ""},    // Kiro stores sessions per directory and resumes by CLI flag
 		{"cursor", ""},  // Cursor uses --resume with chatId directly
 		{"auggie", ""},  // Auggie uses --resume directly
 		{"amp", ""},     // AMP uses 'threads continue' subcommand
@@ -733,6 +744,7 @@ func TestGetProcessNames(t *testing.T) {
 		{"claude", []string{"node", "claude"}},
 		{"gemini", []string{"gemini"}},
 		{"codex", []string{"codex"}},
+		{"kiro", []string{"kiro-cli"}},
 		{"cursor", []string{"cursor-agent", "agent"}},
 		{"auggie", []string{"auggie"}},
 		{"amp", []string{"amp"}},
@@ -909,6 +921,59 @@ func TestCursorAgentPreset(t *testing.T) {
 	}
 	if info.ReadyDelayMs != 5000 {
 		t.Errorf("cursor ReadyDelayMs = %d, want 5000 (nudge poller + WaitForRuntimeReady)", info.ReadyDelayMs)
+	}
+}
+
+func TestKiroAgentPreset(t *testing.T) {
+	t.Parallel()
+
+	info := GetAgentPreset(AgentKiro)
+	if info == nil {
+		t.Fatal("kiro preset not found")
+	}
+
+	if info.Command != "kiro-cli" {
+		t.Errorf("kiro Command = %q, want kiro-cli", info.Command)
+	}
+	wantArgs := []string{"chat", "--trust-all-tools"}
+	if len(info.Args) != len(wantArgs) {
+		t.Fatalf("kiro Args = %v, want %v", info.Args, wantArgs)
+	}
+	for i, want := range wantArgs {
+		if info.Args[i] != want {
+			t.Errorf("kiro Args[%d] = %q, want %q", i, info.Args[i], want)
+		}
+	}
+
+	if len(info.ProcessNames) != 1 || info.ProcessNames[0] != "kiro-cli" {
+		t.Errorf("kiro ProcessNames = %v, want [kiro-cli]", info.ProcessNames)
+	}
+	if info.SessionIDEnv != "" {
+		t.Errorf("kiro SessionIDEnv = %q, want empty", info.SessionIDEnv)
+	}
+	if info.ResumeFlag != "--resume-id" {
+		t.Errorf("kiro ResumeFlag = %q, want --resume-id", info.ResumeFlag)
+	}
+	if info.ContinueFlag != "--resume" {
+		t.Errorf("kiro ContinueFlag = %q, want --resume", info.ContinueFlag)
+	}
+	if info.ResumeStyle != "flag" {
+		t.Errorf("kiro ResumeStyle = %q, want flag", info.ResumeStyle)
+	}
+	if info.SupportsHooks {
+		t.Error("kiro SupportsHooks should remain false until Gas Town has a Kiro hook adapter")
+	}
+	if info.SupportsForkSession {
+		t.Error("kiro should not support fork session")
+	}
+	if info.NonInteractive != nil {
+		t.Errorf("kiro NonInteractive = %+v, want nil until --no-interactive positional prompts are modeled", info.NonInteractive)
+	}
+	if info.ReadyDelayMs != 5000 {
+		t.Errorf("kiro ReadyDelayMs = %d, want 5000", info.ReadyDelayMs)
+	}
+	if info.InstructionsFile != "AGENTS.md" {
+		t.Errorf("kiro InstructionsFile = %q, want AGENTS.md", info.InstructionsFile)
 	}
 }
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -3811,11 +3811,11 @@ func TestBuildArgsWithPromptWarnsOnDroppedPrompt(t *testing.T) {
 //	}
 //
 // Manual test procedure:
-//  1. Set role_agents.mayor to each agent (claude, gemini, codex, cursor, auggie, amp, opencode)
+//  1. Set role_agents.mayor to each agent (claude, gemini, codex, kiro, cursor, auggie, amp, opencode)
 //  2. Run: gt start
 //  3. Verify mayor starts with correct agent config
 //  4. Run: GT_NUKE_ACKNOWLEDGED=1 gt down --nuke
-//  5. Repeat for all 7 built-in agents
+//  5. Repeat for all built-in agents
 func TestRoleAgentConfigWithCustomAgent(t *testing.T) {
 	skipIfAgentBinaryMissing(t, "opencode", "claude")
 	t.Parallel()
@@ -3906,7 +3906,7 @@ func TestRoleAgentConfigWithCustomAgent(t *testing.T) {
 }
 
 // TestMultipleAgentTypes tests that various built-in agent presets work correctly.
-// NOTE: Only these are actual built-in presets: claude, gemini, codex, cursor, auggie, amp, opencode.
+// NOTE: Only these are actual built-in presets: claude, gemini, codex, kiro, cursor, auggie, amp, opencode.
 // Variants like "claude-opus", "claude-haiku", "claude-sonnet" are NOT built-in - they need
 // to be defined as custom agents in TownSettings.Agents if specific model selection is needed.
 func TestMultipleAgentTypes(t *testing.T) {

--- a/internal/crew/manager_test.go
+++ b/internal/crew/manager_test.go
@@ -660,6 +660,19 @@ func TestBuildResumeArgs(t *testing.T) {
 			sessionID: "sess-456",
 			wantArgs:  "--resume sess-456",
 		},
+		// Kiro: has ContinueFlag and flag-style session ID resume
+		{
+			name:      "kiro last uses --resume",
+			agent:     "kiro",
+			sessionID: "last",
+			wantArgs:  "--resume",
+		},
+		{
+			name:      "kiro specific ID uses --resume-id",
+			agent:     "kiro",
+			sessionID: "f2946a26-3735-4b08-8d05-c928010302d5",
+			wantArgs:  "--resume-id f2946a26-3735-4b08-8d05-c928010302d5",
+		},
 		// Codex: subcommand-style resume
 		{
 			name:      "codex rejected as subcommand-style",


### PR DESCRIPTION
## Summary
Adds a minimal `kiro` runtime preset through the existing agent registry.

This intentionally keeps the useful runtime-support part of #4368 separate and follows the narrower direction from #4401:
- no `.kiro/steering` repo files
- no Kiro hook adapter or `.kiro` hook files
- no broad documentation rewrite
- no provider-specific conditionals outside the runtime registry

## Kiro CLI validation
Checked current Kiro CLI docs before choosing the preset shape:
- `kiro-cli chat [OPTIONS] [INPUT]`
- `--trust-all-tools`
- `--resume` for the most recent session
- `--resume-id <ID>` for a specific session
- `--no-interactive` exists, but Gas Town's current `NonInteractiveConfig` cannot accurately model Kiro's positional prompt plus `--no-interactive`, so non-interactive metadata is left unset for now
- Kiro hooks exist, but Gas Town has no Kiro hook adapter yet, so `SupportsHooks` stays false

Refs #4401.

## Changes
- Add `AgentKiro` and the built-in `kiro` registry preset.
- Model launch, process detection, resume, ready delay, and instruction file metadata.
- Add focused config and crew resume tests.
- Add minimal README/install/reference docs.

## Testing
All local verification was run in Docker containers.

- `go test ./internal/config -run "Test(BuiltinPresets|GetAgentPresetByName|RuntimeConfigFromPreset|BuildResumeCommand|SupportsSessionResume|GetSessionIDEnvVar|GetProcessNames|KiroAgentPreset)$" -count=1`
- `go test ./internal/config ./internal/crew -run "Test(BuiltinPresets|GetAgentPresetByName|RuntimeConfigFromPreset|BuildResumeCommand|SupportsSessionResume|GetSessionIDEnvVar|GetProcessNames|KiroAgentPreset|BuildResumeArgs)$" -count=1`
- `go test ./internal/config ./internal/crew -count=1`
- `go build -v ./cmd/gt`
- `go test -race -short -timeout=10m ./internal/config ./internal/crew`
- `git diff --check`