### PR TITLE
fix: create witness workdir before redirect

### DIFF
--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -86,19 +86,25 @@ func (m *Manager) Status() (*tmux.SessionInfo, error) {
 }
 
 // witnessDir returns the working directory for the witness.
-// Prefers witness/rig/, falls back to witness/, then rig root.
+// Prefers witness/rig/ for existing legacy clones, otherwise uses witness/.
 func (m *Manager) witnessDir() string {
 	witnessRigDir := filepath.Join(m.rig.Path, "witness", "rig")
 	if _, err := os.Stat(witnessRigDir); err == nil {
 		return witnessRigDir
 	}
 
-	witnessDir := filepath.Join(m.rig.Path, "witness")
-	if _, err := os.Stat(witnessDir); err == nil {
-		return witnessDir
-	}
+	return filepath.Join(m.rig.Path, "witness")
+}
 
-	return m.rig.Path
+func (m *Manager) prepareWitnessDir(townRoot string) (string, error) {
+	witnessDir := m.witnessDir()
+	if err := os.MkdirAll(witnessDir, 0755); err != nil {
+		return "", fmt.Errorf("creating witness dir: %w", err)
+	}
+	if err := beads.SetupRedirect(townRoot, witnessDir); err != nil {
+		return "", fmt.Errorf("ensuring witness beads redirect: %w", err)
+	}
+	return witnessDir, nil
 }
 
 // Start starts the witness.
@@ -155,10 +161,10 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	// package config) to prevent concurrent rig starts from corrupting the
 	// global agent registry.
 	// Working directory
-	witnessDir := m.witnessDir()
 	townRoot := m.townRoot()
-	if err := beads.SetupRedirect(townRoot, witnessDir); err != nil {
-		return fmt.Errorf("ensuring witness beads redirect: %w", err)
+	witnessDir, err := m.prepareWitnessDir(townRoot)
+	if err != nil {
+		return err
 	}
 
 	// Resolve CLAUDE_CONFIG_DIR from accounts.json so witness sessions

--- a/internal/witness/manager_test.go
+++ b/internal/witness/manager_test.go
@@ -1,6 +1,8 @@
 package witness
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -16,6 +18,47 @@ func TestManagerStartForegroundDeprecated(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "foreground mode is deprecated") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPrepareWitnessDirCreatesMissingAddedRigWitnessDir(t *testing.T) {
+	t.Parallel()
+
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "gastown")
+	rigBeadsDir := filepath.Join(rigPath, ".beads")
+	mayorBeadsDir := filepath.Join(rigPath, "mayor", "rig", ".beads")
+
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+	if err := os.MkdirAll(mayorBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "redirect"), []byte("mayor/rig/.beads\n"), 0644); err != nil {
+		t.Fatalf("write rig beads redirect: %v", err)
+	}
+
+	mgr := NewManager(&rig.Rig{Name: "gastown", Path: rigPath})
+	witnessDir, err := mgr.prepareWitnessDir(townRoot)
+	if err != nil {
+		t.Fatalf("prepareWitnessDir: %v", err)
+	}
+
+	wantWitnessDir := filepath.Join(rigPath, "witness")
+	if witnessDir != wantWitnessDir {
+		t.Fatalf("witnessDir = %q, want %q", witnessDir, wantWitnessDir)
+	}
+	if info, err := os.Stat(witnessDir); err != nil || !info.IsDir() {
+		t.Fatalf("witness dir was not created: info=%v err=%v", info, err)
+	}
+
+	redirectData, err := os.ReadFile(filepath.Join(witnessDir, ".beads", "redirect"))
+	if err != nil {
+		t.Fatalf("read witness redirect: %v", err)
+	}
+	if got, want := string(redirectData), "../mayor/rig/.beads\n"; got != want {
+		t.Fatalf("redirect = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- create the canonical witness work directory before setting up its beads redirect
- remove the invalid fallback from a missing witness directory to the rig root
- add regression coverage for added rigs whose witness directory has not yet been created

## Attribution
This clean upstream-based replacement carries forward #4253. Commit `b9412c0c` is an exact patch-equivalent cherry-pick of silvanshade's `edb776c5`; the original author is preserved. Keep #4253 open until this replacement merges, then close it as superseded.

## Validation
- `CGO_ENABLED=0 go test ./internal/witness -run ^TestPrepareWitnessDirCreatesMissingAddedRigWitnessDir$ -count=1`
- `CGO_ENABLED=0 go test ./internal/witness -count=1`
- `CGO_ENABLED=0 go test ./internal/beads -run ^TestSetupRedirect$ -count=1`
- `CGO_ENABLED=0 go test ./internal/cmd -run ^TestEnsureBeadsRedirect_WitnessCreatesRedirect$ -count=1`
- `git diff --check`

## Review Evidence
The Gastown PR Sheriff workflow completed 15 independent research legs, 5 approving pre-implementation reviews, and 5 approving final-head post-implementation reviews. `gt-pr-sheriff-check --merge-gate` passed with `merge_path_allowed=true` and `verdict=merge_replacement`. The clean branch commit `b9412c0c` is patch-identical to reviewed head `3ee295bf` and is based directly on current upstream `main`.