### PR TITLE
fix(cmd): allow underscored bead prefixes

### DIFF
--- a/internal/cmd/cat.go
+++ b/internal/cmd/cat.go
@@ -61,17 +61,22 @@ func runCat(cmd *cobra.Command, args []string) error {
 }
 
 // isBeadID checks if a string looks like a bead ID.
-// Bead IDs have the format <prefix>-<id> where prefix is lowercase letters
-// (e.g. gt-abc123, bd-xyz, hq-cv-foo, wisp-bar, mol-baz).
+// Bead IDs have the format <prefix>-<id> where prefix starts with a
+// lowercase letter and may contain underscores (e.g. gt-abc123,
+// japanese_reader-id3a).
 func isBeadID(s string) bool {
-	// Must contain a dash and start with lowercase letters
 	dashIdx := strings.Index(s, "-")
 	if dashIdx <= 0 || dashIdx >= len(s)-1 {
 		return false
 	}
-	// Prefix must be all lowercase letters
-	for _, c := range s[:dashIdx] {
-		if c < 'a' || c > 'z' {
+	for i, c := range s[:dashIdx] {
+		if i == 0 {
+			if c < 'a' || c > 'z' {
+				return false
+			}
+			continue
+		}
+		if !((c >= 'a' && c <= 'z') || c == '_') {
 			return false
 		}
 	}

--- a/internal/cmd/cat_test.go
+++ b/internal/cmd/cat_test.go
@@ -16,14 +16,19 @@ func TestIsBeadID(t *testing.T) {
 		{"dolt-qux", true},
 		{"sky-abc", true},
 		{"wy-def", true},
-		// Multi-segment prefixes
+		// IDs may contain hyphens after the routing prefix.
 		{"hq-cv-foo", true},
+		// Rig-derived prefixes may contain underscores.
+		{"japanese_reader-id3a", true},
+		{"mcp_fit-92f", true},
 		// Invalid inputs
 		{"", false},
 		{"-abc", false},
 		{"abc", false},
 		{"ABC-123", false},
+		{"my_Rig-abc", false},
 		{"123-abc", false},
+		{"_rig-abc", false},
 		{"gt-", false},
 		{"-", false},
 	}


### PR DESCRIPTION
## Summary
- allow rig-derived bead prefixes to contain underscores after a required lowercase first character
- preserve existing empty prefix/suffix, uppercase, digit-leading, and leading-underscore rejection
- add focused positive and negative parser coverage

## Attribution
This clean upstream-based replacement carries forward #4203. The commit preserves TomCruiseTorpedo as author and records the original PR and commit. Keep #4203 open until this replacement merges, then close it as superseded.

## Validation
- `CGO_ENABLED=0 go test ./internal/cmd -run ^TestIsBeadID$ -count=1`
- `git diff --check`

## Review Evidence
The Gastown PR Sheriff workflow completed 15 research legs, 5 approving pre-implementation reviews, and 5 approving post-implementation reviews. `gt-pr-sheriff-check --merge-gate` passed with `merge_path_allowed=true` and `verdict=merge_replacement`. The diff is limited to the existing validator and focused tests.