### PR TITLE
fix(patrol): stamp deacon heartbeat on patrol report + inline full step bodies into root-only patrol wisps

### DIFF
--- a/internal/cmd/heartbeat.go
+++ b/internal/cmd/heartbeat.go
@@ -93,9 +93,13 @@ func syncDeaconHeartbeatStores(townRoot, action string) error {
 	} else {
 		err = deacon.Touch(townRoot)
 	}
-	syncDeaconAgentBeadHeartbeat(townRoot)
+	deaconAgentBeadHeartbeatSync(townRoot)
 	return err
 }
+
+// deaconAgentBeadHeartbeatSync is swappable in tests: the agent-bead label
+// refresh shells out to bd (Dolt), which unit tests must not touch.
+var deaconAgentBeadHeartbeatSync = syncDeaconAgentBeadHeartbeat
 
 // syncDeaconAgentBeadHeartbeat refreshes the heartbeat:EPOCH label on the
 // Deacon's agent bead — the third heartbeat store, read by Witness

--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/cli"
+	"github.com/steveyegge/gastown/internal/formula"
 	"github.com/steveyegge/gastown/internal/refinery"
 	"github.com/steveyegge/gastown/internal/style"
 	"golang.org/x/text/cases"
@@ -290,8 +291,16 @@ func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
 		return "", fmt.Errorf("created wisp but could not parse ID from output")
 	}
 
-	// Hook the wisp to the agent so gt mol status sees it
-	if err := BdCmd("update", patrolID, "--status=hooked", "--assignee="+cfg.Assignee).
+	// Hook the wisp to the agent so gt mol status sees it. Root-only wisps
+	// carry no step children, so inline the full step bodies into the root
+	// description in the same update — otherwise per-step instructions
+	// (including the Deacon's mandatory heartbeat command) never reach the
+	// executing session (hq-eofrg).
+	updateArgs := []string{"update", patrolID, "--status=hooked", "--assignee=" + cfg.Assignee}
+	if desc := renderPatrolWispDescription(cfg); desc != "" {
+		updateArgs = append(updateArgs, "--description="+desc)
+	}
+	if err := BdCmd(updateArgs...).
 		WithAutoCommit().
 		WithBeadsDir(resolvedBeadsDir).
 		Dir(cfg.BeadsDir).
@@ -300,6 +309,45 @@ func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
 	}
 
 	return patrolID, nil
+}
+
+// patrolRigName extracts the rig name from a patrol assignee.
+// Rig-scoped assignees look like "<rig>/witness"; town-level assignees
+// (e.g. the Deacon's "deacon") have no rig and return "".
+func patrolRigName(cfg PatrolConfig) string {
+	if i := strings.IndexByte(cfg.Assignee, '/'); i > 0 {
+		return cfg.Assignee[:i]
+	}
+	return ""
+}
+
+// renderPatrolWispDescription builds a self-contained description for a
+// root-only patrol wisp: the formula's root description followed by the full
+// body of every step, with vars substituted. Patrol wisps have no step
+// children, so the root description is the only place the executing session
+// can read per-step instructions from the DB (hq-eofrg).
+// Returns "" on any formula load/parse failure so the caller keeps the
+// default description written at wisp creation.
+func renderPatrolWispDescription(cfg PatrolConfig) string {
+	rig := patrolRigName(cfg)
+	content, err := formula.ResolveFormulaContent(cfg.PatrolMolName, cfg.BeadsDir, rig)
+	if err != nil {
+		return ""
+	}
+	f, err := formula.Parse(content)
+	if err != nil {
+		return ""
+	}
+	steps, err := renderFormulaStepsFull(cfg.PatrolMolName, cfg.BeadsDir, rig, cfg.ExtraVars)
+	if err != nil || steps == "" {
+		return ""
+	}
+	varMap := buildFormulaVarMap(f, cfg.ExtraVars)
+	root := strings.TrimSpace(applyFormulaVars(f.Description, varMap))
+	if root == "" {
+		return strings.TrimSpace(steps)
+	}
+	return root + "\n" + steps
 }
 
 // outputPatrolContext is the main function that handles patrol display logic.

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -1093,3 +1093,80 @@ func TestBurnPreviousPatrolWisps_IgnoresOtherBeads(t *testing.T) {
 		t.Errorf("non-patrol bead status = %q, want %q (should not be burned)", otherIssue.Status, beads.StatusHooked)
 	}
 }
+
+func TestPatrolRigName(t *testing.T) {
+	tests := []struct {
+		assignee string
+		want     string
+	}{
+		{"deacon", ""},
+		{"openclaw/witness", "openclaw"},
+		{"gastown/refinery", "gastown"},
+		{"/witness", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := patrolRigName(PatrolConfig{Assignee: tt.assignee})
+		if got != tt.want {
+			t.Errorf("patrolRigName(%q) = %q, want %q", tt.assignee, got, tt.want)
+		}
+	}
+}
+
+func TestRenderPatrolWispDescription_DeaconInlinesStepBodies(t *testing.T) {
+	cfg := PatrolConfig{
+		RoleName:      "deacon",
+		PatrolMolName: constants.MolDeaconPatrol,
+		BeadsDir:      t.TempDir(), // no town overlays — resolves to embedded formula
+		Assignee:      "deacon",
+	}
+
+	desc := renderPatrolWispDescription(cfg)
+	if desc == "" {
+		t.Fatal("renderPatrolWispDescription returned empty for mol-deacon-patrol")
+	}
+
+	// Formula root description must be preserved.
+	if !strings.Contains(desc, "Idle Town Principle") {
+		t.Error("root formula description missing from wisp description")
+	}
+	// Full step bodies must be inlined — in particular the mandatory
+	// heartbeat command whose omission gets the Deacon killed by the daemon.
+	if !strings.Contains(desc, "gt deacon heartbeat") {
+		t.Error("mandatory heartbeat command missing from wisp description")
+	}
+	if !strings.Contains(desc, "Refresh heartbeat") {
+		t.Error("heartbeat step title missing from wisp description")
+	}
+	// Var placeholders must be substituted with defaults.
+	if strings.Contains(desc, "{{idle_effort_threshold}}") {
+		t.Error("unsubstituted {{idle_effort_threshold}} placeholder in wisp description")
+	}
+}
+
+func TestRenderPatrolWispDescription_ExtraVarsOverrideDefaults(t *testing.T) {
+	cfg := PatrolConfig{
+		RoleName:      "deacon",
+		PatrolMolName: constants.MolDeaconPatrol,
+		BeadsDir:      t.TempDir(),
+		Assignee:      "deacon",
+		ExtraVars:     []string{"idle_effort_threshold=7"},
+	}
+
+	desc := renderPatrolWispDescription(cfg)
+	if !strings.Contains(desc, "idle_cycles >= 7") {
+		t.Error("ExtraVars override not substituted into wisp description")
+	}
+}
+
+func TestRenderPatrolWispDescription_UnknownFormula(t *testing.T) {
+	cfg := PatrolConfig{
+		RoleName:      "deacon",
+		PatrolMolName: "mol-does-not-exist",
+		BeadsDir:      t.TempDir(),
+		Assignee:      "deacon",
+	}
+	if got := renderPatrolWispDescription(cfg); got != "" {
+		t.Errorf("expected empty description for unknown formula, got %d bytes", len(got))
+	}
+}

--- a/internal/cmd/patrol_report.go
+++ b/internal/cmd/patrol_report.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/deacon"
 	"github.com/steveyegge/gastown/internal/formula"
 	"github.com/steveyegge/gastown/internal/style"
 )
@@ -122,6 +123,14 @@ func runPatrolReport(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("%s Closed patrol %s\n", style.Success.Render("✓"), patrolID)
 
+	// A successful patrol report from the Deacon is proof-of-life by
+	// construction: only a live session can close its patrol cycle. Stamp the
+	// heartbeat stores so the daemon doesn't kill a healthy Deacon whose
+	// session skipped the explicit `gt deacon heartbeat` step (hq-eofrg).
+	if roleInfo.Role == RoleDeacon {
+		stampDeaconHeartbeatOnReport(roleInfo.TownRoot, patrolReportSummary)
+	}
+
 	// Start next cycle
 	newPatrolID, err := autoSpawnPatrol(cfg)
 	if err != nil {
@@ -135,6 +144,20 @@ func runPatrolReport(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("%s Started new patrol: %s\n", style.Success.Render("✓"), newPatrolID)
 	return nil
+}
+
+// stampDeaconHeartbeatOnReport records Deacon proof-of-life after a successful
+// patrol report, using the same store-sync path as `gt deacon heartbeat`.
+// A paused Deacon must not refresh its heartbeat (matching runDeaconHeartbeat).
+// Best-effort: a stamp failure must not fail the report.
+func stampDeaconHeartbeatOnReport(townRoot, summary string) {
+	paused, _, err := deacon.IsPaused(townRoot)
+	if err == nil && paused {
+		return
+	}
+	if err := syncDeaconHeartbeatStores(townRoot, "patrol report: "+summary); err != nil {
+		style.PrintWarning("could not stamp deacon heartbeat: %v", err)
+	}
 }
 
 // buildStepAudit builds a step checklist from the formula's steps and the

--- a/internal/cmd/patrol_report_heartbeat_test.go
+++ b/internal/cmd/patrol_report_heartbeat_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/deacon"
+)
+
+// stubBeadSync replaces the agent-bead heartbeat sync (which shells out to bd)
+// for the duration of a test and reports whether it was invoked.
+func stubBeadSync(t *testing.T) *bool {
+	t.Helper()
+	called := false
+	orig := deaconAgentBeadHeartbeatSync
+	deaconAgentBeadHeartbeatSync = func(string) { called = true }
+	t.Cleanup(func() { deaconAgentBeadHeartbeatSync = orig })
+	return &called
+}
+
+func TestStampDeaconHeartbeatOnReport_StampsAllStores(t *testing.T) {
+	townRoot := t.TempDir()
+	synced := stubBeadSync(t)
+
+	stampDeaconHeartbeatOnReport(townRoot, "all clear")
+
+	hb := deacon.ReadHeartbeat(townRoot)
+	if hb == nil {
+		t.Fatal("heartbeat.json not written after successful patrol report")
+	}
+	if !hb.IsFresh() {
+		t.Errorf("heartbeat not fresh: timestamp %v", hb.Timestamp)
+	}
+	if want := "patrol report: all clear"; hb.LastAction != want {
+		t.Errorf("LastAction = %q, want %q", hb.LastAction, want)
+	}
+
+	legacy := filepath.Join(townRoot, "deacon", ".deacon-heartbeat")
+	if _, err := os.Stat(legacy); err != nil {
+		t.Errorf("legacy .deacon-heartbeat not touched: %v", err)
+	}
+	if !*synced {
+		t.Error("agent-bead heartbeat sync not invoked")
+	}
+}
+
+func TestStampDeaconHeartbeatOnReport_SkipsWhenPaused(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := deacon.Pause(townRoot, "test pause", "test"); err != nil {
+		t.Fatalf("pausing deacon: %v", err)
+	}
+	synced := stubBeadSync(t)
+
+	stampDeaconHeartbeatOnReport(townRoot, "all clear")
+
+	if deacon.ReadHeartbeat(townRoot) != nil {
+		t.Error("heartbeat written while Deacon is paused")
+	}
+	if *synced {
+		t.Error("agent-bead heartbeat sync must not run while paused")
+	}
+}

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -338,7 +338,11 @@ func outputDeaconPatrolContext(ctx RoleContext) {
 		},
 	}
 	outputPatrolContext(cfg)
-	showFormulaSteps(constants.MolDeaconPatrol, "Patrol Steps", ctx.TownRoot, ctx.Rig)
+	// Full step bodies, not truncated one-liners: the heartbeat step's
+	// mandatory `gt deacon heartbeat` command lives in the body, and the
+	// daemon kills a Deacon whose heartbeat goes stale. Truncated rendering
+	// meant the command never reached the executing session (hq-eofrg).
+	showFormulaStepsFull(constants.MolDeaconPatrol, ctx.TownRoot, ctx.Rig)
 }
 
 // outputWitnessPatrolContext shows patrol molecule status for the Witness.


### PR DESCRIPTION
## Summary

Fixes three linked defects observed in production (a Deacon's `heartbeat.json` went stale for 80 minutes across 11 healthy patrol cycles, and the daemon's staleness watchdog nearly killed a healthy Deacon):

1. **`gt patrol report` now stamps the deacon heartbeat on success.** A successful report is proof-of-life by construction. After the patrol root closes, the deacon role stamps `deacon/heartbeat.json` + `.deacon-heartbeat` + the agent-bead label via the same store-sync path as `gt deacon heartbeat` (`syncDeaconHeartbeatStores`). Skipped when paused (matching `runDeaconHeartbeat` semantics); best-effort, never fails the report.

2. **`gt patrol new` root-only wisps are now self-describing.** The wisp cook is root-only by design ("steps are read inline at prime time"), but the per-step instructions — including the mandatory `gt deacon heartbeat` command whose omission gets the Deacon killed by the daemon — never reached the executing session: the wisp description carried only the formula root text, and `gt mol progress` errors on child-less roots. `autoSpawnPatrol` now inlines the formula root description + full step bodies (vars substituted, overlays applied) into the root wisp description, in the same `bd update` call that hooks the wisp (no extra Dolt commit). Applies to all patrol roles (deacon/witness/refinery).

3. **Deacon prime renders full step bodies.** `outputDeaconPatrolContext` used `showFormulaSteps` (120-char truncated one-liners), which dropped the heartbeat command from the step body. Now uses `showFormulaStepsFull`, matching the refinery path.

## Tests

- `TestStampDeaconHeartbeatOnReport_StampsAllStores` / `_SkipsWhenPaused` — file stores written with the report action, legacy file touched, bead sync invoked; paused Deacon skips entirely (bead-label sync stubbed via a package var: it shells out to bd).
- `TestRenderPatrolWispDescription_*` — root text preserved, step bodies + heartbeat command inlined, `{{vars}}` substituted, ExtraVars override defaults, unknown formula falls back to empty (keeps bd's default description).
- `TestPatrolRigName` — rig extraction from assignee.

`go build ./...`, `go vet`, and targeted tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)