### PR TITLE
fix(daemon): deacon crash-loop state decays instead of sticking forever

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -93,6 +93,12 @@ type Daemon struct {
 	// Restart tracking with exponential backoff to prevent crash loops
 	restartTracker *RestartTracker
 
+	// deaconCrashLoopLogged tracks whether the deacon crash-loop guard has
+	// already been logged, so transitions are logged once instead of every
+	// heartbeat cycle (op-r9fx: 16k+ repeated skip lines over six weeks).
+	// Only accessed from heartbeat loop goroutine - no sync needed.
+	deaconCrashLoopLogged bool
+
 	// telemetry exports metrics and logs to VictoriaMetrics / VictoriaLogs.
 	// Nil when telemetry is disabled (GT_OTEL_METRICS_URL / GT_OTEL_LOGS_URL not set).
 	otelProvider *telemetry.Provider
@@ -1466,7 +1472,7 @@ func (d *Daemon) ensureDeaconRunning() {
 	// Check restart tracker for backoff/crash loop
 	if d.restartTracker != nil {
 		if d.restartTracker.IsInCrashLoop(agentID) {
-			d.logger.Printf("Deacon is in crash loop, skipping restart (use 'gt daemon clear-backoff deacon' to reset)")
+			d.logDeaconCrashLoopTransition(true)
 			return
 		}
 		if !d.restartTracker.CanRestart(agentID) {
@@ -1513,6 +1519,21 @@ func (d *Daemon) deaconGracePeriod() time.Duration {
 	return d.loadOperationalConfig().GetDaemonConfig().DeaconGracePeriodD()
 }
 
+// logDeaconCrashLoopTransition logs deacon crash-loop guard state changes
+// exactly once per transition instead of on every heartbeat cycle (op-r9fx:
+// the per-cycle skip line produced 16k+ log lines over six weeks).
+func (d *Daemon) logDeaconCrashLoopTransition(active bool) {
+	if active == d.deaconCrashLoopLogged {
+		return
+	}
+	d.deaconCrashLoopLogged = active
+	if active {
+		d.logger.Printf("Deacon entered crash-loop state: auto-restarts and heartbeat kill check suspended (clears after sustained healthy heartbeats, on crash-loop expiry, or via 'gt daemon clear-backoff deacon')")
+	} else {
+		d.logger.Printf("Deacon crash-loop state cleared: heartbeat supervision resumed")
+	}
+}
+
 // checkDeaconHeartbeat checks if the Deacon is making progress.
 // This is a belt-and-suspenders fallback in case Boot doesn't detect stuck states.
 // Uses the heartbeat file that the Deacon updates on each patrol cycle.
@@ -1523,16 +1544,32 @@ func (d *Daemon) deaconGracePeriod() time.Duration {
 // - Grace period only applies if heartbeat is from BEFORE we started Deacon
 // - If heartbeat is from AFTER start but stale, Deacon is stuck
 func (d *Daemon) checkDeaconHeartbeat() {
+	// Always read heartbeat first (PATCH-005)
+	hb := deacon.ReadHeartbeat(d.config.TownRoot)
+
 	// Respect crash-loop guard: if the restart tracker says Deacon is in a
 	// crash loop, do not kill the session — the guard is deliberately holding
 	// off restarts to break the cycle. (Fixes #2086)
+	//
+	// The guard is not a life sentence (op-r9fx). A fresh heartbeat means the
+	// Deacon is alive and patrolling (e.g. it was revived manually), so record
+	// success: once the tracker's StabilityPeriod has passed since the last
+	// restart attempt, that clears the crash-loop state and normal heartbeat
+	// supervision resumes. A Deacon that stays dead is covered by the
+	// tracker's CrashLoopExpiry instead.
 	if d.restartTracker != nil && d.restartTracker.IsInCrashLoop("deacon") {
-		d.logger.Printf("Deacon is in crash-loop state, skipping heartbeat kill check")
-		return
+		if hb != nil && hb.IsFresh() {
+			d.restartTracker.RecordSuccess("deacon")
+		}
+		if d.restartTracker.IsInCrashLoop("deacon") {
+			d.logDeaconCrashLoopTransition(true)
+			return
+		}
+		if err := d.restartTracker.Save(); err != nil {
+			d.logger.Printf("Warning: failed to save restart state: %v", err)
+		}
 	}
-
-	// Always read heartbeat first (PATCH-005)
-	hb := deacon.ReadHeartbeat(d.config.TownRoot)
+	d.logDeaconCrashLoopTransition(false)
 
 	sessionName := d.getDeaconSessionName()
 

--- a/internal/daemon/deacon_crashloop_guard_test.go
+++ b/internal/daemon/deacon_crashloop_guard_test.go
@@ -107,3 +107,110 @@ func TestCheckDeaconHeartbeat_RespectsCrashLoopGuard(t *testing.T) {
 		t.Fatalf("kill-session count = %d, want 0 while crash-loop guard is active", kills)
 	}
 }
+
+// Regression test for op-r9fx: a fresh heartbeat while in crash-loop state
+// means the Deacon recovered (e.g. it was revived manually). Once the
+// stability period has passed since the last restart attempt, the flag must
+// clear and be persisted — before this fix the guard blocked the only code
+// path that could ever clear it, so the flag was permanent (6 weeks live).
+func TestCheckDeaconHeartbeat_ClearsCrashLoopOnFreshHeartbeat(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "daemon"), 0o755); err != nil {
+		t.Fatalf("mkdir daemon dir: %v", err)
+	}
+
+	// Fresh heartbeat: the Deacon is alive and patrolling.
+	if err := deacon.WriteHeartbeat(townRoot, &deacon.Heartbeat{
+		Timestamp: time.Now(),
+		Cycle:     42,
+	}); err != nil {
+		t.Fatalf("write heartbeat: %v", err)
+	}
+
+	// Crash loop entered 45m ago (still within the 1h expiry), last restart
+	// attempt 45m ago (past the 30m stability period).
+	rt := NewRestartTracker(townRoot, RestartTrackerConfig{})
+	rt.state.Agents["deacon"] = &AgentRestartInfo{
+		LastRestart:    time.Now().Add(-45 * time.Minute),
+		RestartCount:   5,
+		CrashLoopSince: time.Now().Add(-45 * time.Minute),
+	}
+
+	d := &Daemon{
+		config:         &Config{TownRoot: townRoot},
+		logger:         log.New(io.Discard, "", 0),
+		tmux:           tmux.NewTmux(),
+		restartTracker: rt,
+	}
+
+	d.checkDeaconHeartbeat()
+
+	if rt.IsInCrashLoop("deacon") {
+		t.Fatal("crash-loop state not cleared despite fresh heartbeat past stability period")
+	}
+
+	// The clear must be persisted so a daemon restart doesn't resurrect it.
+	reloaded := NewRestartTracker(townRoot, RestartTrackerConfig{})
+	if err := reloaded.Load(); err != nil {
+		t.Fatalf("reload restart state: %v", err)
+	}
+	if reloaded.IsInCrashLoop("deacon") {
+		t.Fatal("cleared crash-loop state was not persisted to disk")
+	}
+}
+
+// Regression test for op-r9fx: the crash-loop guard must log state
+// transitions, not one line per heartbeat cycle (16k+ spam lines over six
+// weeks of "Deacon is in crash-loop state, skipping heartbeat kill check").
+func TestCheckDeaconHeartbeat_LogsCrashLoopOncePerTransition(t *testing.T) {
+	townRoot := t.TempDir()
+
+	// Stale heartbeat: the Deacon is down, so the guard stays active.
+	if err := deacon.WriteHeartbeat(townRoot, &deacon.Heartbeat{
+		Timestamp: time.Now().Add(-20 * time.Minute),
+		Cycle:     1,
+	}); err != nil {
+		t.Fatalf("write heartbeat: %v", err)
+	}
+
+	rt := NewRestartTracker(townRoot, RestartTrackerConfig{})
+	rt.state.Agents["deacon"] = &AgentRestartInfo{
+		LastRestart:    time.Now().Add(-5 * time.Minute),
+		RestartCount:   5,
+		CrashLoopSince: time.Now().Add(-5 * time.Minute),
+	}
+
+	var buf strings.Builder
+	d := &Daemon{
+		config:         &Config{TownRoot: townRoot},
+		logger:         log.New(&buf, "", 0),
+		tmux:           tmux.NewTmux(),
+		restartTracker: rt,
+	}
+
+	for i := 0; i < 3; i++ {
+		d.checkDeaconHeartbeat()
+	}
+
+	logged := strings.Count(buf.String(), "entered crash-loop state")
+	if logged != 1 {
+		t.Fatalf("crash-loop guard logged %d times over 3 cycles, want exactly 1 (transition only):\n%s", logged, buf.String())
+	}
+
+	// Clear the flag (fresh heartbeat keeps the post-guard path away from
+	// tmux); the next cycle must log the cleared transition exactly once.
+	rt.ClearCrashLoop("deacon")
+	if err := deacon.WriteHeartbeat(townRoot, &deacon.Heartbeat{
+		Timestamp: time.Now(),
+		Cycle:     2,
+	}); err != nil {
+		t.Fatalf("write fresh heartbeat: %v", err)
+	}
+	d.checkDeaconHeartbeat()
+	d.checkDeaconHeartbeat()
+
+	cleared := strings.Count(buf.String(), "crash-loop state cleared")
+	if cleared != 1 {
+		t.Fatalf("crash-loop clear logged %d times, want exactly 1 (transition only):\n%s", cleared, buf.String())
+	}
+}

--- a/internal/daemon/restart_tracker.go
+++ b/internal/daemon/restart_tracker.go
@@ -27,6 +27,15 @@ type RestartTrackerConfig struct {
 	// CrashLoopCount is how many restarts within the window trigger crash-loop state (default 5).
 	CrashLoopCount int `json:"crash_loop_count,omitempty"`
 
+	// CrashLoopExpiry is how long crash-loop state holds before the daemon is
+	// allowed to attempt restarts again (default 1h). Crash-loop state must
+	// decay: while it is set the daemon performs no restarts, so RecordRestart's
+	// stability reset can never fire, and without an expiry the flag is
+	// permanent — the deacon heartbeat kill check stayed disabled for six weeks
+	// on a stale flag (op-r9fx). One retry per expiry period is cheap; a truly
+	// still-broken agent re-enters crash loop after CrashLoopCount failures.
+	CrashLoopExpiry time.Duration `json:"crash_loop_expiry,omitempty"`
+
 	// StabilityPeriod is how long an agent must run without restarting
 	// before its backoff resets (default 30m).
 	StabilityPeriod time.Duration `json:"stability_period,omitempty"`
@@ -48,6 +57,7 @@ func DefaultRestartTrackerConfig() RestartTrackerConfig {
 		BackoffMultiplier: 2.0,
 		CrashLoopWindow:   15 * time.Minute,
 		CrashLoopCount:    5,
+		CrashLoopExpiry:   time.Hour,
 		StabilityPeriod:   30 * time.Minute,
 		PauseBackoff:      60 * time.Second,
 	}
@@ -70,6 +80,9 @@ func (c RestartTrackerConfig) withDefaults() RestartTrackerConfig {
 	}
 	if c.CrashLoopCount <= 0 {
 		c.CrashLoopCount = d.CrashLoopCount
+	}
+	if c.CrashLoopExpiry <= 0 {
+		c.CrashLoopExpiry = d.CrashLoopExpiry
 	}
 	if c.StabilityPeriod <= 0 {
 		c.StabilityPeriod = d.StabilityPeriod
@@ -157,7 +170,7 @@ func (rt *RestartTracker) CanRestart(agentID string) bool {
 	}
 
 	// Check if in crash loop
-	if !info.CrashLoopSince.IsZero() {
+	if rt.crashLoopActive(info) {
 		return false
 	}
 
@@ -249,6 +262,7 @@ func (rt *RestartTracker) RecordSuccess(agentID string) {
 }
 
 // IsInCrashLoop returns true if the agent is detected as crash-looping.
+// Crash-loop state expires after CrashLoopExpiry (see crashLoopActive).
 func (rt *RestartTracker) IsInCrashLoop(agentID string) bool {
 	rt.mu.RLock()
 	defer rt.mu.RUnlock()
@@ -257,7 +271,18 @@ func (rt *RestartTracker) IsInCrashLoop(agentID string) bool {
 	if !exists {
 		return false
 	}
-	return !info.CrashLoopSince.IsZero()
+	return rt.crashLoopActive(info)
+}
+
+// crashLoopActive reports whether info's crash-loop state is set and has not
+// yet expired. Expiry is evaluated lazily on read; the stale CrashLoopSince
+// field itself is cleaned up by RecordRestart's stability reset on the next
+// restart attempt. Callers must hold rt.mu.
+func (rt *RestartTracker) crashLoopActive(info *AgentRestartInfo) bool {
+	if info.CrashLoopSince.IsZero() {
+		return false
+	}
+	return time.Since(info.CrashLoopSince) < rt.config.CrashLoopExpiry
 }
 
 // GetBackoffRemaining returns how long until the agent can be restarted.

--- a/internal/daemon/restart_tracker_test.go
+++ b/internal/daemon/restart_tracker_test.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+// op-r9fx: crash-loop state must decay. While the flag is set the daemon
+// performs no restarts, so RecordRestart's stability reset can never fire —
+// without an expiry the flag is permanent and heartbeat supervision stays
+// disabled forever (observed: 6 weeks on a stale deacon flag).
+
+func TestDefaultConfig_HasCrashLoopExpiry(t *testing.T) {
+	cfg := DefaultRestartTrackerConfig()
+	if cfg.CrashLoopExpiry != time.Hour {
+		t.Fatalf("CrashLoopExpiry = %v, want 1h", cfg.CrashLoopExpiry)
+	}
+
+	filled := RestartTrackerConfig{}.withDefaults()
+	if filled.CrashLoopExpiry != time.Hour {
+		t.Fatalf("withDefaults CrashLoopExpiry = %v, want 1h", filled.CrashLoopExpiry)
+	}
+}
+
+func TestIsInCrashLoop_ActiveBeforeExpiry(t *testing.T) {
+	rt := NewRestartTracker(t.TempDir(), RestartTrackerConfig{})
+	rt.state.Agents["deacon"] = &AgentRestartInfo{
+		LastRestart:    time.Now().Add(-5 * time.Minute),
+		RestartCount:   5,
+		CrashLoopSince: time.Now().Add(-5 * time.Minute),
+	}
+
+	if !rt.IsInCrashLoop("deacon") {
+		t.Fatal("IsInCrashLoop = false for 5-minute-old crash loop, want true")
+	}
+	if rt.CanRestart("deacon") {
+		t.Fatal("CanRestart = true during active crash loop, want false")
+	}
+}
+
+func TestIsInCrashLoop_ExpiresAfterCrashLoopExpiry(t *testing.T) {
+	rt := NewRestartTracker(t.TempDir(), RestartTrackerConfig{})
+	rt.state.Agents["deacon"] = &AgentRestartInfo{
+		LastRestart:    time.Now().Add(-2 * time.Hour),
+		RestartCount:   5,
+		CrashLoopSince: time.Now().Add(-2 * time.Hour),
+	}
+
+	if rt.IsInCrashLoop("deacon") {
+		t.Fatal("IsInCrashLoop = true for 2-hour-old crash loop, want expired (false)")
+	}
+	if !rt.CanRestart("deacon") {
+		t.Fatal("CanRestart = false after crash-loop expiry, want true")
+	}
+}
+
+func TestRecordRestart_ResetsBudgetAfterExpiredCrashLoop(t *testing.T) {
+	rt := NewRestartTracker(t.TempDir(), RestartTrackerConfig{})
+	rt.state.Agents["deacon"] = &AgentRestartInfo{
+		LastRestart:    time.Now().Add(-2 * time.Hour),
+		RestartCount:   5,
+		CrashLoopSince: time.Now().Add(-2 * time.Hour),
+	}
+
+	rt.RecordRestart("deacon")
+
+	info := rt.state.Agents["deacon"]
+	if info.RestartCount != 1 {
+		t.Fatalf("RestartCount after restart post-expiry = %d, want 1 (stability reset)", info.RestartCount)
+	}
+	if !info.CrashLoopSince.IsZero() {
+		t.Fatalf("CrashLoopSince not cleared by stability reset: %v", info.CrashLoopSince)
+	}
+	if rt.IsInCrashLoop("deacon") {
+		t.Fatal("IsInCrashLoop = true after post-expiry restart, want false")
+	}
+}


### PR DESCRIPTION
## Problem

`~/gt/daemon/daemon.log` has **16,388** `Deacon is in crash-loop state, skipping heartbeat kill check` lines — first on **2026-05-26 02:56**, still emitting on **2026-07-10**. A crash-loop flag set six weeks ago never cleared, so the daemon permanently skipped the deacon heartbeat kill/restart check. The deacon's only recovery path has been a manual mayor nudge (observed 3× on 2026-07-10 alone, compounded by the swallowed-Enter bug in #4461 / op-03ke).

**Root cause — the guard blocks every path that could clear it:**

1. `RecordRestart` sets `CrashLoopSince` after 5 restarts in 15m.
2. `ensureDeaconRunning` early-returns on `IsInCrashLoop`, so it never reaches `mgr.Start` → never hits the `ErrAlreadyRunning` → `RecordSuccess` path — **the only automatic clear**. Even with the deacon manually revived and heartbeating for weeks, the flag can't clear.
3. The other clear (`RecordRestart`'s stability reset) requires a restart — the very thing the guard suppresses.
4. `checkDeaconHeartbeat` early-returns too, spamming the skip line every 3-minute heartbeat cycle, forever.

## Fix

- **`CrashLoopExpiry`** (new `RestartTracker` config, default **1h**, configurable via `patrols.restart_tracker.crash_loop_expiry` in daemon.json): crash-loop state now decays. `IsInCrashLoop`/`CanRestart` treat an expired flag as inactive, allowing one restart attempt per expiry period; a still-broken agent re-enters crash loop after `CrashLoopCount` failures. `RecordRestart`'s existing stability reset cleans the stale field and restores the full retry budget.
- **Healthy-heartbeat clear** in `checkDeaconHeartbeat`: a fresh heartbeat while crash-looped means the deacon recovered (e.g. manual revive) — record success, which clears the flag once `StabilityPeriod` (30m) has passed since the last restart attempt, persist it, and resume normal supervision.
- **Transition logging**: `entered crash-loop state` / `crash-loop state cleared` logged exactly once per transition instead of one skip line per cycle.
- **One-time remediation is implicit**: the live flag (`crash_loop_since` = 2026-05-26) is long past expiry, so the first heartbeat after deploy resumes supervision and the first successful check/restart scrubs the stale state. (`gt daemon clear-backoff deacon` remains the manual override.)

## Tests

- `TestCheckDeaconHeartbeat_ClearsCrashLoopOnFreshHeartbeat` — fresh heartbeat + stability elapsed → flag cleared **and persisted**.
- `TestCheckDeaconHeartbeat_LogsCrashLoopOncePerTransition` — 3 guarded cycles log once; clearing logs once.
- `restart_tracker_test.go` — expiry active/expired behavior, default config, post-expiry restart resets the budget.
- Existing regression guard `TestCheckDeaconHeartbeat_RespectsCrashLoopGuard` (#2086, gt-d61) still passes: an *active* (unexpired, unhealthy) crash loop still suppresses kills.
- `go build ./...`, `go vet ./internal/daemon`, full `internal/daemon` suite pass locally.

## Deploy note

**Do not deploy / `make install` from this PR** — deploy is a separate mayor/Blair-gated step per op-r9fx.

Refs: openclaw op-r9fx

🤖 Generated with [Claude Code](https://claude.com/claude-code)
