### PR TITLE
fix(compact-report): restore patrol coverage

### DIFF
--- a/internal/cmd/compact_report.go
+++ b/internal/cmd/compact_report.go
@@ -69,6 +69,8 @@ var wispCategoryMap = map[string]string{
 // categoryOrder is the display order for categories in reports.
 var categoryOrder = []string{"Heartbeats", "Patrols", "Errors", "Untyped"}
 
+const zeroPatrolReportingGap = "0 eligible patrol wisps in the report query/window (patrol health not assessed)"
+
 // categoryStats tracks per-category compaction statistics.
 type categoryStats struct {
 	Deleted  int `json:"deleted"`
@@ -171,7 +173,7 @@ func runDailyDigest() error {
 		return fmt.Errorf("getting working dir: %w", err)
 	}
 	bd := beads.New(workDir)
-	activeWisps, err := listWisps(bd)
+	activeWisps, err := listReportWisps(bd)
 	if err != nil {
 		return fmt.Errorf("listing active wisps: %w", err)
 	}
@@ -214,6 +216,29 @@ func runDailyDigest() error {
 	}
 
 	return nil
+}
+
+// listReportWisps includes infrastructure wisps that the default bd list view
+// hides. This is intentionally separate from listWisps, whose result drives
+// mutating compaction decisions and must retain its existing scope.
+func listReportWisps(bd *beads.Beads) ([]*compactIssue, error) {
+	out, err := bd.Run("list", "--include-infra", "--json", "--all", "-n", "0")
+	if err != nil {
+		return nil, err
+	}
+
+	var allIssues []*compactIssue
+	if err := json.Unmarshal(extractJSONArray(out), &allIssues); err != nil {
+		return nil, fmt.Errorf("parsing report issue list: %w", err)
+	}
+
+	var wisps []*compactIssue
+	for _, issue := range allIssues {
+		if issue.Ephemeral {
+			wisps = append(wisps, issue)
+		}
+	}
+	return wisps, nil
 }
 
 // buildReport aggregates compaction results by category.
@@ -276,9 +301,9 @@ func detectAnomalies(report *compactReport) []string {
 				stats.Deleted/300)) // ~300/day is baseline for a rig
 		}
 
-		// Zero patrols is suspicious (witness may be down)
+		// A zero query result is a reporting observation, not agent-health proof.
 		if cat == "Patrols" && stats.Active == 0 && stats.Deleted == 0 && stats.Promoted == 0 {
-			anomalies = append(anomalies, "0 patrol wisps (patrol agents may be down)")
+			anomalies = append(anomalies, zeroPatrolReportingGap)
 		}
 
 		// High promotion rate (> 50% of non-skipped suggests miscategorized wisps)
@@ -445,7 +470,9 @@ func runWeeklyRollup() error {
 			rollup.Totals[cat].Active = stats.Active // Use latest active count
 		}
 		rollup.Promotions += len(report.Promotions)
-		rollup.Anomalies = append(rollup.Anomalies, report.Anomalies...)
+		for _, anomaly := range report.Anomalies {
+			rollup.Anomalies = append(rollup.Anomalies, normalizeCompactionAnomaly(anomaly))
+		}
 	}
 
 	if compactReportJSON {
@@ -494,6 +521,7 @@ func runWeeklyRollup() error {
 func queryCompactionReports(startDate, endDate string) ([]*compactReport, error) {
 	listCmd := exec.Command("bd", "list",
 		"--type=event",
+		"--status=all",
 		"--json",
 		"--limit=0",
 	)
@@ -503,15 +531,19 @@ func queryCompactionReports(startDate, endDate string) ([]*compactReport, error)
 	}
 
 	var events []struct {
-		ID           string `json:"id"`
-		Title        string `json:"title"`
-		EventPayload string `json:"event_payload"`
+		ID        string `json:"id"`
+		Title     string `json:"title"`
+		Payload   string `json:"payload"`
+		CreatedAt string `json:"created_at"`
 	}
 	if err := json.Unmarshal(extractJSONArray(listOutput), &events); err != nil {
 		return nil, fmt.Errorf("parsing event list: %w", err)
 	}
 
 	var reports []*compactReport
+	reportIndexByDate := make(map[string]int)
+	reportCreatedAtByDate := make(map[string]string)
+	matchingEvents := 0
 	for _, evt := range events {
 		if !strings.HasPrefix(evt.Title, "Compaction Report ") {
 			continue
@@ -521,16 +553,31 @@ func queryCompactionReports(startDate, endDate string) ([]*compactReport, error)
 		if evtDate < startDate || evtDate > endDate {
 			continue
 		}
+		matchingEvents++
 
 		// Parse the event payload back into a compactReport
-		if evt.EventPayload == "" {
+		if evt.Payload == "" {
 			continue
 		}
 		var report compactReport
-		if err := json.Unmarshal([]byte(evt.EventPayload), &report); err != nil {
+		if err := json.Unmarshal([]byte(evt.Payload), &report); err != nil {
 			continue
 		}
+		if idx, exists := reportIndexByDate[report.Date]; exists {
+			// A failed historical idempotency check can leave duplicate daily
+			// audit beads. Count each calendar day once and keep the newest copy.
+			if evt.CreatedAt > reportCreatedAtByDate[report.Date] {
+				reports[idx] = &report
+				reportCreatedAtByDate[report.Date] = evt.CreatedAt
+			}
+			continue
+		}
+		reportIndexByDate[report.Date] = len(reports)
+		reportCreatedAtByDate[report.Date] = evt.CreatedAt
 		reports = append(reports, &report)
+	}
+	if matchingEvents > 0 && len(reports) == 0 {
+		return nil, fmt.Errorf("found %d matching compaction report event(s), but no usable payload", matchingEvents)
 	}
 
 	// Sort by date
@@ -541,12 +588,23 @@ func queryCompactionReports(startDate, endDate string) ([]*compactReport, error)
 	return reports, nil
 }
 
+func normalizeCompactionAnomaly(anomaly string) string {
+	if anomaly == "0 patrol wisps (patrol agents may be down)" {
+		return zeroPatrolReportingGap
+	}
+	return anomaly
+}
+
 // formatWeeklyRollup renders the markdown weekly rollup.
 func formatWeeklyRollup(rollup *weeklyRollup) string {
 	var sb strings.Builder
 
 	sb.WriteString(fmt.Sprintf("## Weekly Wisp Compaction: %s to %s\n\n", rollup.WeekStart, rollup.WeekEnd))
 	sb.WriteString(fmt.Sprintf("**Days reported:** %d\n\n", rollup.Days))
+	if rollup.Days == 0 {
+		sb.WriteString("### Coverage\n")
+		sb.WriteString("- No eligible daily compaction reports were found in this date range; patrol health was not assessed.\n\n")
+	}
 
 	// Totals table
 	sb.WriteString("### Totals\n")

--- a/internal/cmd/compact_report_test.go
+++ b/internal/cmd/compact_report_test.go
@@ -109,6 +109,154 @@ func TestBuildReport(t *testing.T) {
 	}
 }
 
+func TestListReportWispsIncludesInfrastructure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script command stubs not supported on Windows")
+	}
+
+	binDir := t.TempDir()
+	argsLog := filepath.Join(t.TempDir(), "bd-args.log")
+	bdScript := `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_ARGS_LOG"
+case "$*" in
+  *list*)
+    printf '[{"id":"hq-wisp-patrol","title":"mol-deacon-patrol","status":"hooked","issue_type":"molecule","ephemeral":true,"wisp_type":"patrol"}]\n'
+    ;;
+  *)
+    printf 'bd test stub\n'
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_ARGS_LOG", argsLog)
+	beads.ResetBdAllowStaleCacheForTest()
+	t.Cleanup(beads.ResetBdAllowStaleCacheForTest)
+
+	wisps, err := listReportWisps(beads.New(t.TempDir()))
+	if err != nil {
+		t.Fatalf("listReportWisps: %v", err)
+	}
+	if len(wisps) != 1 || wisps[0].ID != "hq-wisp-patrol" {
+		t.Fatalf("wisps = %#v, want patrol infrastructure wisp", wisps)
+	}
+
+	args, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("read bd args: %v", err)
+	}
+	if !strings.Contains(string(args), "--include-infra") {
+		t.Fatalf("bd args = %q, want --include-infra", string(args))
+	}
+}
+
+func TestQueryCompactionReportsReadsPayloadField(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script command stubs not supported on Windows")
+	}
+
+	binDir := t.TempDir()
+	bdScript := `#!/bin/sh
+printf '%s\n' '[{"id":"hq-report","title":"Compaction Report 2026-07-12","payload":"{\"date\":\"2026-07-12\",\"categories\":{\"Patrols\":{\"active\":2}}}"}]'
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	reports, err := queryCompactionReports("2026-07-05", "2026-07-12")
+	if err != nil {
+		t.Fatalf("queryCompactionReports: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("len(reports) = %d, want 1", len(reports))
+	}
+	if got := reports[0].Categories["Patrols"].Active; got != 2 {
+		t.Fatalf("Patrols.Active = %d, want 2", got)
+	}
+}
+
+func TestQueryCompactionReportsIncludesClosedEvents(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script command stubs not supported on Windows")
+	}
+
+	binDir := t.TempDir()
+	argsLog := filepath.Join(t.TempDir(), "bd-args.log")
+	bdScript := `#!/bin/sh
+printf '%s\n' "$*" > "$BD_ARGS_LOG"
+printf '%s\n' '[{"id":"hq-report","title":"Compaction Report 2026-07-12","payload":"{\"date\":\"2026-07-12\",\"categories\":{}}"}]'
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_ARGS_LOG", argsLog)
+
+	reports, err := queryCompactionReports("2026-07-05", "2026-07-12")
+	if err != nil {
+		t.Fatalf("queryCompactionReports: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("len(reports) = %d, want 1 closed event", len(reports))
+	}
+	args, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("read bd args: %v", err)
+	}
+	if !strings.Contains(string(args), "--status=all") {
+		t.Fatalf("bd args = %q, want --status=all", string(args))
+	}
+}
+
+func TestQueryCompactionReportsDeduplicatesReportDates(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script command stubs not supported on Windows")
+	}
+
+	binDir := t.TempDir()
+	bdScript := `#!/bin/sh
+printf '%s\n' '[{"id":"hq-old","title":"Compaction Report 2026-07-08","created_at":"2026-07-08T00:00:00Z","payload":"{\"date\":\"2026-07-08\",\"categories\":{\"Patrols\":{\"active\":1}}}"},{"id":"hq-new","title":"Compaction Report 2026-07-08","created_at":"2026-07-08T01:00:00Z","payload":"{\"date\":\"2026-07-08\",\"categories\":{\"Patrols\":{\"active\":2}}}"}]'
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	reports, err := queryCompactionReports("2026-07-05", "2026-07-12")
+	if err != nil {
+		t.Fatalf("queryCompactionReports: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("len(reports) = %d, want 1 unique report date", len(reports))
+	}
+	if got := reports[0].Categories["Patrols"].Active; got != 2 {
+		t.Fatalf("Patrols.Active = %d, want first/latest report value 2", got)
+	}
+}
+
+func TestQueryCompactionReportsRejectsMatchingEventsWithoutUsablePayload(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script command stubs not supported on Windows")
+	}
+
+	binDir := t.TempDir()
+	bdScript := `#!/bin/sh
+printf '%s\n' '[{"id":"hq-report","title":"Compaction Report 2026-07-12","payload":"not-json"}]'
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := queryCompactionReports("2026-07-05", "2026-07-12")
+	if err == nil || !strings.Contains(err.Error(), "no usable payload") {
+		t.Fatalf("error = %v, want no usable payload diagnostic", err)
+	}
+}
+
 func TestDetectAnomalies(t *testing.T) {
 	t.Run("high heartbeat volume", func(t *testing.T) {
 		report := &compactReport{
@@ -143,12 +291,17 @@ func TestDetectAnomalies(t *testing.T) {
 		anomalies := detectAnomalies(report)
 		found := false
 		for _, a := range anomalies {
-			if strings.Contains(a, "0 patrol wisps") {
+			if strings.Contains(a, "0 eligible patrol wisps") {
 				found = true
 			}
 		}
 		if !found {
 			t.Error("expected zero patrol anomaly, got none")
+		}
+		for _, a := range anomalies {
+			if strings.Contains(a, "patrol agents may be down") {
+				t.Fatalf("reporting gap must not claim agent health: %q", a)
+			}
 		}
 	})
 
@@ -289,6 +442,34 @@ func TestFormatWeeklyRollup(t *testing.T) {
 	}
 	if !strings.Contains(md, "### Anomalies This Week") {
 		t.Error("missing anomalies section")
+	}
+}
+
+func TestFormatWeeklyRollupExplainsZeroDayCoverage(t *testing.T) {
+	rollup := &weeklyRollup{
+		WeekStart: "2026-07-05",
+		WeekEnd:   "2026-07-12",
+		Totals: map[string]*categoryStats{
+			"Heartbeats": {},
+			"Patrols":    {},
+			"Errors":     {},
+			"Untyped":    {},
+		},
+	}
+
+	md := formatWeeklyRollup(rollup)
+	if !strings.Contains(md, "No eligible daily compaction reports") {
+		t.Fatalf("zero-day rollup lacks coverage explanation:\n%s", md)
+	}
+}
+
+func TestNormalizeCompactionAnomalyRemovesUnsupportedHealthClaim(t *testing.T) {
+	got := normalizeCompactionAnomaly("0 patrol wisps (patrol agents may be down)")
+	if strings.Contains(got, "agents may be down") {
+		t.Fatalf("normalized anomaly still claims agent health: %q", got)
+	}
+	if !strings.Contains(got, "patrol health not assessed") {
+		t.Fatalf("normalized anomaly = %q, want reporting-scope explanation", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- include infrastructure wisps in daily report-only queries
- read closed daily event payloads and deduplicate report dates for weekly rollups
- distinguish reporting gaps from patrol-health evidence

## Verification
- go test ./internal/cmd -run Test(ListReportWisps|QueryCompactionReports|DetectAnomalies|FormatWeeklyRollup|NormalizeCompactionAnomaly) -count=1
- live daily dry-run reported Patrols Active = 2
- live weekly dry-run reported 5 unique days for 2026-07-05 through 2026-07-12