### PR TITLE
test: align convoy JSON fixture with injected flags

### DIFF
--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -305,7 +305,7 @@ func (d *testDAG) BdStubScript() string {
 	sb.WriteString(fmt.Sprintf("    echo '%s'\n", convoyListJSON))
 	sb.WriteString("    exit 0\n")
 	sb.WriteString("    ;;\n")
-	sb.WriteString("  list\\ --json\\ --limit=0|list\\ --json\\ --limit=0\\ --all|list\\ --json\\ --limit=0\\ --status=*)\n")
+	sb.WriteString("  list\\ --json\\ --limit=0*)\n")
 	sb.WriteString("    echo '[]'\n")
 	sb.WriteString("    exit 0\n")
 	sb.WriteString("    ;;\n")


### PR DESCRIPTION
## Summary
- carry forward the one still-relevant test expectation from #4249
- make the convoy JSON fixture accept suffix flags injected by production, including `--flat`
- leave production code unchanged

## Attribution
This cleanup-first replacement preserves Andrew Boldi's #4249 intent. The commit references the original PR and includes `Co-authored-by: Andrew Boldi <andrewjboldi@gmail.com>`. The original PR is already closed.

## Validation
- `CGO_ENABLED=0 go test -short -count=1 -run ^(TestReadBeadsRuntimeConfigDefaultServerAddr|TestJSONOutput_.*|TestRunConvoyList_UsesTownRootAndStripsBeadsDir)$ ./internal/cmd`
- `git diff --check`

## Review Evidence
The Gastown PR Sheriff workflow completed 15 research legs, 5 approving pre-implementation reviews, and 5 approving post-implementation reviews tied to final head `f2d8a51f`. `gt-pr-sheriff-check --merge-gate` passed with `merge_path_allowed=true` and `verdict=merge_replacement`. This branch is one test-only hunk; current CI should provide fresh-main verification before merge.