### PR TITLE
fix(nudge): verify submission by composer state + C-j recovery for swallowed Enter

### DIFF
--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -245,7 +245,25 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 				Message:  message,
 				Priority: nudgePriorityFlag,
 			}})
-			return t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot})
+			deliverErr := t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot})
+			if !errors.Is(deliverErr, tmux.ErrSubmitNotVerified) {
+				return deliverErr
+			}
+			// The payload was typed but submission could not be verified —
+			// the composer swallowed the Enter (op-03ke). Fall back to the
+			// queue so the message is not lost, and watch for a delivery
+			// window (the C-j remedy has already reset the composer, so a
+			// later attempt has a fresh buffer).
+			fmt.Fprintf(os.Stderr, "wait-idle: %v; queueing for %s\n", deliverErr, sessionName)
+			if qErr := nudge.Enqueue(townRoot, sessionName, nudge.QueuedNudge{
+				Sender:   sender,
+				Message:  message,
+				Priority: nudgePriorityFlag,
+			}); qErr != nil {
+				return fmt.Errorf("queue fallback after unverified submit failed: %v (original: %w)", qErr, deliverErr)
+			}
+			watchAndDeliver(t, townRoot, sessionName)
+			return nil
 		}
 		// Terminal errors (session gone, no server) — propagate, don't queue.
 		// Queueing a nudge for a dead session means it will never be delivered.
@@ -339,6 +357,14 @@ func watchAndDeliver(t *tmux.Tmux, townRoot, sessionName string) {
 			formatted := nudge.FormatForInjection(drained)
 			if err := t.NudgeSessionWithOpts(sessionName, formatted, tmux.NudgeOpts{TownRoot: townRoot}); err != nil {
 				fmt.Fprintf(os.Stderr, "idle-watcher: delivery for %s failed: %v\n", sessionName, err)
+				// Drain already removed these from the queue — put them back
+				// so a failed delivery (e.g. unverified submit, op-03ke)
+				// doesn't silently lose them.
+				for _, n := range drained {
+					if qErr := nudge.Enqueue(townRoot, sessionName, n); qErr != nil {
+						fmt.Fprintf(os.Stderr, "idle-watcher: re-enqueue for %s failed: %v\n", sessionName, qErr)
+					}
+				}
 			}
 			return
 		}

--- a/internal/cmd/nudge_poller.go
+++ b/internal/cmd/nudge_poller.go
@@ -130,6 +130,14 @@ func runNudgePoller(cmd *cobra.Command, args []string) error {
 			formatted := nudge.FormatForInjection(drained)
 			if err := t.NudgeSessionWithOpts(sessionName, formatted, nudgeOpts); err != nil {
 				fmt.Fprintf(os.Stderr, "nudge-poller: injection error for %s: %v\n", sessionName, err)
+				// Drain already removed these from the queue — put them back
+				// so a failed injection (e.g. unverified submit, op-03ke)
+				// retries on the next poll instead of losing the nudges.
+				for _, n := range drained {
+					if qErr := nudge.Enqueue(townRoot, sessionName, n); qErr != nil {
+						fmt.Fprintf(os.Stderr, "nudge-poller: re-enqueue for %s failed: %v\n", sessionName, qErr)
+					}
+				}
 			}
 		}
 	}

--- a/internal/tmux/submit_verify.go
+++ b/internal/tmux/submit_verify.go
@@ -1,0 +1,403 @@
+package tmux
+
+// submit_verify.go — composer-state submission verification for nudge delivery.
+//
+// Evidence (openclaw op-03ke; hq-zrpgf / hq-ygybv): the nudge/daemon-wake
+// delivery path types the payload into the target Claude Code pane, but the
+// trailing Enter is sometimes swallowed when the composer buffer is in a bad
+// state (suspected lost/duplicated bracketed-paste boundary). The text then
+// sits unsubmitted in the composer until something resets the buffer — five
+// documented deacon strandings on 2026-07-09/10, each costing a patrol cycle.
+//
+// Live debugging of occurrence #5 (hq-zrpgf) showed:
+//   - printable keys still echo, so the TUI event loop is alive
+//   - Enter / C-m / CSI-u 13u / Escape+Enter are ALL swallowed
+//   - C-j (LF) clears the parked buffer without submitting
+//   - after that clear, retyping the text + plain Enter submits normally
+//
+// sendEnterVerified's "did the pane change" heuristic cannot catch this: the
+// pane keeps repainting (spinner, clock, token counter) while the composer
+// stays wedged, and its remedy — more Enters — is exactly the keystroke being
+// swallowed. Verification here inspects the *composer state* instead: a nudge
+// counts as submitted only when the turn visibly started (busy indicator) or
+// the typed text is no longer sitting in the composer at normal intensity.
+//
+// Dim (SGR 2) composer text is Claude Code's ghost placeholder replaying a
+// previous draft over an EMPTY composer and must NOT be treated as stranded
+// input — boot's triage on hq-zrpgf documented a false-positive rescue caused
+// by exactly that confusion. Capturing with escape sequences (-e) lets us
+// tell the two apart.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// ErrSubmitNotVerified reports that a nudge's payload was typed into the
+// target composer but its submission could not be verified: the text was
+// still sitting in the composer (normal intensity) after the Enter retries
+// and the C-j buffer-reset remedy. Callers should fall back to queueing so
+// the message is not lost.
+var ErrSubmitNotVerified = errors.New("submit not verified: message stranded in composer")
+
+// submitProbe classifies the state of a target composer after a submit
+// keystroke was sent.
+type submitProbe int
+
+const (
+	// probeUnknown means the pane could not be captured or no composer line
+	// was found — verification is impossible, fall back to best-effort.
+	probeUnknown submitProbe = iota
+	// probeTurnStarted means the busy indicator is visible — the agent is
+	// working, so the submission definitely went through.
+	probeTurnStarted
+	// probeComposerCleared means the composer no longer contains the typed
+	// text at normal intensity (empty, different content, or dim ghost text).
+	probeComposerCleared
+	// probeStranded means the typed text is still sitting in the composer at
+	// normal intensity — the submit keystroke was swallowed.
+	probeStranded
+)
+
+// submitProbeAttempts and submitProbeInterval bound the post-Enter
+// verification poll: attempt, sleep, attempt, ... (~1.4s total for 3
+// attempts), matching the 1-2s x3 window from the op-03ke spec.
+const (
+	submitProbeAttempts = 3
+	submitProbeInterval = 700 * time.Millisecond
+)
+
+// submitNeedleMaxRunes bounds the needle length so it fits on the composer's
+// first rendered line even in narrow panes (composer wraps long input).
+const submitNeedleMaxRunes = 32
+
+// submitNeedle returns a short distinctive prefix of the typed message used
+// to detect it sitting unsubmitted in the composer. Empty when the message
+// has no printable content.
+func submitNeedle(message string) string {
+	for _, line := range strings.Split(message, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		runes := []rune(line)
+		if len(runes) > submitNeedleMaxRunes {
+			return string(runes[:submitNeedleMaxRunes])
+		}
+		return line
+	}
+	return ""
+}
+
+// applySGR updates the dim flag for one CSI ... m parameter string.
+// Handles: 0/empty (reset all), 2 (dim on), 22 (dim/bold off), and skips the
+// arguments of extended-color sequences (38;5;n / 38;2;r;g;b and the 48/58
+// variants) so their literal "2" params don't read as dim.
+func applySGR(params string, dim bool) bool {
+	if params == "" {
+		return false
+	}
+	fields := strings.Split(params, ";")
+	for k := 0; k < len(fields); k++ {
+		switch fields[k] {
+		case "", "0":
+			dim = false
+		case "2":
+			dim = true
+		case "22":
+			dim = false
+		case "38", "48", "58":
+			if k+1 < len(fields) {
+				switch fields[k+1] {
+				case "5":
+					k += 2
+				case "2":
+					k += 4
+				}
+			}
+		}
+	}
+	return dim
+}
+
+// stripAnsiTrackDim strips ANSI escape sequences from s, returning the plain
+// runes plus a parallel slice marking which runes were rendered dim (SGR 2).
+// Only SGR state relevant to dim detection is tracked; all other escape
+// sequences (cursor movement, OSC titles, etc.) are dropped.
+func stripAnsiTrackDim(s string) ([]rune, []bool) {
+	var plain []rune
+	var dim []bool
+	cur := false
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b {
+			if i+1 < len(s) && s[i+1] == '[' {
+				// CSI: ESC [ params final-byte
+				j := i + 2
+				for j < len(s) && (s[j] < 0x40 || s[j] > 0x7e) {
+					j++
+				}
+				if j < len(s) {
+					if s[j] == 'm' {
+						cur = applySGR(s[i+2:j], cur)
+					}
+					i = j + 1
+				} else {
+					i = len(s)
+				}
+				continue
+			}
+			if i+1 < len(s) && s[i+1] == ']' {
+				// OSC: ESC ] ... (BEL | ESC \)
+				j := i + 2
+				for j < len(s) && s[j] != 0x07 && !(s[j] == 0x1b && j+1 < len(s) && s[j+1] == '\\') {
+					j++
+				}
+				if j < len(s) {
+					if s[j] == 0x1b {
+						j++ // consume the backslash of ST too
+					}
+					i = j + 1
+				} else {
+					i = len(s)
+				}
+				continue
+			}
+			// Other two-byte escape (ESC c, ESC =, ...)
+			i += 2
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		plain = append(plain, r)
+		dim = append(dim, cur)
+		i += size
+	}
+	return plain, dim
+}
+
+// runeIndex returns the index of the first occurrence of needle in haystack,
+// or -1 if absent.
+func runeIndex(haystack, needle []rune) int {
+	if len(needle) == 0 || len(needle) > len(haystack) {
+		return -1
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := range needle {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
+// minStrandPrefixRunes is the minimum length of composer content required for
+// the prefix-match fallback (narrow panes that truncate the needle) to count
+// as stranded input. Shorter fragments are too ambiguous.
+const minStrandPrefixRunes = 8
+
+// analyzeSubmission classifies a pane capture (taken with -e so escape
+// sequences are preserved) after a submit keystroke:
+//
+//   - any busy indicator → probeTurnStarted
+//   - no composer line (prompt prefix) found → probeUnknown
+//   - needle present at normal intensity on the composer line (the
+//     bottom-most prompt line) → probeStranded; a composer whose visible
+//     content is a ≥8-rune prefix of the needle (input truncated by pane
+//     width or wrap) also counts as stranded
+//   - needle absent or rendered dim (ghost placeholder) → probeComposerCleared
+//
+// Only the composer line itself is inspected — text on lines below it is
+// transcript/status output, not composer content (a fake idle pane that
+// tty-echoes typed input below its prompt must not read as stranded).
+func analyzeSubmission(escContent, needle, promptPrefix string) submitProbe {
+	if needle == "" {
+		return probeUnknown
+	}
+	plain, dim := stripAnsiTrackDim(escContent)
+
+	// Split into lines while keeping the dim flags aligned.
+	var lines [][]rune
+	var lineDims [][]bool
+	start := 0
+	for i := 0; i <= len(plain); i++ {
+		if i == len(plain) || plain[i] == '\n' {
+			lines = append(lines, plain[start:i])
+			lineDims = append(lineDims, dim[start:i])
+			start = i + 1
+		}
+	}
+
+	for _, ln := range lines {
+		if hasBusyIndicator(string(ln)) {
+			return probeTurnStarted
+		}
+	}
+
+	// Bottom-most prompt line is the live composer; transcript echoes of past
+	// messages render with a different prefix.
+	composerIdx := -1
+	for i := len(lines) - 1; i >= 0; i-- {
+		if matchesPromptPrefix(string(lines[i]), promptPrefix) {
+			composerIdx = i
+			break
+		}
+	}
+	if composerIdx == -1 {
+		return probeUnknown
+	}
+
+	line := lines[composerIdx]
+	lineDim := lineDims[composerIdx]
+
+	if idx := runeIndex(line, []rune(needle)); idx >= 0 {
+		if lineDim[idx] {
+			// Dim = Claude Code's ghost/draft placeholder over an empty
+			// composer (hq-zrpgf boot triage), not stranded input.
+			return probeComposerCleared
+		}
+		return probeStranded
+	}
+
+	// Prefix fallback: in a narrow pane the composer line truncates/wraps the
+	// input before the full needle fits. If the visible content after the
+	// prompt is a sufficiently long prefix of the needle, the message is
+	// still sitting there.
+	isSpace := func(r rune) bool { return r == ' ' || r == '\u00a0' || r == '\t' }
+	promptRunes := []rune(strings.TrimSpace(promptPrefix))
+	if len(promptRunes) == 0 {
+		return probeComposerCleared
+	}
+	pos := runeIndex(line, promptRunes[:1])
+	if pos < 0 {
+		return probeComposerCleared
+	}
+	after := line[pos+1:]
+	afterDim := lineDim[pos+1:]
+	// Trim surrounding whitespace (incl. NBSP), keeping dim flags aligned.
+	for len(after) > 0 && isSpace(after[0]) {
+		after = after[1:]
+		afterDim = afterDim[1:]
+	}
+	for len(after) > 0 && isSpace(after[len(after)-1]) {
+		after = after[:len(after)-1]
+		afterDim = afterDim[:len(afterDim)-1]
+	}
+	if len(after) >= minStrandPrefixRunes && strings.HasPrefix(needle, string(after)) {
+		if afterDim[0] {
+			return probeComposerCleared
+		}
+		return probeStranded
+	}
+	return probeComposerCleared
+}
+
+// probeSubmission captures the target pane with escape sequences (so dim
+// ghost text is distinguishable from real input) and classifies the
+// composer state.
+func (t *Tmux) probeSubmission(target, needle, promptPrefix string) submitProbe {
+	content, err := t.run("capture-pane", "-p", "-e", "-t", target, "-S", "-25")
+	if err != nil {
+		return probeUnknown
+	}
+	return analyzeSubmission(content, needle, promptPrefix)
+}
+
+// pollSubmission probes up to attempts times, returning early on any
+// conclusive success (turn started / composer cleared). The first probe is
+// immediate — callers have already slept after the submit keystroke.
+func (t *Tmux) pollSubmission(target, needle, promptPrefix string, attempts int) submitProbe {
+	last := probeUnknown
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			time.Sleep(submitProbeInterval)
+		}
+		last = t.probeSubmission(target, needle, promptPrefix)
+		if last == probeTurnStarted || last == probeComposerCleared {
+			return last
+		}
+	}
+	return last
+}
+
+// submitComposer submits a just-typed message and verifies it actually left
+// the composer. Layered defense:
+//
+//  1. sendEnterVerified — the existing load-race guard (GH#gt-0b5): Enter with
+//     content-change polling and Enter retries.
+//  2. Composer-strand verification (op-03ke): confirm the typed text is no
+//     longer parked in the composer. If it is, Enter is being swallowed.
+//  3. C-j remedy: reset the wedged input buffer, retype if C-j cleared the
+//     text, submit, and re-verify.
+//
+// Returns an error wrapping ErrSubmitNotVerified when the message is still
+// stranded after all remedies, so callers can fall back to queueing.
+func (t *Tmux) submitComposer(target, message string) error {
+	enterErr := t.sendEnterVerified(target)
+
+	needle := submitNeedle(message)
+	if needle == "" {
+		return enterErr
+	}
+	promptPrefix := readyPromptPrefixForSession(t, target)
+
+	switch t.pollSubmission(target, needle, promptPrefix, submitProbeAttempts) {
+	case probeTurnStarted, probeComposerCleared:
+		return nil
+	case probeUnknown:
+		// Composer state not observable — fall back to the legacy verdict.
+		return enterErr
+	}
+
+	// Stranded: the composer still shows the message at normal intensity, so
+	// every Enter so far was swallowed. Apply the C-j remedy.
+	return t.recoverStrandedComposer(target, message, needle, promptPrefix)
+}
+
+// recoverStrandedComposer applies boot's evidenced remedy for a wedged
+// composer (hq-zrpgf occurrence #5): C-j clears the parked buffer without
+// submitting; after that reset, retyping the text and sending a plain Enter
+// submits normally.
+func (t *Tmux) recoverStrandedComposer(target, message, needle, promptPrefix string) error {
+	if _, err := t.run("send-keys", "-t", target, "C-j"); err != nil {
+		return fmt.Errorf("%w (C-j reset failed: %v)", ErrSubmitNotVerified, err)
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	switch t.probeSubmission(target, needle, promptPrefix) {
+	case probeTurnStarted:
+		return nil // C-j itself submitted (LF-as-submit state)
+	case probeStranded:
+		// Buffer didn't clear, but C-j may still have reset the wedged input
+		// state — try one more plain Enter before giving up.
+		if _, err := t.run("send-keys", "-t", target, "Enter"); err != nil {
+			return fmt.Errorf("%w (Enter retry failed: %v)", ErrSubmitNotVerified, err)
+		}
+	case probeComposerCleared:
+		// C-j cleared the parked text without submitting — retype and submit.
+		if err := t.sendMessageToTarget(target, message); err != nil {
+			return fmt.Errorf("%w (retype failed: %v)", ErrSubmitNotVerified, err)
+		}
+		time.Sleep(adaptiveTextDelay(len(message)))
+		if _, err := t.run("send-keys", "-t", target, "Enter"); err != nil {
+			return fmt.Errorf("%w (Enter after retype failed: %v)", ErrSubmitNotVerified, err)
+		}
+	case probeUnknown:
+		// Pane no longer observable — best-effort Enter, can't verify further.
+		_, _ = t.run("send-keys", "-t", target, "Enter")
+		return nil
+	}
+
+	switch t.pollSubmission(target, needle, promptPrefix, submitProbeAttempts) {
+	case probeTurnStarted, probeComposerCleared, probeUnknown:
+		return nil
+	}
+	return fmt.Errorf("nudge submit to %q: %w", target, ErrSubmitNotVerified)
+}

--- a/internal/tmux/submit_verify_test.go
+++ b/internal/tmux/submit_verify_test.go
@@ -1,0 +1,314 @@
+package tmux
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSubmitNeedle(t *testing.T) {
+	long := strings.Repeat("x", 100)
+	tests := []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{"short message", "resume the patrol", "resume the patrol"},
+		{"long message truncated", long, long[:submitNeedleMaxRunes]},
+		{"multiline uses first line", "first line\nsecond line", "first line"},
+		{"leading blank lines skipped", "\n\n  \nreal content", "real content"},
+		{"surrounding space trimmed", "  hello  ", "hello"},
+		{"empty message", "", ""},
+		{"whitespace only", " \n \n ", ""},
+		{"unicode truncated at rune boundary", strings.Repeat("é", 50), strings.Repeat("é", submitNeedleMaxRunes)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := submitNeedle(tt.message); got != tt.want {
+				t.Errorf("submitNeedle(%q) = %q, want %q", tt.message, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripAnsiTrackDim(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantPlain string
+		wantDim   string // 'd' for dim, '.' for normal, per rune
+	}{
+		{
+			name:      "plain text",
+			input:     "hello",
+			wantPlain: "hello",
+			wantDim:   ".....",
+		},
+		{
+			name:      "dim span with reset",
+			input:     "ab\x1b[2mcd\x1b[0mef",
+			wantPlain: "abcdef",
+			wantDim:   "..dd..",
+		},
+		{
+			name:      "dim off via 22",
+			input:     "\x1b[2mab\x1b[22mcd",
+			wantPlain: "abcd",
+			wantDim:   "dd..",
+		},
+		{
+			name:      "256-color arg 2 is not dim",
+			input:     "\x1b[38;5;2mgreen\x1b[0m",
+			wantPlain: "green",
+			wantDim:   ".....",
+		},
+		{
+			name:      "truecolor args not dim",
+			input:     "\x1b[38;2;10;20;30mrgb\x1b[0m",
+			wantPlain: "rgb",
+			wantDim:   "...",
+		},
+		{
+			name:      "combined params",
+			input:     "\x1b[1;2;31mx\x1b[my",
+			wantPlain: "xy",
+			wantDim:   "d.",
+		},
+		{
+			name:      "OSC sequence stripped",
+			input:     "\x1b]0;title\x07text",
+			wantPlain: "text",
+			wantDim:   "....",
+		},
+		{
+			name:      "cursor movement stripped",
+			input:     "a\x1b[2Ab",
+			wantPlain: "ab",
+			wantDim:   "..",
+		},
+		{
+			name:      "unicode preserved",
+			input:     "❯ \x1b[2mghost\x1b[0m",
+			wantPlain: "❯ ghost",
+			wantDim:   "..ddddd",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plain, dim := stripAnsiTrackDim(tt.input)
+			if string(plain) != tt.wantPlain {
+				t.Errorf("plain = %q, want %q", string(plain), tt.wantPlain)
+			}
+			if len(dim) != len(plain) {
+				t.Fatalf("dim length %d != plain length %d", len(dim), len(plain))
+			}
+			var got strings.Builder
+			for _, d := range dim {
+				if d {
+					got.WriteByte('d')
+				} else {
+					got.WriteByte('.')
+				}
+			}
+			if got.String() != tt.wantDim {
+				t.Errorf("dim = %q, want %q", got.String(), tt.wantDim)
+			}
+		})
+	}
+}
+
+func TestAnalyzeSubmission(t *testing.T) {
+	const needle = "resume the patrol"
+	const prompt = DefaultReadyPromptPrefix // "❯ "
+
+	tests := []struct {
+		name    string
+		content string
+		want    submitProbe
+	}{
+		{
+			name:    "busy indicator means turn started",
+			content: "some transcript\n❯ resume the patrol\n· Thinking… (esc to interrupt)",
+			want:    probeTurnStarted,
+		},
+		{
+			name:    "normal-intensity text in composer is stranded",
+			content: "transcript above\n❯ resume the patrol\n⏵⏵ bypass permissions",
+			want:    probeStranded,
+		},
+		{
+			name:    "dim ghost text is not stranded",
+			content: "transcript above\n❯ \x1b[2mresume the patrol\x1b[0m\n⏵⏵ bypass permissions",
+			want:    probeComposerCleared,
+		},
+		{
+			name:    "empty composer is cleared",
+			content: "transcript above\n❯\n⏵⏵ bypass permissions",
+			want:    probeComposerCleared,
+		},
+		{
+			name:    "different composer content is cleared",
+			content: "transcript above\n❯ something else entirely\n",
+			want:    probeComposerCleared,
+		},
+		{
+			name:    "no composer line found is unknown",
+			content: "just some\nshell output\nwithout a prompt",
+			want:    probeUnknown,
+		},
+		{
+			name: "wrapped input detected via prefix fallback",
+			// Composer wraps: only the first part of the needle fits on the
+			// prompt line; the visible content is a prefix of the needle.
+			content: "transcript\n❯ resume the\n patrol\n",
+			want:    probeStranded,
+		},
+		{
+			name: "typed text echoed below prompt is not composer content",
+			// A fake idle pane (printf prompt + cat) tty-echoes delivered
+			// input below the prompt line; the composer itself is empty.
+			// Regression: internal/mail TestNotifyRecipient_IdleAgent.
+			content: "❯ \nresume the patrol\nresume the patrol\n",
+			want:    probeComposerCleared,
+		},
+		{
+			name:    "dim wrapped prefix is ghost text",
+			content: "transcript\n❯ \x1b[2mresume the\x1b[0m\n",
+			want:    probeComposerCleared,
+		},
+		{
+			name: "bottom-most prompt line wins",
+			// An old prompt with text sits in the transcript; the live
+			// composer below it is empty → cleared.
+			content: "❯ resume the patrol\nagent response here\n❯\n",
+			want:    probeComposerCleared,
+		},
+		{
+			name:    "needle above composer in transcript does not strand",
+			content: "> resume the patrol\nagent working on it\n❯\n",
+			want:    probeComposerCleared,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := analyzeSubmission(tt.content, needle, prompt); got != tt.want {
+				t.Errorf("analyzeSubmission(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("empty needle is unknown", func(t *testing.T) {
+		if got := analyzeSubmission("❯ anything", "", prompt); got != probeUnknown {
+			t.Errorf("analyzeSubmission with empty needle = %v, want probeUnknown", got)
+		}
+	})
+}
+
+// TestAnalyzeSubmission_PrefixFallback pins the narrow-pane fallback: composer
+// content that is a prefix of the needle counts as stranded only when it is
+// long enough (minStrandPrefixRunes) to be unambiguous.
+func TestAnalyzeSubmission_PrefixFallback(t *testing.T) {
+	// 8-rune prefix "abcdefgh" of a longer needle → stranded.
+	if got := analyzeSubmission("❯ abcdefgh\n", "abcdefghij", DefaultReadyPromptPrefix); got != probeStranded {
+		t.Errorf("long prefix = %v, want probeStranded", got)
+	}
+	// 4-rune fragment is too short to be conclusive → cleared.
+	if got := analyzeSubmission("❯ abcd\n", "abcdefghij", DefaultReadyPromptPrefix); got != probeComposerCleared {
+		t.Errorf("short fragment = %v, want probeComposerCleared", got)
+	}
+	// Non-prefix content of qualifying length → cleared.
+	if got := analyzeSubmission("❯ zzzzzzzzzz\n", "abcdefghij", DefaultReadyPromptPrefix); got != probeComposerCleared {
+		t.Errorf("non-prefix content = %v, want probeComposerCleared", got)
+	}
+}
+
+// TestErrSubmitNotVerified_Wrapping pins the errors.Is contract callers rely
+// on for the queue fallback.
+func TestErrSubmitNotVerified_Wrapping(t *testing.T) {
+	wrapped := fmt.Errorf("nudge to session %q: %w",
+		"gt-deacon", fmt.Errorf("nudge submit to %q: %w", "gt-deacon", ErrSubmitNotVerified))
+	if !errors.Is(wrapped, ErrSubmitNotVerified) {
+		t.Fatal("double-wrapped ErrSubmitNotVerified not detected by errors.Is")
+	}
+}
+
+// TestProbeSubmission_LivePane exercises the composer probe against a real
+// tmux pane (capture-only). A fake composer is rendered with printf so the
+// probe's -e capture and dim detection run against genuine tmux output.
+func TestProbeSubmission_LivePane(t *testing.T) {
+	tm := newTestTmux(t)
+	session := "gt-test-probe-submit"
+
+	_ = tm.KillSession(session)
+	if err := tm.NewSession(session, ""); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tm.KillSession(session) }()
+
+	const needle = "resume the patrol"
+	prompt := DefaultReadyPromptPrefix
+
+	// The town shell hook can show an interactive "Add to Gas Town?" prompt
+	// on startup that swallows the first typed command. Send a probe command
+	// until the shell is demonstrably executing input.
+	readyDeadline := time.Now().Add(15 * time.Second)
+	for {
+		_ = tm.SendKeys(session, `echo shell-ready-$((40+2))`)
+		time.Sleep(300 * time.Millisecond)
+		out, _ := tm.CapturePane(session, 30)
+		if strings.Contains(out, "shell-ready-42") {
+			break
+		}
+		if time.Now().After(readyDeadline) {
+			t.Skipf("shell never became ready for input; pane:\n%s", out)
+		}
+		time.Sleep(700 * time.Millisecond)
+	}
+
+	waitForProbe := func(desc string, want submitProbe) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		var got submitProbe
+		for time.Now().Before(deadline) {
+			got = tm.probeSubmission(session, needle, prompt)
+			if got == want {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		out, _ := tm.CapturePane(session, 20)
+		t.Fatalf("%s: probe = %v, want %v; pane:\n%s", desc, got, want, out)
+	}
+
+	// No composer line yet (plain shell prompt) → unknown.
+	waitForProbe("plain shell", probeUnknown)
+
+	// Render a stranded composer: normal-intensity text after ❯.
+	// (\342\235\257 is the UTF-8 octal encoding of ❯.)
+	if err := tm.SendKeys(session, `printf '\342\235\257 resume the patrol'`); err != nil {
+		t.Fatalf("SendKeys: %v", err)
+	}
+	waitForProbe("stranded composer", probeStranded)
+
+	// Render a dim ghost composer → cleared, not stranded.
+	if err := tm.SendKeys(session, "clear"); err != nil {
+		t.Fatalf("SendKeys clear: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+	if err := tm.SendKeys(session, `printf '\342\235\257 \033[2mresume the patrol\033[0m'`); err != nil {
+		t.Fatalf("SendKeys dim: %v", err)
+	}
+	waitForProbe("dim ghost composer", probeComposerCleared)
+
+	// Render a busy indicator → turn started.
+	if err := tm.SendKeys(session, "clear"); err != nil {
+		t.Fatalf("SendKeys clear: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+	if err := tm.SendKeys(session, `printf 'esc to interrupt'`); err != nil {
+		t.Fatalf("SendKeys busy: %v", err)
+	}
+	waitForProbe("busy indicator", probeTurnStarted)
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1809,9 +1809,10 @@ func (t *Tmux) NudgeSessionWithOpts(session, message string, opts NudgeOpts) err
 		}
 	}
 
-	// 7. Send Enter with verification — polls pane content to confirm Enter
-	// was processed, retrying with exponential backoff under load. (GH#gt-0b5)
-	if err := t.sendEnterVerified(target); err != nil {
+	// 7. Submit with verification — confirms Enter was processed AND the
+	// message actually left the composer (not stranded by a swallowed CR),
+	// applying the C-j buffer-reset remedy on failure. (GH#gt-0b5, op-03ke)
+	if err := t.submitComposer(target, sanitized); err != nil {
 		return fmt.Errorf("nudge to session %q: %w", session, err)
 	}
 
@@ -1881,9 +1882,10 @@ func (t *Tmux) NudgePane(pane, message string) error {
 		}
 	}
 
-	// 7. Send Enter with verification — polls pane content to confirm Enter
-	// was processed, retrying with exponential backoff under load. (GH#gt-0b5)
-	if err := t.sendEnterVerified(pane); err != nil {
+	// 7. Submit with verification — confirms Enter was processed AND the
+	// message actually left the composer (not stranded by a swallowed CR),
+	// applying the C-j buffer-reset remedy on failure. (GH#gt-0b5, op-03ke)
+	if err := t.submitComposer(pane, sanitized); err != nil {
 		return fmt.Errorf("nudge to pane %q: %w", pane, err)
 	}
 


### PR DESCRIPTION
## Problem

Nudge delivery (`gt nudge`, nudge-poller injection, daemon health-check pokes) types the payload into the target Claude Code pane, but the trailing Enter is sometimes swallowed when the composer buffer is in a bad state — the text sits unsubmitted in the composer until something resets the input buffer. We hit this **five times in one day** on our deacon (incident evidence: openclaw beads `op-03ke`, `hq-zrpgf`, `hq-ygybv`), each stranding costing a 27–44 min stale-heartbeat gap and an escalation.

Live debugging of one occurrence showed:
- printable keys still echo → the Ink event loop is alive
- Enter / C-m / CSI-u `13u` / Escape+Enter are **all** swallowed
- **C-j (LF) clears the parked buffer** without submitting
- after that clear, retyping the text + plain Enter submits normally

Consistent with a lost/duplicated bracketed-paste boundary wedging the composer so CR is dropped until the buffer is reset.

The existing `sendEnterVerified` guard cannot catch this: its "did the pane change" heuristic passes while the pane repaints (spinner/clock) around a wedged composer, and its remedy — more Enters — is exactly the keystroke being swallowed.

## Fix

At the delivery choke point (`NudgeSessionWithOpts` / `NudgePane`), layered on the existing Enter-retry guard:

1. **`submitComposer`** (new, `internal/tmux/submit_verify.go`): verify the message actually *left the composer* — `capture-pane -e`, locate the live composer line (bottom-most `❯` prompt line), and classify:
   - busy indicator visible → turn started ✓
   - typed text absent, or present but **dim (SGR 2)** → cleared ✓ (dim is Claude Code's ghost/draft placeholder rendered over an *empty* composer; treating it as stranded input caused a documented false-positive rescue)
   - typed text present at normal intensity → **stranded**: Enter was swallowed
2. **C-j recovery**: send C-j to reset the wedged buffer; if it cleared the text, retype + Enter; re-verify. Still stranded → sentinel `ErrSubmitNotVerified`.
3. **Queue fallback** so unverified submits are never lost:
   - `--mode=wait-idle` direct delivery falls back to the nudge queue (+ idle watcher) on `ErrSubmitNotVerified`.
   - The idle watcher and `gt nudge-poller` re-enqueue drained nudges when injection fails (previously a failed injection silently discarded them).

Agents without prompt-based detection degrade gracefully: no composer line found → `probeUnknown` → the legacy `sendEnterVerified` verdict stands.

## Tests

- Table-driven unit tests for the ANSI dim tracker (incl. `38;5;2` / truecolor args not reading as SGR-2 dim), needle extraction, and the composer-state classifier (stranded / ghost / cleared / wrapped input / bottom-most-prompt selection / busy).
- `TestProbeSubmission_LivePane`: renders stranded, dim-ghost, and busy composers in a real tmux pane and asserts the probe classification end-to-end (skips when tmux is unavailable).

Related prior work: #1216 (nudge delivery reliability), GH#gt-0b5 (`sendEnterVerified`), GH#gt-8el (Rewind recovery) — this addresses the remaining swallowed-CR mode those don't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)