### PR TITLE
test: align convoy JSON fixture for PR 4249

### DIFF
--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -305,7 +305,7 @@ func (d *testDAG) BdStubScript() string {
 	sb.WriteString(fmt.Sprintf("    echo '%s'\n", convoyListJSON))
 	sb.WriteString("    exit 0\n")
 	sb.WriteString("    ;;\n")
-	sb.WriteString("  list\\ --json\\ --limit=0|list\\ --json\\ --limit=0\\ --all|list\\ --json\\ --limit=0\\ --status=*)\n")
+	sb.WriteString("  list\\ --json\\ --limit=0*)\n")
 	sb.WriteString("    echo '[]'\n")
 	sb.WriteString("    exit 0\n")
 	sb.WriteString("    ;;\n")


### PR DESCRIPTION
Replacement for PR #4249.\n\nThis carries forward the still-relevant convoy fixture hunk from #4249 on a clean upstream-based branch. The original PR remains open and should only be closed as superseded after this replacement merges.\n\nEvidence from bead hq-hzzls:\n- PR Sheriff verdict: merge_replacement\n- Checker: gt-pr-sheriff-check --evidence .pr-sheriff-evidence-hq-hzzls.json --merge-gate -> PASS\n- Merge path allowed: true\n- Focused verification: CGO_ENABLED=0 go test -short -count=1 -run '^(TestReadBeadsRuntimeConfigDefaultServerAddr|TestJSONOutput_.*|TestRunConvoyList_UsesTownRootAndStripsBeadsDir)$' ./internal/cmd\n- Default CGO/full local run was blocked by missing ICU headers.\n\nAttribution is preserved in the commit with Co-authored-by: Andrew Boldi <andrewjboldi@gmail.com>.\n\nRefs #4249\nRefs hq-hzzls