### PR TITLE
fix(polecat): require agent-process death before reconcile-killing stale-heartbeat sessions

### DIFF
--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2086,7 +2086,20 @@ func isSessionProcessDead(t *tmux.Tmux, sessionName string, townRoot string) boo
 	if townRoot != "" {
 		stale, exists := IsSessionHeartbeatStale(townRoot, sessionName)
 		if exists {
-			return stale
+			if !stale {
+				return false
+			}
+			// Stale heartbeat alone is not proof of death (hq-rzrdv). Heartbeats
+			// only advance when the agent runs gt/bd commands, so a polecat deep
+			// in a single long tool call (builds, API polls, big file sweeps) goes
+			// stale within SessionHeartbeatStaleThreshold while working normally.
+			// Killing on staleness alone reaped healthy mid-work polecats whenever
+			// a reconcile ran (spawn/nuke). Require the agent process itself to be
+			// gone before declaring the session dead.
+			if t != nil && t.IsAgentAlive(sessionName) {
+				return false
+			}
+			return true
 		}
 		// No heartbeat file — fall through to PID-based check for backward compatibility.
 	}


### PR DESCRIPTION
## Problem

`isSessionProcessDead()` treats a stale session heartbeat as proof of death. Polecat heartbeats only advance when the agent runs gt/bd commands, and `SessionHeartbeatStaleThreshold` is 3 minutes — so a polecat inside a single long tool call (builds, API polls, large file sweeps) goes "stale" while working normally. The next `ReconcilePool` — which runs on any polecat spawn/nuke/allocate — then `KillSessionWithProcesses`es the healthy session mid-work.

Observed as a death cascade: each operator recovery (nuke + re-sling) reconciled the pool and killed the *other* working polecat, whose recovery then killed the next one. Transcripts end abruptly after a tool_result with no error and no feed event.

## Fix

When the heartbeat is stale, additionally require `tmux.IsAgentAlive(session) == false` before declaring the session dead — the same liveness primitive the daemon idle-reaper already uses (GH#3342). Fresh heartbeats still short-circuit as alive; missing heartbeat files still fall through to the legacy PID probe.

Verified in production: a polecat that previously died on every reconcile survived nuke-triggered reconciles and ran a multi-step review bead to completion.

`go vet ./internal/polecat/` clean; package tests pass except `TestManagerAgentLifecycleUsesTownBeadsDir`, which fails identically without this change on the test machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)