### PR TITLE
refactor(tmux): centralize busy indicators

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3040,6 +3040,10 @@ func hasBusyIndicator(line string) bool {
 		return false
 	}
 	for _, marker := range busyIndicators {
+		marker = strings.TrimSpace(marker)
+		if marker == "" {
+			continue
+		}
 		if strings.Contains(trimmed, marker) {
 			return true
 		}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3016,12 +3016,35 @@ func matchesPromptPrefix(line, readyPromptPrefix string) bool {
 	return strings.HasPrefix(trimmed, normalizedPrefix) || (prefix != "" && trimmed == prefix)
 }
 
+// busyIndicators is the single source of truth for the substrings an agent TUI
+// renders in its status bar while actively generating. Detection of "is the
+// agent working?" scrapes the pane for any of these (see hasBusyIndicator), and
+// that signal underpins IsIdle, WaitForIdle, and the nudge Escape-suppression in
+// shouldSendEscape. Claude Code, Codex, and Gemini all surface "esc to
+// interrupt"; if an agent uses different wording, add it here — that is the only
+// place that needs to change.
+//
+// FRAGILITY (gastownhall/gastown#4240): this couples to upstream TUI status
+// text. Scraping the status bar cannot detect a silent upstream rename on its
+// own — a truly structural readiness signal would, but none is available across
+// all agents today. Centralizing the markers here keeps any required update to a
+// single reviewable line, and TestBusyIndicators pins the known marker so a
+// change is intentional rather than accidental. The idle side is already
+// centralized via the agent presets' ReadyPromptPrefix; this is its busy-side
+// counterpart.
+var busyIndicators = []string{"esc to interrupt"}
+
 func hasBusyIndicator(line string) bool {
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" {
 		return false
 	}
-	return strings.Contains(trimmed, "esc to interrupt")
+	for _, marker := range busyIndicators {
+		if strings.Contains(trimmed, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // shouldSendEscapeForLines reports whether the vim-mode Escape keystroke

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2268,6 +2268,38 @@ func TestShouldSendEscape_CaptureErrorSuppressesEscape(t *testing.T) {
 	}
 }
 
+// TestBusyIndicators pins the centralized busy-indicator source of truth so a
+// change to the upstream-coupled status string is intentional and reviewed
+// rather than accidental (gastownhall/gastown#4240).
+func TestBusyIndicators(t *testing.T) {
+	t.Parallel()
+
+	if len(busyIndicators) == 0 {
+		t.Fatal("busyIndicators must not be empty — busy/idle detection would silently break")
+	}
+
+	// "esc to interrupt" is the marker Claude Code / Codex / Gemini render while
+	// generating. If this assertion fails, the change must be deliberate.
+	found := false
+	for _, m := range busyIndicators {
+		if m == "esc to interrupt" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("busyIndicators = %q, want it to contain the known \"esc to interrupt\" marker", busyIndicators)
+	}
+
+	// Every marker must be matched by hasBusyIndicator (guards against an empty
+	// or whitespace-only entry slipping in).
+	for _, m := range busyIndicators {
+		if !hasBusyIndicator("⏵⏵ status · " + m) {
+			t.Errorf("hasBusyIndicator did not match a registered busy indicator %q", m)
+		}
+	}
+}
+
 func TestDefaultReadyPromptPrefix(t *testing.T) {
 	t.Parallel()
 	// Verify the constant is set correctly

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2294,6 +2294,9 @@ func TestBusyIndicators(t *testing.T) {
 	// Every marker must be matched by hasBusyIndicator (guards against an empty
 	// or whitespace-only entry slipping in).
 	for _, m := range busyIndicators {
+		if strings.TrimSpace(m) == "" {
+			t.Fatal("busyIndicators must not contain empty or whitespace-only markers")
+		}
 		if !hasBusyIndicator("⏵⏵ status · " + m) {
 			t.Errorf("hasBusyIndicator did not match a registered busy indicator %q", m)
 		}


### PR DESCRIPTION
Replacement for #4244.

Carries forward the accepted contribution from @andrewboldi while avoiding the stale/conflicting original branch.

Original PR: #4244
Original author: Andrew Boldi
Replacement branch: `polecat/mayor/pr-4244-busy-indicators-clean`
Final head: `32cbbc36`

PR Sheriff evidence:
- Source bead: `gt-pr-sheriff-4244`
- Original replacement MR: `gt-wisp-390d`
- Checker: `gt-pr-sheriff-check --evidence /tmp/opencode/pr-sheriff-4244-evidence.json --merge-gate` passed in the worker report.
- Verdict: `merge_replacement`, `merge_path_allowed=true`.
- Research/pre/post gates: 15 research legs, 5 pre-implementation reviews, 5 post-implementation reviews completed.

Clean-branch note:
The worker-submitted fork branch included the two intended commits on top of contaminated fork history. Mayor rebuilt this branch from current `origin/main` and cherry-picked only:
- `882aff80533df0193a517a388f947a44976afa67` from #4244, preserving Andrew Boldi as author.
- `0faef07829b366e47ae5df76448a10be5ba576ba` Sheriff fixup for blank busy indicators.

Verification on rebuilt clean branch:
- `CGO_ENABLED=0 go test ./internal/tmux -run "TestBusyIndicators|TestHasBusyIndicator|TestShouldSendEscapeForLines|TestShouldSendEscape_LivePane|TestShouldSendEscape_CaptureErrorSuppressesEscape" -count=1 -timeout=30s`
- `git diff --check origin/main...HEAD`

Do not close original #4244 until this replacement merges.