### PR TITLE
fix(memories): tolerate non-string bd kv values

### DIFF
--- a/internal/cmd/remember.go
+++ b/internal/cmd/remember.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -215,7 +216,7 @@ func bdKvClear(key string) error {
 	return cmd.Run()
 }
 
-// parseBdKvListJSON parses bd kv list --json output, keeping only string values.
+// parseBdKvListJSON parses bd kv list --json output into displayable string values.
 func parseBdKvListJSON(data []byte) (map[string]string, error) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -225,10 +226,23 @@ func parseBdKvListJSON(data []byte) (map[string]string, error) {
 	kvs := make(map[string]string, len(raw))
 	for k, v := range raw {
 		var s *string
-		if err := json.Unmarshal(v, &s); err != nil || s == nil {
+		if err := json.Unmarshal(v, &s); err == nil {
+			if s != nil {
+				kvs[k] = *s
+			}
 			continue
 		}
-		kvs[k] = *s
+
+		if !strings.HasPrefix(k, memoryKeyPrefix) {
+			continue
+		}
+
+		// Keep non-string memory values visible without promoting bd metadata.
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, v); err != nil {
+			continue
+		}
+		kvs[k] = compact.String()
 	}
 	return kvs, nil
 }

--- a/internal/cmd/remember_test.go
+++ b/internal/cmd/remember_test.go
@@ -195,7 +195,12 @@ func TestParseBdKvListJSON(t *testing.T) {
 	got, err := parseBdKvListJSON([]byte(`{
 		"memory.project.note":"keep me",
 		"memory.project.empty":"",
+		"memory.project.count":12,
+		"memory.project.enabled":true,
+		"memory.project.tags":["one"],
+		"memory.project.config":{"nested":"value"},
 		"schema_version":1,
+		"other":"keep string kvs",
 		"enabled":true,
 		"tags":["one"],
 		"config":{"nested":"value"},
@@ -206,8 +211,13 @@ func TestParseBdKvListJSON(t *testing.T) {
 	}
 
 	want := map[string]string{
-		"memory.project.note":  "keep me",
-		"memory.project.empty": "",
+		"memory.project.note":    "keep me",
+		"memory.project.empty":   "",
+		"memory.project.count":   "12",
+		"memory.project.enabled": "true",
+		"memory.project.tags":    `["one"]`,
+		"memory.project.config":  `{"nested":"value"}`,
+		"other":                  "keep string kvs",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("parseBdKvListJSON() returned %d entries, want %d: %#v", len(got), len(want), got)
@@ -219,6 +229,11 @@ func TestParseBdKvListJSON(t *testing.T) {
 	}
 	if _, ok := got["memory.project.null"]; ok {
 		t.Error("parseBdKvListJSON() kept null memory value")
+	}
+	for _, k := range []string{"schema_version", "enabled", "tags", "config"} {
+		if _, ok := got[k]; ok {
+			t.Errorf("parseBdKvListJSON() kept non-memory non-string value for %q", k)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes `gt memories` failing when `bd kv list` returns non-string JSON values.

Bead: `gt-memories-nonstring-values`
Branch: `polecat/dust/gt-memories-nonstring-values+761afe`
Final head: `431e9a8fd0d6baf8db4a5223663d6a3612aee4ea`

Implementation notes:
- Parses mixed JSON value types without corrupting or hiding valid memory data.
- Keeps the fix focused on memory parsing behavior; no compatibility shim or workaround layer.
- Mandatory workflow recorded in the bead: 15 research legs, 5 pre-implementation reviews, and 5 post-implementation reviews.

Verification recorded by the worker on the final branch:
- `CGO_ENABLED=0 go test ./internal/cmd -run 'Test(ParseBdKvListJSON|ParseMemoryKey|MemTypeRank|RunPrimeExternalTools)' -count=1`\n- `CGO_ENABLED=0 go test ./cmd/gt -run '^$' -count=1`\n- `CGO_ENABLED=0 go run ./cmd/gt memories --type feedback`\n- `git diff --check upstream/main...HEAD`\n\nReady for PR Sheriff review; not claiming merge readiness until PR Sheriff evidence gates pass.