### PR TITLE
fix(scheduler): converge queued context readiness

### DIFF
--- a/internal/cmd/capacity_dispatch.go
+++ b/internal/cmd/capacity_dispatch.go
@@ -329,6 +329,16 @@ type slingContextRecord struct {
 	beadsDir string
 }
 
+type scheduledContextAssessment struct {
+	context        slingContextRecord
+	fields         *capacity.SlingContextFields
+	info           beadStatusInfo
+	found          bool
+	blocked        bool
+	blockedUnknown bool
+	ready          bool
+}
+
 func beadsForContextRecord(rec slingContextRecord) *beads.Beads {
 	return beads.NewWithBeadsDir(rec.workDir, rec.beadsDir)
 }
@@ -390,6 +400,17 @@ type beadStatusInfo struct {
 	Labels []string
 }
 
+func beadStatusInfoFromBeadInfo(info *beadInfo) beadStatusInfo {
+	if info == nil {
+		return beadStatusInfo{}
+	}
+	return beadStatusInfo{
+		Status: info.Status,
+		Title:  info.Title,
+		Labels: info.Labels,
+	}
+}
+
 // batchFetchBeadInfoByIDs returns a map of bead ID → status+title+labels for specific beads.
 // Uses `bd show` with multiple IDs per rig directory instead of fetching all beads.
 // This avoids the O(minutes) latency of `bd list --all --json --limit=0` on large repos.
@@ -399,7 +420,8 @@ func batchFetchBeadInfoByIDs(townRoot string, ids []string) map[string]beadStatu
 		return result
 	}
 
-	idsByBeadsDir := groupBeadIDsByResolvedBeadsDir(townRoot, ids)
+	requestedIDs := uniqueNonEmptyIDs(ids)
+	idsByBeadsDir := groupBeadIDsByResolvedBeadsDir(townRoot, requestedIDs)
 	for beadsDir, groupedIDs := range idsByBeadsDir {
 		// Use Beads wrapper to get proper BEADS_DIR resolution, --allow-stale,
 		// and BEADS_DOLT_PORT translation (matching how all other bd-invoking
@@ -418,15 +440,40 @@ func batchFetchBeadInfoByIDs(townRoot string, ids []string) map[string]beadStatu
 			Title  string   `json:"title"`
 			Labels []string `json:"labels"`
 		}
-		if err := json.Unmarshal(out, &items); err == nil {
-			for _, item := range items {
-				result[item.ID] = beadStatusInfo{
-					Status: item.Status,
-					Title:  item.Title,
-					Labels: item.Labels,
-				}
+		if err := json.Unmarshal(out, &items); err != nil {
+			continue
+		}
+		for _, item := range items {
+			result[item.ID] = beadStatusInfo{
+				Status: item.Status,
+				Title:  item.Title,
+				Labels: item.Labels,
 			}
 		}
+	}
+
+	for _, id := range requestedIDs {
+		if _, found := result[id]; found {
+			continue
+		}
+		info, err := getBeadInfoFromTownRoot(townRoot, id)
+		if err != nil {
+			continue
+		}
+		result[id] = beadStatusInfoFromBeadInfo(info)
+	}
+	return result
+}
+
+func uniqueNonEmptyIDs(ids []string) []string {
+	result := make([]string, 0, len(ids))
+	seen := make(map[string]bool)
+	for _, id := range ids {
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		result = append(result, id)
 	}
 	return result
 }
@@ -450,100 +497,96 @@ func groupBeadIDsByResolvedBeadsDir(townRoot string, ids []string) map[string][]
 	return idsByBeadsDir
 }
 
+func assessScheduledContexts(townRoot string) ([]scheduledContextAssessment, error) {
+	contexts := listAllSlingContextRecords(townRoot)
+	if len(contexts) == 0 {
+		return nil, nil
+	}
+
+	candidates := make([]scheduledContextAssessment, 0, len(contexts))
+	workBeadIDs := make([]string, 0, len(contexts))
+	for _, ctx := range contexts {
+		fields := beads.ParseSlingContextFields(ctx.issue.Description)
+		if fields == nil || fields.WorkBeadID == "" || fields.TargetRig == "" {
+			continue
+		}
+		if fields.DispatchFailures >= maxDispatchFailures {
+			continue
+		}
+		candidates = append(candidates, scheduledContextAssessment{context: ctx, fields: fields})
+		workBeadIDs = append(workBeadIDs, fields.WorkBeadID)
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		fi := candidates[i].fields
+		fj := candidates[j].fields
+		if fi.EnqueuedAt != fj.EnqueuedAt {
+			return fi.EnqueuedAt < fj.EnqueuedAt
+		}
+		return candidates[i].context.issue.ID < candidates[j].context.issue.ID
+	})
+
+	workBeadInfo := batchFetchBeadInfoByIDs(townRoot, workBeadIDs)
+	blockedWorkIDs, blockedUnknownIDs, blockedErr := listBlockedWorkBeadIDStates(townRoot, workBeadIDs)
+
+	seenWork := make(map[string]bool)
+	assessments := make([]scheduledContextAssessment, 0, len(candidates))
+	for _, candidate := range candidates {
+		workBeadID := candidate.fields.WorkBeadID
+		if seenWork[workBeadID] {
+			continue
+		}
+		seenWork[workBeadID] = true
+
+		info, found := workBeadInfo[workBeadID]
+		candidate.info = info
+		candidate.found = found
+		candidate.blocked = blockedWorkIDs[workBeadID]
+		candidate.blockedUnknown = blockedUnknownIDs[workBeadID]
+		candidate.ready = isScheduledWorkBeadReady(workBeadID, info, found, blockedWorkIDs, blockedUnknownIDs)
+		assessments = append(assessments, candidate)
+	}
+
+	return assessments, blockedErr
+}
+
 // getReadySlingContexts queries for sling context beads whose work beads are ready.
 // This is a pure query — no destructive side effects. Call cleanupStaleContexts()
 // before this function to handle invalid/stale contexts.
 //
-// Sling contexts are queried from HQ only (authoritative). Work bead readiness
-// is checked across all rig dirs since work beads live in rig-local DBs.
+// Sling contexts are scanned from HQ and rig DBs. Work bead readiness is checked
+// by source ID so context location and source readiness cannot diverge.
 func getReadySlingContexts(townRoot string) ([]capacity.PendingBead, error) {
-	// 1. List all open sling context beads from HQ (authoritative)
-	allContexts := listAllSlingContextRecords(townRoot)
-
-	if len(allContexts) == 0 {
-		return nil, nil
-	}
-
-	// 2. Batch-fetch work bead labels/status so we can defensively filter messaging
-	// beads (gt:message / gt:handoff / gt:merge-request) that should never be
-	// handed to a polecat. See gt-el4 / gastownhall/gastown#3800.
-	workBeadIDs := make([]string, 0, len(allContexts))
-	for _, ctx := range allContexts {
-		fields := beads.ParseSlingContextFields(ctx.issue.Description)
-		if fields == nil {
-			continue
-		}
-		workBeadIDs = append(workBeadIDs, fields.WorkBeadID)
-	}
-	workBeadInfo := batchFetchBeadInfoByIDs(townRoot, workBeadIDs)
-	blockedWorkIDs, blockedErr := listBlockedWorkBeadIDsWithError(townRoot, workBeadIDs)
+	assessments, blockedErr := assessScheduledContexts(townRoot)
 	if blockedErr != nil {
 		return nil, blockedErr
 	}
 
-	// 3. Build PendingBead list — pure filtering, no mutations.
-	// Sort by EnqueuedAt for deterministic deduplication: when concurrent
-	// scheduleBead calls create multiple contexts for the same work bead,
-	// the oldest context always wins.
-	sort.Slice(allContexts, func(i, j int) bool {
-		fi := beads.ParseSlingContextFields(allContexts[i].issue.Description)
-		fj := beads.ParseSlingContextFields(allContexts[j].issue.Description)
-		if fi == nil || fj == nil {
-			return fi != nil // valid contexts sort before invalid
-		}
-		if fi.EnqueuedAt != fj.EnqueuedAt {
-			return fi.EnqueuedAt < fj.EnqueuedAt
-		}
-		return allContexts[i].issue.ID < allContexts[j].issue.ID // deterministic tiebreaker
-	})
-
-	seenWork := make(map[string]bool)
 	var result []capacity.PendingBead
-	for _, ctx := range allContexts {
-		fields := beads.ParseSlingContextFields(ctx.issue.Description)
-		if fields == nil {
-			continue // Skip invalid — cleanupStaleContexts handles these
-		}
-
-		// Circuit breaker filter
-		if fields.DispatchFailures >= maxDispatchFailures {
+	for _, assessment := range assessments {
+		if !assessment.ready {
 			continue
 		}
-
-		// Only include open, unblocked work beads. This uses the fast blocked
-		// cache plus targeted show output instead of shelling out to bd ready for
-		// every rig, which is prohibitively expensive in large towns.
-		info, found := workBeadInfo[fields.WorkBeadID]
-		if !isScheduledWorkBeadReady(fields.WorkBeadID, info, found, blockedWorkIDs) {
-			continue
-		}
-
-		// Deduplicate: one dispatch per work bead (oldest context wins)
-		if seenWork[fields.WorkBeadID] {
-			continue
-		}
-		seenWork[fields.WorkBeadID] = true
-
-		// Defensive filter: messaging beads (gt:message / gt:handoff /
-		// gt:merge-request) must never reach a rig polecat. Log the skip so
-		// the gap is observable and operators can chase the upstream cause.
-		workLabels := info.Labels
+		workLabels := assessment.info.Labels
 		if capacity.IsMessagingBead(workLabels) {
 			fmt.Fprintf(os.Stderr, "%s dispatch_skip reason=messaging_label bead=%s labels=%v\n",
-				style.Dim.Render("○"), fields.WorkBeadID, workLabels)
+				style.Dim.Render("○"), assessment.fields.WorkBeadID, workLabels)
 			continue
 		}
 
 		result = append(result, capacity.PendingBead{
-			ID:              ctx.issue.ID,
-			WorkBeadID:      fields.WorkBeadID,
-			Title:           ctx.issue.Title,
-			TargetRig:       fields.TargetRig,
-			Description:     ctx.issue.Description,
+			ID:              assessment.context.issue.ID,
+			WorkBeadID:      assessment.fields.WorkBeadID,
+			Title:           assessment.info.Title,
+			TargetRig:       assessment.fields.TargetRig,
+			Description:     assessment.context.issue.Description,
 			Labels:          workLabels,
-			Context:         fields,
-			ContextWorkDir:  ctx.workDir,
-			ContextBeadsDir: ctx.beadsDir,
+			Context:         assessment.fields,
+			ContextWorkDir:  assessment.context.workDir,
+			ContextBeadsDir: assessment.context.beadsDir,
 		})
 	}
 
@@ -725,21 +768,31 @@ func listAllSlingContextRecords(townRoot string) []slingContextRecord {
 	return records
 }
 
-// listBlockedWorkBeadIDsWithError returns a set of work bead IDs that have active blockers.
-// Returns an error only when ALL dirs fail (partial success is acceptable).
-func listBlockedWorkBeadIDsWithError(townRoot string, workBeadIDs []string) (map[string]bool, error) {
+type blockedWorkQuery func(beadsDir string, groupedIDs []string) ([]byte, error)
+
+func runBlockedWorkQuery(beadsDir string, _ []string) ([]byte, error) {
+	// Use Beads wrapper to get proper BEADS_DIR resolution, --allow-stale,
+	// and BEADS_DOLT_PORT translation.
+	b := beads.NewWithBeadsDir(filepath.Dir(beadsDir), beadsDir)
+	return b.Run("blocked", "--json")
+}
+
+func listBlockedWorkBeadIDStates(townRoot string, workBeadIDs []string) (map[string]bool, map[string]bool, error) {
+	return listBlockedWorkBeadIDStatesWithRunner(townRoot, workBeadIDs, runBlockedWorkQuery)
+}
+
+func listBlockedWorkBeadIDStatesWithRunner(townRoot string, workBeadIDs []string, query blockedWorkQuery) (map[string]bool, map[string]bool, error) {
 	blockedIDs := make(map[string]bool)
+	blockedUnknownIDs := make(map[string]bool)
 	idsByBeadsDir := groupBeadIDsByResolvedBeadsDir(townRoot, workBeadIDs)
 	failCount := 0
 	var lastErr error
-	for beadsDir := range idsByBeadsDir {
-		// Use Beads wrapper to get proper BEADS_DIR resolution, --allow-stale,
-		// and BEADS_DOLT_PORT translation.
-		b := beads.NewWithBeadsDir(filepath.Dir(beadsDir), beadsDir)
-		blockedOut, err := b.Run("blocked", "--json")
+	for beadsDir, groupedIDs := range idsByBeadsDir {
+		blockedOut, err := query(beadsDir, groupedIDs)
 		if err != nil {
 			failCount++
 			lastErr = err
+			markBlockedUnknown(blockedUnknownIDs, groupedIDs)
 			fmt.Fprintf(os.Stderr, "%s Warning: bd blocked failed for %s: %v\n",
 				style.Dim.Render("⚠"), filepath.Dir(beadsDir), err)
 			continue
@@ -747,30 +800,34 @@ func listBlockedWorkBeadIDsWithError(townRoot string, workBeadIDs []string) (map
 		var blockedBeads []struct {
 			ID string `json:"id"`
 		}
-		if err := json.Unmarshal(blockedOut, &blockedBeads); err == nil {
-			for _, b := range blockedBeads {
-				blockedIDs[b.ID] = true
-			}
+		if err := json.Unmarshal(blockedOut, &blockedBeads); err != nil {
+			failCount++
+			lastErr = err
+			markBlockedUnknown(blockedUnknownIDs, groupedIDs)
+			fmt.Fprintf(os.Stderr, "%s Warning: parsing bd blocked failed for %s: %v\n",
+				style.Dim.Render("⚠"), filepath.Dir(beadsDir), err)
+			continue
+		}
+		for _, b := range blockedBeads {
+			blockedIDs[b.ID] = true
 		}
 	}
 	if failCount == len(idsByBeadsDir) && failCount > 0 {
-		return nil, fmt.Errorf("all %d bd blocked queries failed (last: %w)", failCount, lastErr)
+		return blockedIDs, blockedUnknownIDs, fmt.Errorf("all %d bd blocked queries failed (last: %w)", failCount, lastErr)
 	}
-	return blockedIDs, nil
+	return blockedIDs, blockedUnknownIDs, nil
 }
 
-// listBlockedWorkBeadIDs returns a set of work bead IDs that have active blockers.
-// Convenience wrapper that ignores errors (used by listScheduledBeads for display).
-func listBlockedWorkBeadIDs(townRoot string) map[string]bool {
-	ids, _ := listBlockedWorkBeadIDsWithError(townRoot, listAllScheduledBeadIDs(townRoot))
-	if ids == nil {
-		return make(map[string]bool)
+func markBlockedUnknown(blockedUnknownIDs map[string]bool, ids []string) {
+	for _, id := range ids {
+		if id != "" {
+			blockedUnknownIDs[id] = true
+		}
 	}
-	return ids
 }
 
-func isScheduledWorkBeadReady(workBeadID string, info beadStatusInfo, found bool, blockedWorkIDs map[string]bool) bool {
-	if !found || blockedWorkIDs[workBeadID] {
+func isScheduledWorkBeadReady(workBeadID string, info beadStatusInfo, found bool, blockedWorkIDs, blockedUnknownIDs map[string]bool) bool {
+	if !found || blockedWorkIDs[workBeadID] || blockedUnknownIDs[workBeadID] {
 		return false
 	}
 	return info.Status == "open"

--- a/internal/cmd/capacity_dispatch_test.go
+++ b/internal/cmd/capacity_dispatch_test.go
@@ -2,10 +2,13 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 )
 
@@ -87,4 +90,59 @@ func TestDispatchSingleBeadRawReviewOnlyHookFailureClearsMetadata(t *testing.T) 
 		t.Fatal("expected scheduler dispatch hook failure")
 	}
 	assertNoRawReviewMetadata(t, readMutableBDDescription(t, descPath))
+}
+
+func TestListBlockedWorkBeadIDStatesPartialFailureFailsClosedPerGroup(t *testing.T) {
+	townRoot := t.TempDir()
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir town beads: %v", err)
+	}
+	routes := []beads.Route{
+		{Prefix: "a-", Path: "rig-a"},
+		{Prefix: "b-", Path: "rig-b"},
+	}
+	if err := beads.WriteRoutes(townBeadsDir, routes); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	blocked, unknown, err := listBlockedWorkBeadIDStatesWithRunner(townRoot, []string{"a-ready", "b-ready", "b-other"}, func(beadsDir string, groupedIDs []string) ([]byte, error) {
+		switch groupedIDs[0][:1] {
+		case "a":
+			return []byte(`[{"id":"a-ready"}]`), nil
+		case "b":
+			return nil, fmt.Errorf("blocked query failed")
+		default:
+			return nil, fmt.Errorf("unexpected group %s", beadsDir)
+		}
+	})
+	if err != nil {
+		t.Fatalf("partial blocked query failure returned error: %v", err)
+	}
+	if !blocked["a-ready"] {
+		t.Fatalf("a-ready should be marked blocked from successful group")
+	}
+	if unknown["a-ready"] {
+		t.Fatalf("a-ready should not be blocked-unknown")
+	}
+	if !unknown["b-ready"] || !unknown["b-other"] {
+		t.Fatalf("failed group IDs should be blocked-unknown, got %#v", unknown)
+	}
+
+	_, unknown, err = listBlockedWorkBeadIDStatesWithRunner(townRoot, []string{"a-ready", "b-ready"}, func(string, []string) ([]byte, error) {
+		return []byte(`not-json`), nil
+	})
+	if err == nil {
+		t.Fatalf("all blocked query JSON failures should return an error")
+	}
+	if !unknown["a-ready"] || !unknown["b-ready"] {
+		t.Fatalf("all failed groups should mark every ID blocked-unknown, got %#v", unknown)
+	}
+}
+
+func TestIsScheduledWorkBeadReadyFailsClosedForBlockedUnknown(t *testing.T) {
+	info := beadStatusInfo{Status: "open"}
+	if isScheduledWorkBeadReady("gt-ready", info, true, nil, map[string]bool{"gt-ready": true}) {
+		t.Fatalf("blocked-unknown source must not be scheduler-ready")
+	}
 }

--- a/internal/cmd/scheduler.go
+++ b/internal/cmd/scheduler.go
@@ -368,89 +368,39 @@ func runSchedulerRun(cmd *cobra.Command, args []string) error {
 // Reconciles sling context beads with work bead readiness to mark blocked status.
 // Uses batch fetch for work bead info to avoid N+1 subprocess spawns.
 func listScheduledBeads(townRoot string) []scheduledBeadInfo {
-	allContexts := listAllSlingContexts(townRoot)
-
-	if len(allContexts) == 0 {
-		return nil
-	}
-
-	// Collect work bead IDs from contexts for targeted fetch
-	var workBeadIDs []string
-	for _, ctx := range allContexts {
-		fields := beads.ParseSlingContextFields(ctx.Description)
-		if fields != nil && fields.WorkBeadID != "" {
-			workBeadIDs = append(workBeadIDs, fields.WorkBeadID)
-		}
-	}
-
-	// Build blockedIDs set and batch-fetch work bead info for specific IDs.
-	// bd blocked is fast because it reads the cached blocked set; bd ready walks
-	// the full ready graph and is too slow for scheduler display paths.
-	blockedWorkIDs, _ := listBlockedWorkBeadIDsWithError(townRoot, workBeadIDs)
-	workBeadInfo := batchFetchBeadInfoByIDs(townRoot, workBeadIDs)
-
-	seenWork := make(map[string]bool)
+	assessments, _ := assessScheduledContexts(townRoot)
 	var result []scheduledBeadInfo
-	for _, ctx := range allContexts {
-		fields := beads.ParseSlingContextFields(ctx.Description)
-		if fields == nil {
+	for _, assessment := range assessments {
+		bead, ok := scheduledBeadInfoFromWork(assessment.context.issue.Title, assessment.fields, assessment.info, assessment.found, assessment.ready)
+		if !ok {
 			continue
 		}
-
-		// Exclude circuit-broken
-		if fields.DispatchFailures >= maxDispatchFailures {
-			continue
-		}
-
-		// Dedup by WorkBeadID (mirrors getReadySlingContexts logic)
-		if seenWork[fields.WorkBeadID] {
-			continue
-		}
-		seenWork[fields.WorkBeadID] = true
-
-		// Get work bead info for title/status from batch-fetched map
-		title := ctx.Title
-		status := "open"
-		info, found := workBeadInfo[fields.WorkBeadID]
-		if found {
-			title = info.Title
-			status = info.Status
-			// Skip if work bead is hooked/closed
-			if status == "hooked" || status == "closed" || status == "tombstone" {
-				continue
-			}
-		}
-
-		result = append(result, scheduledBeadInfo{
-			ID:        fields.WorkBeadID,
-			Title:     title,
-			Status:    status,
-			TargetRig: fields.TargetRig,
-			Blocked:   !isScheduledWorkBeadReady(fields.WorkBeadID, info, found, blockedWorkIDs),
-		})
+		result = append(result, bead)
 	}
 
 	return result
 }
 
-// listAllScheduledBeadIDs returns the work bead IDs of all scheduled beads.
-func listAllScheduledBeadIDs(townRoot string) []string {
-	allContexts := listAllSlingContexts(townRoot)
-
-	var ids []string
-	seen := make(map[string]bool)
-	for _, ctx := range allContexts {
-		fields := beads.ParseSlingContextFields(ctx.Description)
-		if fields == nil {
-			continue
-		}
-		if !seen[fields.WorkBeadID] {
-			seen[fields.WorkBeadID] = true
-			ids = append(ids, fields.WorkBeadID)
+func scheduledBeadInfoFromWork(ctxTitle string, fields *capacity.SlingContextFields, info beadStatusInfo, found, ready bool) (scheduledBeadInfo, bool) {
+	if fields == nil {
+		return scheduledBeadInfo{}, false
+	}
+	title := ctxTitle
+	status := "open"
+	if found {
+		title = info.Title
+		status = info.Status
+		if status == string(beads.IssueStatusHooked) || status == "closed" || status == "tombstone" {
+			return scheduledBeadInfo{}, false
 		}
 	}
-
-	return ids
+	return scheduledBeadInfo{
+		ID:        fields.WorkBeadID,
+		Title:     title,
+		Status:    status,
+		TargetRig: fields.TargetRig,
+		Blocked:   !ready,
+	}, true
 }
 
 // beadsSearchDirs returns directories to scan for scheduled beads:

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -499,6 +499,16 @@ func TestSchedulerBlockedStatusReporting(t *testing.T) {
 	if ready != 1 {
 		t.Errorf("queued_ready = %d, want 1", ready)
 	}
+	out := runGTCmdOutput(t, gtBinary, hqPath, env, "scheduler", "run", "--dry-run")
+	if !strings.Contains(out, readyID) {
+		t.Fatalf("dry-run should include ready bead %s while sibling is blocked\noutput: %s", readyID, out)
+	}
+	if strings.Contains(out, blockedID) {
+		t.Fatalf("dry-run should not include blocked bead %s\noutput: %s", blockedID, out)
+	}
+	if !strings.Contains(out, "ready: 1") {
+		t.Fatalf("dry-run should report exactly one ready bead while blocked source is queued\noutput: %s", out)
+	}
 
 	// Close the blocker and verify the already-queued work becomes ready without
 	// creating a new sling context.
@@ -545,7 +555,7 @@ func TestSchedulerBlockedStatusReporting(t *testing.T) {
 		t.Errorf("queued_ready after unblock = %d, want 2", ready)
 	}
 
-	out := runGTCmdOutput(t, gtBinary, hqPath, env, "scheduler", "run", "--dry-run")
+	out = runGTCmdOutput(t, gtBinary, hqPath, env, "scheduler", "run", "--dry-run")
 	if !strings.Contains(out, blockedID) {
 		t.Errorf("dry-run dispatch should include newly unblocked bead %s\noutput: %s", blockedID, out)
 	}
@@ -631,6 +641,9 @@ func TestSchedulerMissingSourceDoesNotHideReadyContext(t *testing.T) {
 		t.Fatalf("queued_ready = %d, want 1 (status: %#v)", ready, status)
 	}
 	out := runGTCmdOutput(t, gtBinary, hqPath, env, "scheduler", "run", "--dry-run")
+	if !strings.Contains(out, "ready: 1") {
+		t.Fatalf("dry-run should report exactly one ready bead with missing source queued, got:\n%s", out)
+	}
 	if !strings.Contains(out, readyID) {
 		t.Fatalf("dry-run should include valid ready source %s, got:\n%s", readyID, out)
 	}
@@ -642,7 +655,9 @@ func TestSchedulerMissingSourceDoesNotHideReadyContext(t *testing.T) {
 func TestSchedulerClosedSourceContextCleansUpFailClosed(t *testing.T) {
 	hqPath, rigPath, gtBinary, env := setupSchedulerIntegrationTown(t)
 
+	readyID := createTestBead(t, rigPath, "Ready beside closed source")
 	beadID := createTestBead(t, rigPath, "Closed queued source")
+	slingToScheduler(t, gtBinary, hqPath, env, readyID, "testrig")
 	slingToScheduler(t, gtBinary, hqPath, env, beadID, "testrig")
 
 	closeCmd := exec.Command("bd", "close", beadID)
@@ -652,9 +667,26 @@ func TestSchedulerClosedSourceContextCleansUpFailClosed(t *testing.T) {
 		t.Fatalf("bd close %s failed: %v\n%s", beadID, err, out)
 	}
 
+	status := getSchedulerStatus(t, gtBinary, hqPath, env)
+	if ready := int(status["queued_ready"].(float64)); ready != 1 {
+		t.Fatalf("queued_ready = %d, want 1 with closed source beside ready source (status: %#v)", ready, status)
+	}
 	out := runGTCmdOutput(t, gtBinary, hqPath, env, "scheduler", "run", "--dry-run")
+	if !strings.Contains(out, readyID) {
+		t.Fatalf("dry-run should include ready source %s beside closed source, got:\n%s", readyID, out)
+	}
 	if strings.Contains(out, beadID) {
 		t.Fatalf("dry-run should not dispatch closed source %s, got:\n%s", beadID, out)
+	}
+	if !strings.Contains(out, "ready: 1") {
+		t.Fatalf("dry-run should report exactly one ready bead with closed source queued, got:\n%s", out)
+	}
+
+	closeReadyCmd := exec.Command("bd", "close", readyID)
+	closeReadyCmd.Dir = rigPath
+	closeReadyCmd.Env = env
+	if out, err := closeReadyCmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd close ready source %s failed: %v\n%s", readyID, err, out)
 	}
 
 	runGTCmdOutput(t, gtBinary, hqPath, env, "scheduler", "run")

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -551,6 +551,118 @@ func TestSchedulerBlockedStatusReporting(t *testing.T) {
 	}
 }
 
+func TestSchedulerQueuedContextOpenSourceIsReady(t *testing.T) {
+	hqPath, rigPath, gtBinary, env := setupSchedulerIntegrationTown(t)
+
+	beadID := createTestBead(t, rigPath, "Queued open source readiness")
+	slingToScheduler(t, gtBinary, hqPath, env, beadID, "testrig")
+
+	listed := getSchedulerList(t, gtBinary, hqPath, env)
+	found := false
+	for _, item := range listed {
+		id, _ := item["id"].(string)
+		blocked, _ := item["blocked"].(bool)
+		if id == beadID {
+			found = true
+			if blocked {
+				t.Fatalf("queued open source %s should be ready, list item: %#v", beadID, item)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("queued source %s not found in scheduler list: %#v", beadID, listed)
+	}
+
+	status := getSchedulerStatus(t, gtBinary, hqPath, env)
+	if ready := int(status["queued_ready"].(float64)); ready != 1 {
+		t.Fatalf("queued_ready = %d, want 1 (status: %#v)", ready, status)
+	}
+	out := runGTCmdOutput(t, gtBinary, hqPath, env, "scheduler", "run", "--dry-run")
+	if strings.Contains(out, "No ready beads") || !strings.Contains(out, beadID) {
+		t.Fatalf("dry-run should include ready queued source %s, got:\n%s", beadID, out)
+	}
+}
+
+func TestSchedulerMissingSourceDoesNotHideReadyContext(t *testing.T) {
+	hqPath, rigPath, gtBinary, env := setupSchedulerIntegrationTown(t)
+
+	readyID := createTestBead(t, rigPath, "Ready beside missing source")
+	slingToScheduler(t, gtBinary, hqPath, env, readyID, "testrig")
+
+	missingID := beads.ExtractPrefix(readyID) + "missing-source"
+	rigBeads := beads.NewWithBeadsDir(rigPath, filepath.Join(rigPath, ".beads"))
+	if _, err := rigBeads.CreateSlingContext("missing source", missingID, &capacity.SlingContextFields{
+		Version:    1,
+		WorkBeadID: missingID,
+		TargetRig:  "testrig",
+		EnqueuedAt: "2026-01-01T00:00:01Z",
+	}); err != nil {
+		t.Fatalf("CreateSlingContext for missing source: %v", err)
+	}
+
+	listed := getSchedulerList(t, gtBinary, hqPath, env)
+	foundReady := false
+	foundMissing := false
+	for _, item := range listed {
+		id, _ := item["id"].(string)
+		blocked, _ := item["blocked"].(bool)
+		switch id {
+		case readyID:
+			foundReady = true
+			if blocked {
+				t.Fatalf("valid source %s should remain ready when another source is missing", readyID)
+			}
+		case missingID:
+			foundMissing = true
+			if !blocked {
+				t.Fatalf("missing source %s should fail closed/not-ready", missingID)
+			}
+		}
+	}
+	if !foundReady || !foundMissing {
+		t.Fatalf("scheduler list found ready=%v missing=%v; list=%#v", foundReady, foundMissing, listed)
+	}
+
+	status := getSchedulerStatus(t, gtBinary, hqPath, env)
+	if total := int(status["queued_total"].(float64)); total != 2 {
+		t.Fatalf("queued_total = %d, want 2 (status: %#v)", total, status)
+	}
+	if ready := int(status["queued_ready"].(float64)); ready != 1 {
+		t.Fatalf("queued_ready = %d, want 1 (status: %#v)", ready, status)
+	}
+	out := runGTCmdOutput(t, gtBinary, hqPath, env, "scheduler", "run", "--dry-run")
+	if !strings.Contains(out, readyID) {
+		t.Fatalf("dry-run should include valid ready source %s, got:\n%s", readyID, out)
+	}
+	if strings.Contains(out, missingID) {
+		t.Fatalf("dry-run should not include missing source %s, got:\n%s", missingID, out)
+	}
+}
+
+func TestSchedulerClosedSourceContextCleansUpFailClosed(t *testing.T) {
+	hqPath, rigPath, gtBinary, env := setupSchedulerIntegrationTown(t)
+
+	beadID := createTestBead(t, rigPath, "Closed queued source")
+	slingToScheduler(t, gtBinary, hqPath, env, beadID, "testrig")
+
+	closeCmd := exec.Command("bd", "close", beadID)
+	closeCmd.Dir = rigPath
+	closeCmd.Env = env
+	if out, err := closeCmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd close %s failed: %v\n%s", beadID, err, out)
+	}
+
+	out := runGTCmdOutput(t, gtBinary, hqPath, env, "scheduler", "run", "--dry-run")
+	if strings.Contains(out, beadID) {
+		t.Fatalf("dry-run should not dispatch closed source %s, got:\n%s", beadID, out)
+	}
+
+	runGTCmdOutput(t, gtBinary, hqPath, env, "scheduler", "run")
+	if hasSlingContext(t, hqPath, beadID) {
+		t.Fatalf("closed source context for %s should be cleaned up", beadID)
+	}
+}
+
 // TestSchedulerSlingDryRun verifies that gt sling deferred dispatch (max_polecats > 0) --dry-run
 // has no side effects: no sling context created, no convoy created.
 func TestSchedulerSlingDryRun(t *testing.T) {
@@ -825,6 +937,46 @@ func TestSchedulerMultiRigDispatch(t *testing.T) {
 	}
 	if !strings.Contains(out, bead2) {
 		t.Errorf("dry-run should mention rig2 bead %s", bead2)
+	}
+}
+
+func TestSchedulerQueuedContextUsesRoutedCrossRigSourceLookup(t *testing.T) {
+	hqPath, _, rig2Path, gtBinary, env := setupMultiRigSchedulerTown(t)
+
+	beadID := createTestBead(t, rig2Path, "Routed cross-rig source")
+	createSlingContext(t, hqPath, &capacity.SlingContextFields{
+		Version:    1,
+		WorkBeadID: beadID,
+		TargetRig:  "rig2",
+		EnqueuedAt: "2026-01-01T00:00:00Z",
+	})
+
+	listed := getSchedulerList(t, gtBinary, hqPath, env)
+	found := false
+	for _, item := range listed {
+		id, _ := item["id"].(string)
+		if id != beadID {
+			continue
+		}
+		found = true
+		if blocked, _ := item["blocked"].(bool); blocked {
+			t.Fatalf("routed cross-rig source %s should be ready, list item: %#v", beadID, item)
+		}
+		if target, _ := item["target_rig"].(string); target != "rig2" {
+			t.Fatalf("target_rig = %q, want rig2", target)
+		}
+	}
+	if !found {
+		t.Fatalf("routed source %s not found in scheduler list: %#v", beadID, listed)
+	}
+
+	status := getSchedulerStatus(t, gtBinary, hqPath, env)
+	if ready := int(status["queued_ready"].(float64)); ready != 1 {
+		t.Fatalf("queued_ready = %d, want 1 (status: %#v)", ready, status)
+	}
+	out := runGTCmdOutput(t, gtBinary, hqPath, env, "scheduler", "run", "--dry-run")
+	if !strings.Contains(out, beadID) || strings.Contains(out, "No ready beads") {
+		t.Fatalf("dry-run should include routed cross-rig source %s, got:\n%s", beadID, out)
 	}
 }
 

--- a/internal/cmd/sling_schedule.go
+++ b/internal/cmd/sling_schedule.go
@@ -319,20 +319,11 @@ func resolveFormula(explicit string, hookRawBead bool, townRoot, rigName string)
 	return "mol-polecat-work"
 }
 
-// slingContextTTL is the maximum age of a sling context before it's considered
-// stale and ignored by areScheduled(). This prevents orphaned sling contexts
-// (from failed spawns or throttled dispatches) from permanently blocking tasks.
-// See GH#2279.
-const slingContextTTL = 30 * time.Minute
-
 // areScheduled returns a set of bead IDs that have open sling contexts.
 // Scans all rig beads dirs since sling contexts are created in the target
 // rig's beads dir (GH#3468). On error, fails closed: treats ALL requested
 // beads as scheduled to prevent false stranded detection and duplicate
 // scheduling attempts.
-//
-// Sling contexts older than slingContextTTL are ignored — they are likely
-// orphans from failed spawn attempts (GH#2279).
 func areScheduled(beadIDs []string) map[string]bool {
 	result := make(map[string]bool)
 	if len(beadIDs) == 0 {
@@ -351,20 +342,10 @@ func areScheduled(beadIDs []string) map[string]bool {
 	// Scan all rig beads dirs (sling contexts live in target rig's DB). (GH#3468)
 	contexts := listAllSlingContexts(townRoot)
 
-	// Build lookup of work bead IDs from open contexts, skipping stale ones.
+	// Build lookup of work bead IDs from open contexts. Cleanup owns stale-state
+	// closure; idempotency must not use a different definition of scheduled.
 	scheduledWorkBeads := make(map[string]bool)
-	now := time.Now()
 	for _, ctx := range contexts {
-		// Skip stale sling contexts (GH#2279): contexts older than the TTL
-		// are likely orphans from failed spawn attempts. Ignoring them allows
-		// the task to appear as "ready" again for re-dispatch.
-		if ctx.CreatedAt != "" {
-			if created, err := time.Parse(time.RFC3339, ctx.CreatedAt); err == nil {
-				if now.Sub(created) > slingContextTTL {
-					continue
-				}
-			}
-		}
 		fields := beads.ParseSlingContextFields(ctx.Description)
 		if fields != nil {
 			scheduledWorkBeads[fields.WorkBeadID] = true


### PR DESCRIPTION
## Summary
- make scheduler list, status, dry-run, and dispatch share one queued sling-context readiness assessment
- isolate batch source lookup misses with routed per-ID fallback instead of collapsing them into false not-found state
- fail closed when blocked-state queries are uncertain
- remove the stale TTL-based scheduledness split that hid otherwise ready contexts
- cover open, blocked, missing, closed, and cross-rig source behavior in focused and integration tests

## Root Cause
Scheduled sling contexts and direct dispatch used different source-readiness paths. Batch lookup misses and blocked-query uncertainty were rendered as a pause/blocked marker even when the routed source bead was open and capacity existed, producing `0 ready` and scheduler no-ops.

## Validation
- focused `CGO_ENABLED=0` scheduler readiness tests in `internal/cmd`
- `CGO_ENABLED=0 go test ./internal/scheduler/capacity -count=1`
- routed show tests in `internal/beads`
- scheduler integration test binary compiles with integration tags
- integration execution is environment-blocked by unavailable rootless Docker, documented in evidence
- `git diff --check`

## Review Evidence
The cleanup-first workflow completed 15 independent research legs, 5 approving pre-implementation reviews, and 5 approving final-head post-implementation reviews. The branch is a current-main, patch-equivalent rebuild of the reviewed implementation with two intentional non-WIP commits. `gt-pr-sheriff-check --merge-gate` passed with `merge_path_allowed=true` and `verdict=merge_as_is`.

Local source context: `gt-scheduler-context-readiness-cmap` / `cmap-qa7f`.