### PR TITLE
Add policy-driven lifecycle artifact cleanup

### DIFF
--- a/docs/CLEANUP.md
+++ b/docs/CLEANUP.md
@@ -14,6 +14,18 @@ A comprehensive catalog of all cleanup-related commands in the gastown/beads eco
 | `gt deacon cleanup-orphans` | Kills orphaned Claude subagent processes (no controlling TTY) |
 | `gt deacon zombie-scan` | Finds/kills zombie Claude processes not in active tmux sessions |
 
+## Lifecycle Artifact Cleanup
+
+| Command | What it does |
+|---------|-------------|
+| `gt cleanup artifacts --rig <rig> --scope rig` | Dry-run the merged allowlisted artifact policy |
+| `gt cleanup artifacts ... --apply` | Apply only after explicit MR/runner verification gates |
+| `gt cleanup artifacts --scope dolt --json` | Report protected Dolt bytes and native-maintenance recommendations; never deletes |
+| `gt cleanup disk --top 15` | Read-only report of the largest immediate workspace children |
+
+See [Lifecycle Artifact Cleanup](artifact-cleanup.md) for policy fields, safety
+invariants, the polecat pre-reuse hook, and CI/Dolt retention guidance.
+
 ## Polecat (Agent Sandbox) Cleanup
 
 | Command | What it does |

--- a/docs/artifact-cleanup.md
+++ b/docs/artifact-cleanup.md
@@ -1,0 +1,207 @@
+# Lifecycle Artifact Cleanup
+
+Gas Town can account for and remove reproducible build/cache directories without
+treating an entire rig or runner workspace as disposable. The policy is deny by
+default: a manual command is a dry run, automatic cleanup is disabled, and each
+candidate needs an exact relative allowlist rule.
+
+## Commands
+
+```bash
+# Uses the merged town + rig policy. Does not delete anything.
+gt cleanup artifacts --rig bridge_town_core --scope rig --json
+
+# Manual mutation needs an explicit apply flag and MR verification.
+gt cleanup artifacts --rig bridge_town_core --scope rig \
+  --verify-no-active-mr --apply
+
+# A CI maintenance dry run. Paths may be supplied while evaluating a policy.
+gt cleanup artifacts --scope ci \
+  --path 'work/*/.pnpm-store' --path 'shared/trivy-cache' --json
+
+# CI apply is host-side only and requires town policy, installed runner hooks,
+# no active job/handoff markers, and the explicit operator verification.
+gt cleanup artifacts --scope ci --verify-runners-idle --apply
+
+# Compact, read-only top-consumer report.
+gt cleanup disk --top 15 --json
+
+# Dolt is accounting/recommendation-only, even if --apply is supplied.
+gt cleanup artifacts --scope dolt --json
+```
+
+`--root` is available for a specific polecat or dry-run fixture but must resolve
+inside the town workspace. Mutating CI maintenance is restricted to the
+canonical `<town>/ci-runner` root, and protected paths remain anchored above a
+narrowed root. Mutating rig cleanup must use its canonical rig worktree;
+mutating polecat cleanup must use a registered polecat worktree top level. It
+cannot select the town root except for the report-only Dolt scope. JSON mode
+writes one JSON document with no styled prose.
+
+## Policy
+
+Town defaults live at `settings/config.json`; rig overrides live at
+`<rig>/settings/config.json`. Rig values replace town scalar/list values when
+present. A rig is the only level allowed to opt business data out of protection.
+
+```json
+{
+  "type": "rig-settings",
+  "version": 1,
+  "lifecycle": {
+    "cleanup": {
+      "enabled": true,
+      "mode": "apply",
+      "paths": [
+        "target",
+        ".next",
+        "coverage",
+        "dist",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+        ".pnpm-store"
+      ],
+      "protected_paths": ["generated/release-evidence"],
+      "max_age": "168h",
+      "max_bytes": 10737418240,
+      "on_polecat_reuse": true,
+      "on_post_merge": false,
+      "on_ci_maintenance": false
+    }
+  }
+}
+```
+
+- `enabled` and `mode=apply` authorize unattended hooks. A manual command still
+  needs `--apply`; manual `--apply` is itself the enable switch.
+- `paths` is the complete relative allowlist. Globs are allowed only below a
+  literal first component, for example `work/*/.pnpm-store`; `*`, `..`, absolute
+  paths, recursive `**`, and root selection are rejected.
+- `max_age` uses the newest descendant modification time, so one recently used
+  file keeps its containing cache. Zero/omitted disables the age threshold.
+- `max_bytes` is the retained high-water mark across eligible candidates. The
+  oldest candidates are selected until eligible bytes fall below it. Zero/omitted
+  disables the size threshold.
+- `protected_paths` adds rig/project protections; it never subtracts built-ins.
+- `allow_protected_paths` is a rig-only second key for deliberate business-data
+  retention. The same path must also appear in `paths`. It may opt in only
+  `data`, `ml/models`, or `seif_ingestion/checkpoints*`. Use this only with a
+  documented backup/retention plan.
+
+The following metadata, secrets, and runner-managed setup roots are permanently
+protected and cannot be overridden: `.git`, `.repo.git`, `.beads`, `.dolt-*`,
+`.env*`, `secrets`, `_actions`, `_temp`, `_work`, and `_tool`.
+Business data is protected by default: `data`, `ml/models`, and
+`seif_ingestion/checkpoints*`. Permanent names are protected even when nested
+inside an allowlisted parent; business/custom protections are anchored at the
+worktree policy root so a generated cache subdirectory merely named `data`
+does not disable cleanup.
+
+## Safety and accounting
+
+Before deletion, the engine requires containment under the canonical root,
+rejects every symlink path component, rejects tracked paths, and (for Git
+worktrees) requires candidates to be Git-ignored. Directory scans fail closed
+on an unreadable entry or Unix filesystem/mount boundary. Permanent metadata or
+secret descendants block deletion of their parent candidate. It refuses
+mutation for dirty/untracked non-ignored work, open or unverified MRs, and
+active or unverified runner jobs. Immediately before mutation it repeats the
+lifecycle and Git checks, verifies candidate identity/content/age, then deletes
+through a confined `os.Root` handle rather than an unrestricted pathname.
+
+Manual worktree cleanup cannot infer authoritative MR state from the absence of
+a marker; `--verify-no-active-mr` records that the operator checked. Likewise,
+CI apply requires `--verify-runners-idle`, and manual polecat apply additionally
+requires `--verify-polecat-idle`. These flags never override a detected active
+marker or dirty worktree.
+
+Every result records `bytes_considered`, `bytes_eligible`, `bytes_freed`, paths
+cleaned or planned, paths skipped with reasons, scope, and hook point. Protected
+Dolt paths contribute to considered bytes but remain ineligible. Byte counts are
+logical-size estimates (not APFS clone or sparse-file physical blocks); partial
+removal is remeasured and marked `apply_incomplete`. A refused or incomplete
+manual apply exits nonzero after emitting its report.
+
+## Lifecycle placement
+
+The first automatic hook is `polecat-pre-reuse`. It runs only after Gas Town's
+canonical reuse decision has established an idle slot, clean Git state, and no
+pending MR. Cleanup happens before the new branch assignment, when previous
+ignored build products are no longer evidence for the completed assignment.
+The decision is re-read before mutation. Hook errors are logged as structured
+accounting and remain non-fatal to dispatch.
+
+The legacy `polecat.target_clean_policy` remains compatible and still controls
+its narrow `target/` cleaner. The generic hook is a sibling and is opt-in.
+
+Post-merge cleanup is intentionally not enabled by this initial hook: merge/CI
+evidence may still be needed immediately after landing. A future post-merge
+caller can use `on_post_merge` only after it proves evidence retention complete.
+
+## CI runner policy
+
+Persistent runner workdirs and shared caches need a job protocol, not a broad
+`rm -rf`:
+
+1. Install start/completion hooks on every selected persistent runner. The
+   Bridge Town runner configuration writes `.ci-job-hooks-installed` and
+   publishes `shared/.ci-active-jobs/<runner>/.job-active` at job start; only
+   the runner-level completion wrapper removes that runner entry after post-job
+   cleanup. The sentinel must contain the exact `mkdir-v1` protocol version.
+   Before acquisition, Gas Town verifies every live runner in the exact Compose
+   project: current environment, canonical start/completion paths, byte-identical
+   executable hook/helper scripts, and exact read-only `scripts` plus writable
+   `shared` and per-runner `work` bind sources. Any uninstrumented or stale
+   runner family blocks maintenance.
+2. Keep `.handoff-active` inside each run-scoped coverage/auth handoff directory
+   until the final consumer removes that directory. Either marker blocks the
+   whole CI cleanup run; a crash intentionally fails closed.
+3. Configure explicit nested allowlists such as `work/*/.pnpm-store` and
+   `shared/trivy-cache`, plus meaningful age/byte thresholds. Runner-managed
+   `_actions`, `_temp`, `_work`, and `_tool` paths are permanently denied:
+   GitHub Runner can mutate them while preparing actions before the configured
+   started-job hook runs, so the hook protocol cannot prove them idle.
+4. Set `lifecycle.cleanup.on_ci_maintenance=true` in town settings. Apply only
+   against `<town>/ci-runner`. A GitHub Actions job self-identifies as active and
+   cannot clean its own persistent workdir. Gas Town generates a cryptographic
+   nonce and uses `docker exec` in one verified runner to invoke
+   `scripts/ci-maintenance-protocol.sh acquire <nonce>`; it proceeds only after
+   the helper returns the exact nonce attestation. Job start, completion, and
+   maintenance all serialize through the runner-side `.ci-protocol-mutex`
+   atomic-mkdir protocol. The helper refuses acquisition while
+   `.ci-active-jobs` has any child or any `.handoff-active` exists, then publishes
+   `.maintenance-active`. This keeps the race decision in one Linux container
+   filesystem domain instead of relying on macOS-to-Docker advisory-lock or
+   visibility semantics. Gas Town re-verifies the complete live runner set before
+   each deletion and surfaces release failures.
+5. Run package-native pruning first (`pnpm store prune`, Trivy scan-cache clean,
+   and BuildKit cache pruning on a dedicated CI builder). Reclaim runner-managed
+   setup/checkouts only through a separately cordoned runner recreation process,
+   never through artifact-path deletion.
+
+Runner container writable layers should be made reproducible and recreated on
+a maintenance cadence; they are not host-path artifact candidates. Docker
+maintenance must select only CI-labelled containers/images/builders, refuse
+running jobs, omit `docker volume prune -a`, and use Docker/BuildKit native
+prune filters and byte caps. Application images and named volumes are outside
+this policy. A crash or lost runner while `.maintenance-active` is owned fails
+closed; an operator must verify runner/job/handoff state and use the same helper
+recovery procedure rather than deleting protocol directories opportunistically.
+
+## Dolt retention
+
+`.dolt-data` is the live shared database store and `.dolt-backup` is recovery
+state, not an artifact cache. Direct filesystem deletion is permanently denied.
+The `dolt` scope only reports their sizes and recommendations.
+
+Before native Dolt compaction or backup expiration:
+
+1. Check `bd vc status`, configured Dolt remotes, and backup recency/integrity.
+2. Quiesce writers and use Dolt's native GC/backup mechanisms in a maintenance
+   window; never delete chunk files by age.
+3. Treat `hq` as control-plane data shared across rigs. Its issue, agent, mail,
+   and MR state can outlive any one checkout, so require a verified backup and
+   remote before changing retention.
+4. Record before/after sizes for `.dolt-data`, `.dolt-backup`, and `hq`
+   separately. If no verified remote exists, retain rather than prune.

--- a/docs/examples/rig-settings.example.json
+++ b/docs/examples/rig-settings.example.json
@@ -73,5 +73,19 @@
 
     "workflow": {
         "default_formula": "mol-polecat-work"
+    },
+
+    "lifecycle": {
+        "cleanup": {
+            "enabled": true,
+            "mode": "apply",
+            "paths": ["target", ".next", "coverage", "dist", ".pytest_cache", ".ruff_cache", ".mypy_cache", ".pnpm-store"],
+            "protected_paths": ["generated/release-evidence"],
+            "max_age": "168h",
+            "max_bytes": 10737418240,
+            "on_polecat_reuse": true,
+            "on_post_merge": false,
+            "on_ci_maintenance": false
+        }
     }
 }

--- a/internal/artifact/ci_lock.go
+++ b/internal/artifact/ci_lock.go
@@ -1,0 +1,90 @@
+package artifact
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const ciMaintenanceProtocolScript = "ci-maintenance-protocol.sh"
+
+type ciProtocolInvoker func(containerID, helperPath, action, nonce string) ([]byte, error)
+
+// AcquireCIMaintenanceLock asks a previously verified runner container to
+// acquire the shared mkdir-v1 maintenance protocol. The helper executes in the
+// same Linux filesystem view as job hooks, so atomic mkdir—not host filesystem
+// behavior—is the serialization primitive.
+func AcquireCIMaintenanceLock(root, containerID string) (func() error, error) {
+	return acquireCIMaintenanceLock(root, containerID, invokeCIProtocol)
+}
+
+func acquireCIMaintenanceLock(root, containerID string, invoke ciProtocolInvoker) (func() error, error) {
+	if !filepath.IsAbs(root) || filepath.Clean(root) == string(filepath.Separator) {
+		return nil, fmt.Errorf("CI maintenance root must be an absolute non-root path")
+	}
+	if strings.TrimSpace(containerID) == "" {
+		return nil, fmt.Errorf("verified CI runner container is required")
+	}
+	nonceBytes := make([]byte, 16)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		return nil, fmt.Errorf("creating CI maintenance nonce: %w", err)
+	}
+	nonce := hex.EncodeToString(nonceBytes)
+	helperPath := filepath.Join(root, "scripts", ciMaintenanceProtocolScript)
+	out, err := invoke(containerID, helperPath, "acquire", nonce)
+	if err != nil {
+		return nil, fmt.Errorf("acquiring CI maintenance protocol: %w", err)
+	}
+	if attestErr := validateCIProtocolAttestation(out, "acquired", nonce); attestErr != nil {
+		// A zero exit status means the helper may have published maintenance
+		// intent. Release only our nonce before returning the attestation error.
+		releaseOut, releaseErr := invoke(containerID, helperPath, "release", nonce)
+		if releaseErr == nil {
+			releaseErr = validateCIProtocolAttestation(releaseOut, "released", nonce)
+		}
+		if releaseErr != nil {
+			releaseErr = fmt.Errorf("releasing CI maintenance after invalid acquire attestation: %w", releaseErr)
+		}
+		return nil, errors.Join(attestErr, releaseErr)
+	}
+
+	return func() error {
+		out, err := invoke(containerID, helperPath, "release", nonce)
+		if err != nil {
+			return fmt.Errorf("releasing CI maintenance protocol: %w", err)
+		}
+		if err := validateCIProtocolAttestation(out, "released", nonce); err != nil {
+			return fmt.Errorf("releasing CI maintenance protocol: %w", err)
+		}
+		return nil
+	}, nil
+}
+
+func invokeCIProtocol(containerID, helperPath, action, nonce string) ([]byte, error) {
+	cmd := exec.Command("docker", "exec", containerID, helperPath, action, nonce) //nolint:gosec // fixed executable; id and helper were verified before acquisition
+	out, err := cmd.Output()
+	if err == nil {
+		return out, nil
+	}
+	detail := ""
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		detail = strings.TrimSpace(string(exitErr.Stderr))
+	}
+	if detail == "" {
+		return out, err
+	}
+	return out, fmt.Errorf("%w: %s", err, detail)
+}
+
+func validateCIProtocolAttestation(out []byte, action, nonce string) error {
+	expected := action + ":" + nonce + "\n"
+	if string(out) != expected {
+		return fmt.Errorf("CI maintenance helper returned invalid %s attestation", action)
+	}
+	return nil
+}

--- a/internal/artifact/cleanup.go
+++ b/internal/artifact/cleanup.go
@@ -1,0 +1,936 @@
+// Package artifact implements policy-driven cleanup of generated lifecycle artifacts.
+// It is deliberately filesystem-only: callers discover lifecycle state and pass it
+// in as SafetyState, while the engine enforces path and deletion invariants.
+package artifact
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	ModeDryRun = "dry-run"
+	ModeApply  = "apply"
+	// CIHookProtocolVersion is written by participating runner start hooks and
+	// checked exactly before runner-mediated maintenance is authorized.
+	CIHookProtocolVersion = "mkdir-v1"
+)
+
+// DefaultPaths are generated, reproducible directories. They are matched only
+// at the cleanup root; nested CI paths must be explicitly configured.
+var DefaultPaths = []string{
+	"target", ".next", "coverage", "dist", ".pytest_cache", ".ruff_cache",
+	".mypy_cache", ".pnpm-store",
+}
+
+// DefaultProtectedPaths cannot be cleaned merely by putting them in Paths.
+// A rig-level AllowProtectedPaths entry is also required. The two-key model
+// prevents a broad town policy from opting project data into deletion.
+var PermanentProtectedPaths = []string{
+	".git", ".repo.git", ".beads", ".dolt-*", "secrets", ".env*",
+	".ci-maintenance.lock", ".ci-protocol-mutex", ".maintenance-active", ".ci-active-jobs",
+	".job-starting", ".job-active", ".handoff-active", ".ci-job-hooks-installed",
+	"_actions", "_temp", "_work", "_tool",
+}
+
+var OverridableProtectedPaths = []string{
+	"data", "ml/models", "seif_ingestion/checkpoints*",
+}
+
+var DefaultProtectedPaths = append(append([]string(nil), PermanentProtectedPaths...), OverridableProtectedPaths...)
+
+// PolicyConfig is the JSON-facing, mergeable policy. Pointer scalar fields
+// distinguish an omitted value from an explicit false/zero override.
+type PolicyConfig struct {
+	Enabled             *bool    `json:"enabled,omitempty"`
+	Mode                string   `json:"mode,omitempty"`
+	Paths               []string `json:"paths,omitempty"`
+	ProtectedPaths      []string `json:"protected_paths,omitempty"`
+	AllowProtectedPaths []string `json:"allow_protected_paths,omitempty"`
+	MaxAge              string   `json:"max_age,omitempty"`
+	MaxBytes            *int64   `json:"max_bytes,omitempty"`
+	OnPolecatReuse      *bool    `json:"on_polecat_reuse,omitempty"`
+	OnPostMerge         *bool    `json:"on_post_merge,omitempty"`
+	OnCIMaintenance     *bool    `json:"on_ci_maintenance,omitempty"`
+}
+
+// Policy is a resolved policy ready for execution.
+type Policy struct {
+	Enabled             bool
+	Mode                string
+	Paths               []string
+	ProtectedPaths      []string
+	AllowProtectedPaths []string
+	MaxAge              time.Duration
+	MaxBytes            int64
+	OnPolecatReuse      bool
+	OnPostMerge         bool
+	OnCIMaintenance     bool
+}
+
+// DefaultPolicy is conservative: useful build paths are known, but automatic
+// cleanup is disabled and manual execution remains a dry run.
+func DefaultPolicy() Policy {
+	return Policy{
+		Mode:           ModeDryRun,
+		Paths:          append([]string(nil), DefaultPaths...),
+		ProtectedPaths: append([]string(nil), DefaultProtectedPaths...),
+	}
+}
+
+// ResolvePolicy merges defaults, town settings, then rig settings. Protected
+// defaults are additive and cannot be removed; protected overrides are accepted
+// only from the rig policy, never from a town-wide policy.
+func ResolvePolicy(town, rig *PolicyConfig) (Policy, error) {
+	p := DefaultPolicy()
+	applyConfig := func(c *PolicyConfig, allowProtectedOverride bool) error {
+		if c == nil {
+			return nil
+		}
+		if c.Enabled != nil {
+			p.Enabled = *c.Enabled
+		}
+		if c.Mode != "" {
+			p.Mode = c.Mode
+		}
+		if c.Paths != nil {
+			p.Paths = append([]string(nil), c.Paths...)
+		}
+		if c.ProtectedPaths != nil {
+			p.ProtectedPaths = appendUnique(p.ProtectedPaths, c.ProtectedPaths...)
+		}
+		if allowProtectedOverride && c.AllowProtectedPaths != nil {
+			p.AllowProtectedPaths = append([]string(nil), c.AllowProtectedPaths...)
+		}
+		if c.MaxAge != "" {
+			d, err := time.ParseDuration(c.MaxAge)
+			if err != nil || d < 0 {
+				return fmt.Errorf("invalid cleanup max_age %q", c.MaxAge)
+			}
+			p.MaxAge = d
+		}
+		if c.MaxBytes != nil {
+			p.MaxBytes = *c.MaxBytes
+		}
+		if c.OnPolecatReuse != nil {
+			p.OnPolecatReuse = *c.OnPolecatReuse
+		}
+		if c.OnPostMerge != nil {
+			p.OnPostMerge = *c.OnPostMerge
+		}
+		if c.OnCIMaintenance != nil {
+			p.OnCIMaintenance = *c.OnCIMaintenance
+		}
+		return nil
+	}
+	if err := applyConfig(town, false); err != nil {
+		return Policy{}, err
+	}
+	if err := applyConfig(rig, true); err != nil {
+		return Policy{}, err
+	}
+	if err := p.Validate(); err != nil {
+		return Policy{}, err
+	}
+	return p, nil
+}
+
+// Validate checks policy values before any filesystem traversal.
+func (p Policy) Validate() error {
+	if p.Mode != "" && p.Mode != ModeDryRun && p.Mode != ModeApply {
+		return fmt.Errorf("invalid cleanup mode %q (want dry-run or apply)", p.Mode)
+	}
+	if p.MaxAge < 0 {
+		return errors.New("cleanup max_age must not be negative")
+	}
+	if p.MaxBytes < 0 {
+		return errors.New("cleanup max_bytes must not be negative")
+	}
+	if len(p.Paths) == 0 {
+		return errors.New("cleanup paths allowlist must not be empty")
+	}
+	for _, path := range p.Paths {
+		if err := ValidateRelativePattern(path); err != nil {
+			return err
+		}
+	}
+	for _, path := range p.ProtectedPaths {
+		if err := validateProtectedPattern(path); err != nil {
+			return err
+		}
+	}
+	for _, path := range p.AllowProtectedPaths {
+		if err := ValidateRelativePattern(path); err != nil {
+			return fmt.Errorf("invalid protected-path override: %w", err)
+		}
+		if !eligibleProtectedOverride(path) {
+			return fmt.Errorf("protected-path override %q is not an overridable business-data path", path)
+		}
+	}
+	return nil
+}
+
+func validateProtectedPattern(pattern string) error {
+	normalized := filepath.ToSlash(pattern)
+	if pattern == "" || filepath.IsAbs(pattern) || filepath.VolumeName(pattern) != "" || path.Clean(normalized) != normalized || normalized == "." {
+		return fmt.Errorf("unsafe protected cleanup path %q", pattern)
+	}
+	for _, part := range strings.Split(normalized, "/") {
+		if part == "" || part == "." || part == ".." {
+			return fmt.Errorf("unsafe protected cleanup path %q", pattern)
+		}
+		if i := strings.IndexAny(part, "*?["); i == 0 {
+			return fmt.Errorf("protected cleanup path %q has an unanchored component", pattern)
+		}
+	}
+	if strings.Contains(pattern, "**") {
+		return fmt.Errorf("recursive protected cleanup glob is not allowed: %q", pattern)
+	}
+	if _, err := path.Match(normalized, normalized); err != nil {
+		return fmt.Errorf("invalid protected cleanup pattern %q: %w", pattern, err)
+	}
+	return nil
+}
+
+func eligibleProtectedOverride(path string) bool {
+	for _, permanent := range PermanentProtectedPaths {
+		if patternsIntersect(path, permanent) {
+			return false
+		}
+	}
+	for _, overridable := range OverridableProtectedPaths {
+		if protectedPatternCoversOverride(overridable, path) {
+			return true
+		}
+	}
+	return false
+}
+
+func protectedPatternCoversOverride(protected, override string) bool {
+	protected = strings.ToLower(filepath.ToSlash(protected))
+	override = strings.ToLower(filepath.ToSlash(override))
+	// The override must equal or descend from a path selected by the protected
+	// pattern. Walking only override ancestors deliberately rejects broader
+	// parents such as "ml" for the protected "ml/models" subtree.
+	for current := override; current != ""; {
+		if matched, _ := path.Match(protected, current); matched {
+			return true
+		}
+		cut := strings.LastIndex(current, "/")
+		if cut < 0 {
+			break
+		}
+		current = current[:cut]
+	}
+	return false
+}
+
+// ValidateRelativePattern rejects paths that could select the root or escape it.
+// Globs are supported, but must be anchored by a literal first component.
+func ValidateRelativePattern(pattern string) error {
+	if pattern == "" {
+		return errors.New("cleanup path must not be empty")
+	}
+	if filepath.IsAbs(pattern) || filepath.VolumeName(pattern) != "" {
+		return fmt.Errorf("cleanup path %q must be relative", pattern)
+	}
+	normalized := filepath.ToSlash(pattern)
+	clean := path.Clean(normalized)
+	if clean != normalized || clean == "." || clean == "/" {
+		return fmt.Errorf("unsafe cleanup path %q", pattern)
+	}
+	parts := strings.Split(normalized, "/")
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return fmt.Errorf("unsafe cleanup path %q", pattern)
+		}
+	}
+	if strings.ContainsAny(parts[0], "*?[") {
+		return fmt.Errorf("cleanup path %q must have a literal first component", pattern)
+	}
+	if strings.Contains(pattern, "**") {
+		return fmt.Errorf("recursive cleanup glob is not allowed: %q", pattern)
+	}
+	if _, err := path.Match(normalized, normalized); err != nil {
+		return fmt.Errorf("invalid cleanup pattern %q: %w", pattern, err)
+	}
+	return nil
+}
+
+// SafetyState contains lifecycle facts discovered by the caller.
+type SafetyState struct {
+	Dirty               bool     `json:"dirty"`
+	ActiveMR            bool     `json:"active_mr"`
+	MRVerified          bool     `json:"mr_verified"`
+	ActiveRunner        bool     `json:"active_runner"`
+	RunnerHooksVerified bool     `json:"runner_hooks_verified"`
+	RunnerVerified      bool     `json:"runner_verified"`
+	Reasons             []string `json:"reasons,omitempty"`
+}
+
+func (s SafetyState) refusalReasons() []string {
+	reasons := append([]string(nil), s.Reasons...)
+	if s.Dirty {
+		reasons = append(reasons, "dirty-worktree")
+	}
+	if s.ActiveMR {
+		reasons = append(reasons, "active-merge-request")
+	}
+	if s.ActiveRunner {
+		reasons = append(reasons, "active-runner-job")
+	}
+	return appendUnique(nil, reasons...)
+}
+
+type Options struct {
+	Root string
+	// ProtectionRoot optionally anchors protected paths above Root. Commands
+	// that permit a narrowed --root should set this to their trusted workspace
+	// boundary so selecting .dolt-data, data, or another protected subtree cannot
+	// relabel its descendants and bypass protection.
+	ProtectionRoot string
+	Policy         Policy
+	Apply          bool
+	Scope          string
+	HookPoint      string
+	Safety         SafetyState
+	RequireGit     bool
+	// RequireIgnored is appropriate for worktree lifecycle hooks: even an
+	// allowlisted directory must also be classified as ignored by Git.
+	RequireIgnored            bool
+	RequireMRVerification     bool
+	RequireRunnerVerification bool
+	// SafetyCheck is called immediately before every mutation. Lifecycle hooks
+	// should use it to re-read canonical MR/runner/worktree state after scanning.
+	SafetyCheck func() SafetyState
+	Now         time.Time
+}
+
+type PathResult struct {
+	Path   string `json:"path"`
+	Bytes  int64  `json:"bytes"`
+	Action string `json:"action"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type Result struct {
+	Root            string       `json:"root"`
+	Scope           string       `json:"scope"`
+	HookPoint       string       `json:"hook_point"`
+	DryRun          bool         `json:"dry_run"`
+	Refused         bool         `json:"refused"`
+	ApplyIncomplete bool         `json:"apply_incomplete"`
+	RefusalReasons  []string     `json:"refusal_reasons,omitempty"`
+	BytesConsidered int64        `json:"bytes_considered"`
+	BytesEligible   int64        `json:"bytes_eligible"`
+	BytesFreed      int64        `json:"bytes_freed"`
+	PathsCleaned    []PathResult `json:"paths_cleaned"`
+	PathsSkipped    []PathResult `json:"paths_skipped"`
+	Recommendations []string     `json:"recommendations,omitempty"`
+}
+
+type candidate struct {
+	rel    string
+	abs    string
+	bytes  int64
+	newest time.Time
+	info   fs.FileInfo
+}
+
+var errFilesystemBoundary = errors.New("filesystem boundary")
+var errProtectedDescendant = errors.New("protected descendant")
+var errSymlinkDescendant = errors.New("symlink descendant")
+
+// Clean evaluates and optionally applies a cleanup policy. Apply must be set
+// explicitly by the caller; policy mode alone never makes a manual dry run write.
+func Clean(opts Options) (Result, error) {
+	result := Result{
+		Root:         opts.Root,
+		Scope:        opts.Scope,
+		HookPoint:    opts.HookPoint,
+		DryRun:       !opts.Apply,
+		PathsCleaned: []PathResult{},
+		PathsSkipped: []PathResult{},
+	}
+	if err := opts.Policy.Validate(); err != nil {
+		return result, err
+	}
+	root, err := canonicalRoot(opts.Root)
+	if err != nil {
+		return result, err
+	}
+	result.Root = root
+	rootInfo, err := os.Lstat(root)
+	if err != nil {
+		return result, fmt.Errorf("stating cleanup root: %w", err)
+	}
+	rootFilesystem, verifyFilesystem := filesystemID(rootInfo)
+	var deletionRoot *os.Root
+	if opts.Apply {
+		deletionRoot, err = os.OpenRoot(root)
+		if err != nil {
+			return result, fmt.Errorf("opening confined cleanup root: %w", err)
+		}
+		defer func() { _ = deletionRoot.Close() }()
+	}
+	// A caller may intentionally select a subdirectory as the cleanup root, but
+	// protected paths remain anchored at the containing worktree. Otherwise a
+	// root such as <worktree>/data combined with path "raw" would turn the
+	// protected data/raw directory into an apparently unprotected raw directory.
+	protectionRoot := root
+	if opts.ProtectionRoot != "" {
+		protectionRoot, err = canonicalRoot(opts.ProtectionRoot)
+		if err != nil {
+			return result, fmt.Errorf("resolving protection root: %w", err)
+		}
+		if !pathWithinRoot(protectionRoot, root) {
+			return result, fmt.Errorf("cleanup root %q is outside protection root %q", root, protectionRoot)
+		}
+	} else if gitRoot, ok := containingGitRoot(root); ok {
+		protectionRoot = gitRoot
+	}
+	if opts.Now.IsZero() {
+		opts.Now = time.Now()
+	}
+	if !opts.Policy.Enabled && opts.Apply {
+		result.Refused = true
+		result.RefusalReasons = []string{"policy-disabled"}
+	}
+
+	var candidates []candidate
+	var candidateBytes int64
+	seen := make(map[string]bool)
+	for _, pattern := range opts.Policy.Paths {
+		matches, globErr := filepath.Glob(filepath.Join(root, pattern))
+		if globErr != nil {
+			return result, fmt.Errorf("expanding cleanup path %q: %w", pattern, globErr)
+		}
+		if len(matches) == 0 {
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: pattern, Action: "skipped", Reason: "missing"})
+			continue
+		}
+		for _, match := range matches {
+			rel, relErr := filepath.Rel(root, match)
+			if relErr != nil || !isContainedRelative(rel) {
+				result.ApplyIncomplete = result.ApplyIncomplete || opts.Apply
+				result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: pattern, Action: "skipped", Reason: "outside-root"})
+				continue
+			}
+			rel = filepath.ToSlash(rel)
+			if seen[rel] {
+				continue
+			}
+			seen[rel] = true
+			if reason := safeDirectory(root, match); reason != "" {
+				result.ApplyIncomplete = result.ApplyIncomplete || opts.Apply
+				result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: rel, Action: "skipped", Reason: reason})
+				continue
+			}
+			candidateInfo, infoErr := os.Lstat(match)
+			if infoErr != nil || !candidateInfo.IsDir() {
+				result.ApplyIncomplete = result.ApplyIncomplete || opts.Apply
+				result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: rel, Action: "skipped", Reason: "stat-failed"})
+				continue
+			}
+			bytes, newest, scanErr := directoryFactsOnFilesystem(match, rootFilesystem, verifyFilesystem)
+			if scanErr != nil {
+				result.ApplyIncomplete = result.ApplyIncomplete || opts.Apply
+				reason := "scan-failed: " + scanErr.Error()
+				if errors.Is(scanErr, errFilesystemBoundary) {
+					reason = "filesystem-boundary"
+				}
+				result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: rel, Action: "skipped", Reason: reason})
+				continue
+			}
+			result.BytesConsidered += bytes
+			protectedRel := rel
+			if protectionRoot != root {
+				anchoredRel, anchorErr := filepath.Rel(protectionRoot, match)
+				if anchorErr != nil || !isContainedRelative(anchoredRel) {
+					result.ApplyIncomplete = result.ApplyIncomplete || opts.Apply
+					result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: rel, Bytes: bytes, Action: "skipped", Reason: "outside-protection-root"})
+					continue
+				}
+				protectedRel = filepath.ToSlash(anchoredRel)
+			}
+			if protectedByPolicy(rel, opts.Policy) || protectedByPolicy(protectedRel, opts.Policy) {
+				result.ApplyIncomplete = result.ApplyIncomplete || opts.Apply
+				result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: rel, Bytes: bytes, Action: "skipped", Reason: "protected"})
+				continue
+			}
+			if protectedPath, descendantErr := findProtectedDescendant(match, root, protectionRoot, opts.Policy, rootFilesystem, verifyFilesystem); descendantErr != nil {
+				result.ApplyIncomplete = result.ApplyIncomplete || opts.Apply
+				reason := descendantScanReason(protectedPath, descendantErr)
+				result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: rel, Bytes: bytes, Action: "skipped", Reason: reason})
+				continue
+			}
+			tracked, gitVerified := containsTrackedPath(root, rel)
+			if opts.RequireGit && !gitVerified {
+				result.ApplyIncomplete = result.ApplyIncomplete || opts.Apply
+				result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: rel, Action: "skipped", Reason: "git-unverified"})
+				continue
+			}
+			if tracked {
+				result.ApplyIncomplete = result.ApplyIncomplete || opts.Apply
+				result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: rel, Action: "skipped", Reason: "tracked-path"})
+				continue
+			}
+			if opts.RequireIgnored && !isGitIgnored(root, rel) {
+				result.ApplyIncomplete = result.ApplyIncomplete || opts.Apply
+				result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: rel, Action: "skipped", Reason: "not-gitignored"})
+				continue
+			}
+			candidateBytes += bytes
+			candidates = append(candidates, candidate{rel: rel, abs: match, bytes: bytes, newest: newest, info: candidateInfo})
+		}
+	}
+
+	refusals := append([]string(nil), result.RefusalReasons...)
+	refusals = appendUnique(refusals, opts.Safety.refusalReasons()...)
+	if opts.Apply && opts.RequireMRVerification && !opts.Safety.MRVerified {
+		refusals = appendUnique(refusals, "active-mr-unverified")
+	}
+	if opts.Apply && opts.RequireRunnerVerification && !opts.Safety.RunnerVerified {
+		refusals = appendUnique(refusals, "runner-state-unverified")
+	}
+	if len(refusals) > 0 {
+		result.Refused = true
+		result.ApplyIncomplete = opts.Apply
+		result.RefusalReasons = refusals
+		for _, c := range candidates {
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: strings.Join(refusals, ",")})
+		}
+		return result, nil
+	}
+
+	// Oldest artifacts are selected first. MaxBytes is a high-water threshold:
+	// cleanup stops once considered bytes fall to or below it.
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].newest.Equal(candidates[j].newest) {
+			return candidates[i].rel < candidates[j].rel
+		}
+		return candidates[i].newest.Before(candidates[j].newest)
+	})
+	remaining := candidateBytes
+	lateRefused := false
+	for _, c := range candidates {
+		if lateRefused {
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: "safety-state-changed"})
+			continue
+		}
+		if opts.Policy.MaxBytes > 0 && remaining <= opts.Policy.MaxBytes {
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: "within-size-limit"})
+			continue
+		}
+		if opts.Policy.MaxAge > 0 && opts.Now.Sub(c.newest) < opts.Policy.MaxAge {
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: "younger-than-max-age"})
+			continue
+		}
+		result.BytesEligible += c.bytes
+		if !opts.Apply {
+			result.PathsCleaned = append(result.PathsCleaned, PathResult{Path: c.rel, Bytes: c.bytes, Action: "would-clean"})
+			remaining -= c.bytes
+			continue
+		}
+		if opts.SafetyCheck != nil {
+			lateState := opts.SafetyCheck()
+			lateReasons := lateState.refusalReasons()
+			if opts.RequireMRVerification && !lateState.MRVerified {
+				lateReasons = appendUnique(lateReasons, "active-mr-unverified")
+			}
+			if opts.RequireRunnerVerification && !lateState.RunnerVerified {
+				lateReasons = appendUnique(lateReasons, "runner-state-unverified")
+			}
+			if len(lateReasons) > 0 {
+				lateRefused = true
+				result.Refused = true
+				result.ApplyIncomplete = true
+				result.RefusalReasons = appendUnique(result.RefusalReasons, lateReasons...)
+				result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: "safety-state-changed: " + strings.Join(lateReasons, ",")})
+				continue
+			}
+		}
+		// Revalidate immediately before deletion to narrow TOCTOU exposure.
+		if reason := safeDirectory(root, c.abs); reason != "" {
+			result.ApplyIncomplete = true
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: reason})
+			continue
+		}
+		// Git classification can change while a directory is being scanned. Repeat
+		// the tracked/ignored checks at the final mutation boundary so a newly
+		// tracked artifact is never removed by a stale decision.
+		tracked, gitVerified := containsTrackedPath(root, c.rel)
+		if opts.RequireGit && !gitVerified {
+			result.ApplyIncomplete = true
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: "git-unverified"})
+			continue
+		}
+		if tracked {
+			result.ApplyIncomplete = true
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: "tracked-path"})
+			continue
+		}
+		if opts.RequireIgnored && !isGitIgnored(root, c.rel) {
+			result.ApplyIncomplete = true
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: "not-gitignored"})
+			continue
+		}
+		lateInfo, lateInfoErr := deletionRoot.Lstat(filepath.FromSlash(c.rel))
+		if lateInfoErr != nil || !lateInfo.IsDir() || !os.SameFile(c.info, lateInfo) {
+			result.ApplyIncomplete = true
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: "candidate-identity-changed"})
+			continue
+		}
+		lateBytes, lateNewest, lateScanErr := directoryFactsOnFilesystem(c.abs, rootFilesystem, verifyFilesystem)
+		if lateScanErr != nil || lateBytes != c.bytes || !lateNewest.Equal(c.newest) {
+			result.ApplyIncomplete = true
+			reason := "candidate-contents-changed"
+			if errors.Is(lateScanErr, errFilesystemBoundary) {
+				reason = "filesystem-boundary"
+			}
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: reason})
+			continue
+		}
+		if protectedPath, descendantErr := findProtectedDescendant(c.abs, root, protectionRoot, opts.Policy, rootFilesystem, verifyFilesystem); descendantErr != nil {
+			result.ApplyIncomplete = true
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: descendantScanReason(protectedPath, descendantErr)})
+			continue
+		}
+		// Root.RemoveAll resolves every path component relative to the open root
+		// handle and refuses escapes. Unlike a pathname-based RemoveAll, this stays
+		// confined if another process swaps an ancestor for a symlink after the
+		// validation and Git checks above.
+		if err := deletionRoot.RemoveAll(filepath.FromSlash(c.rel)); err != nil {
+			result.ApplyIncomplete = true
+			freed := estimatedRemovedBytes(c.abs, c.bytes, rootFilesystem, verifyFilesystem)
+			result.BytesFreed += freed
+			remaining -= freed
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: fmt.Sprintf("remove-failed (estimated %d bytes removed): %v", freed, err)})
+			continue
+		}
+		if _, err := deletionRoot.Lstat(filepath.FromSlash(c.rel)); !errors.Is(err, fs.ErrNotExist) {
+			result.ApplyIncomplete = true
+			result.PathsSkipped = append(result.PathsSkipped, PathResult{Path: c.rel, Bytes: c.bytes, Action: "skipped", Reason: "remove-incomplete"})
+			continue
+		}
+		result.BytesFreed += c.bytes
+		remaining -= c.bytes
+		result.PathsCleaned = append(result.PathsCleaned, PathResult{Path: c.rel, Bytes: c.bytes, Action: "cleaned"})
+	}
+	return result, nil
+}
+
+func canonicalRoot(root string) (string, error) {
+	if root == "" || !filepath.IsAbs(root) {
+		return "", fmt.Errorf("cleanup root must be an absolute path, got %q", root)
+	}
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("resolving cleanup root: %w", err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() {
+		return "", fmt.Errorf("cleanup root is not a directory: %s", root)
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func containingGitRoot(root string) (string, bool) {
+	cmd := exec.Command("git", "-C", root, "rev-parse", "--show-toplevel") //nolint:gosec // fixed executable
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	gitRoot, err := canonicalRoot(strings.TrimSpace(string(out)))
+	if err != nil {
+		return "", false
+	}
+	rel, err := filepath.Rel(gitRoot, root)
+	if err != nil || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return gitRoot, true
+}
+
+func pathWithinRoot(root, candidate string) bool {
+	rel, err := filepath.Rel(root, candidate)
+	return err == nil && !filepath.IsAbs(rel) && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func safeDirectory(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil || !isContainedRelative(rel) {
+		return "outside-root"
+	}
+	current := root
+	for _, part := range strings.Split(filepath.Clean(rel), string(filepath.Separator)) {
+		current = filepath.Join(current, part)
+		info, statErr := os.Lstat(current)
+		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				return "missing"
+			}
+			return "stat-failed"
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "symlink"
+		}
+	}
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return "not-directory"
+	}
+	return ""
+}
+
+func isContainedRelative(rel string) bool {
+	return rel != "." && rel != "" && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+func directoryFacts(root string) (int64, time.Time, error) {
+	return directoryFactsOnFilesystem(root, 0, false)
+}
+
+func directoryFactsOnFilesystem(root string, expectedFilesystem uint64, verifyFilesystem bool) (int64, time.Time, error) {
+	var bytes int64
+	var newest time.Time
+	err := filepath.WalkDir(root, func(walkPath string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.ModTime().After(newest) {
+			newest = info.ModTime()
+		}
+		if info.Mode().IsRegular() {
+			bytes += info.Size()
+		}
+		if entry.IsDir() {
+			mounted, mountErr := isMountPoint(walkPath)
+			if mountErr != nil {
+				return fmt.Errorf("reading mount table: %w", mountErr)
+			}
+			if mounted {
+				return fmt.Errorf("%w at %s", errFilesystemBoundary, entry.Name())
+			}
+		}
+		if verifyFilesystem {
+			if currentFilesystem, ok := filesystemID(info); !ok || currentFilesystem != expectedFilesystem {
+				return fmt.Errorf("%w at %s", errFilesystemBoundary, entry.Name())
+			}
+		}
+		return nil
+	})
+	return bytes, newest, err
+}
+
+func findProtectedDescendant(candidate, cleanupRoot, protectionRoot string, policy Policy, expectedFilesystem uint64, verifyFilesystem bool) (string, error) {
+	protectedPath := ""
+	err := filepath.WalkDir(candidate, func(walkPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if walkPath == candidate {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%w: %s", errSymlinkDescendant, entry.Name())
+		}
+		if verifyFilesystem {
+			if currentFilesystem, ok := filesystemID(info); !ok || currentFilesystem != expectedFilesystem {
+				return fmt.Errorf("%w at %s", errFilesystemBoundary, entry.Name())
+			}
+		}
+		cleanupRel, err := filepath.Rel(cleanupRoot, walkPath)
+		if err != nil || !isContainedRelative(cleanupRel) {
+			return fmt.Errorf("protected descendant containment check failed for %s", walkPath)
+		}
+		protectionRel, err := filepath.Rel(protectionRoot, walkPath)
+		if err != nil || !isContainedRelative(protectionRel) {
+			return fmt.Errorf("protected descendant anchor check failed for %s", walkPath)
+		}
+		cleanupRel = filepath.ToSlash(cleanupRel)
+		protectionRel = filepath.ToSlash(protectionRel)
+		if protectedByPolicy(cleanupRel, policy) || protectedByPolicy(protectionRel, policy) {
+			protectedPath = cleanupRel
+			return fmt.Errorf("%w", errProtectedDescendant)
+		}
+		return nil
+	})
+	return protectedPath, err
+}
+
+func descendantScanReason(protectedPath string, err error) string {
+	switch {
+	case errors.Is(err, errProtectedDescendant):
+		return "protected-descendant: " + protectedPath
+	case errors.Is(err, errFilesystemBoundary):
+		return "filesystem-boundary"
+	case errors.Is(err, errSymlinkDescendant):
+		return "symlink-descendant"
+	default:
+		return "scan-failed: " + err.Error()
+	}
+}
+
+func estimatedRemovedBytes(candidate string, originalBytes int64, expectedFilesystem uint64, verifyFilesystem bool) int64 {
+	remainingBytes, _, err := directoryFactsOnFilesystem(candidate, expectedFilesystem, verifyFilesystem)
+	if errors.Is(err, fs.ErrNotExist) || os.IsNotExist(err) {
+		return originalBytes
+	}
+	if err != nil || remainingBytes >= originalBytes {
+		return 0
+	}
+	return originalBytes - remainingBytes
+}
+
+func protectedByPolicy(path string, p Policy) bool {
+	protectedPaths := appendUnique(append([]string(nil), DefaultProtectedPaths...), p.ProtectedPaths...)
+	for _, protected := range protectedPaths {
+		matchingPaths := []string{}
+		if patternsIntersect(path, protected) {
+			matchingPaths = append(matchingPaths, filepath.ToSlash(path))
+		}
+		// Permanent metadata and secret names stay protected wherever they occur
+		// inside a candidate. Business/custom data rules remain anchored to the
+		// worktree policy root so ordinary build paths named "data" are cleanable.
+		if isPermanentProtectedPattern(protected) {
+			matchingPaths = appendUnique(matchingPaths, protectedPathSuffixes(path, protected)...)
+		}
+		if len(matchingPaths) == 0 {
+			continue
+		}
+		allowed := false
+		for _, matchedPath := range matchingPaths {
+			for _, override := range p.AllowProtectedPaths {
+				if patternCoversPath(override, matchedPath) {
+					allowed = true
+					break
+				}
+			}
+			if allowed {
+				break
+			}
+		}
+		if !allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func isPermanentProtectedPattern(pattern string) bool {
+	pattern = strings.ToLower(filepath.ToSlash(pattern))
+	for _, permanent := range PermanentProtectedPaths {
+		if pattern == strings.ToLower(filepath.ToSlash(permanent)) {
+			return true
+		}
+	}
+	return false
+}
+
+// protectedPathSuffixes makes protections independent of how broadly a caller
+// anchors cleanup. For example, both data/raw and rig/mayor/rig/data/raw match
+// the protected data prefix. This is intentionally conservative.
+func protectedPathSuffixes(candidate, protected string) []string {
+	parts := strings.Split(filepath.ToSlash(candidate), "/")
+	var matches []string
+	for i := range parts {
+		suffix := strings.Join(parts[i:], "/")
+		if patternsIntersect(suffix, protected) {
+			matches = append(matches, suffix)
+		}
+	}
+	return matches
+}
+
+func patternCoversPath(pattern, candidate string) bool {
+	// Be conservative on every platform. Gas Town commonly runs on default
+	// case-insensitive APFS, where .BEADS and .beads name the same directory.
+	pattern = strings.ToLower(filepath.ToSlash(pattern))
+	candidate = strings.ToLower(filepath.ToSlash(candidate))
+	if matched, _ := path.Match(pattern, candidate); matched {
+		return true
+	}
+	if strings.ContainsAny(pattern, "*?[") {
+		return false
+	}
+	return strings.HasPrefix(candidate, strings.TrimSuffix(pattern, "/")+"/")
+}
+
+// containsTrackedPath prevents cleanup from turning a clean worktree dirty and
+// reports whether Git classification was available.
+func containsTrackedPath(root, rel string) (tracked, verified bool) {
+	probe := exec.Command("git", "-C", root, "rev-parse", "--is-inside-work-tree") //nolint:gosec // fixed executable
+	if out, err := probe.Output(); err != nil || strings.TrimSpace(string(out)) != "true" {
+		return false, false
+	}
+	// icase closes the APFS alias gap (.BEADS and .beads can be the same path)
+	// while literal prevents cleanup patterns from becoming Git pathspec syntax.
+	pathspec := ":(icase,literal)" + filepath.ToSlash(rel)
+	cmd := exec.Command("git", "-C", root, "ls-files", "--", pathspec) //nolint:gosec // fixed executable and validated relative path
+	out, err := cmd.Output()
+	if err != nil {
+		return false, false
+	}
+	return strings.TrimSpace(string(out)) != "", true
+}
+
+func isGitIgnored(root, rel string) bool {
+	cmd := exec.Command("git", "-C", root, "check-ignore", "-q", "--", filepath.FromSlash(rel)) //nolint:gosec // fixed executable and validated relative path
+	return cmd.Run() == nil
+}
+
+func patternsIntersect(candidate, pattern string) bool {
+	// Protection matching must follow case-insensitive filesystem aliases even
+	// when tests or callers run on a case-sensitive host.
+	candidate = strings.ToLower(filepath.ToSlash(candidate))
+	pattern = strings.ToLower(filepath.ToSlash(pattern))
+	// Match the candidate and each of its ancestors. A protected directory glob
+	// such as .dolt-* must also cover .dolt-data/hq/chunks.
+	for current := candidate; current != ""; {
+		if matched, _ := path.Match(pattern, current); matched {
+			return true
+		}
+		cut := strings.LastIndex(current, "/")
+		if cut < 0 {
+			break
+		}
+		current = current[:cut]
+	}
+	// Refuse deletion of either a protected descendant or its ancestor.
+	staticPrefix := pattern
+	if i := strings.IndexAny(staticPrefix, "*?["); i >= 0 {
+		staticPrefix = strings.TrimSuffix(staticPrefix[:i], "/")
+	}
+	return staticPrefix != "" && (strings.HasPrefix(candidate, staticPrefix+"/") || strings.HasPrefix(staticPrefix, candidate+"/") || candidate == staticPrefix)
+}
+
+func appendUnique(dst []string, values ...string) []string {
+	seen := make(map[string]bool, len(dst)+len(values))
+	for _, item := range dst {
+		seen[item] = true
+	}
+	for _, item := range values {
+		if item != "" && !seen[item] {
+			dst = append(dst, item)
+			seen[item] = true
+		}
+	}
+	return dst
+}

--- a/internal/artifact/cleanup_test.go
+++ b/internal/artifact/cleanup_test.go
@@ -1,0 +1,805 @@
+package artifact
+
+import (
+	"encoding/hex"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func boolPtr(v bool) *bool    { return &v }
+func int64Ptr(v int64) *int64 { return &v }
+
+func testPolicy(paths ...string) Policy {
+	p := DefaultPolicy()
+	p.Enabled = true
+	p.Paths = paths
+	return p
+}
+
+func writeArtifact(t *testing.T, root, rel, body string) string {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestResolvePolicyTownAndRigOverrides(t *testing.T) {
+	town := &PolicyConfig{
+		Enabled:        boolPtr(true),
+		Mode:           ModeApply,
+		Paths:          []string{"target", "dist"},
+		MaxAge:         "24h",
+		MaxBytes:       int64Ptr(100),
+		OnPolecatReuse: boolPtr(true),
+		// A town may not opt protected data into deletion.
+		AllowProtectedPaths: []string{"data/raw"},
+	}
+	rig := &PolicyConfig{
+		Paths:               []string{"dist", "data/raw"},
+		AllowProtectedPaths: []string{"data/raw"},
+		MaxAge:              "48h",
+	}
+	got, err := ResolvePolicy(town, rig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Enabled || got.Mode != ModeApply || got.MaxAge != 48*time.Hour || got.MaxBytes != 100 || !got.OnPolecatReuse {
+		t.Fatalf("unexpected merged policy: %+v", got)
+	}
+	if strings.Join(got.Paths, ",") != "dist,data/raw" || strings.Join(got.AllowProtectedPaths, ",") != "data/raw" {
+		t.Fatalf("rig overrides not applied: %+v", got)
+	}
+}
+
+func TestResolvePolicyRejectsPermanentOrUnrelatedProtectedOverrides(t *testing.T) {
+	for _, path := range []string{".git", ".dolt-data", ".env", "secrets", "target", "ml", "seif_ingestion"} {
+		t.Run(path, func(t *testing.T) {
+			_, err := ResolvePolicy(nil, &PolicyConfig{AllowProtectedPaths: []string{path}})
+			if err == nil {
+				t.Fatalf("expected override %q to fail", path)
+			}
+		})
+	}
+}
+
+func TestResolvePolicyAllowsOnlyProtectedSubtreeOverrides(t *testing.T) {
+	for _, override := range []string{"data/raw", "ml/models", "ml/models/cache", "seif_ingestion/checkpoints-1", "seif_ingestion/checkpoints-1/cache"} {
+		t.Run(override, func(t *testing.T) {
+			if _, err := ResolvePolicy(nil, &PolicyConfig{AllowProtectedPaths: []string{override}}); err != nil {
+				t.Fatalf("valid narrow override %q was rejected: %v", override, err)
+			}
+		})
+	}
+}
+
+func TestValidateRelativePatternRejectsKnownBadPatterns(t *testing.T) {
+	bad := []string{"", ".", "..", "../target", "target/../data", "/tmp/target", "*", "*/target", "foo/**/target", "foo/["}
+	if runtime.GOOS == "windows" {
+		bad = append(bad, `C:\target`)
+	}
+	for _, pattern := range bad {
+		t.Run(pattern, func(t *testing.T) {
+			if err := ValidateRelativePattern(pattern); err == nil {
+				t.Fatalf("expected %q to be rejected", pattern)
+			}
+		})
+	}
+	for _, pattern := range []string{"target", "work/*/.pnpm-store", "shared/trivy-cache"} {
+		if err := ValidateRelativePattern(pattern); err != nil {
+			t.Fatalf("expected %q to be valid: %v", pattern, err)
+		}
+	}
+}
+
+func TestCleanDryRunThenApply(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, "dist/bundle.js", strings.Repeat("x", 128))
+	policy := testPolicy("dist")
+
+	dry, err := Clean(Options{Root: root, Policy: policy, HookPoint: "manual"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dry.DryRun || dry.BytesEligible != 128 || dry.BytesFreed != 0 || len(dry.PathsCleaned) != 1 || dry.PathsCleaned[0].Action != "would-clean" {
+		t.Fatalf("unexpected dry-run result: %+v", dry)
+	}
+	if _, err := os.Stat(filepath.Join(root, "dist")); err != nil {
+		t.Fatalf("dry run removed artifact: %v", err)
+	}
+
+	applied, err := Clean(Options{Root: root, Policy: policy, Apply: true, HookPoint: "manual"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied.DryRun || applied.BytesFreed != 128 || len(applied.PathsCleaned) != 1 || applied.PathsCleaned[0].Action != "cleaned" {
+		t.Fatalf("unexpected apply result: %+v", applied)
+	}
+	if _, err := os.Stat(filepath.Join(root, "dist")); !os.IsNotExist(err) {
+		t.Fatalf("apply did not remove artifact: %v", err)
+	}
+}
+
+func TestCleanRefusesDisabledPolicy(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, "dist/x", "x")
+	policy := testPolicy("dist")
+	policy.Enabled = false
+	result, err := Clean(Options{Root: root, Policy: policy, Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Refused || strings.Join(result.RefusalReasons, ",") != "policy-disabled" {
+		t.Fatalf("expected disabled refusal: %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(root, "dist")); err != nil {
+		t.Fatal("disabled policy removed artifact")
+	}
+}
+
+func TestCleanSafetyRefusals(t *testing.T) {
+	tests := []struct {
+		name   string
+		state  SafetyState
+		reason string
+	}{
+		{"dirty worktree", SafetyState{Dirty: true}, "dirty-worktree"},
+		{"active MR", SafetyState{ActiveMR: true}, "active-merge-request"},
+		{"active runner", SafetyState{ActiveRunner: true}, "active-runner-job"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeArtifact(t, root, "dist/x", "x")
+			result, err := Clean(Options{Root: root, Policy: testPolicy("dist"), Apply: true, Safety: tc.state})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.Refused || !contains(result.RefusalReasons, tc.reason) {
+				t.Fatalf("expected %s refusal: %+v", tc.reason, result)
+			}
+			if _, err := os.Stat(filepath.Join(root, "dist")); err != nil {
+				t.Fatal("unsafe cleanup removed artifact")
+			}
+		})
+	}
+}
+
+func TestCleanRequiresExplicitStateVerification(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, "dist/x", "x")
+	result, err := Clean(Options{
+		Root: root, Policy: testPolicy("dist"), Apply: true,
+		RequireMRVerification: true, RequireRunnerVerification: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Refused || !contains(result.RefusalReasons, "active-mr-unverified") || !contains(result.RefusalReasons, "runner-state-unverified") {
+		t.Fatalf("unverified state did not fail closed: %+v", result)
+	}
+}
+
+func TestCleanDryRunDoesNotRequireStateAssertion(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, "dist/x", "x")
+	result, err := Clean(Options{
+		Root: root, Policy: testPolicy("dist"),
+		RequireMRVerification: true, RequireRunnerVerification: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Refused || len(result.PathsCleaned) != 1 || result.PathsCleaned[0].Action != "would-clean" {
+		t.Fatalf("read-only dry run was blocked by apply-only verification: %+v", result)
+	}
+}
+
+func TestCleanRechecksSafetyBeforeMutation(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, "dist/x", "x")
+	checks := 0
+	result, err := Clean(Options{
+		Root: root, Policy: testPolicy("dist"), Apply: true,
+		SafetyCheck: func() SafetyState {
+			checks++
+			return SafetyState{ActiveMR: true}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checks != 1 || !result.Refused || !contains(result.RefusalReasons, "active-merge-request") {
+		t.Fatalf("late state was not refused: %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(root, "dist")); err != nil {
+		t.Fatal("late safety refusal did not preserve artifact")
+	}
+}
+
+func TestCleanMissingPathIsSkipped(t *testing.T) {
+	result, err := Clean(Options{Root: t.TempDir(), Policy: testPolicy("dist")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "missing" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestCleanProtectedPathsNeedSecondKey(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, "data/raw/input.csv", "business data")
+	policy := testPolicy("data/raw")
+	blocked, err := Clean(Options{Root: root, Policy: policy, Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocked.PathsSkipped) != 1 || blocked.PathsSkipped[0].Reason != "protected" {
+		t.Fatalf("protected data was not blocked: %+v", blocked)
+	}
+
+	policy.AllowProtectedPaths = []string{"data/raw"}
+	allowed, err := Clean(Options{Root: root, Policy: policy, Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowed.BytesFreed == 0 {
+		t.Fatalf("two-key protected override did not apply: %+v", allowed)
+	}
+}
+
+func TestProtectedPathsAreAccountedWithoutBecomingEligible(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, ".dolt-data/hq/chunk", strings.Repeat("d", 23))
+	result, err := Clean(Options{Root: root, Policy: testPolicy(".dolt-data"), Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.BytesConsidered != 23 || result.BytesEligible != 0 || result.BytesFreed != 0 {
+		t.Fatalf("protected accounting is wrong: %+v", result)
+	}
+	if len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Bytes != 23 || result.PathsSkipped[0].Reason != "protected" {
+		t.Fatalf("protected path detail missing: %+v", result.PathsSkipped)
+	}
+}
+
+func TestPermanentProtectionCannotBeRemovedFromDirectPolicy(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, ".beads/state", "keep")
+	policy := Policy{Enabled: true, Mode: ModeApply, Paths: []string{".beads"}}
+	result, err := Clean(Options{Root: root, Policy: policy, Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.ApplyIncomplete || len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "protected" {
+		t.Fatalf("direct policy removed built-in protection: %+v", result)
+	}
+}
+
+func TestPermanentProtectionIsCaseInsensitive(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, ".BEADS/state", "keep")
+	result, err := Clean(Options{Root: root, Policy: testPolicy(".BEADS"), Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "protected" {
+		t.Fatalf("case alias bypassed built-in protection: %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".BEADS", "state")); err != nil {
+		t.Fatal("case-aliased protected directory was removed")
+	}
+}
+
+func TestEnvironmentProtectionIncludesEnvrc(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, ".envrc/cache", "secret-adjacent")
+	result, err := Clean(Options{Root: root, Policy: testPolicy(".envrc"), Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "protected" {
+		t.Fatalf(".env* protection did not cover .envrc: %+v", result)
+	}
+}
+
+func TestProtectedDescendantBlocksParentRemoval(t *testing.T) {
+	for _, descendant := range []string{"dist/.git/objects/x", "dist/.beads/state", "dist/secrets/token"} {
+		t.Run(descendant, func(t *testing.T) {
+			root := t.TempDir()
+			writeArtifact(t, root, descendant, "keep")
+			result, err := Clean(Options{Root: root, Policy: testPolicy("dist"), Apply: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(result.PathsSkipped) != 1 || !strings.HasPrefix(result.PathsSkipped[0].Reason, "protected-descendant:") {
+				t.Fatalf("parent cleanup ignored protected descendant: %+v", result)
+			}
+			if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(descendant))); err != nil {
+				t.Fatal("parent cleanup removed protected descendant")
+			}
+		})
+	}
+}
+
+func TestCIMaintenanceProtocolFilesProtectSharedParent(t *testing.T) {
+	for _, protocolPath := range []string{
+		"shared/.ci-protocol-mutex/owner",
+		"shared/.maintenance-active/owner",
+		"shared/.ci-active-jobs/runner-1/.job-active",
+	} {
+		t.Run(protocolPath, func(t *testing.T) {
+			root := t.TempDir()
+			writeArtifact(t, root, "shared/cache/data", "generated")
+			writeArtifact(t, root, protocolPath, CIHookProtocolVersion+"\n")
+			result, err := Clean(Options{Root: root, Policy: testPolicy("shared"), Apply: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.ApplyIncomplete || len(result.PathsSkipped) != 1 || !strings.HasPrefix(result.PathsSkipped[0].Reason, "protected-descendant:") {
+				t.Fatalf("shared parent cleanup could remove protocol state: %+v", result)
+			}
+			if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(protocolPath))); err != nil {
+				t.Fatalf("cleanup removed protocol state %s", protocolPath)
+			}
+		})
+	}
+}
+
+func TestCIRunnerManagedSetupPathsArePermanentlyProtected(t *testing.T) {
+	for _, managedPath := range []string{
+		"work/runner-1/_actions/cache/data",
+		"work/runner-1/_temp/job/data",
+		"work/runner-1/_work/repository/data",
+		"work/runner-1/_tool/python/data",
+	} {
+		t.Run(managedPath, func(t *testing.T) {
+			root := t.TempDir()
+			writeArtifact(t, root, managedPath, "runner-managed")
+			candidate := filepath.ToSlash(filepath.Dir(managedPath))
+			result, err := Clean(Options{Root: root, Policy: testPolicy(candidate), Apply: true, Scope: "ci"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !result.ApplyIncomplete || len(result.PathsCleaned) != 0 || len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "protected" {
+				t.Fatalf("runner setup path was not permanently protected: %+v", result)
+			}
+			if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(managedPath))); err != nil {
+				t.Fatalf("runner setup path was removed: %v", err)
+			}
+		})
+	}
+}
+
+func TestNestedBuildDirectoryNamedDataIsNotBusinessData(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, ".next/types/app/(protected)/data/generated", "generated")
+	result, err := Clean(Options{Root: root, Policy: testPolicy(".next"), Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.BytesFreed == 0 || len(result.PathsCleaned) != 1 {
+		t.Fatalf("nested generated data directory blocked cache cleanup: %+v", result)
+	}
+}
+
+func TestCleanNarrowedRootKeepsWorktreeProtectedPaths(t *testing.T) {
+	worktree := t.TempDir()
+	for _, args := range [][]string{{"init", "-q"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = worktree
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	dataRoot := filepath.Join(worktree, "data")
+	writeArtifact(t, dataRoot, "raw/input.csv", "business data")
+	result, err := Clean(Options{Root: dataRoot, Policy: testPolicy("raw"), Apply: true, RequireGit: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "protected" {
+		t.Fatalf("narrowed cleanup root bypassed worktree protection: %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(dataRoot, "raw", "input.csv")); err != nil {
+		t.Fatal("narrowed cleanup root removed protected project data")
+	}
+}
+
+func TestCleanProtectionRootBlocksNonGitNarrowing(t *testing.T) {
+	town := t.TempDir()
+	doltRoot := filepath.Join(town, ".dolt-data")
+	writeArtifact(t, doltRoot, "hq/chunk", "control-plane data")
+	result, err := Clean(Options{
+		Root: doltRoot, ProtectionRoot: town, Policy: testPolicy("hq"), Apply: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "protected" {
+		t.Fatalf("non-Git narrowed root bypassed protection anchor: %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(doltRoot, "hq", "chunk")); err != nil {
+		t.Fatal("narrowed CI-style root removed protected Dolt data")
+	}
+}
+
+func TestCleanProtectionRootBlocksGitMetadataNarrowing(t *testing.T) {
+	town := t.TempDir()
+	gitRoot := filepath.Join(town, "rig", ".git")
+	writeArtifact(t, gitRoot, "objects/valuable", "repository data")
+	result, err := Clean(Options{
+		Root: gitRoot, ProtectionRoot: town, Policy: testPolicy("objects"), Apply: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "protected" {
+		t.Fatalf("narrowed .git root bypassed protection anchor: %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(gitRoot, "objects", "valuable")); err != nil {
+		t.Fatal("narrowed cleanup root removed Git object storage")
+	}
+}
+
+func TestCleanNarrowOverrideCannotDeleteProtectedParent(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, "data/raw/input.csv", "x")
+	policy := testPolicy("data")
+	policy.AllowProtectedPaths = []string{"data/raw"}
+	result, err := Clean(Options{Root: root, Policy: policy, Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "protected" {
+		t.Fatalf("narrow override authorized parent deletion: %+v", result)
+	}
+}
+
+func TestCleanRejectsSymlinkComponentsAndEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	writeArtifact(t, outside, "payload/valuable", "keep")
+	if err := os.Symlink(filepath.Join(outside, "payload"), filepath.Join(root, "dist")); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Clean(Options{Root: root, Policy: testPolicy("dist"), Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "symlink" {
+		t.Fatalf("symlink not rejected: %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "payload", "valuable")); err != nil {
+		t.Fatal("symlink escape deleted outside data")
+	}
+}
+
+func TestCleanRejectsTrackedArtifact(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, "dist/checked-in.txt", "tracked")
+	for _, args := range [][]string{{"init", "-q"}, {"add", "dist/checked-in.txt"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	result, err := Clean(Options{Root: root, Policy: testPolicy("dist"), Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "tracked-path" {
+		t.Fatalf("tracked artifact not rejected: %+v", result)
+	}
+}
+
+func TestTrackedClassificationIsCaseInsensitiveAndLiteral(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, ".beads/state", "tracked")
+	for _, args := range [][]string{{"init", "-q"}, {"add", ".beads/state"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	tracked, verified := containsTrackedPath(root, ".BEADS")
+	if !verified || !tracked {
+		t.Fatalf("case-aliased tracked path was not detected: tracked=%t verified=%t", tracked, verified)
+	}
+}
+
+func TestCleanRequiresGitIgnoredArtifactForWorktreeScope(t *testing.T) {
+	root := t.TempDir()
+	for _, args := range [][]string{{"init", "-q"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	writeArtifact(t, root, "dist/x", "x")
+	policy := testPolicy("dist")
+	blocked, err := Clean(Options{Root: root, Policy: policy, Apply: true, RequireGit: true, RequireIgnored: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocked.PathsSkipped) != 1 || blocked.PathsSkipped[0].Reason != "not-gitignored" {
+		t.Fatalf("nonignored path was not blocked: %+v", blocked)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("dist/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	allowed, err := Clean(Options{Root: root, Policy: policy, Apply: true, RequireGit: true, RequireIgnored: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowed.BytesFreed != 1 {
+		t.Fatalf("ignored path was not cleaned: %+v", allowed)
+	}
+}
+
+func TestCleanRechecksGitClassificationBeforeMutation(t *testing.T) {
+	root := t.TempDir()
+	cmd := exec.Command("git", "init", "-q")
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("dist/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeArtifact(t, root, "dist/x", "x")
+	checks := 0
+	result, err := Clean(Options{
+		Root: root, Policy: testPolicy("dist"), Apply: true, RequireGit: true, RequireIgnored: true,
+		SafetyCheck: func() SafetyState {
+			checks++
+			add := exec.Command("git", "add", "-f", "dist/x")
+			add.Dir = root
+			if out, addErr := add.CombinedOutput(); addErr != nil {
+				t.Fatalf("git add: %v: %s", addErr, out)
+			}
+			return SafetyState{}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checks != 1 || len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "tracked-path" {
+		t.Fatalf("late Git state change was not blocked: %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(root, "dist", "x")); err != nil {
+		t.Fatal("newly tracked artifact was removed")
+	}
+}
+
+func TestCleanAgeUsesNewestDescendantAndMaxBytes(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	root := t.TempDir()
+	old := writeArtifact(t, root, "work/a/cache/old", strings.Repeat("a", 10))
+	newer := writeArtifact(t, root, "work/b/cache/new", strings.Repeat("b", 10))
+	oldTime := now.Add(-72 * time.Hour)
+	newTime := now.Add(-time.Hour)
+	for _, path := range []string{old, filepath.Dir(old), filepath.Dir(filepath.Dir(old))} {
+		if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chtimes(newer, newTime, newTime); err != nil {
+		t.Fatal(err)
+	}
+
+	policy := testPolicy("work/*/cache")
+	policy.MaxAge = 24 * time.Hour
+	policy.MaxBytes = 10 // high-water mark: remove the old 10 bytes, retain new 10.
+	result, err := Clean(Options{Root: root, Policy: policy, Now: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.PathsCleaned) != 1 || result.PathsCleaned[0].Path != "work/a/cache" {
+		t.Fatalf("unexpected age/size selection: %+v", result)
+	}
+	if len(result.PathsSkipped) != 1 || result.PathsSkipped[0].Reason != "within-size-limit" {
+		t.Fatalf("new candidate should be within retained size: %+v", result.PathsSkipped)
+	}
+}
+
+func TestDetectSafetyDirtyMRRunnerAndHandoff(t *testing.T) {
+	root := t.TempDir()
+	cmd := exec.Command("git", "init", "-q")
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	writeArtifact(t, root, "untracked.txt", "dirty")
+	writeArtifact(t, root, "work/runner-1/.job-active", "")
+	writeArtifact(t, root, ".active-mr", "hq-mr")
+	state := DetectSafety(root, "ci")
+	if state.Dirty || !state.ActiveMR || !state.ActiveRunner {
+		t.Fatalf("incomplete safety discovery: %+v", state)
+	}
+	if err := os.Remove(filepath.Join(root, "work", "runner-1", ".job-active")); err != nil {
+		t.Fatal(err)
+	}
+	writeArtifact(t, root, "shared/handoff/.handoff-active", "")
+	if state := DetectSafety(root, "ci"); !state.ActiveRunner {
+		t.Fatal("active cross-job handoff marker did not block CI cleanup")
+	}
+}
+
+func TestDetectSafetyRequiresInstalledRunnerHooks(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "work", "runner-1", "_actions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if state := DetectSafety(root, "ci"); state.RunnerHooksVerified {
+		t.Fatal("runner without installed lifecycle hooks was treated as verified")
+	}
+	writeArtifact(t, root, "work/runner-1/.ci-job-hooks-installed", CIHookProtocolVersion+"\n")
+	if state := DetectSafety(root, "ci"); !state.RunnerHooksVerified {
+		t.Fatal("installed runner hook sentinel was not recognized")
+	}
+	if err := os.MkdirAll(filepath.Join(root, "work", "dd-runner-1", "_temp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if state := DetectSafety(root, "ci"); state.RunnerHooksVerified {
+		t.Fatal("uninstrumented alternate runner family was ignored")
+	}
+	writeArtifact(t, root, "work/dd-runner-1/.ci-job-hooks-installed", CIHookProtocolVersion+"\n")
+	if state := DetectSafety(root, "ci"); !state.RunnerHooksVerified {
+		t.Fatal("all instrumented runner families were not recognized")
+	}
+}
+
+func TestDetectSafetyDirtyGateIsWorktreeOnly(t *testing.T) {
+	root := t.TempDir()
+	cmd := exec.Command("git", "init", "-q")
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	writeArtifact(t, root, "untracked", "dirty")
+	if state := DetectSafety(root, "rig"); !state.Dirty {
+		t.Fatal("rig worktree dirtiness was not detected")
+	}
+	if state := DetectSafety(root, "ci"); state.Dirty {
+		t.Fatal("CI root inherited enclosing Git dirtiness")
+	}
+}
+
+func TestCIMaintenanceLockUsesVerifiedRunnerHelperAndNonce(t *testing.T) {
+	root := t.TempDir()
+	type invocation struct {
+		containerID string
+		helperPath  string
+		action      string
+		nonce       string
+	}
+	var calls []invocation
+	invoke := func(containerID, helperPath, action, nonce string) ([]byte, error) {
+		calls = append(calls, invocation{containerID, helperPath, action, nonce})
+		attestation := map[string]string{"acquire": "acquired", "release": "released"}[action]
+		return []byte(attestation + ":" + nonce + "\n"), nil
+	}
+	release, err := acquireCIMaintenanceLock(root, "runner-container", invoke)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := release(); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 2 || calls[0].action != "acquire" || calls[1].action != "release" {
+		t.Fatalf("unexpected helper calls: %+v", calls)
+	}
+	if calls[0].containerID != "runner-container" || calls[0].helperPath != filepath.Join(root, "scripts", ciMaintenanceProtocolScript) {
+		t.Fatalf("maintenance did not use the verified runner/helper: %+v", calls[0])
+	}
+	if calls[0].nonce != calls[1].nonce || len(calls[0].nonce) != 32 {
+		t.Fatalf("nonce was not a stable 128-bit value: %+v", calls)
+	}
+	if _, err := hex.DecodeString(calls[0].nonce); err != nil {
+		t.Fatalf("nonce was not hex encoded: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "shared")); !os.IsNotExist(err) {
+		t.Fatal("Gas Town mutated host protocol directories instead of invoking the runner helper")
+	}
+}
+
+func TestCIMaintenanceLockRejectsBadAcquireAttestationAndReleasesNonce(t *testing.T) {
+	root := t.TempDir()
+	var released bool
+	invoke := func(_, _ string, action, nonce string) ([]byte, error) {
+		if action == "acquire" {
+			return []byte("acquired:wrong-nonce\n"), nil
+		}
+		released = true
+		return []byte("released:" + nonce + "\n"), nil
+	}
+	if release, err := acquireCIMaintenanceLock(root, "runner-container", invoke); err == nil || release != nil {
+		t.Fatal("invalid acquire attestation was accepted")
+	}
+	if !released {
+		t.Fatal("invalid successful acquire was not released with its nonce")
+	}
+}
+
+func TestCIMaintenanceReleaseErrorIsSurfaced(t *testing.T) {
+	root := t.TempDir()
+	invoke := func(_, _ string, action, nonce string) ([]byte, error) {
+		if action == "release" {
+			return nil, errors.New("runner disappeared")
+		}
+		return []byte("acquired:" + nonce + "\n"), nil
+	}
+	release, err := acquireCIMaintenanceLock(root, "runner-container", invoke)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := release(); err == nil || !strings.Contains(err.Error(), "runner disappeared") {
+		t.Fatalf("release failure was not surfaced: %v", err)
+	}
+}
+
+func TestDetectSafetyTreatsOnlyNonemptyActiveJobDirectoryAsActive(t *testing.T) {
+	root := t.TempDir()
+	activeJobs := filepath.Join(root, "shared", ".ci-active-jobs")
+	if err := os.MkdirAll(activeJobs, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if state := DetectSafety(root, "ci"); state.ActiveRunner {
+		t.Fatalf("empty active-job directory was treated as active: %+v", state)
+	}
+	writeArtifact(t, root, "shared/.ci-active-jobs/runner-1/.job-active", "run:job\n")
+	if state := DetectSafety(root, "ci"); !state.ActiveRunner {
+		t.Fatal("nonempty active-job directory did not block CI cleanup")
+	}
+}
+
+func TestDetectSafetyFailsClosedWhenMarkersCannotBeScanned(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing")
+	state := DetectSafety(root, "ci")
+	if !state.ActiveRunner || !contains(state.Reasons, "runner-state-unverified") || !contains(state.Reasons, "mr-state-unverified") {
+		t.Fatalf("marker scan error did not fail closed: %+v", state)
+	}
+}
+
+func TestReportDisk(t *testing.T) {
+	root := t.TempDir()
+	writeArtifact(t, root, "large/x", strings.Repeat("x", 20))
+	writeArtifact(t, root, "small/x", strings.Repeat("x", 5))
+	report, err := ReportDisk(root, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.TotalBytes != 25 || len(report.Entries) != 1 || report.Entries[0].Path != "large" {
+		t.Fatalf("unexpected disk report: %+v", report)
+	}
+}
+
+func TestDirectoryFactsDoesNotSuppressScanErrors(t *testing.T) {
+	if _, _, err := directoryFacts(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("expected missing directory scan to fail")
+	}
+}
+
+func contains(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/artifact/cleanup_test.go
+++ b/internal/artifact/cleanup_test.go
@@ -754,6 +754,9 @@ func TestCIMaintenanceReleaseErrorIsSurfaced(t *testing.T) {
 }
 
 func TestDetectSafetyTreatsOnlyNonemptyActiveJobDirectoryAsActive(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("RUNNER_TRACKING_ID", "")
+
 	root := t.TempDir()
 	activeJobs := filepath.Join(root, "shared", ".ci-active-jobs")
 	if err := os.MkdirAll(activeJobs, 0o755); err != nil {
@@ -765,6 +768,26 @@ func TestDetectSafetyTreatsOnlyNonemptyActiveJobDirectoryAsActive(t *testing.T) 
 	writeArtifact(t, root, "shared/.ci-active-jobs/runner-1/.job-active", "run:job\n")
 	if state := DetectSafety(root, "ci"); !state.ActiveRunner {
 		t.Fatal("nonempty active-job directory did not block CI cleanup")
+	}
+}
+
+func TestDetectSafetyTreatsRunnerEnvironmentAsActive(t *testing.T) {
+	tests := []struct {
+		name             string
+		githubActions    string
+		runnerTrackingID string
+	}{
+		{name: "GitHub Actions", githubActions: "true"},
+		{name: "runner tracking ID", runnerTrackingID: "runner-process"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_ACTIONS", tt.githubActions)
+			t.Setenv("RUNNER_TRACKING_ID", tt.runnerTrackingID)
+			if state := DetectSafety(t.TempDir(), "ci"); !state.ActiveRunner {
+				t.Fatalf("runner environment was not treated as active: %+v", state)
+			}
+		})
 	}
 }
 

--- a/internal/artifact/filesystem_other.go
+++ b/internal/artifact/filesystem_other.go
@@ -1,0 +1,11 @@
+//go:build !unix
+
+package artifact
+
+import "io/fs"
+
+// Symlink/reparse-point checks and os.Root confinement still apply on non-Unix
+// platforms. A portable filesystem identity is not exposed by os.FileInfo.
+func filesystemID(_ fs.FileInfo) (uint64, bool) {
+	return 0, false
+}

--- a/internal/artifact/filesystem_unix.go
+++ b/internal/artifact/filesystem_unix.go
@@ -12,5 +12,5 @@ func filesystemID(info fs.FileInfo) (uint64, bool) {
 	if !ok {
 		return 0, false
 	}
-	return uint64(stat.Dev), true
+	return uint64(stat.Dev), true //nolint:unconvert // Dev needs conversion on Darwin but is already uint64 on Linux.
 }

--- a/internal/artifact/filesystem_unix.go
+++ b/internal/artifact/filesystem_unix.go
@@ -1,0 +1,16 @@
+//go:build unix
+
+package artifact
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+func filesystemID(info fs.FileInfo) (uint64, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return uint64(stat.Dev), true
+}

--- a/internal/artifact/mount_darwin.go
+++ b/internal/artifact/mount_darwin.go
@@ -1,0 +1,49 @@
+//go:build darwin
+
+package artifact
+
+import (
+	"path/filepath"
+	"sync"
+	"syscall"
+)
+
+var darwinMounts struct {
+	sync.Once
+	paths map[string]bool
+	err   error
+}
+
+const mntNowait = 2 // getfsstat(2) MNT_NOWAIT; not exported by syscall on Darwin.
+
+func isMountPoint(candidate string) (bool, error) {
+	darwinMounts.Do(func() {
+		count, err := syscall.Getfsstat(nil, mntNowait)
+		if err != nil {
+			darwinMounts.err = err
+			return
+		}
+		stats := make([]syscall.Statfs_t, count)
+		count, err = syscall.Getfsstat(stats, mntNowait)
+		if err != nil {
+			darwinMounts.err = err
+			return
+		}
+		darwinMounts.paths = make(map[string]bool, count)
+		for _, stat := range stats[:count] {
+			darwinMounts.paths[filepath.Clean(int8CString(stat.Mntonname[:]))] = true
+		}
+	})
+	return darwinMounts.paths[filepath.Clean(candidate)], darwinMounts.err
+}
+
+func int8CString(value []int8) string {
+	bytes := make([]byte, 0, len(value))
+	for _, char := range value {
+		if char == 0 {
+			break
+		}
+		bytes = append(bytes, byte(char))
+	}
+	return string(bytes)
+}

--- a/internal/artifact/mount_linux.go
+++ b/internal/artifact/mount_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package artifact
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var linuxMounts struct {
+	sync.Once
+	paths map[string]bool
+	err   error
+}
+
+func isMountPoint(candidate string) (bool, error) {
+	linuxMounts.Do(func() {
+		data, err := os.ReadFile("/proc/self/mountinfo")
+		if err != nil {
+			linuxMounts.err = err
+			return
+		}
+		linuxMounts.paths = make(map[string]bool)
+		unescape := strings.NewReplacer(`\040`, " ", `\011`, "\t", `\012`, "\n", `\134`, `\`)
+		for _, line := range strings.Split(string(data), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 5 {
+				continue
+			}
+			linuxMounts.paths[filepath.Clean(unescape.Replace(fields[4]))] = true
+		}
+	})
+	return linuxMounts.paths[filepath.Clean(candidate)], linuxMounts.err
+}

--- a/internal/artifact/mount_other.go
+++ b/internal/artifact/mount_other.go
@@ -1,0 +1,7 @@
+//go:build !linux && !darwin
+
+package artifact
+
+func isMountPoint(_ string) (bool, error) {
+	return false, nil
+}

--- a/internal/artifact/report.go
+++ b/internal/artifact/report.go
@@ -1,0 +1,57 @@
+package artifact
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+type DiskEntry struct {
+	Path  string `json:"path"`
+	Bytes int64  `json:"bytes"`
+}
+
+type DiskReport struct {
+	Root       string      `json:"root"`
+	TotalBytes int64       `json:"total_bytes"`
+	Entries    []DiskEntry `json:"entries"`
+}
+
+// ReportDisk returns the largest immediate children of root. It never follows
+// symlinks and is intended as a compact pointer to the next safe investigation.
+func ReportDisk(root string, limit int) (DiskReport, error) {
+	canonical, err := canonicalRoot(root)
+	if err != nil {
+		return DiskReport{}, err
+	}
+	entries, err := os.ReadDir(canonical)
+	if err != nil {
+		return DiskReport{}, fmt.Errorf("reading report root: %w", err)
+	}
+	report := DiskReport{Root: canonical, Entries: []DiskEntry{}}
+	for _, entry := range entries {
+		path := filepath.Join(canonical, entry.Name())
+		info, statErr := os.Lstat(path)
+		if statErr != nil || info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		var bytes int64
+		if info.IsDir() {
+			var scanErr error
+			bytes, _, scanErr = directoryFacts(path)
+			if scanErr != nil {
+				return DiskReport{}, fmt.Errorf("scanning %s: %w", path, scanErr)
+			}
+		} else if info.Mode().IsRegular() {
+			bytes = info.Size()
+		}
+		report.TotalBytes += bytes
+		report.Entries = append(report.Entries, DiskEntry{Path: entry.Name(), Bytes: bytes})
+	}
+	sort.Slice(report.Entries, func(i, j int) bool { return report.Entries[i].Bytes > report.Entries[j].Bytes })
+	if limit > 0 && len(report.Entries) > limit {
+		report.Entries = report.Entries[:limit]
+	}
+	return report, nil
+}

--- a/internal/artifact/safety.go
+++ b/internal/artifact/safety.go
@@ -1,0 +1,121 @@
+package artifact
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// DetectSafety discovers conservative local safety facts without network calls
+// or inspecting process/container environments. Lifecycle callers with richer
+// canonical state should OR those facts into the returned value.
+func DetectSafety(root, scope string) SafetyState {
+	state := SafetyState{}
+	if scope == "rig" || scope == "polecat" {
+		cmd := exec.Command("git", "-C", root, "status", "--porcelain", "--untracked-files=normal") //nolint:gosec // fixed executable
+		if out, err := cmd.Output(); err == nil {
+			if strings.TrimSpace(string(out)) != "" {
+				state.Dirty = true
+			}
+		} else {
+			state.Reasons = append(state.Reasons, "git-state-unverified")
+		}
+	}
+	mrMarker, mrErr := markerExists(root, map[string]bool{".active-mr": true, "active_mr": true}, 2)
+	if mrErr != nil {
+		state.Reasons = append(state.Reasons, "mr-state-unverified")
+	} else if os.Getenv("GT_ACTIVE_MR") != "" || mrMarker {
+		state.ActiveMR = true
+	}
+	if scope == "ci" {
+		state.RunnerHooksVerified = runnerHooksInstalled(root)
+		runnerMarker, runnerErr := markerExists(root, map[string]bool{
+			".job-starting":   true,
+			".runner-active":  true,
+			".job-active":     true,
+			".handoff-active": true,
+		}, 6)
+		activeJobEntry, activeJobErr := activeCIJobEntryExists(root)
+		if runnerErr != nil || activeJobErr != nil {
+			state.ActiveRunner = true
+			state.Reasons = append(state.Reasons, "runner-state-unverified")
+		} else if os.Getenv("GITHUB_ACTIONS") == "true" || os.Getenv("RUNNER_TRACKING_ID") != "" || runnerMarker || activeJobEntry {
+			state.ActiveRunner = true
+		}
+	}
+	return state
+}
+
+func activeCIJobEntryExists(root string) (bool, error) {
+	entries, err := os.ReadDir(filepath.Join(root, "shared", ".ci-active-jobs"))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return len(entries) > 0, nil
+}
+
+func runnerHooksInstalled(root string) bool {
+	workRoot := filepath.Join(root, "work")
+	entries, err := os.ReadDir(workRoot)
+	if os.IsNotExist(err) {
+		return false
+	}
+	if err != nil {
+		return false
+	}
+	foundRunner := false
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		runnerRoot := filepath.Join(workRoot, entry.Name())
+		if !looksLikeRunnerWorkdir(runnerRoot) {
+			continue
+		}
+		foundRunner = true
+		sentinel := filepath.Join(workRoot, entry.Name(), ".ci-job-hooks-installed")
+		data, readErr := os.ReadFile(sentinel)
+		if readErr != nil || string(data) != CIHookProtocolVersion+"\n" {
+			return false
+		}
+	}
+	return foundRunner
+}
+
+func looksLikeRunnerWorkdir(root string) bool {
+	for _, marker := range []string{"_actions", "_temp", ".pnpm-store"} {
+		if info, err := os.Stat(filepath.Join(root, marker)); err == nil && info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+func markerExists(root string, names map[string]bool, maxDepth int) (bool, error) {
+	found := false
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if found {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		depth := len(strings.Split(filepath.ToSlash(rel), "/"))
+		if entry.IsDir() && depth > maxDepth {
+			return filepath.SkipDir
+		}
+		if !entry.IsDir() && names[entry.Name()] {
+			found = true
+		}
+		return nil
+	})
+	return found, err
+}

--- a/internal/cmd/cleanup_artifacts.go
+++ b/internal/cmd/cleanup_artifacts.go
@@ -1,0 +1,772 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/artifact"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+var (
+	artifactRig               string
+	artifactRoot              string
+	artifactScope             string
+	artifactApply             bool
+	artifactJSON              bool
+	artifactPaths             []string
+	artifactMaxAge            string
+	artifactMaxBytes          int64
+	artifactVerifyNoActiveMR  bool
+	artifactVerifyRunnersIdle bool
+	artifactVerifyPolecatIdle bool
+	diskReportRoot            string
+	diskReportLimit           int
+	diskReportJSON            bool
+)
+
+var cleanupArtifactsCmd = &cobra.Command{
+	Use:   "artifacts",
+	Short: "Safely report or clean allowlisted lifecycle artifacts",
+	Long: `Evaluate a merged town/rig lifecycle cleanup policy.
+
+The command is a dry run unless --apply is explicit. Every candidate must be
+under the selected root, allowlisted, untracked, and outside protected paths.
+Dirty worktrees, active merge requests, and active CI job/handoff markers block
+deletion. Automatic hooks additionally require lifecycle.cleanup.enabled and
+mode=apply in rig settings.`,
+	Args: cobra.NoArgs,
+	RunE: runCleanupArtifacts,
+}
+
+var cleanupDiskCmd = &cobra.Command{
+	Use:   "disk",
+	Short: "Report the largest immediate disk consumers",
+	Args:  cobra.NoArgs,
+	RunE:  runCleanupDiskReport,
+}
+
+func init() {
+	cleanupArtifactsCmd.Flags().StringVar(&artifactRig, "rig", "", "Rig whose lifecycle policy should be used")
+	cleanupArtifactsCmd.Flags().StringVar(&artifactRoot, "root", "", "Cleanup root (must remain inside the town workspace)")
+	cleanupArtifactsCmd.Flags().StringVar(&artifactScope, "scope", "rig", "Cleanup scope: rig, polecat, ci, or dolt")
+	cleanupArtifactsCmd.Flags().BoolVar(&artifactApply, "apply", false, "Apply the cleanup (default is dry-run)")
+	cleanupArtifactsCmd.Flags().BoolVar(&artifactJSON, "json", false, "Emit only machine-readable JSON")
+	cleanupArtifactsCmd.Flags().StringArrayVar(&artifactPaths, "path", nil, "Override the configured relative allowlist (repeatable)")
+	cleanupArtifactsCmd.Flags().StringVar(&artifactMaxAge, "max-age", "", "Override maximum artifact age (for example 168h)")
+	cleanupArtifactsCmd.Flags().Int64Var(&artifactMaxBytes, "max-bytes", -1, "Override retained high-water bytes (0 disables size threshold)")
+	cleanupArtifactsCmd.Flags().BoolVar(&artifactVerifyNoActiveMR, "verify-no-active-mr", false, "Assert that MR state was checked and no active MR exists")
+	cleanupArtifactsCmd.Flags().BoolVar(&artifactVerifyRunnersIdle, "verify-runners-idle", false, "Assert runners and cross-job handoffs were checked idle")
+	cleanupArtifactsCmd.Flags().BoolVar(&artifactVerifyPolecatIdle, "verify-polecat-idle", false, "Assert the selected polecat is idle and unassigned")
+
+	cleanupDiskCmd.Flags().StringVar(&diskReportRoot, "root", "", "Report root (must remain inside the town workspace)")
+	cleanupDiskCmd.Flags().IntVar(&diskReportLimit, "top", 10, "Number of largest immediate children to show")
+	cleanupDiskCmd.Flags().BoolVar(&diskReportJSON, "json", false, "Emit only machine-readable JSON")
+
+	cleanupCmd.AddCommand(cleanupArtifactsCmd, cleanupDiskCmd)
+}
+
+func runCleanupArtifacts(cmd *cobra.Command, _ []string) (runErr error) {
+	var releaseMaintenance func() error
+	defer func() {
+		if releaseMaintenance == nil {
+			return
+		}
+		if err := releaseMaintenance(); err != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("releasing CI maintenance: %w", err))
+		}
+	}()
+
+	if err := validateArtifactNumericFlags(artifactMaxBytes, cmd.Flags().Changed("max-bytes"), diskReportLimit); err != nil {
+		return err
+	}
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("finding town workspace: %w", err)
+	}
+	rigName := artifactRig
+	if rigName == "" && artifactScope != "ci" && artifactScope != "dolt" {
+		rigName, err = inferRigFromCwd(townRoot)
+		if err != nil {
+			return fmt.Errorf("select a rig with --rig: %w", err)
+		}
+	}
+	if strings.Contains(rigName, string(filepath.Separator)) || rigName == "." || strings.HasPrefix(rigName, ".") {
+		return fmt.Errorf("invalid rig name %q", rigName)
+	}
+	rigPath := ""
+	if rigName != "" {
+		rigPath = filepath.Join(townRoot, rigName)
+	}
+	policy, err := config.ResolveArtifactCleanupPolicy(townRoot, rigPath)
+	if err != nil {
+		return err
+	}
+	if len(artifactPaths) > 0 {
+		policy.Paths = append([]string(nil), artifactPaths...)
+	}
+	if artifactMaxAge != "" {
+		policy.MaxAge, err = time.ParseDuration(artifactMaxAge)
+		if err != nil || policy.MaxAge < 0 {
+			return fmt.Errorf("invalid --max-age %q", artifactMaxAge)
+		}
+	}
+	if artifactMaxBytes >= 0 {
+		policy.MaxBytes = artifactMaxBytes
+	}
+	// Explicit manual --apply is the enable switch; config enabled/mode govern
+	// unattended hooks, not an operator's one-shot request.
+	if artifactApply {
+		policy.Enabled = true
+	}
+
+	root, err := resolveArtifactRoot(townRoot, rigPath, artifactScope, artifactRoot)
+	if err != nil {
+		return err
+	}
+	apply := artifactApply
+	if err := validateWorktreeApplyRoot(rigPath, root, artifactScope, apply); err != nil {
+		return err
+	}
+	if err := validateCIApply(townRoot, root, artifactScope, apply, policy); err != nil {
+		return err
+	}
+	if artifactScope == "dolt" {
+		policy.Paths = []string{".dolt-data", ".dolt-backup"}
+		apply = false // Dolt storage is permanently report-only here.
+	}
+	if err := policy.Validate(); err != nil {
+		return err
+	}
+	liveRunnerHooksVerified := false
+	verifiedRunnerSet := ""
+	if apply && artifactScope == "ci" {
+		containerID, runnerSet, verifyErr := verifyLiveCIRunnerHooks(root)
+		if verifyErr != nil {
+			return fmt.Errorf("verifying live CI runner protocol: %w", verifyErr)
+		}
+		releaseMaintenance, err = artifact.AcquireCIMaintenanceLock(root, containerID)
+		if err != nil {
+			return err
+		}
+		liveRunnerHooksVerified = true
+		verifiedRunnerSet = runnerSet
+	} else {
+		liveRunnerHooksVerified = true
+	}
+	safety := artifact.DetectSafety(root, artifactScope)
+	safety.RunnerHooksVerified = safety.RunnerHooksVerified && liveRunnerHooksVerified
+	if apply && artifactScope == "ci" && !liveRunnerHooksVerified {
+		safety.Reasons = append(safety.Reasons, "live-runner-hooks-unverified")
+	}
+	requireGit := artifactScope == "rig" || artifactScope == "polecat"
+	if artifactVerifyNoActiveMR {
+		safety.MRVerified = true
+	}
+	if artifactVerifyRunnersIdle {
+		safety.RunnerVerified = safety.RunnerHooksVerified
+	}
+	if apply && artifactScope == "polecat" && !artifactVerifyPolecatIdle {
+		safety.Reasons = append(safety.Reasons, "polecat-state-unverified")
+	}
+	safetyCheck := func() artifact.SafetyState {
+		state := artifact.DetectSafety(root, artifactScope)
+		currentRunnerHooksVerified := liveRunnerHooksVerified
+		if apply && artifactScope == "ci" {
+			_, currentRunnerSet, verifyErr := verifyLiveCIRunnerHooks(root)
+			currentRunnerHooksVerified = verifyErr == nil && currentRunnerSet == verifiedRunnerSet
+		}
+		state.RunnerHooksVerified = state.RunnerHooksVerified && currentRunnerHooksVerified
+		if apply && artifactScope == "ci" && !currentRunnerHooksVerified {
+			state.Reasons = append(state.Reasons, "live-runner-hooks-unverified")
+		}
+		state.MRVerified = artifactVerifyNoActiveMR
+		state.RunnerVerified = artifactVerifyRunnersIdle && state.RunnerHooksVerified
+		if apply && artifactScope == "polecat" && !artifactVerifyPolecatIdle {
+			state.Reasons = append(state.Reasons, "polecat-state-unverified")
+		}
+		return state
+	}
+	hookPoint := "manual"
+	if artifactScope == "ci" {
+		hookPoint = "ci-maintenance"
+	}
+	protectionRoot := ""
+	if artifactScope == "ci" || artifactScope == "dolt" {
+		protectionRoot = townRoot
+	}
+	result, err := artifact.Clean(artifact.Options{
+		Root:                      root,
+		ProtectionRoot:            protectionRoot,
+		Policy:                    policy,
+		Apply:                     apply,
+		Scope:                     artifactScope,
+		HookPoint:                 hookPoint,
+		Safety:                    safety,
+		RequireGit:                requireGit,
+		RequireIgnored:            requireGit,
+		RequireMRVerification:     requireGit,
+		RequireRunnerVerification: artifactScope == "ci",
+		SafetyCheck:               safetyCheck,
+	})
+	if err != nil {
+		return err
+	}
+	if artifactScope == "dolt" {
+		result.Recommendations = []string{
+			"Never delete .dolt-data or .dolt-backup directly; verify bd vc status and configured Dolt remotes first.",
+			"Treat the hq database as shared control-plane state; take and verify a backup before native Dolt garbage collection.",
+			"Use native Dolt GC/backup retention only during a maintenance window with the server quiesced.",
+		}
+	}
+	if err := writeArtifactResult(cmd.OutOrStdout(), result, artifactJSON); err != nil {
+		return err
+	}
+	return artifactApplyError(apply, result)
+}
+
+func validateWorktreeApplyRoot(rigPath, root, scope string, apply bool) error {
+	if !apply || (scope != "rig" && scope != "polecat") {
+		return nil
+	}
+	if rigPath == "" {
+		return fmt.Errorf("--rig is required for %s apply", scope)
+	}
+	rigCanonical, err := filepath.EvalSymlinks(rigPath)
+	if err != nil {
+		return err
+	}
+	actual, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return err
+	}
+	if scope == "rig" {
+		expected := filepath.Join(rigCanonical, "mayor", "rig")
+		if _, statErr := os.Stat(expected); os.IsNotExist(statErr) {
+			expected = rigCanonical
+		}
+		expected, err = filepath.EvalSymlinks(expected)
+		if err != nil {
+			return err
+		}
+		if filepath.Clean(actual) != filepath.Clean(expected) {
+			return fmt.Errorf("rig apply must use the canonical rig worktree %q", expected)
+		}
+		return nil
+	}
+
+	gitTop := exec.Command("git", "-C", actual, "rev-parse", "--show-toplevel") //nolint:gosec // fixed executable
+	out, err := gitTop.Output()
+	if err != nil {
+		return fmt.Errorf("verifying polecat worktree root: %w", err)
+	}
+	top, err := filepath.EvalSymlinks(strings.TrimSpace(string(out)))
+	if err != nil || filepath.Clean(top) != filepath.Clean(actual) {
+		return fmt.Errorf("polecat apply root must be the worktree top level")
+	}
+	rel, err := filepath.Rel(rigCanonical, actual)
+	if err != nil {
+		return err
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) < 2 || len(parts) > 3 || parts[0] != "polecats" {
+		return fmt.Errorf("polecat apply root must be a registered worktree below %s", filepath.Join(rigCanonical, "polecats"))
+	}
+	registered, err := rigWorktreeRegistered(rigCanonical, actual)
+	if err != nil {
+		return fmt.Errorf("verifying registered polecat worktree: %w", err)
+	}
+	if !registered {
+		return fmt.Errorf("polecat apply root is not registered with the selected rig repository")
+	}
+	return nil
+}
+
+func rigWorktreeRegistered(rigPath, candidate string) (bool, error) {
+	rigWorktree := filepath.Join(rigPath, "mayor", "rig")
+	if _, err := os.Stat(rigWorktree); os.IsNotExist(err) {
+		rigWorktree = rigPath
+	}
+	rigWorktree, err := filepath.EvalSymlinks(rigWorktree)
+	if err != nil {
+		return false, err
+	}
+	cmd := exec.Command("git", "-C", rigWorktree, "worktree", "list", "--porcelain", "-z") //nolint:gosec // fixed executable and canonical rig path
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	for _, field := range strings.Split(string(out), "\x00") {
+		worktreePath, ok := strings.CutPrefix(field, "worktree ")
+		if !ok {
+			continue
+		}
+		registered, resolveErr := filepath.EvalSymlinks(worktreePath)
+		if resolveErr == nil && filepath.Clean(registered) == filepath.Clean(candidate) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+type dockerInspectContainer struct {
+	ID     string `json:"Id"`
+	Name   string `json:"Name"`
+	Config struct {
+		Env    []string          `json:"Env"`
+		Labels map[string]string `json:"Labels"`
+	} `json:"Config"`
+	State struct {
+		Running bool `json:"Running"`
+	} `json:"State"`
+	Mounts []dockerInspectMount `json:"Mounts"`
+}
+
+type dockerInspectMount struct {
+	Type        string `json:"Type"`
+	Source      string `json:"Source"`
+	Destination string `json:"Destination"`
+	RW          bool   `json:"RW"`
+}
+
+type verifiedCIRunner struct {
+	containerID string
+	service     string
+	workdir     string
+	runnerName  string
+}
+
+func verifyLiveCIRunnerHooks(root string) (string, string, error) {
+	if err := validateRunnerProtocolFiles(root); err != nil {
+		return "", "", err
+	}
+	project := filepath.Base(filepath.Clean(root))
+	list := exec.Command("docker", "ps", "--all", //nolint:gosec // fixed executable and arguments
+		"--filter", "label=com.docker.compose.project="+project,
+		"--format", "{{.ID}}")
+	out, err := list.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("listing live CI runners: %w", err)
+	}
+	var runners []verifiedCIRunner
+	seenWorkdirs := make(map[string]bool)
+	seenRunnerNames := make(map[string]bool)
+	for _, containerID := range strings.Fields(string(out)) {
+		container, inspectErr := inspectDockerContainer(containerID)
+		if inspectErr != nil {
+			return "", "", inspectErr
+		}
+		service := container.Config.Labels["com.docker.compose.service"]
+		if !isComposeRunnerService(service) {
+			continue
+		}
+		runner, validateErr := validateLiveRunnerContainer(root, container)
+		if validateErr != nil {
+			return "", "", fmt.Errorf("runner %s: %w", strings.TrimPrefix(container.Name, "/"), validateErr)
+		}
+		if err := verifyContainerRunnerProtocol(root, container.ID); err != nil {
+			return "", "", fmt.Errorf("runner %s: %w", strings.TrimPrefix(container.Name, "/"), err)
+		}
+		if seenWorkdirs[runner.workdir] {
+			return "", "", fmt.Errorf("multiple live runners claim workdir %s", runner.workdir)
+		}
+		if seenRunnerNames[runner.runnerName] {
+			return "", "", fmt.Errorf("multiple live runners claim runner name %s", runner.runnerName)
+		}
+		seenWorkdirs[runner.workdir] = true
+		seenRunnerNames[runner.runnerName] = true
+		runners = append(runners, runner)
+	}
+	configured, err := countRunnerWorkdirs(root)
+	if err != nil {
+		return "", "", err
+	}
+	if len(runners) == 0 || len(runners) != configured {
+		return "", "", fmt.Errorf("live runner set (%d) does not match configured workdirs (%d)", len(runners), configured)
+	}
+	sort.Slice(runners, func(i, j int) bool { return runners[i].service < runners[j].service })
+	identity := make([]string, 0, len(runners))
+	for _, runner := range runners {
+		identity = append(identity, strings.Join([]string{runner.service, runner.containerID, runner.workdir, runner.runnerName}, "\x00"))
+	}
+	return runners[0].containerID, strings.Join(identity, "\x1e"), nil
+}
+
+func inspectDockerContainer(containerID string) (dockerInspectContainer, error) {
+	inspect := exec.Command("docker", "inspect", containerID) //nolint:gosec // id comes from exact Compose project listing
+	out, err := inspect.Output()
+	if err != nil {
+		return dockerInspectContainer{}, fmt.Errorf("inspecting CI runner container %s: %w", containerID, err)
+	}
+	var containers []dockerInspectContainer
+	if err := json.Unmarshal(out, &containers); err != nil || len(containers) != 1 {
+		return dockerInspectContainer{}, fmt.Errorf("decoding CI runner container %s inspection", containerID)
+	}
+	return containers[0], nil
+}
+
+func isComposeRunnerService(service string) bool {
+	parts := strings.Split(service, "-")
+	if len(parts) < 2 || parts[len(parts)-2] != "runner" {
+		return false
+	}
+	n, err := strconv.Atoi(parts[len(parts)-1])
+	return err == nil && n > 0
+}
+
+func validateLiveRunnerContainer(root string, container dockerInspectContainer) (verifiedCIRunner, error) {
+	labels := container.Config.Labels
+	service := labels["com.docker.compose.service"]
+	project := filepath.Base(filepath.Clean(root))
+	if !container.State.Running {
+		return verifiedCIRunner{}, fmt.Errorf("Compose runner container is not running")
+	}
+	if labels["com.docker.compose.project"] != project ||
+		filepath.Clean(labels["com.docker.compose.project.working_dir"]) != filepath.Clean(root) ||
+		filepath.Clean(labels["com.docker.compose.project.config_files"]) != filepath.Join(filepath.Clean(root), "docker-compose.yml") ||
+		!strings.EqualFold(labels["com.docker.compose.oneoff"], "false") ||
+		!isComposeRunnerService(service) {
+		return verifiedCIRunner{}, fmt.Errorf("container is not an exact service from the canonical CI Compose project")
+	}
+	env := dockerEnvironment(container.Config.Env)
+	values := []string{
+		env["RUNNER_WORKDIR"], env["RUNNER_NAME"], env["CI_JOB_HOOK_PROTOCOL_VERSION"],
+		env["ACTIONS_RUNNER_HOOK_JOB_STARTED"], env["ACTIONS_RUNNER_HOOK_JOB_COMPLETED"],
+	}
+	expectedWorkdir := filepath.Join(filepath.Clean(root), "work", service)
+	if filepath.Clean(values[0]) != expectedWorkdir {
+		return verifiedCIRunner{}, fmt.Errorf("runner workdir is not the exact canonical service workdir")
+	}
+	if err := validateLiveRunnerProtocol(root, values); err != nil {
+		return verifiedCIRunner{}, err
+	}
+	for _, mount := range []struct {
+		source   string
+		writable bool
+	}{
+		{source: filepath.Join(root, "scripts"), writable: false},
+		{source: filepath.Join(root, "shared"), writable: true},
+		{source: expectedWorkdir, writable: true},
+	} {
+		if err := validateExactBindMount(container.Mounts, mount.source, mount.source, mount.writable); err != nil {
+			return verifiedCIRunner{}, err
+		}
+	}
+	return verifiedCIRunner{
+		containerID: container.ID,
+		service:     service,
+		workdir:     expectedWorkdir,
+		runnerName:  values[1],
+	}, nil
+}
+
+func dockerEnvironment(entries []string) map[string]string {
+	env := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+	return env
+}
+
+func validateExactBindMount(mounts []dockerInspectMount, source, destination string, writable bool) error {
+	mode := "read-only"
+	if writable {
+		mode = "writable"
+	}
+	found := 0
+	for _, mount := range mounts {
+		if filepath.Clean(mount.Destination) != filepath.Clean(destination) {
+			continue
+		}
+		found++
+		if mount.Type != "bind" || filepath.Clean(mount.Source) != filepath.Clean(source) || mount.RW != writable {
+			return fmt.Errorf("runner mount %s is not the exact %s bind", destination, mode)
+		}
+	}
+	if found != 1 {
+		return fmt.Errorf("runner must have exactly one bind mount at %s", destination)
+	}
+	return nil
+}
+
+func countRunnerWorkdirs(root string) (int, error) {
+	entries, err := os.ReadDir(filepath.Join(root, "work"))
+	if err != nil {
+		return 0, fmt.Errorf("reading runner workdirs: %w", err)
+	}
+	count := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		workdir := filepath.Join(root, "work", entry.Name())
+		isRunner := false
+		for _, marker := range []string{"_actions", "_temp", ".pnpm-store", ".ci-job-hooks-installed"} {
+			if _, err := os.Lstat(filepath.Join(workdir, marker)); err == nil {
+				isRunner = true
+				break
+			}
+		}
+		if isRunner {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func verifyContainerRunnerProtocol(root, containerID string) error {
+	paths := []string{
+		filepath.Join(root, "scripts", "pre-job-workspace-heal.sh"),
+		filepath.Join(root, "scripts", "ci-job-completed.sh"),
+		filepath.Join(root, "scripts", "ci-docker-lib.sh"),
+		filepath.Join(root, "scripts", "ci-maintenance-protocol.sh"),
+	}
+	for _, filePath := range paths {
+		hostData, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("reading host protocol file %s: %w", filepath.Base(filePath), err)
+		}
+		containerData := exec.Command("docker", "exec", containerID, "cat", filePath) //nolint:gosec // id from labeled docker ps, fixed cat path
+		out, err := containerData.Output()
+		if err != nil || string(out) != string(hostData) {
+			return fmt.Errorf("container does not see current host protocol file %s", filepath.Base(filePath))
+		}
+	}
+	for _, script := range paths {
+		check := exec.Command("docker", "exec", containerID, "test", "-x", script) //nolint:gosec // id from labeled docker ps
+		if err := check.Run(); err != nil {
+			return fmt.Errorf("container protocol file %s is not executable", filepath.Base(script))
+		}
+	}
+	return nil
+}
+
+func validateLiveRunnerProtocol(root string, values []string) error {
+	if len(values) != 5 {
+		return fmt.Errorf("incomplete runner hook metadata")
+	}
+	workdir := filepath.Clean(values[0])
+	workRoot := filepath.Join(root, "work")
+	if !pathInside(workRoot, workdir) {
+		return fmt.Errorf("runner workdir is outside canonical work root")
+	}
+	if values[1] == "" || values[2] != artifact.CIHookProtocolVersion {
+		return fmt.Errorf("runner hook protocol version is missing or stale")
+	}
+	expectedStart := filepath.Join(root, "scripts", "pre-job-workspace-heal.sh")
+	expectedCompleted := filepath.Join(root, "scripts", "ci-job-completed.sh")
+	if filepath.Clean(values[3]) != expectedStart || filepath.Clean(values[4]) != expectedCompleted {
+		return fmt.Errorf("runner lifecycle hook paths are not installed")
+	}
+	if err := validateRunnerProtocolFiles(root); err != nil {
+		return err
+	}
+	sentinel, err := os.ReadFile(filepath.Join(workdir, ".ci-job-hooks-installed"))
+	if err != nil || string(sentinel) != artifact.CIHookProtocolVersion+"\n" {
+		return fmt.Errorf("runner hook deployment sentinel is missing or stale")
+	}
+	return nil
+}
+
+func validateRunnerProtocolFiles(root string) error {
+	required := map[string][]string{
+		"pre-job-workspace-heal.sh": {"ci_mark_runner_job_active"},
+		"ci-job-completed.sh":       {"ci_clear_runner_job_active"},
+		"ci-docker-lib.sh":          {`CI_JOB_HOOK_PROTOCOL_REQUIRED="mkdir-v1"`, ".ci-active-jobs", ".ci-protocol-mutex"},
+		"ci-maintenance-protocol.sh": {
+			"ci-docker-lib.sh", "active_jobs_exist", "active_handoffs_exist", "acquire)", "release)",
+		},
+	}
+	for name, markers := range required {
+		filePath := filepath.Join(root, "scripts", name)
+		info, err := os.Lstat(filePath)
+		if err != nil || !info.Mode().IsRegular() || info.Mode()&0o111 == 0 {
+			return fmt.Errorf("runner protocol file %s is missing, non-regular, or non-executable", name)
+		}
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("reading runner protocol file %s: %w", name, err)
+		}
+		for _, marker := range markers {
+			if !strings.Contains(string(data), marker) {
+				return fmt.Errorf("runner protocol file %s does not implement %s", name, artifact.CIHookProtocolVersion)
+			}
+		}
+	}
+	return nil
+}
+
+func pathInside(root, candidate string) bool {
+	rel, err := filepath.Rel(root, candidate)
+	return err == nil && rel != "." && rel != ".." && !filepath.IsAbs(rel) && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func validateCIApply(townRoot, root, scope string, apply bool, policy artifact.Policy) error {
+	if !apply || scope != "ci" {
+		return nil
+	}
+	expected, err := filepath.EvalSymlinks(filepath.Join(townRoot, "ci-runner"))
+	if err != nil {
+		return fmt.Errorf("resolving canonical CI maintenance root: %w", err)
+	}
+	actual, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return fmt.Errorf("resolving requested CI maintenance root: %w", err)
+	}
+	if filepath.Clean(actual) != filepath.Clean(expected) {
+		return fmt.Errorf("CI apply must use the canonical runner root %q", expected)
+	}
+	if !policy.OnCIMaintenance {
+		return fmt.Errorf("CI apply requires lifecycle.cleanup.on_ci_maintenance=true in town settings")
+	}
+	return nil
+}
+
+func artifactApplyError(apply bool, result artifact.Result) error {
+	if apply && (result.Refused || result.ApplyIncomplete) {
+		return fmt.Errorf("artifact cleanup apply was refused or incomplete; inspect skipped paths and refusal reasons")
+	}
+	return nil
+}
+
+func validateArtifactNumericFlags(maxBytes int64, maxBytesSet bool, top int) error {
+	if maxBytesSet && maxBytes < 0 {
+		return fmt.Errorf("--max-bytes must not be negative")
+	}
+	if top <= 0 {
+		return fmt.Errorf("--top must be greater than zero")
+	}
+	return nil
+}
+
+func resolveArtifactRoot(townRoot, rigPath, scope, explicit string) (string, error) {
+	switch scope {
+	case "rig", "polecat", "ci", "dolt":
+	default:
+		return "", fmt.Errorf("invalid cleanup scope %q", scope)
+	}
+	var root string
+	if explicit != "" {
+		var err error
+		root, err = filepath.Abs(explicit)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		switch scope {
+		case "rig":
+			if rigPath == "" {
+				return "", fmt.Errorf("--rig is required for rig scope")
+			}
+			root = filepath.Join(rigPath, "mayor", "rig")
+			if _, err := os.Stat(root); os.IsNotExist(err) {
+				root = rigPath
+			}
+		case "polecat":
+			return "", fmt.Errorf("polecat scope requires an explicit --root worktree")
+		case "ci":
+			root = filepath.Join(townRoot, "ci-runner")
+		case "dolt":
+			root = townRoot
+		}
+	}
+	rootCanonical, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("resolving cleanup root: %w", err)
+	}
+	townCanonical, err := filepath.EvalSymlinks(townRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolving town root: %w", err)
+	}
+	rel, err := filepath.Rel(townCanonical, rootCanonical)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("cleanup root %q is outside town workspace %q", root, townRoot)
+	}
+	if rootCanonical == townCanonical && scope != "dolt" {
+		return "", fmt.Errorf("cleanup root may not be the town root for scope %q", scope)
+	}
+	if scope == "rig" || scope == "polecat" {
+		if rigPath == "" {
+			return "", fmt.Errorf("--rig is required for %s scope", scope)
+		}
+		rigCanonical, err := filepath.EvalSymlinks(rigPath)
+		if err != nil {
+			return "", fmt.Errorf("resolving rig root: %w", err)
+		}
+		rigRel, err := filepath.Rel(rigCanonical, rootCanonical)
+		if err != nil || rigRel == ".." || strings.HasPrefix(rigRel, ".."+string(filepath.Separator)) || filepath.IsAbs(rigRel) {
+			return "", fmt.Errorf("cleanup root %q is outside selected rig %q", root, rigPath)
+		}
+	}
+	return rootCanonical, nil
+}
+
+func writeArtifactResult(w io.Writer, result artifact.Result, asJSON bool) error {
+	if asJSON {
+		encoder := json.NewEncoder(w)
+		return encoder.Encode(result)
+	}
+	mode := "dry-run"
+	if !result.DryRun {
+		mode = "apply"
+	}
+	fmt.Fprintf(w, "Artifact cleanup (%s, scope=%s, hook=%s)\n", mode, result.Scope, result.HookPoint)
+	fmt.Fprintf(w, "  root: %s\n  considered: %d bytes\n  eligible: %d bytes\n  freed: %d bytes\n", result.Root, result.BytesConsidered, result.BytesEligible, result.BytesFreed)
+	if result.Refused {
+		fmt.Fprintf(w, "  refused: %s\n", strings.Join(result.RefusalReasons, ", "))
+	}
+	for _, path := range result.PathsCleaned {
+		fmt.Fprintf(w, "  %s %s (%d bytes)\n", path.Action, path.Path, path.Bytes)
+	}
+	for _, path := range result.PathsSkipped {
+		fmt.Fprintf(w, "  skipped %s: %s\n", path.Path, path.Reason)
+	}
+	for _, recommendation := range result.Recommendations {
+		fmt.Fprintf(w, "  recommendation: %s\n", recommendation)
+	}
+	return nil
+}
+
+func runCleanupDiskReport(cmd *cobra.Command, _ []string) error {
+	if err := validateArtifactNumericFlags(artifactMaxBytes, false, diskReportLimit); err != nil {
+		return err
+	}
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("finding town workspace: %w", err)
+	}
+	root := diskReportRoot
+	if root == "" {
+		root = townRoot
+	}
+	root, err = resolveArtifactRoot(townRoot, "", "dolt", root)
+	if err != nil {
+		return err
+	}
+	report, err := artifact.ReportDisk(root, diskReportLimit)
+	if err != nil {
+		return err
+	}
+	if diskReportJSON {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(report)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Disk usage under %s (%d bytes)\n", report.Root, report.TotalBytes)
+	for _, entry := range report.Entries {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %12d  %s\n", entry.Bytes, entry.Path)
+	}
+	return nil
+}

--- a/internal/cmd/cleanup_artifacts_test.go
+++ b/internal/cmd/cleanup_artifacts_test.go
@@ -1,0 +1,301 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/artifact"
+)
+
+func TestCleanupArtifactsIsChildWithoutReplacingProcessCleanup(t *testing.T) {
+	if cleanupCmd.RunE == nil {
+		t.Fatal("existing process cleanup behavior was replaced")
+	}
+	found, _, err := cleanupCmd.Find([]string{"artifacts"})
+	if err != nil || found != cleanupArtifactsCmd {
+		t.Fatalf("artifact child command missing: found=%v err=%v", found, err)
+	}
+	found, _, err = cleanupCmd.Find([]string{"disk"})
+	if err != nil || found != cleanupDiskCmd {
+		t.Fatalf("disk child command missing: found=%v err=%v", found, err)
+	}
+}
+
+func TestWriteArtifactResultJSONHasNoProseNoise(t *testing.T) {
+	result := artifact.Result{
+		Root: "/tmp/rig", Scope: "rig", HookPoint: "manual", DryRun: true,
+		PathsCleaned: []artifact.PathResult{}, PathsSkipped: []artifact.PathResult{},
+	}
+	var out bytes.Buffer
+	if err := writeArtifactResult(&out, result, true); err != nil {
+		t.Fatal(err)
+	}
+	var decoded artifact.Result
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("output was not one JSON document: %q: %v", out.String(), err)
+	}
+	if strings.Contains(out.String(), "Artifact cleanup") || decoded.HookPoint != "manual" {
+		t.Fatalf("JSON output contained prose or lost fields: %q", out.String())
+	}
+}
+
+func TestResolveArtifactRootRejectsOutsideAndBroadRoots(t *testing.T) {
+	town := t.TempDir()
+	rig := filepath.Join(town, "rig")
+	root := filepath.Join(rig, "mayor", "rig")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveArtifactRoot(town, rig, "rig", root)
+	want, canonicalErr := filepath.EvalSymlinks(root)
+	if canonicalErr != nil {
+		t.Fatal(canonicalErr)
+	}
+	if err != nil || got != want {
+		t.Fatalf("valid root failed: got=%q err=%v", got, err)
+	}
+	if _, err := resolveArtifactRoot(town, rig, "rig", t.TempDir()); err == nil {
+		t.Fatal("outside root should be rejected")
+	}
+	if _, err := resolveArtifactRoot(town, rig, "rig", town); err == nil {
+		t.Fatal("town root should be rejected for mutating scope")
+	}
+	otherRig := filepath.Join(town, "other", "mayor", "rig")
+	if err := os.MkdirAll(otherRig, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveArtifactRoot(town, rig, "rig", otherRig); err == nil {
+		t.Fatal("per-rig policy should not authorize a different rig root")
+	}
+	if _, err := resolveArtifactRoot(town, rig, "unknown", root); err == nil {
+		t.Fatal("unknown explicit-root scope should be rejected")
+	}
+}
+
+func TestValidateArtifactNumericFlags(t *testing.T) {
+	if err := validateArtifactNumericFlags(-1, false, 10); err != nil {
+		t.Fatalf("internal max-bytes sentinel should be accepted: %v", err)
+	}
+	if err := validateArtifactNumericFlags(-1, true, 10); err == nil {
+		t.Fatal("explicit negative --max-bytes should fail")
+	}
+	if err := validateArtifactNumericFlags(0, true, 0); err == nil {
+		t.Fatal("non-positive --top should fail")
+	}
+}
+
+func TestValidateCIApplyRequiresCanonicalRootAndPolicy(t *testing.T) {
+	town := t.TempDir()
+	canonical := filepath.Join(town, "ci-runner")
+	fixture := filepath.Join(town, "fixture")
+	for _, dir := range []string{canonical, fixture} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	policy := artifact.DefaultPolicy()
+	policy.OnCIMaintenance = true
+	if err := validateCIApply(town, fixture, "ci", true, policy); err == nil {
+		t.Fatal("CI apply accepted a narrowed fixture root")
+	}
+	policy.OnCIMaintenance = false
+	if err := validateCIApply(town, canonical, "ci", true, policy); err == nil {
+		t.Fatal("CI apply ignored disabled on_ci_maintenance policy")
+	}
+	policy.OnCIMaintenance = true
+	if err := validateCIApply(town, canonical, "ci", true, policy); err != nil {
+		t.Fatalf("canonical configured CI apply was rejected: %v", err)
+	}
+}
+
+func TestValidateWorktreeApplyRootRejectsNarrowedSubdirectory(t *testing.T) {
+	rig := t.TempDir()
+	worktree := filepath.Join(rig, "mayor", "rig")
+	narrow := filepath.Join(worktree, "data")
+	if err := os.MkdirAll(narrow, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateWorktreeApplyRoot(rig, narrow, "rig", true); err == nil {
+		t.Fatal("rig apply accepted a narrowed protected root")
+	}
+	if err := validateWorktreeApplyRoot(rig, worktree, "rig", true); err != nil {
+		t.Fatalf("canonical rig worktree was rejected: %v", err)
+	}
+}
+
+func TestValidatePolecatApplyRootRequiresRigRegisteredWorktree(t *testing.T) {
+	rig := t.TempDir()
+	mainWorktree := filepath.Join(rig, "mayor", "rig")
+	if err := os.MkdirAll(mainWorktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runCleanupGit(t, mainWorktree, "init")
+	runCleanupGit(t, mainWorktree, "config", "user.email", "test@example.com")
+	runCleanupGit(t, mainWorktree, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(mainWorktree, "README.md"), []byte("fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runCleanupGit(t, mainWorktree, "add", "README.md")
+	runCleanupGit(t, mainWorktree, "commit", "-m", "fixture")
+
+	registered := filepath.Join(rig, "polecats", "amber")
+	if err := os.MkdirAll(filepath.Dir(registered), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runCleanupGit(t, mainWorktree, "worktree", "add", "-b", "polecat/amber", registered)
+	if err := validateWorktreeApplyRoot(rig, registered, "polecat", true); err != nil {
+		t.Fatalf("registered polecat worktree was rejected: %v", err)
+	}
+
+	unregistered := filepath.Join(rig, "polecats", "unregistered")
+	if err := os.MkdirAll(unregistered, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runCleanupGit(t, unregistered, "init")
+	if err := validateWorktreeApplyRoot(rig, unregistered, "polecat", true); err == nil {
+		t.Fatal("independent repository under polecats was accepted as registered")
+	}
+}
+
+func runCleanupGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func TestApplyIncompleteIsMachineReadableAndFailsAutomation(t *testing.T) {
+	result := artifact.Result{
+		Root: "/tmp/rig", Scope: "rig", HookPoint: "manual", ApplyIncomplete: true,
+		PathsCleaned: []artifact.PathResult{}, PathsSkipped: []artifact.PathResult{{Path: "dist", Action: "skipped", Reason: "remove-failed"}},
+	}
+	var out bytes.Buffer
+	if err := writeArtifactResult(&out, result, true); err != nil {
+		t.Fatal(err)
+	}
+	var decoded artifact.Result
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil || !decoded.ApplyIncomplete {
+		t.Fatalf("incomplete apply was not machine-readable: %q err=%v", out.String(), err)
+	}
+	if err := artifactApplyError(true, result); err == nil {
+		t.Fatal("incomplete apply should return a non-zero command error")
+	}
+	if err := artifactApplyError(false, result); err != nil {
+		t.Fatalf("dry-run reporting should remain successful: %v", err)
+	}
+}
+
+func TestValidateLiveRunnerProtocol(t *testing.T) {
+	root := t.TempDir()
+	workdir := filepath.Join(root, "work", "dd-runner-1")
+	installTestRunnerProtocol(t, root, workdir)
+	values := []string{
+		workdir, "dd-runner-1", artifact.CIHookProtocolVersion,
+		filepath.Join(root, "scripts", "pre-job-workspace-heal.sh"),
+		filepath.Join(root, "scripts", "ci-job-completed.sh"),
+	}
+	if err := validateLiveRunnerProtocol(root, values); err != nil {
+		t.Fatalf("valid live runner protocol was rejected: %v", err)
+	}
+	values[2] = "stale-v0"
+	if err := validateLiveRunnerProtocol(root, values); err == nil {
+		t.Fatal("stale live runner protocol was accepted")
+	}
+	values[2] = artifact.CIHookProtocolVersion
+	values[3] = "/bogus/pre-job-workspace-heal.sh"
+	if err := validateLiveRunnerProtocol(root, values); err == nil {
+		t.Fatal("same-named hook outside the canonical root was accepted")
+	}
+}
+
+func TestValidateLiveRunnerContainerRequiresExactComposeIdentityAndBinds(t *testing.T) {
+	root := t.TempDir()
+	service := "dd-runner-1"
+	workdir := filepath.Join(root, "work", service)
+	installTestRunnerProtocol(t, root, workdir)
+	var container dockerInspectContainer
+	container.ID = "container-id"
+	container.Name = "/ci-runner-dd-runner-1-1"
+	container.State.Running = true
+	container.Config.Labels = map[string]string{
+		"com.docker.compose.project":              filepath.Base(root),
+		"com.docker.compose.project.working_dir":  root,
+		"com.docker.compose.project.config_files": filepath.Join(root, "docker-compose.yml"),
+		"com.docker.compose.oneoff":               "False",
+		"com.docker.compose.service":              service,
+	}
+	container.Config.Env = []string{
+		"RUNNER_WORKDIR=" + workdir,
+		"RUNNER_NAME=gastown-dd-runner-1",
+		"CI_JOB_HOOK_PROTOCOL_VERSION=" + artifact.CIHookProtocolVersion,
+		"ACTIONS_RUNNER_HOOK_JOB_STARTED=" + filepath.Join(root, "scripts", "pre-job-workspace-heal.sh"),
+		"ACTIONS_RUNNER_HOOK_JOB_COMPLETED=" + filepath.Join(root, "scripts", "ci-job-completed.sh"),
+	}
+	container.Mounts = []dockerInspectMount{
+		{Type: "bind", Source: filepath.Join(root, "scripts"), Destination: filepath.Join(root, "scripts"), RW: false},
+		{Type: "bind", Source: filepath.Join(root, "shared"), Destination: filepath.Join(root, "shared"), RW: true},
+		{Type: "bind", Source: workdir, Destination: workdir, RW: true},
+	}
+	if _, err := validateLiveRunnerContainer(root, container); err != nil {
+		t.Fatalf("exact runner container was rejected: %v", err)
+	}
+
+	container.Mounts[1].Source = filepath.Join(root, "lookalike-shared")
+	if _, err := validateLiveRunnerContainer(root, container); err == nil {
+		t.Fatal("runner with a lookalike shared bind source was accepted")
+	}
+	container.Mounts[1].Source = filepath.Join(root, "shared")
+	container.Mounts[0].RW = true
+	if _, err := validateLiveRunnerContainer(root, container); err == nil {
+		t.Fatal("runner with writable protocol scripts was accepted")
+	}
+	container.Mounts[0].RW = false
+	container.Config.Labels["com.docker.compose.project.working_dir"] = filepath.Join(root, "other")
+	if _, err := validateLiveRunnerContainer(root, container); err == nil {
+		t.Fatal("runner from a same-named noncanonical Compose project was accepted")
+	}
+}
+
+func TestComposeRunnerServiceNamesAreExact(t *testing.T) {
+	for _, service := range []string{"runner-1", "dd-runner-2", "dardasha-runner-3"} {
+		if !isComposeRunnerService(service) {
+			t.Fatalf("valid runner service %q was rejected", service)
+		}
+	}
+	for _, service := range []string{"runner", "buildkit_runner-1", "runner-zero", "runner-0", "not-a-runner-1-extra"} {
+		if isComposeRunnerService(service) {
+			t.Fatalf("non-runner service %q was accepted", service)
+		}
+	}
+}
+
+func installTestRunnerProtocol(t *testing.T, root, workdir string) {
+	t.Helper()
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, ".ci-job-hooks-installed"), []byte(artifact.CIHookProtocolVersion+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	protocolFiles := map[string]string{
+		"pre-job-workspace-heal.sh":  "ci_mark_runner_job_active",
+		"ci-job-completed.sh":        "ci_clear_runner_job_active",
+		"ci-docker-lib.sh":           "CI_JOB_HOOK_PROTOCOL_REQUIRED=\"mkdir-v1\"\n.ci-active-jobs\n.ci-protocol-mutex",
+		"ci-maintenance-protocol.sh": "ci-docker-lib.sh\nactive_jobs_exist\nactive_handoffs_exist\nacquire)\nrelease)",
+	}
+	for name, body := range protocolFiles {
+		path := filepath.Join(root, "scripts", name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/internal/config/artifact_cleanup_test.go
+++ b/internal/config/artifact_cleanup_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/artifact"
+)
+
+func cleanupBool(v bool) *bool    { return &v }
+func cleanupInt64(v int64) *int64 { return &v }
+
+func TestResolveArtifactCleanupPolicyMergesTownAndRigSettings(t *testing.T) {
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "testrig")
+	town := NewTownSettings()
+	town.Lifecycle = &LifecycleConfig{Cleanup: &artifact.PolicyConfig{
+		Enabled:             cleanupBool(true),
+		Mode:                artifact.ModeApply,
+		Paths:               []string{"target", "dist"},
+		MaxAge:              "24h",
+		MaxBytes:            cleanupInt64(1000),
+		OnPolecatReuse:      cleanupBool(true),
+		AllowProtectedPaths: []string{"data/raw"}, // town override must be ignored
+	}}
+	if err := SaveTownSettings(TownSettingsPath(townRoot), town); err != nil {
+		t.Fatal(err)
+	}
+	rig := NewRigSettings()
+	rig.Lifecycle = &LifecycleConfig{Cleanup: &artifact.PolicyConfig{
+		Paths:               []string{"dist", "data/raw"},
+		MaxAge:              "48h",
+		AllowProtectedPaths: []string{"data/raw"},
+	}}
+	if err := SaveRigSettings(RigSettingsPath(rigPath), rig); err != nil {
+		t.Fatal(err)
+	}
+
+	policy, err := ResolveArtifactCleanupPolicy(townRoot, rigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !policy.Enabled || policy.Mode != artifact.ModeApply || policy.MaxAge != 48*time.Hour || policy.MaxBytes != 1000 || !policy.OnPolecatReuse {
+		t.Fatalf("unexpected merged policy: %+v", policy)
+	}
+	if len(policy.AllowProtectedPaths) != 1 || policy.AllowProtectedPaths[0] != "data/raw" {
+		t.Fatalf("rig protected override missing: %+v", policy.AllowProtectedPaths)
+	}
+}
+
+func TestRigSettingsRejectPermanentProtectedOverride(t *testing.T) {
+	settings := NewRigSettings()
+	settings.Lifecycle = &LifecycleConfig{Cleanup: &artifact.PolicyConfig{
+		AllowProtectedPaths: []string{".dolt-data"},
+	}}
+	if err := SaveRigSettings(filepath.Join(t.TempDir(), "settings", "config.json"), settings); err == nil {
+		t.Fatal("expected permanent protected override to be rejected")
+	}
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/artifact"
 	"github.com/steveyegge/gastown/internal/atomicfile"
 	"github.com/steveyegge/gastown/internal/constants"
 )
@@ -234,6 +235,11 @@ func validateRigSettings(c *RigSettings) error {
 	if c.MergeQueue != nil {
 		if err := validateMergeQueueConfig(c.MergeQueue); err != nil {
 			return err
+		}
+	}
+	if c.Lifecycle != nil && c.Lifecycle.Cleanup != nil {
+		if _, err := artifact.ResolvePolicy(nil, c.Lifecycle.Cleanup); err != nil {
+			return fmt.Errorf("invalid lifecycle.cleanup: %w", err)
 		}
 	}
 	return nil
@@ -1068,6 +1074,31 @@ func TownSettingsPath(townRoot string) string {
 // RigSettingsPath returns the path to rig settings file.
 func RigSettingsPath(rigPath string) string {
 	return filepath.Join(rigPath, "settings", "config.json")
+}
+
+// ResolveArtifactCleanupPolicy merges compiled defaults, town settings, and
+// per-rig settings. A missing settings file is equivalent to no override.
+func ResolveArtifactCleanupPolicy(townRoot, rigPath string) (artifact.Policy, error) {
+	var townPolicy, rigPolicy *artifact.PolicyConfig
+	if townRoot != "" {
+		settings, err := LoadOrCreateTownSettings(TownSettingsPath(townRoot))
+		if err != nil {
+			return artifact.Policy{}, fmt.Errorf("loading town cleanup settings: %w", err)
+		}
+		if settings.Lifecycle != nil {
+			townPolicy = settings.Lifecycle.Cleanup
+		}
+	}
+	if rigPath != "" {
+		settings, err := LoadRigSettings(RigSettingsPath(rigPath))
+		if err != nil && !errors.Is(err, ErrNotFound) {
+			return artifact.Policy{}, fmt.Errorf("loading rig cleanup settings: %w", err)
+		}
+		if settings != nil && settings.Lifecycle != nil {
+			rigPolicy = settings.Lifecycle.Cleanup
+		}
+	}
+	return artifact.ResolvePolicy(townPolicy, rigPolicy)
 }
 
 // LoadOrCreateTownSettings loads town settings or creates defaults if missing.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/artifact"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 )
 
@@ -109,6 +110,11 @@ type TownSettings struct {
 	// Polecat configures per-polecat behavior (target/ clean hook, etc.).
 	// Added for hq-x0v7v.
 	Polecat *PolecatConfig `json:"polecat,omitempty"`
+
+	// Lifecycle configures safe cleanup of reproducible lifecycle artifacts.
+	// Rig settings may override this policy, but only a rig can opt a protected
+	// project path into cleanup.
+	Lifecycle *LifecycleConfig `json:"lifecycle,omitempty"`
 
 	// Operational configures operational thresholds (timeouts, retries, intervals).
 	// These were previously hardcoded as Go constants throughout the codebase.
@@ -523,6 +529,12 @@ type PolecatConfig struct {
 	TargetCleanPolicy string `json:"target_clean_policy,omitempty"`
 }
 
+// LifecycleConfig groups lifecycle maintenance policies shared by town and rig
+// settings. Cleanup scalars use pointers so false and zero are valid overrides.
+type LifecycleConfig struct {
+	Cleanup *artifact.PolicyConfig `json:"cleanup,omitempty"`
+}
+
 // ParseDurationOrDefault parses a Go duration string, returning fallback on error or empty input.
 func ParseDurationOrDefault(s string, fallback time.Duration) time.Duration {
 	if s == "" {
@@ -675,6 +687,7 @@ type RigSettings struct {
 	Namepool   *NamepoolConfig   `json:"namepool,omitempty"`    // polecat name pool settings
 	Crew       *CrewConfig       `json:"crew,omitempty"`        // crew startup settings
 	Workflow   *WorkflowConfig   `json:"workflow,omitempty"`    // workflow settings
+	Lifecycle  *LifecycleConfig  `json:"lifecycle,omitempty"`   // artifact lifecycle settings
 	Runtime    *RuntimeConfig    `json:"runtime,omitempty"`     // LLM runtime settings (deprecated: use Agent)
 
 	// Agent selects which agent preset to use for this rig.

--- a/internal/polecat/artifact_clean.go
+++ b/internal/polecat/artifact_clean.go
@@ -1,0 +1,75 @@
+package polecat
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/steveyegge/gastown/internal/artifact"
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+// runArtifactCleanupHook evaluates the per-rig generic artifact policy at the
+// pre-reuse lifecycle point. ReuseIdlePolecat has already applied its canonical
+// workstate veto; this method repeats that decision before every mutation so an
+// MR/assignment/state change during the filesystem scan fails closed.
+func (m *Manager) runArtifactCleanupHook(name, clonePath string) (artifact.Result, bool, error) {
+	townRoot := filepath.Dir(m.rig.Path)
+	policy, err := config.ResolveArtifactCleanupPolicy(townRoot, m.rig.Path)
+	if err != nil {
+		return artifact.Result{}, true, err
+	}
+	if !policy.Enabled || !policy.OnPolecatReuse {
+		return artifact.Result{}, false, nil
+	}
+
+	safetyCheck := func() artifact.SafetyState {
+		state := artifact.DetectSafety(clonePath, "polecat")
+		current, loadErr := m.loadFromBeads(name)
+		if loadErr != nil {
+			state.Reasons = append(state.Reasons, "polecat-state-unverified")
+			return state
+		}
+		if current.Issue == "" {
+			switch current.State {
+			case StateWorking, StateStalled, StateReviewNeeded:
+				current.State = StateIdle
+			}
+		}
+		decision := m.reuseDecisionForPolecat(name, current.State)
+		state.MRVerified = true
+		if !decision.Reusable {
+			state.Reasons = append(state.Reasons, "polecat-not-reusable: "+decision.Reason)
+		}
+		return state
+	}
+	return executeArtifactCleanupHook(clonePath, policy, safetyCheck)
+}
+
+func executeArtifactCleanupHook(clonePath string, policy artifact.Policy, safetyCheck func() artifact.SafetyState) (artifact.Result, bool, error) {
+	if !policy.Enabled || !policy.OnPolecatReuse {
+		return artifact.Result{}, false, nil
+	}
+	result, err := artifact.Clean(artifact.Options{
+		Root:                  clonePath,
+		ProtectionRoot:        clonePath,
+		Policy:                policy,
+		Apply:                 policy.Mode == artifact.ModeApply,
+		Scope:                 "polecat",
+		HookPoint:             "polecat-pre-reuse",
+		Safety:                safetyCheck(),
+		RequireGit:            true,
+		RequireIgnored:        true,
+		RequireMRVerification: true,
+		SafetyCheck:           safetyCheck,
+	})
+	return result, true, err
+}
+
+func formatArtifactHookResult(result artifact.Result) string {
+	data, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Sprintf("artifact-clean: considered=%d freed=%d refused=%t", result.BytesConsidered, result.BytesFreed, result.Refused)
+	}
+	return "artifact-clean: " + string(data)
+}

--- a/internal/polecat/artifact_clean_test.go
+++ b/internal/polecat/artifact_clean_test.go
@@ -1,0 +1,88 @@
+package polecat
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/artifact"
+)
+
+func TestFormatArtifactHookResultIncludesMachineAccounting(t *testing.T) {
+	result := artifact.Result{
+		HookPoint: "polecat-pre-reuse", BytesConsidered: 10, BytesFreed: 7,
+		PathsCleaned: []artifact.PathResult{}, PathsSkipped: []artifact.PathResult{},
+	}
+	line := formatArtifactHookResult(result)
+	const prefix = "artifact-clean: "
+	if !strings.HasPrefix(line, prefix) {
+		t.Fatalf("missing log prefix: %q", line)
+	}
+	var got artifact.Result
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(line, prefix)), &got); err != nil {
+		t.Fatalf("hook accounting is not JSON: %v", err)
+	}
+	if got.HookPoint != "polecat-pre-reuse" || got.BytesConsidered != 10 || got.BytesFreed != 7 {
+		t.Fatalf("hook accounting lost fields: %+v", got)
+	}
+}
+
+func TestExecuteArtifactCleanupHookDryRunApplyAndSafety(t *testing.T) {
+	newWorktree := func(t *testing.T) string {
+		t.Helper()
+		root := t.TempDir()
+		cmd := exec.Command("git", "init", "-q")
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git init: %v: %s", err, out)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("dist/\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(root, "dist"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "dist", "bundle"), []byte("generated"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return root
+	}
+
+	policy := artifact.DefaultPolicy()
+	policy.Enabled = true
+	policy.OnPolecatReuse = true
+	policy.Paths = []string{"dist"}
+	cleanState := func() artifact.SafetyState { return artifact.SafetyState{MRVerified: true} }
+
+	dryRoot := newWorktree(t)
+	result, ran, err := executeArtifactCleanupHook(dryRoot, policy, cleanState)
+	if err != nil || !ran || !result.DryRun || len(result.PathsCleaned) != 1 {
+		t.Fatalf("dry-run hook failed: ran=%t result=%+v err=%v", ran, result, err)
+	}
+	if _, err := os.Stat(filepath.Join(dryRoot, "dist")); err != nil {
+		t.Fatal("dry-run hook removed the artifact")
+	}
+
+	applyRoot := newWorktree(t)
+	policy.Mode = artifact.ModeApply
+	result, ran, err = executeArtifactCleanupHook(applyRoot, policy, cleanState)
+	if err != nil || !ran || result.BytesFreed == 0 {
+		t.Fatalf("apply hook failed: ran=%t result=%+v err=%v", ran, result, err)
+	}
+	if _, err := os.Stat(filepath.Join(applyRoot, "dist")); !os.IsNotExist(err) {
+		t.Fatal("apply hook did not remove the artifact")
+	}
+
+	unsafeRoot := newWorktree(t)
+	unsafeState := func() artifact.SafetyState { return artifact.SafetyState{MRVerified: true, ActiveMR: true} }
+	result, _, err = executeArtifactCleanupHook(unsafeRoot, policy, unsafeState)
+	if err != nil || !result.Refused {
+		t.Fatalf("unsafe hook was not refused: result=%+v err=%v", result, err)
+	}
+	if _, err := os.Stat(filepath.Join(unsafeRoot, "dist")); err != nil {
+		t.Fatal("unsafe hook removed the artifact")
+	}
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1810,6 +1810,17 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 		}
 	}
 
+	// hq-0onko: generic per-rig artifact cleanup. The canonical reuse decision
+	// above has already ruled out dirty work, pending MRs, and non-idle state.
+	// The hook repeats that decision immediately before each deletion and only
+	// touches configured, ignored paths. Failures remain observable but do not
+	// block dispatch, matching the compatibility behavior of target-clean.
+	if result, ran, err := m.runArtifactCleanupHook(name, clonePath); err != nil {
+		style.PrintWarning("artifact-clean hook for %s: %v", name, err)
+	} else if ran {
+		fmt.Println(formatArtifactHookResult(result))
+	}
+
 	polecatGit := git.NewGit(clonePath)
 
 	// Fetch latest from origin (non-fatal: may be offline)


### PR DESCRIPTION
## Summary

- add `gt cleanup artifacts` with dry-run default, explicit apply, JSON accounting, allowlists, protected paths, age and byte thresholds
- add a confined cleanup engine with Git, symlink, mount/filesystem, identity/content, and lifecycle rechecks
- add an opt-in polecat pre-reuse hook for ignored reproducible artifacts
- add `gt cleanup disk` plus documented CI and Dolt retention guidance
- integrate runner-mediated `mkdir-v1` maintenance verification for canonical CI apply

## Data-loss protections

Business data (`data`, `ml/models`, checkpoints) needs a rig-only two-key override; metadata, secrets, Dolt stores, protocol state, and runner-managed `_actions`/`_temp`/`_work`/`_tool` paths are permanently protected. Apply is restricted to canonical rig, registered polecat, or canonical CI roots. Deletion uses `os.Root`, refuses symlink and mount/filesystem boundaries, rechecks tracked/ignored state and candidate identity/content, and reports partial/incomplete outcomes nonzero.

CI apply verifies every exact Compose runner, environment, hook, byte-identical executable protocol script, and bind source before acquisition and before each mutation. The maintenance nonce is acquired/released inside a verified runner so the safety decision stays in the Linux mount domain; runner-set changes and release failures fail closed.

Related bead: `hq-0onko`.

## Runtime evidence

Captured 2026-07-13:

- real `ci-runner` dry run: 10,689,445,493 bytes considered; 9,705,240,232 bytes eligible; 0 bytes freed
- six Bridge pnpm stores and two Trivy caches were eligible; both Dardasha pnpm stores were conservatively skipped for symlink descendants
- workspace: 83,282,084 KiB; `ci-runner`: 15,217,316 KiB; `.dolt-backup`: 5,514,240 KiB; `.dolt-data`: 4,528,352 KiB; Bridge polecats: 5,159,724 KiB
- Docker.raw: 133,340,584 KiB; Docker images 104.8 GB; containers 31.9 GB; volumes 24.72 GB; build cache 23.44 GB

## Validation

Candidate: `6c8356583e056ada57c60e7a75edbc5009bf13ed`.

- GitHub CI run 29188031478: 5/5 jobs passed
- GitHub Windows CI run 29188031421: passed
- complete PR rollup: 7/7 checks passed
- full `internal/artifact` suite and focused command/config/polecat suites passed
- synthetic dry-run/apply fixture passed
- `go vet` passed; focused `golangci-lint` reported 0 issues
- Linux and Windows artifact package compilation, example JSON validation, and `git diff --check` passed
- Codecov's patch-coverage comment is advisory and non-gating

## Deployment note

Live CI apply intentionally remains blocked until Bridge Town's protocol PR is deployed and `hq-zrgm9` instruments both Dardasha runners. Runner writable-layer recreation remains `hq-uvw1l`; Dolt deletion remains report-only.
