### PR TITLE
fix(refinery): merged-PR sweep drains PRs merged outside the refinery flow

### DIFF
--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -96,6 +96,8 @@ This happens when idle_cycles >= {{idle_effort_threshold}} (no events on channel
 Abbreviated patrol rules:
 - **inbox-check**: Run `gt mail drain` and quick inbox check. Skip individual message processing unless new MERGE_READY found.
 - **queue-scan**: Quick `gt mq list` check. If queue is empty, skip directly to check-integration-branches.
+- **merged-pr-sweep**: ALWAYS run when any open MRs exist (one `gh pr view` per MR — cheap).
+  This is the only signal for owner-initiated GitHub merges; skipping it strands polecats in PENDING_MR.
 - **process-branch through merge-push**: Only run if queue-scan found work. Otherwise SKIP all.
 - **loop-check through generate-summary**: SKIP if no merges were processed.
 - **check-integration-branches**: Quick check only.
@@ -107,7 +109,7 @@ When `await-event` outputs `EFFORT: full`, run all steps thoroughly (normal mode
 
 The goal: idle cycles should burn ~10% of the tokens a full patrol uses."""
 formula = "mol-refinery-patrol"
-version = 15
+version = 16
 
 [vars]
 [vars.wisp_type]
@@ -270,15 +272,87 @@ git branch -r | grep <branch>
 ```
 
 If branch doesn't exist for a queued MR:
-- Close the MR bead: `bd close <mr-id> --reason "Branch no longer exists"`
-- Remove from processing queue
+- **First check for an owner-merged PR** (the branch may be gone because GitHub
+  deleted it when a human merged the PR):
+  ```bash
+  gh pr view <branch> --json state -q '.state' 2>/dev/null
+  ```
+  If this prints `MERGED`, do NOT close the MR here — keep it in the list for
+  the merged-pr-sweep step (next), which runs the full post-merge drain
+  (MERGED mail to witness + `gt mq post-merge`). Closing it here would skip
+  the drain: the source issue stays open and the witness never learns the
+  polecat's work landed.
+- Otherwise (no PR, or PR not merged): close the MR bead:
+  `bd close <mr-id> --reason "Branch no longer exists"` and remove from
+  processing queue.
 
 Track verified MR list for this cycle."""
 
 [[steps]]
+id = "merged-pr-sweep"
+title = "Sweep for externally-merged PRs"
+needs = ["queue-scan"]
+description = """
+Detect MRs whose PR was merged OUTSIDE the refinery flow and drain them.
+
+**Why this step exists (op-3d5o):** In repos with a no-self-merge rule, the
+repo owner merges every PR by hand on GitHub. An owner-initiated merge fires
+NO refinery gate event — nothing wakes the refinery, and no later step
+re-checks PR state. Without this sweep the MR bead stays open and the polecat
+sits PENDING_MR indefinitely (PR 788 sat 2h+ until a manual witness nudge).
+This sweep is the refinery's ONLY signal for owner-initiated merges, so it
+runs EVERY patrol cycle — including abbreviated (EFFORT: reduced) cycles.
+It is cheap: one `gh pr view` per open MR.
+
+**For each open MR from queue-scan** (skip this step only if the queue is empty):
+
+```bash
+gh pr view <polecat-branch> --json state,mergedAt,number,url -q '.state + " " + (.mergedAt // "none") + " #" + (.number|tostring) + " " + .url' 2>/dev/null
+```
+
+Interpret the result:
+
+- **Command fails (no PR for this branch)**: nothing to sweep — leave the MR
+  for normal processing (process-branch onward).
+- **State `OPEN`**: PR still pending — leave the MR for normal processing.
+- **State `CLOSED`** (closed without merging): the work did NOT land. Do NOT
+  drain. Leave the MR bead open, note it in the patrol summary — normal
+  processing will handle resubmission.
+- **State `MERGED`**: the work already landed. Run the post-merge drain NOW:
+
+**Post-merge drain (all four required, in order):**
+
+1. **Send MERGED mail to witness** (releases the polecat — without this the
+   worktree is never cleaned up):
+   ```bash
+   gt mail send <rig>/witness -s "MERGED <polecat-name>" -m "Branch: <branch>
+   Issue: <issue-id>
+   PR: <pr-url>
+   Merged-At: <mergedAt from gh output>
+   Merged-By: external (owner-initiated GitHub merge, detected by merged-pr-sweep)"
+   ```
+
+2. **Post-merge cleanup** (closes MR bead + source issue):
+   ```bash
+   gt mq post-merge <rig> <mr-bead-id> --skip-branch-delete
+   ```
+   Always pass `--skip-branch-delete`: in PR mode GitHub owns branch cleanup,
+   and the branch may already be gone.
+
+3. **Archive any MERGE_READY mail** for this branch (if still in inbox):
+   ```bash
+   gt mail archive <merge-ready-message-id>
+   ```
+
+4. **Remove the MR from this cycle's processing queue** — do NOT rebase or
+   re-process it in process-branch.
+
+Track for the patrol summary: MRs swept (count, branches, PR numbers)."""
+
+[[steps]]
 id = "process-branch"
 title = "Mechanical rebase"
-needs = ["queue-scan"]
+needs = ["merged-pr-sweep"]
 description = """
 Pick next branch from queue. Attempt mechanical rebase on the MR's effective target branch.
 
@@ -1193,6 +1267,7 @@ After await-event returns, check the EFFORT directive in the output:
 **If `EFFORT: reduced`** — Run ABBREVIATED patrol:
 - inbox-check: Quick drain + check for MERGE_READY only
 - queue-scan: Quick `gt mq list`. If empty, skip to check-integration-branches
+- merged-pr-sweep: ALWAYS run when any open MRs exist (cheap; only signal for owner-initiated merges)
 - process-branch through merge-push: SKIP if queue empty
 - loop-check through generate-summary: SKIP if no merges processed
 - check-integration-branches: Quick check only

--- a/internal/formula/refinery_merged_pr_sweep_test.go
+++ b/internal/formula/refinery_merged_pr_sweep_test.go
@@ -1,0 +1,168 @@
+package formula
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRefineryPatrolHasMergedPRSweep verifies that the refinery patrol formula
+// includes a merged-pr-sweep step that detects PRs merged outside the refinery
+// flow (owner-initiated GitHub merges).
+//
+// In repos with a no-self-merge rule, the repo owner merges every PR by hand.
+// An owner-initiated merge fires no refinery gate event, so without a per-cycle
+// sweep the MR bead stays open and the polecat sits PENDING_MR indefinitely
+// (PR 788 sat 2h+ until a manual witness nudge).
+//
+// Regression test for op-3d5o.
+func TestRefineryPatrolHasMergedPRSweep(t *testing.T) {
+	content, err := formulasFS.ReadFile("formulas/mol-refinery-patrol.formula.toml")
+	if err != nil {
+		t.Fatalf("reading refinery patrol formula: %v", err)
+	}
+
+	f, err := Parse(content)
+	if err != nil {
+		t.Fatalf("parsing refinery patrol formula: %v", err)
+	}
+
+	var sweep, processBranch *Step
+	for i := range f.Steps {
+		switch f.Steps[i].ID {
+		case "merged-pr-sweep":
+			sweep = &f.Steps[i]
+		case "process-branch":
+			processBranch = &f.Steps[i]
+		}
+	}
+
+	if sweep == nil {
+		t.Fatal("refinery patrol formula must have a \"merged-pr-sweep\" step " +
+			"(only signal for owner-initiated GitHub merges; see op-3d5o)")
+	}
+	if processBranch == nil {
+		t.Fatal("refinery patrol formula must have a \"process-branch\" step")
+	}
+
+	// DAG position: the sweep runs after queue-scan (needs the MR list) and
+	// before per-branch processing (drained MRs must not be re-processed).
+	if !containsDep(sweep.Needs, "queue-scan") {
+		t.Errorf("merged-pr-sweep must depend on \"queue-scan\", got needs=%v", sweep.Needs)
+	}
+	if !containsDep(processBranch.Needs, "merged-pr-sweep") {
+		t.Errorf("process-branch must depend on \"merged-pr-sweep\" so drained MRs "+
+			"are removed from the queue before rebase, got needs=%v", processBranch.Needs)
+	}
+
+	// The sweep must use the cheap PR-state check and run the full
+	// post-merge drain on MERGED.
+	requiredPatterns := []string{
+		"gh pr view",             // one PR-state lookup per open MR
+		"state,mergedAt",         // the cheap JSON fields
+		"gt mq post-merge",       // closes MR bead + source issue
+		"--skip-branch-delete",   // GitHub owns branch cleanup in PR mode
+		"MERGED mail to witness", // releases the polecat worktree
+	}
+	for _, pattern := range requiredPatterns {
+		if !strings.Contains(sweep.Description, pattern) {
+			t.Errorf("merged-pr-sweep step missing required pattern %q\n"+
+				"The sweep must check PR state cheaply and run the full "+
+				"post-merge drain (witness mail + gt mq post-merge) on MERGED.",
+				pattern)
+		}
+	}
+
+	// CLOSED-without-merge must NOT be drained — the work didn't land.
+	if !strings.Contains(sweep.Description, "CLOSED") {
+		t.Error("merged-pr-sweep step must distinguish CLOSED (not merged) PRs " +
+			"from MERGED ones — only MERGED PRs get the post-merge drain")
+	}
+}
+
+// TestRefineryPatrolSweepRunsInAbbreviatedMode verifies the merged-pr-sweep
+// step is explicitly included in the abbreviated (EFFORT: reduced) patrol
+// rules. Idle rigs run abbreviated patrols almost exclusively, and an
+// owner-initiated merge is precisely the event that arrives while the
+// refinery is idle — if reduced cycles skip the sweep, the fix is dead code
+// exactly when it is needed.
+//
+// Regression test for op-3d5o.
+func TestRefineryPatrolSweepRunsInAbbreviatedMode(t *testing.T) {
+	content, err := formulasFS.ReadFile("formulas/mol-refinery-patrol.formula.toml")
+	if err != nil {
+		t.Fatalf("reading refinery patrol formula: %v", err)
+	}
+
+	f, err := Parse(content)
+	if err != nil {
+		t.Fatalf("parsing refinery patrol formula: %v", err)
+	}
+
+	// The root description holds the "Abbreviated Patrol Mode" rules.
+	if !strings.Contains(f.Description, "merged-pr-sweep") {
+		t.Error("formula root description's Abbreviated Patrol rules must include " +
+			"merged-pr-sweep (ALWAYS run when open MRs exist)")
+	}
+
+	// burn-or-loop repeats the EFFORT: reduced step list for the next cycle.
+	var loopDesc string
+	for _, step := range f.Steps {
+		if step.ID == "burn-or-loop" {
+			loopDesc = step.Description
+			break
+		}
+	}
+	if loopDesc == "" {
+		t.Fatal("burn-or-loop step not found or has empty description")
+	}
+	if !strings.Contains(loopDesc, "merged-pr-sweep") {
+		t.Error("burn-or-loop's EFFORT: reduced rules must include merged-pr-sweep " +
+			"so abbreviated cycles still detect owner-initiated merges")
+	}
+}
+
+// TestRefineryQueueScanGuardsOwnerMergedBranches verifies that queue-scan's
+// "branch no longer exists" path checks for a merged PR before closing the
+// MR bead. GitHub deletes the head branch when the owner merges a PR, so a
+// bare close there would skip the post-merge drain: the source issue stays
+// open and the witness never learns the work landed.
+//
+// Regression test for op-3d5o.
+func TestRefineryQueueScanGuardsOwnerMergedBranches(t *testing.T) {
+	content, err := formulasFS.ReadFile("formulas/mol-refinery-patrol.formula.toml")
+	if err != nil {
+		t.Fatalf("reading refinery patrol formula: %v", err)
+	}
+
+	f, err := Parse(content)
+	if err != nil {
+		t.Fatalf("parsing refinery patrol formula: %v", err)
+	}
+
+	var queueScanDesc string
+	for _, step := range f.Steps {
+		if step.ID == "queue-scan" {
+			queueScanDesc = step.Description
+			break
+		}
+	}
+	if queueScanDesc == "" {
+		t.Fatal("queue-scan step not found or has empty description")
+	}
+
+	if !strings.Contains(queueScanDesc, "gh pr view") ||
+		!strings.Contains(queueScanDesc, "merged-pr-sweep") {
+		t.Error("queue-scan's branch-missing path must check for an owner-merged PR " +
+			"(gh pr view) and defer MERGED ones to the merged-pr-sweep drain instead " +
+			"of closing the MR bead with \"Branch no longer exists\"")
+	}
+}
+
+func containsDep(needs []string, dep string) bool {
+	for _, n := range needs {
+		if n == dep {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/templates/roles/refinery.md.tmpl
+++ b/internal/templates/roles/refinery.md.tmpl
@@ -74,6 +74,12 @@ Polecat completes → POLECAT_DONE → Witness
 
 When you receive MERGE_READY mail, **work is waiting**. Check your inbox and process.
 
+**Owner-initiated merges fire NO event.** In repos with a no-self-merge rule the
+repo owner merges PRs by hand on GitHub, and nothing wakes you. The
+merged-pr-sweep patrol step is your ONLY signal for these merges — it checks
+each open MR's PR state every cycle and drains merged ones (MERGED mail to
+witness + `{{ cmd }} mq post-merge`). Never skip it while open MRs exist.
+
 ## Working Directory
 
 **IMPORTANT**: Always work from `{{ .WorkDir }}` directory.
@@ -115,16 +121,17 @@ Your work is defined by the `mol-refinery-patrol` molecule with these steps:
 
 1. **inbox-check** — Handle messages, escalations
 2. **queue-scan** — Identify polecat branches waiting
-3. **process-branch** — Rebase on the MR's effective target branch
-4. **run-tests** — Run quality checks and test suite
-5. **handle-failures** — **VERIFICATION GATE** (critical!)
-6. **merge-push** — Merge and push immediately
-7. **loop-check** — More branches? Loop back
-8. **generate-summary** — Summarize cycle
-9. **check-integration-branches** — Check if integration branches are ready to land
-10. **context-check** — Check context usage
-11. **patrol-cleanup** — End-of-cycle inbox hygiene
-12. **burn-or-loop** — Burn wisp, loop or exit
+3. **merged-pr-sweep** — Detect PRs merged outside the refinery (owner-initiated) and drain them
+4. **process-branch** — Rebase on the MR's effective target branch
+5. **run-tests** — Run quality checks and test suite
+6. **handle-failures** — **VERIFICATION GATE** (critical!)
+7. **merge-push** — Merge and push immediately
+8. **loop-check** — More branches? Loop back
+9. **generate-summary** — Summarize cycle
+10. **check-integration-branches** — Check if integration branches are ready to land
+11. **context-check** — Check context usage
+12. **patrol-cleanup** — End-of-cycle inbox hygiene
+13. **burn-or-loop** — Burn wisp, loop or exit
 
 ## Startup Protocol: Propulsion
 
@@ -177,6 +184,7 @@ Step emojis:
 |------|-------|-------------|
 | inbox-check | 📥 | Messages, escalations |
 | queue-scan | 🔍 | Scanning for branches to merge |
+| merged-pr-sweep | 🧲 | Draining PRs merged outside the refinery |
 | process-branch | 🔧 | Rebasing branch on MR target |
 | run-tests | 🧪 | Quality checks and test suite |
 | handle-failures | 🚦 | Verification gate |
@@ -203,6 +211,16 @@ gt mq list {{ .RigName }}
 ```
 ⚠️ **CRITICAL**: `{{ cmd }} mq list` is the ONLY source of truth. NEVER use `git branch -r | grep polecat`.
 If queue empty, skip to context-check.
+
+**merged-pr-sweep**: For each open MR, check whether its PR was merged by a human
+on GitHub (no event fires for owner-initiated merges):
+```bash
+gh pr view <polecat-branch> --json state,mergedAt -q '.state + " " + (.mergedAt // "none")'
+```
+If `MERGED`: send MERGED mail to witness, then
+`{{ cmd }} mq post-merge {{ .RigName }} <mr-id> --skip-branch-delete`, archive any
+MERGE_READY mail, and drop the MR from this cycle's queue. If `OPEN` / no PR:
+continue to normal processing.
 
 **process-branch**: Pick next branch, rebase on effective target
 ```bash


### PR DESCRIPTION
## Problem

The refinery's flow is driven entirely by its own gate events. When a human merges a polecat PR directly on GitHub — the standing pattern in repos with a no-self-merge rule, where the repo owner merges every PR by hand — nothing fires at the refinery. No patrol step ever re-checks PR state, so the MR bead stays open and the polecat sits PENDING_MR indefinitely.

Observed in production: a PR merged by the owner sat 2h+ with post-merge never running (MR bead undrained, polecat stuck PENDING_MR) until a manual witness nudge. Earlier owner-merges only drained by luck of refinery-active timing.

## Fix

**mol-refinery-patrol v16** adds a `merged-pr-sweep` step between `queue-scan` and `process-branch`:

- For each OPEN MR bead: one cheap `gh pr view <branch> --json state,mergedAt`.
- **MERGED** → full post-merge drain: MERGED mail to witness (releases the polecat), `gt mq post-merge <rig> <mr-id> --skip-branch-delete` (closes MR bead + source issue; GitHub owns branch cleanup in PR mode), archive MERGE_READY mail, drop the MR from the cycle queue.
- **CLOSED** (without merging) → explicitly NOT drained; the work didn't land.
- **OPEN / no PR** → normal processing.

Supporting changes:

1. The sweep is included in BOTH `EFFORT: reduced` (abbreviated patrol) rule lists — idle cycles are exactly when external merges arrive.
2. `queue-scan`'s "branch no longer exists → close MR" path now checks for an owner-merged PR first (GitHub deletes the head branch on merge) and defers MERGED ones to the sweep, instead of closing the MR bead without the drain.
3. `refinery.md.tmpl` documents the new step and warns that external merges fire no event.

## Tests

`internal/formula/refinery_merged_pr_sweep_test.go` (content-pinning over the embedded formula, same pattern as `patrol_backoff_test.go`): step existence + DAG position, drain content, abbreviated-mode inclusion, queue-scan guard.

`go build ./...`, `go vet ./...`, `go test ./internal/formula/ ./internal/templates/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)