### PR TITLE
fix(polecat): fail closed on stale-heartbeat liveness queries

### DIFF
--- a/internal/polecat/heartbeat_test.go
+++ b/internal/polecat/heartbeat_test.go
@@ -2,10 +2,13 @@ package polecat
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/tmux"
 )
 
 func TestTouchAndReadSessionHeartbeat(t *testing.T) {
@@ -184,24 +187,73 @@ func TestIsSessionProcessDead_HeartbeatFresh(t *testing.T) {
 	}
 }
 
-func TestIsSessionProcessDead_HeartbeatStale(t *testing.T) {
-	townRoot := t.TempDir()
-	sessionName := "gt-test-hb-dead"
-
-	// Write a stale heartbeat
+func writeStaleSessionHeartbeat(t *testing.T, townRoot, sessionName string) {
+	t.Helper()
 	dir := filepath.Join(townRoot, ".runtime", "heartbeats")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	oldTime := time.Now().Add(-10 * time.Minute).UTC()
-	data := []byte(`{"timestamp":"` + oldTime.Format(time.RFC3339Nano) + `"}`)
+	data, err := json.Marshal(SessionHeartbeat{
+		Timestamp: time.Now().Add(-10 * time.Minute).UTC(),
+		State:     HeartbeatWorking,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, sessionName+".json"), data, 0644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestIsSessionProcessDead_HeartbeatStaleUsesAgentLiveness(t *testing.T) {
+	townRoot := t.TempDir()
+	oldSessionAgentAlive := sessionAgentAlive
+	t.Cleanup(func() { sessionAgentAlive = oldSessionAgentAlive })
+
+	tests := []struct {
+		name     string
+		alive    bool
+		aliveErr error
+		wantDead bool
+	}{
+		{name: "live_agent", alive: true, wantDead: false},
+		{name: "not_live_agent", alive: false, wantDead: true},
+		{name: "query_error", alive: false, aliveErr: errors.New("tmux query failed"), wantDead: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sessionName := "gt-test-hb-stale-" + tt.name
+			writeStaleSessionHeartbeat(t, townRoot, sessionName)
+
+			called := false
+			sessionAgentAlive = func(_ *tmux.Tmux, gotSession string) (bool, error) {
+				called = true
+				if gotSession != sessionName {
+					t.Fatalf("liveness checked session %q, want %q", gotSession, sessionName)
+				}
+				return tt.alive, tt.aliveErr
+			}
+
+			dead := isSessionProcessDead(tmux.NewTmuxWithSocket("gt-unused-test-socket"), sessionName, townRoot)
+			if dead != tt.wantDead {
+				t.Fatalf("isSessionProcessDead() = %v, want %v", dead, tt.wantDead)
+			}
+			if !called {
+				t.Fatal("expected stale heartbeat to check agent liveness")
+			}
+		})
+	}
+}
+
+func TestIsSessionProcessDead_HeartbeatStaleWithoutTmuxFailsClosed(t *testing.T) {
+	townRoot := t.TempDir()
+	sessionName := "gt-test-hb-stale-no-tmux"
+	writeStaleSessionHeartbeat(t, townRoot, sessionName)
 
 	dead := isSessionProcessDead(nil, sessionName, townRoot)
-	if !dead {
-		t.Error("expected dead=true for session with stale heartbeat")
+	if dead {
+		t.Error("expected dead=false for stale heartbeat without tmux liveness evidence")
 	}
 }
 

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2074,7 +2074,8 @@ func (m *Manager) ReconcilePoolWith(namesWithDirs, namesWithSessions []string) {
 // Uses heartbeat-based liveness detection (gt-qjtq): checks whether the session's
 // heartbeat file has been updated recently. Polecat sessions touch their heartbeat
 // via gt commands (gt prime, gt hook, bd show, etc.) which run frequently during
-// normal operation. A stale heartbeat indicates the agent is no longer active.
+// normal operation. A stale heartbeat is only suspect because long-running tool
+// calls can keep a live agent from touching gt/bd for several minutes.
 //
 // Falls back to PID signal probing when no heartbeat file exists (backward
 // compatibility for sessions started before heartbeat support was added).
@@ -2086,9 +2087,22 @@ func isSessionProcessDead(t *tmux.Tmux, sessionName string, townRoot string) boo
 	if townRoot != "" {
 		stale, exists := IsSessionHeartbeatStale(townRoot, sessionName)
 		if exists {
-			return stale
+			if !stale {
+				return false
+			}
+			if t == nil {
+				return false
+			}
+			alive, err := sessionAgentAlive(t, sessionName)
+			if err != nil {
+				return false
+			}
+			return !alive
 		}
 		// No heartbeat file — fall through to PID-based check for backward compatibility.
+	}
+	if t == nil {
+		return false
 	}
 
 	// Fallback: PID signal probing (legacy, for sessions without heartbeat support).
@@ -2116,6 +2130,10 @@ func isSessionProcessDead(t *tmux.Tmux, sessionName string, townRoot string) boo
 		return true
 	}
 	return false
+}
+
+var sessionAgentAlive = func(t *tmux.Tmux, sessionName string) (bool, error) {
+	return t.IsAgentAliveChecked(sessionName)
 }
 
 // pendingMaxAge is how long a .pending reservation marker may exist before

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2389,14 +2389,22 @@ func (t *Tmux) CheckSessionHealth(session string, maxInactivity time.Duration) Z
 // Uses ps to get the actual command name from the process's executable path.
 // This handles cases where argv[0] is modified (e.g., Claude showing version "2.1.30").
 func processMatchesNames(pid string, names []string) bool {
+	matches, _ := processMatchesNamesChecked(pid, names)
+	return matches
+}
+
+func processMatchesNamesChecked(pid string, names []string) (bool, error) {
 	if len(names) == 0 {
-		return false
+		return false, nil
 	}
 	// Use ps to get the command name (COMM column gives the executable name)
 	cmd := exec.Command("ps", "-p", pid, "-o", "comm=")
 	out, err := cmd.Output()
 	if err != nil {
-		return false
+		if isNoMatchExit(err) {
+			return false, nil
+		}
+		return false, err
 	}
 	// Get just the base name (in case it's a full path like /Users/.../claude)
 	commPath := strings.TrimSpace(string(out))
@@ -2405,37 +2413,50 @@ func processMatchesNames(pid string, names []string) bool {
 	// Check if any name matches
 	for _, name := range names {
 		if comm == name {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // hasDescendantWithNames checks if a process has any descendant (child, grandchild, etc.)
 // matching any of the given names. Recursively traverses the process tree up to maxDepth.
 // Used when the pane command is a shell (bash, zsh, pwsh) that launched an agent.
 func hasDescendantWithNames(pid string, names []string, depth int) bool {
+	found, _ := hasDescendantWithNamesChecked(pid, names, depth)
+	return found
+}
+
+func hasDescendantWithNamesChecked(pid string, names []string, depth int) (bool, error) {
 	const maxDepth = 10 // Prevent infinite loops in case of circular references
 	if len(names) == 0 || depth > maxDepth {
-		return false
+		return false, nil
 	}
 	if runtime.GOOS == "windows" {
-		return hasDescendantWithNamesWindows(pid, names, depth)
+		return hasDescendantWithNamesWindows(pid, names, depth), nil
 	}
-	return hasDescendantWithNamesPosix(pid, names, depth)
+	return hasDescendantWithNamesPosixChecked(pid, names, depth)
 }
 
 // hasDescendantWithNamesPosix uses pgrep to find child processes on Unix systems.
 func hasDescendantWithNamesPosix(pid string, names []string, depth int) bool {
+	found, _ := hasDescendantWithNamesPosixChecked(pid, names, depth)
+	return found
+}
+
+func hasDescendantWithNamesPosixChecked(pid string, names []string, depth int) (bool, error) {
 	const maxDepth = 10
 	if depth > maxDepth {
-		return false
+		return false, nil
 	}
 	// Use pgrep to find child processes
 	cmd := exec.Command("pgrep", "-P", pid, "-l")
 	out, err := cmd.Output()
 	if err != nil {
-		return false
+		if isNoMatchExit(err) {
+			return false, nil
+		}
+		return false, err
 	}
 	// Build a set of names for fast lookup
 	nameSet := make(map[string]bool, len(names))
@@ -2456,15 +2477,24 @@ func hasDescendantWithNamesPosix(pid string, names []string, depth int) bool {
 			childName := parts[1]
 			// Direct match
 			if nameSet[childName] {
-				return true
+				return true, nil
 			}
 			// Recursive check of descendants
-			if hasDescendantWithNames(childPid, names, depth+1) {
-				return true
+			found, err := hasDescendantWithNamesChecked(childPid, names, depth+1)
+			if err != nil {
+				return false, err
+			}
+			if found {
+				return true, nil
 			}
 		}
 	}
-	return false
+	return false, nil
+}
+
+func isNoMatchExit(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && exitErr.ExitCode() == 1
 }
 
 // FindSessionByWorkDir finds tmux sessions where the pane's current working directory
@@ -2761,29 +2791,48 @@ func (t *Tmux) IsAgentRunning(session string, expectedPaneCommands ...string) bo
 // then checks only that pane. Falls back to scanning all panes for legacy
 // sessions without GT_PANE_ID.
 func (t *Tmux) IsRuntimeRunning(session string, processNames []string) bool {
+	running, _ := t.IsRuntimeRunningChecked(session, processNames)
+	return running
+}
+
+// IsRuntimeRunningChecked is like IsRuntimeRunning, but preserves tmux/process
+// query errors so destructive cleanup callers can fail closed instead of
+// treating unknown liveness as confirmed absence.
+func (t *Tmux) IsRuntimeRunningChecked(session string, processNames []string) (bool, error) {
 	if len(processNames) == 0 {
-		return false
+		return false, nil
 	}
 
 	// ZFC: check declared pane identity set at session startup (gt-qmsx).
-	if declaredPane, err := t.GetEnvironment(session, "GT_PANE_ID"); err == nil && declaredPane != "" {
-		if t.checkTargetPaneForRuntime(session, declaredPane, processNames) {
-			return true
+	if declaredPane, ok, err := t.getEnvironmentOptional(session, "GT_PANE_ID"); err != nil {
+		return false, err
+	} else if ok && declaredPane != "" {
+		running, err := t.checkTargetPaneForRuntimeChecked(session, declaredPane, processNames)
+		if err != nil {
+			if runtime.GOOS != "windows" {
+				return false, err
+			}
+		} else if running {
+			return true, nil
 		}
 		// On Windows (psmux), pane IDs like %1 may not be supported by
 		// display-message. Fall through to legacy path instead of returning false.
 		if runtime.GOOS != "windows" {
-			return false
+			return false, nil
 		}
 	}
 
 	// Legacy fallback: check first window, then scan all panes.
-	if t.checkPaneForRuntime(session, processNames) {
-		return true
+	running, err := t.checkPaneForRuntimeChecked(session, processNames)
+	if err != nil {
+		return false, err
+	}
+	if running {
+		return true, nil
 	}
 	out, err := t.run("list-panes", "-s", "-t", session, "-F", "#{pane_current_command}\t#{pane_pid}")
 	if err != nil {
-		return false
+		return false, err
 	}
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		parts := strings.SplitN(line, "\t", 2)
@@ -2791,32 +2840,81 @@ func (t *Tmux) IsRuntimeRunning(session string, processNames []string) bool {
 			continue
 		}
 		cmd, pid := parts[0], parts[1]
-		if t.matchesPaneRuntime(session, cmd, pid, processNames) {
-			return true
+		running, err := t.matchesPaneRuntimeChecked(session, cmd, pid, processNames)
+		if err != nil {
+			return false, err
+		}
+		if running {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // checkTargetPaneForRuntime checks if a specific pane (by ID, e.g., "%5") is
 // running a matching process. Used by the ZFC path when GT_PANE_ID is declared.
 func (t *Tmux) checkTargetPaneForRuntime(session, paneID string, processNames []string) bool {
+	running, _ := t.checkTargetPaneForRuntimeChecked(session, paneID, processNames)
+	return running
+}
+
+func (t *Tmux) checkTargetPaneForRuntimeChecked(session, paneID string, processNames []string) (bool, error) {
 	cmd, err := t.run("display-message", "-t", paneID, "-p", "#{pane_current_command}")
 	if err != nil {
-		return false // pane doesn't exist
+		return false, err
 	}
-	pid, _ := t.run("display-message", "-t", paneID, "-p", "#{pane_pid}")
-	return t.matchesPaneRuntime(session, strings.TrimSpace(cmd), strings.TrimSpace(pid), processNames)
+	if running, err := t.matchesPaneRuntimeChecked(session, strings.TrimSpace(cmd), "", processNames); err != nil {
+		return false, err
+	} else if running {
+		return true, nil
+	}
+	pid, err := t.run("display-message", "-t", paneID, "-p", "#{pane_pid}")
+	if err != nil {
+		return false, err
+	}
+	return t.matchesPaneRuntimeChecked(session, strings.TrimSpace(cmd), strings.TrimSpace(pid), processNames)
 }
 
 // checkPaneForRuntime checks if the first window's pane is running a matching process.
 func (t *Tmux) checkPaneForRuntime(session string, processNames []string) bool {
+	running, _ := t.checkPaneForRuntimeChecked(session, processNames)
+	return running
+}
+
+func (t *Tmux) checkPaneForRuntimeChecked(session string, processNames []string) (bool, error) {
 	cmd, err := t.GetPaneCommand(session)
 	if err != nil {
+		return false, err
+	}
+	if running, err := t.matchesPaneRuntimeChecked(session, cmd, "", processNames); err != nil {
+		return false, err
+	} else if running {
+		return true, nil
+	}
+	pid, err := t.GetPanePID(session)
+	if err != nil {
+		return false, err
+	}
+	return t.matchesPaneRuntimeChecked(session, cmd, pid, processNames)
+}
+
+func (t *Tmux) getEnvironmentOptional(session, key string) (string, bool, error) {
+	value, err := t.GetEnvironment(session, key)
+	if err == nil {
+		return value, value != "", nil
+	}
+	if isMissingEnvironmentError(err, key) {
+		return "", false, nil
+	}
+	return "", false, err
+}
+
+func isMissingEnvironmentError(err error, key string) bool {
+	if err == nil {
 		return false
 	}
-	pid, _ := t.GetPanePID(session)
-	return t.matchesPaneRuntime(session, cmd, pid, processNames)
+	msg := err.Error()
+	return strings.Contains(msg, "unknown variable") || strings.Contains(msg, fmt.Sprintf("environment variable %s not found", key))
 }
 
 // cursorAgentSessionDeclaresCursor reports whether tmux session env identifies the Cursor
@@ -2864,33 +2962,91 @@ func processNamesForSession(t *Tmux, session string, processNames []string) []st
 	return withoutProcessName(processNames, "agent")
 }
 
+func processNamesForSessionChecked(t *Tmux, session string, processNames []string) ([]string, error) {
+	if len(processNames) == 0 {
+		return processNames, nil
+	}
+	declaresCursor, err := cursorAgentSessionDeclaresCursorChecked(t, session)
+	if err != nil {
+		return nil, err
+	}
+	if declaresCursor {
+		return processNames, nil
+	}
+	return withoutProcessName(processNames, "agent"), nil
+}
+
+func cursorAgentSessionDeclaresCursorChecked(t *Tmux, session string) (bool, error) {
+	if t == nil || session == "" {
+		return false, nil
+	}
+	agent, ok, err := t.getEnvironmentOptional(session, "GT_AGENT")
+	if err != nil {
+		return false, err
+	}
+	if ok && agent == string(config.AgentCursor) {
+		return true, nil
+	}
+	names, ok, err := t.getEnvironmentOptional(session, "GT_PROCESS_NAMES")
+	if err != nil {
+		return false, err
+	}
+	if ok && names != "" {
+		for _, n := range strings.Split(names, ",") {
+			if strings.TrimSpace(n) == "cursor-agent" {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 // matchesPaneRuntime checks if a pane with the given command and PID is running a matching process.
 func (t *Tmux) matchesPaneRuntime(session, cmd, pid string, processNames []string) bool {
-	names := processNamesForSession(t, session, processNames)
+	running, _ := t.matchesPaneRuntimeChecked(session, cmd, pid, processNames)
+	return running
+}
+
+func (t *Tmux) matchesPaneRuntimeChecked(session, cmd, pid string, processNames []string) (bool, error) {
+	names, err := processNamesForSessionChecked(t, session, processNames)
+	if err != nil {
+		return false, err
+	}
 	if len(names) == 0 {
-		return false
+		return false, nil
 	}
 	// Direct command match
 	for _, name := range names {
 		if cmd == name {
-			return true
+			return true, nil
 		}
 	}
 	if pid == "" {
-		return false
+		return false, nil
 	}
 	// If pane command is a shell, check descendants
 	for _, shell := range constants.SupportedShells {
 		if cmd == shell {
-			return hasDescendantWithNames(pid, names, 0)
+			return hasDescendantWithNamesChecked(pid, names, 0)
 		}
 	}
 	// Unrecognized command: check if process itself matches (version-as-argv[0])
-	if processMatchesNames(pid, names) {
-		return true
+	running, err := processMatchesNamesChecked(pid, names)
+	if err == nil && running {
+		return true, nil
 	}
 	// Finally check descendants as fallback
-	return hasDescendantWithNames(pid, names, 0)
+	descendantRunning, descendantErr := hasDescendantWithNamesChecked(pid, names, 0)
+	if descendantErr != nil {
+		return false, descendantErr
+	}
+	if descendantRunning {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 // IsAgentAlive checks if an agent is running in the session using agent-agnostic detection.
@@ -2898,20 +3054,41 @@ func (t *Tmux) matchesPaneRuntime(session, cmd, pid string, processNames []strin
 // falling back to GT_AGENT-based lookup for legacy sessions.
 // This is the preferred method for zombie detection across all agent types.
 func (t *Tmux) IsAgentAlive(session string) bool {
-	return t.IsRuntimeRunning(session, t.resolveSessionProcessNames(session))
+	alive, _ := t.IsAgentAliveChecked(session)
+	return alive
+}
+
+// IsAgentAliveChecked is like IsAgentAlive, but preserves liveness-query errors
+// for callers that must not treat unknown state as confirmed death.
+func (t *Tmux) IsAgentAliveChecked(session string) (bool, error) {
+	processNames, err := t.resolveSessionProcessNamesChecked(session)
+	if err != nil {
+		return false, err
+	}
+	return t.IsRuntimeRunningChecked(session, processNames)
 }
 
 // resolveSessionProcessNames returns the process names to check for a session.
 // Prefers GT_PROCESS_NAMES (set at startup, handles custom agents that shadow
 // built-in presets). Falls back to GT_AGENT-based lookup for legacy sessions.
 func (t *Tmux) resolveSessionProcessNames(session string) []string {
+	processNames, _ := t.resolveSessionProcessNamesChecked(session)
+	return processNames
+}
+
+func (t *Tmux) resolveSessionProcessNamesChecked(session string) ([]string, error) {
 	// Prefer explicit process names set at startup (handles custom agents correctly)
-	if names, err := t.GetEnvironment(session, "GT_PROCESS_NAMES"); err == nil && names != "" {
-		return strings.Split(names, ",")
+	if names, ok, err := t.getEnvironmentOptional(session, "GT_PROCESS_NAMES"); err != nil {
+		return nil, err
+	} else if ok && names != "" {
+		return strings.Split(names, ","), nil
 	}
 	// Fallback: resolve from agent name (built-in presets only)
-	agentName, _ := t.GetEnvironment(session, "GT_AGENT")
-	return config.GetProcessNames(agentName) // Returns Claude defaults if empty
+	agentName, _, err := t.getEnvironmentOptional(session, "GT_AGENT")
+	if err != nil {
+		return nil, err
+	}
+	return config.GetProcessNames(agentName), nil // Returns Claude defaults if empty
 }
 
 // WaitForCommand polls until the pane is NOT running one of the excluded commands.

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -481,6 +481,23 @@ func TestIsAgentRunning_NonexistentSession(t *testing.T) {
 	}
 }
 
+func TestIsRuntimeRunningChecked_NonexistentSessionErrors(t *testing.T) {
+	tm := newTestTmux(t)
+	sessionName := "gt-test-runtime-missing-" + t.Name()
+	_ = tm.KillSession(sessionName)
+
+	running, err := tm.IsRuntimeRunningChecked(sessionName, []string{"sleep"})
+	if err == nil {
+		t.Fatal("expected checked runtime query to return an error for missing session")
+	}
+	if running {
+		t.Fatal("expected missing session to report not running")
+	}
+	if tm.IsRuntimeRunning(sessionName, []string{"sleep"}) {
+		t.Fatal("legacy bool wrapper should collapse query errors to false")
+	}
+}
+
 func TestIsRuntimeRunning_AgentNameRequiresCursorSession(t *testing.T) {
 	tm := newTestTmux(t)
 	sessionName := "gt-test-runtime-agent-filter-" + t.Name()

--- a/pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/evidence.json
+++ b/pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/evidence.json
@@ -1,0 +1,230 @@
+{
+  "schema_version": "pr-sheriff-evidence/v1",
+  "policy_version": "pr-sheriff-policy/v1.1",
+  "generated_at": "2026-07-13T20:25:00Z",
+  "run_id": "gt-4468fx-pr4468-stale-heartbeat",
+  "subject": {
+    "forge": "github",
+    "repo_id": "Bella-Giraffety/gastown",
+    "default_branch": "main",
+    "change_type": "replacement_pr",
+    "change_id": "gt-4468fx-replacement-for-4468",
+    "url": "https://github.com/Bella-Giraffety/gastown/tree/polecat/mirelurk/gt-4468fx-pr4468-stale-heartbeat",
+    "title": "Current-main replacement for PR #4468 stale-heartbeat live-agent safety",
+    "author": "marvincris / Marvin Cris Andrade",
+    "author_tier": "known",
+    "draft": false,
+    "base_ref": "main",
+    "base_sha": "62fc77c7ecd262461802cd55fcadcd69f5393209",
+    "head_ref": "polecat/mirelurk/gt-4468fx-pr4468-stale-heartbeat",
+    "head_sha": "d3858c3c91c3bee3252b1095551af5579bc07f34",
+    "diff_summary": {
+      "additions": 317,
+      "deletions": 53,
+      "changed_files": 4,
+      "paths": [
+        "internal/polecat/heartbeat_test.go",
+        "internal/polecat/manager.go",
+        "internal/tmux/tmux.go",
+        "internal/tmux/tmux_test.go"
+      ]
+    }
+  },
+  "repo_policy": {
+    "label_aliases": [],
+    "feature_kind_values": ["feature", "enhancement"],
+    "merge_ready_status_values": ["review-approved", "merge-ready"],
+    "approver_roles": ["maintainer", "owner", "mayor"],
+    "evidence_locations": ["local_report", "beads_notes", "artifact_store"],
+    "baseline_checks": [],
+    "no_verification_reasons": []
+  },
+  "action_plan": {
+    "id": "action-plan-gt-4468fx",
+    "mode": "replacement_pr",
+    "proposed_action_ref": "action-plan-gt-4468fx",
+    "summary": "Carry PR #4468's stale-heartbeat live-agent safety forward on current main while preserving marvincris attribution. Tighten only the existing tmux liveness/polecat kill predicate seam by adding checked liveness errors, fail closed on query errors or nil tmux, and add focused stale-heartbeat live/not-live/query-error regressions. No retries, no longer timeouts, and no second liveness layer.",
+    "created_at": "2026-07-13T19:42:00Z"
+  },
+  "labels": {
+    "observed": [
+      {"name": "status/merge-ready", "family": "status", "semantic_value": "merge-ready"},
+      {"name": "priority/p1", "family": "priority", "semantic_value": "p1"},
+      {"name": "kind/bug", "family": "kind", "semantic_value": "bug"}
+    ],
+    "status": "merge-ready",
+    "priority": "p1",
+    "kind": "bug",
+    "snapshot_artifact_ref": "label-snapshot-replacement"
+  },
+  "artifacts": [
+    {"id": "label-snapshot-replacement", "kind": "label_snapshot", "uri": "file:pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/evidence.json#labels", "actor": "gastown/polecats/mirelurk", "created_at": "2026-07-13T20:25:00Z", "digest": null, "summary": "Replacement target semantics: status=merge-ready, priority=p1, kind=bug. Original PR #4468 remains status/needs-review and is not the merge target."},
+    {"id": "original-pr-4468", "kind": "pull_request_snapshot", "uri": "https://github.com/gastownhall/gastown/pull/4468", "actor": "github", "created_at": "2026-07-13T19:28:00Z", "digest": null, "summary": "Original PR #4468 by marvincris is open, kind/bug priority/p1 status/needs-review, no reviews/approval, head 4fabb623753677b514e125c846f0bd7c0781aa17, and base f8e6d072 is stale versus current main."},
+    {"id": "final-head", "kind": "git_commit", "uri": "urn:git:commit:d3858c3c91c3bee3252b1095551af5579bc07f34", "actor": "gastown/polecats/mirelurk", "created_at": "2026-07-13T20:17:00Z", "digest": null, "summary": "Current-main replacement commit d3858c3c91c3bee3252b1095551af5579bc07f34 on upstream/main 62fc77c7; trailers reference PR #4468, original commit 4fabb623, mayor <marvincris@outlook.com>, and Claude Fable 5."},
+    {"id": "verification-focused", "kind": "verification_log", "uri": "file:pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/evidence.json#verification", "actor": "gastown/polecats/mirelurk", "created_at": "2026-07-13T20:22:00Z", "digest": null, "summary": "Focused polecat stale-heartbeat tests, focused tmux checked-runtime tests, full internal/polecat with CGO_ENABLED=0, CGO_ENABLED=0 go build ./cmd/gt, and git diff --check passed on d3858c3c."},
+    {"id": "local-baseline-proof", "kind": "verification_log", "uri": "file:/tmp/opencode/gastown-upstream-main-gt4468fx", "actor": "gastown/polecats/mirelurk", "created_at": "2026-07-13T20:20:00Z", "digest": null, "summary": "The two broad internal/tmux local failures (sleep reported as coreutils) reproduce on clean upstream/main 62fc77c7, proving unrelated local baseline behavior."},
+    {"id": "checker-merge-gate", "kind": "checker_output", "uri": "file:pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/merge-gate-check.txt", "actor": "gt-pr-sheriff-check", "created_at": "2026-07-13T20:26:00Z", "digest": null, "summary": "Checker output persisted after evidence generation."},
+    {"id": "research-01", "kind": "research_report", "uri": "task:ses_0a30c5a4cffeGVapsutmMsTDe1#R01", "actor": "researcher-R01", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "Problem validity: stale heartbeat alone is not proof of death, but PR #4468 as-is still treats IsAgentAlive false/query-error as dead."},
+    {"id": "research-02", "kind": "research_report", "uri": "task:ses_0a30c59b7ffeBcUYiYXXtE35aL#R02", "actor": "researcher-R02", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "Existing tests lacked stale heartbeat plus live agent, not-live agent, and query-error regressions; a narrow liveness seam is sufficient."},
+    {"id": "research-03", "kind": "research_report", "uri": "task:ses_0a30c593effemAK5t81PT34e0T#R03", "actor": "researcher-R03", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "tmux.IsAgentAlive returns bool only and collapses tmux/pane/process query failures to false; checked semantics are needed for destructive cleanup."},
+    {"id": "research-04", "kind": "research_report", "uri": "task:ses_0a30c58f1ffeC3Rmk2FtIqh0xX#R04", "actor": "researcher-R04", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "Original PR base was stale but the touched hunk did not conflict with then-current main; final replacement was later rebased to 62fc77c7."},
+    {"id": "research-05", "kind": "research_report", "uri": "task:ses_0a30c5826ffew344oQiR1eAz4r#R05", "actor": "researcher-R05", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "Cleanup-first review favored tightening the existing predicate and checked liveness errors, not retries/timeouts or another liveness layer."},
+    {"id": "research-06", "kind": "research_report", "uri": "task:ses_0a30c57afffeInz9jzs28LtBXK#R06", "actor": "researcher-R06", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "Attribution evidence: PR #4468 author marvincris / Marvin Cris Andrade; original commit author mayor <marvincris@outlook.com> with Claude co-author."},
+    {"id": "research-07", "kind": "research_report", "uri": "task:ses_0a30c574bffeVcD5C0JFbj7hjR#R07", "actor": "researcher-R07", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "Original labels have valid cardinality but status/needs-review and no review approval block merge-as-is."},
+    {"id": "research-08", "kind": "research_report", "uri": "task:ses_0a30c56f1ffeQT1nVuYiUkI65b#R08", "actor": "researcher-R08", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "CI was green on stale original head but missing focused regressions; local environment needs CGO_ENABLED=0 because ICU headers are absent."},
+    {"id": "research-09", "kind": "research_report", "uri": "task:ses_0a30c5686ffeRyhQdb8rFAlLpl#R09", "actor": "researcher-R09", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "Blocker scan confirmed missing approval, stale current-main verification, missing focused tests, and unresolved false-on-query-error semantics."},
+    {"id": "research-10", "kind": "research_report", "uri": "task:ses_0a30c5616ffemfucg1SUe0D0XG#R10", "actor": "researcher-R10", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "Testability review recommended a narrow package-level liveness seam plus checked tmux helper, not a broad Manager abstraction."},
+    {"id": "research-11", "kind": "research_report", "uri": "task:ses_0a30c55aaffe4O6Qhf3TIa5GJO#R11", "actor": "researcher-R11", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "No-heartbeat sessions should retain legacy PID fallback; stale heartbeat with liveness-query uncertainty should return not-dead."},
+    {"id": "research-12", "kind": "research_report", "uri": "task:ses_0a30c5557ffewmFMdkN5gMX99v#R12", "actor": "researcher-R12", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "Operational safety favors preserving uncertain live sessions over false-positive kills; false negatives are less destructive than killing active work."},
+    {"id": "research-13", "kind": "research_report", "uri": "task:ses_0a30c54ffffemJzISyCV63jq0Q#R13", "actor": "researcher-R13", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "Historical context from GH#3342 and daemon idle-reap protections supports stale-heartbeat plus live-agent preservation but requires fail-closed query semantics."},
+    {"id": "research-14", "kind": "research_report", "uri": "task:ses_0a30c5497ffe8FBpMKpY5Xm6Qj#R14", "actor": "researcher-R14", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "Evidence schema review identified required 15+5+5 records, merge-ready labels, replacement flow, attribution, blocker scan, verification, and checker output."},
+    {"id": "research-15", "kind": "research_report", "uri": "task:ses_0a30c5430ffePLP0kn9QvukpIk#R15", "actor": "researcher-R15", "created_at": "2026-07-13T19:35:00Z", "digest": null, "summary": "Final disposition review recommended sheriff replacement/fixup rather than merge-as-is, with current-main rebase, tests, attribution, and checker evidence."},
+    {"id": "pre-01", "kind": "pre_implementation_review", "uri": "task:ses_0a3040029ffePSxQAecIWOCltw#P01", "actor": "pre-reviewer-P01", "created_at": "2026-07-13T19:42:00Z", "digest": null, "summary": "Approved cleanup-first plan: checked liveness, stale heartbeat fail-closed, focused tests, no retries/timeouts/layers."},
+    {"id": "pre-02", "kind": "pre_implementation_review", "uri": "task:ses_0a303ff5affeWXZSy1REVKj69C#P02", "actor": "pre-reviewer-P02", "created_at": "2026-07-13T19:42:00Z", "digest": null, "summary": "Approved correctness and operational safety plan for isSessionProcessDead and reuse/state behavior."},
+    {"id": "pre-03", "kind": "pre_implementation_review", "uri": "task:ses_0a303fe3fffemGh2iDT6XIptMO#P03", "actor": "pre-reviewer-P03", "created_at": "2026-07-13T19:42:00Z", "digest": null, "summary": "Approved unit-level liveness seam and explicit query-error fail-closed regression."},
+    {"id": "pre-04", "kind": "pre_implementation_review", "uri": "task:ses_0a303fd5dffe4KcQ2bPTzDN4BD#P04", "actor": "pre-reviewer-P04", "created_at": "2026-07-13T19:42:00Z", "digest": null, "summary": "Approved API-compatible checked tmux method while preserving bool IsAgentAlive callers."},
+    {"id": "pre-05", "kind": "pre_implementation_review", "uri": "task:ses_0a303fc3fffeBVL54jpK1WGpfl#P05", "actor": "pre-reviewer-P05", "created_at": "2026-07-13T19:42:00Z", "digest": null, "summary": "Approved policy path for kind/bug replacement with marvincris attribution and post-review/checker gates."},
+    {"id": "post-01", "kind": "post_implementation_review", "uri": "task:ses_0a2de3f3cffeeqEYdBS0NjylUe#POST01", "actor": "post-reviewer-POST01", "created_at": "2026-07-13T20:18:00Z", "digest": null, "summary": "Approved cleanup-first final head d3858c3c: tightens predicate, no retries/timeouts/layers, attribution preserved."},
+    {"id": "post-02", "kind": "post_implementation_review", "uri": "task:ses_0a2de3ee0ffeZCJ41yIUinVcG2#POST02", "actor": "post-reviewer-POST02", "created_at": "2026-07-13T20:18:00Z", "digest": null, "summary": "Approved correctness final head d3858c3c: stale live/not-live/query-error, nil tmux, PID fallback, and descendant fallback behavior are safe."},
+    {"id": "post-03", "kind": "post_implementation_review", "uri": "task:ses_0a2de3e74ffe2zH4O7uYqpBbTw#POST03", "actor": "post-reviewer-POST03", "created_at": "2026-07-13T20:18:00Z", "digest": null, "summary": "Approved verification sufficiency; local tmux full-test failures are baseline/unrelated and focused checks pass."},
+    {"id": "post-04", "kind": "post_implementation_review", "uri": "task:ses_0a2de3dbcffe3ElxIOugqdMXYj#POST04", "actor": "post-reviewer-POST04", "created_at": "2026-07-13T20:18:00Z", "digest": null, "summary": "Approved API compatibility: checked helpers preserve errors, bool wrappers remain compatible, and process-match errors still allow descendant fallback."},
+    {"id": "post-05", "kind": "post_implementation_review", "uri": "task:ses_0a2de3d4fffezeaZb4NP3Tubdn#POST05", "actor": "post-reviewer-POST05", "created_at": "2026-07-13T20:18:00Z", "digest": null, "summary": "Approved policy/attribution final head; merge promotion still requires durable evidence and checker pass."}
+  ],
+  "implementation": {
+    "code_changed_by_sheriff": true,
+    "mode": "replacement_pr",
+    "first_code_change_at": "2026-07-13T19:47:00Z",
+    "modified_paths": [
+      "internal/polecat/heartbeat_test.go",
+      "internal/polecat/manager.go",
+      "internal/tmux/tmux.go",
+      "internal/tmux/tmux_test.go"
+    ],
+    "commits": ["d3858c3c91c3bee3252b1095551af5579bc07f34"]
+  },
+  "evidence": {
+    "research_legs": [
+      {"id": "R01", "independence_key": "R01-problem-validity", "artifact_ref": "research-01", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R01", "lens": "problem validity and exact kill predicate", "summary": "Stale heartbeat alone is not proof of death; PR #4468 intent is valid but bool IsAgentAlive query-error semantics block merge-as-is."},
+      {"id": "R02", "independence_key": "R02-test-coverage", "artifact_ref": "research-02", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R02", "lens": "test coverage gaps", "summary": "Focused live/not-live/query-error regressions are missing and needed."},
+      {"id": "R03", "independence_key": "R03-tmux-liveness", "artifact_ref": "research-03", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R03", "lens": "tmux IsAgentAlive error semantics", "summary": "IsAgentAlive false conflates absence and query failure; checked liveness is needed."},
+      {"id": "R04", "independence_key": "R04-current-main", "artifact_ref": "research-04", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R04", "lens": "current-main drift", "summary": "Original branch was stale but conflict risk low; final branch must rebase onto current main."},
+      {"id": "R05", "independence_key": "R05-cleanup-first", "artifact_ref": "research-05", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R05", "lens": "cleanup-first", "summary": "Minimal fix should tighten existing predicate and checked liveness, not add timeout/retry layers."},
+      {"id": "R06", "independence_key": "R06-attribution", "artifact_ref": "research-06", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R06", "lens": "attribution", "summary": "Preserve marvincris/mayor attribution and original Claude co-author when carrying forward."},
+      {"id": "R07", "independence_key": "R07-label-gate", "artifact_ref": "research-07", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R07", "lens": "labels and merge gate", "summary": "Original status/needs-review and no approval block merge-as-is."},
+      {"id": "R08", "independence_key": "R08-ci-verification", "artifact_ref": "research-08", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R08", "lens": "CI and local verification", "summary": "Original CI is stale and tests missing; final needs focused tests and CGO_ENABLED=0 local verification."},
+      {"id": "R09", "independence_key": "R09-blocker-scan", "artifact_ref": "research-09", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R09", "lens": "blocker scan", "summary": "Approval, stale base, tests, and query-error semantics are unresolved on original PR."},
+      {"id": "R10", "independence_key": "R10-testability", "artifact_ref": "research-10", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R10", "lens": "testability", "summary": "Use narrow liveness seam and checked tmux helper, not broad abstractions."},
+      {"id": "R11", "independence_key": "R11-pid-fallback", "artifact_ref": "research-11", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R11", "lens": "PID fallback", "summary": "Keep no-heartbeat PID fallback; stale query uncertainty should fail closed to not-dead."},
+      {"id": "R12", "independence_key": "R12-operational-safety", "artifact_ref": "research-12", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R12", "lens": "operational safety", "summary": "False-positive kills are higher blast radius than retaining uncertain stale sessions."},
+      {"id": "R13", "independence_key": "R13-related-history", "artifact_ref": "research-13", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R13", "lens": "historical context", "summary": "GH#3342/daemon idle-reap history supports live-agent preservation and fail-closed uncertainty."},
+      {"id": "R14", "independence_key": "R14-evidence-schema", "artifact_ref": "research-14", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R14", "lens": "evidence schema", "summary": "Final evidence requires 15+5+5, replacement flow, attribution, verification, blocker scan, and checker."},
+      {"id": "R15", "independence_key": "R15-disposition", "artifact_ref": "research-15", "completed_at": "2026-07-13T19:35:00Z", "actor": "researcher-R15", "lens": "final disposition", "summary": "Recommend current-main sheriff replacement/fixup instead of merge-as-is."}
+    ],
+    "pre_implementation_reviews": [
+      {"id": "P01", "independence_key": "P01-cleanup", "artifact_ref": "pre-01", "reviewed_action_ref": "action-plan-gt-4468fx", "completed_at": "2026-07-13T19:42:00Z", "actor": "pre-reviewer-P01", "verdict": "approve", "summary": "Approved cleanup-first minimality."},
+      {"id": "P02", "independence_key": "P02-correctness", "artifact_ref": "pre-02", "reviewed_action_ref": "action-plan-gt-4468fx", "completed_at": "2026-07-13T19:42:00Z", "actor": "pre-reviewer-P02", "verdict": "approve", "summary": "Approved correctness and safety."},
+      {"id": "P03", "independence_key": "P03-tests", "artifact_ref": "pre-03", "reviewed_action_ref": "action-plan-gt-4468fx", "completed_at": "2026-07-13T19:42:00Z", "actor": "pre-reviewer-P03", "verdict": "approve", "summary": "Approved focused test plan and query-error regression."},
+      {"id": "P04", "independence_key": "P04-api", "artifact_ref": "pre-04", "reviewed_action_ref": "action-plan-gt-4468fx", "completed_at": "2026-07-13T19:42:00Z", "actor": "pre-reviewer-P04", "verdict": "approve", "summary": "Approved API-compatible checked helper."},
+      {"id": "P05", "independence_key": "P05-policy", "artifact_ref": "pre-05", "reviewed_action_ref": "action-plan-gt-4468fx", "completed_at": "2026-07-13T19:42:00Z", "actor": "pre-reviewer-P05", "verdict": "approve", "summary": "Approved policy and attribution path."}
+    ],
+    "post_implementation_reviews": [
+      {"id": "POST01", "independence_key": "POST01-cleanup-d3858c3c", "artifact_ref": "post-01", "reviewed_action_ref": "action-plan-gt-4468fx", "reviewed_head_sha": "d3858c3c91c3bee3252b1095551af5579bc07f34", "completed_at": "2026-07-13T20:18:00Z", "actor": "post-reviewer-POST01", "verdict": "approve", "summary": "Approved cleanup-first final head."},
+      {"id": "POST02", "independence_key": "POST02-correctness-d3858c3c", "artifact_ref": "post-02", "reviewed_action_ref": "action-plan-gt-4468fx", "reviewed_head_sha": "d3858c3c91c3bee3252b1095551af5579bc07f34", "completed_at": "2026-07-13T20:18:00Z", "actor": "post-reviewer-POST02", "verdict": "approve", "summary": "Approved final correctness and safety."},
+      {"id": "POST03", "independence_key": "POST03-tests-d3858c3c", "artifact_ref": "post-03", "reviewed_action_ref": "action-plan-gt-4468fx", "reviewed_head_sha": "d3858c3c91c3bee3252b1095551af5579bc07f34", "completed_at": "2026-07-13T20:18:00Z", "actor": "post-reviewer-POST03", "verdict": "approve", "summary": "Approved final tests and verification sufficiency."},
+      {"id": "POST04", "independence_key": "POST04-api-d3858c3c", "artifact_ref": "post-04", "reviewed_action_ref": "action-plan-gt-4468fx", "reviewed_head_sha": "d3858c3c91c3bee3252b1095551af5579bc07f34", "completed_at": "2026-07-13T20:18:00Z", "actor": "post-reviewer-POST04", "verdict": "approve", "summary": "Approved final API compatibility."},
+      {"id": "POST05", "independence_key": "POST05-policy-d3858c3c", "artifact_ref": "post-05", "reviewed_action_ref": "action-plan-gt-4468fx", "reviewed_head_sha": "d3858c3c91c3bee3252b1095551af5579bc07f34", "completed_at": "2026-07-13T20:18:00Z", "actor": "post-reviewer-POST05", "verdict": "approve", "summary": "Approved final policy and attribution, pending checker evidence."}
+    ]
+  },
+  "cleanup_first": {
+    "assessment": "acceptable_minimal",
+    "rationale": "The replacement tightens the existing stale-heartbeat dead-session predicate and existing tmux runtime matcher with checked errors. It does not add retry loops, longer timeouts, or a second liveness layer.",
+    "prohibited_patterns": [
+      {"kind": "bandaid", "present": false, "exception_reason": "none", "evidence_ref": "post-01"},
+      {"kind": "workaround_layer", "present": false, "exception_reason": "none", "evidence_ref": "post-01"},
+      {"kind": "compatibility_shim", "present": false, "exception_reason": "none", "evidence_ref": "post-01"},
+      {"kind": "patch_on_patch", "present": false, "exception_reason": "none", "evidence_ref": "post-01"},
+      {"kind": "scope_creep", "present": false, "exception_reason": "none", "evidence_ref": "post-01"}
+    ]
+  },
+  "enhancement_approval": {
+    "required": false,
+    "required_reason": null,
+    "approved": false,
+    "approver": null,
+    "approver_role": null,
+    "approval_ref": null,
+    "approved_at": null
+  },
+  "verification": {
+    "focused_checks": [
+      {"name": "diff-check", "command_or_check": "git diff --check upstream/main..HEAD", "outcome": "pass", "artifact_ref": "verification-focused", "reason": "No whitespace or conflict-marker issues."},
+      {"name": "polecat-focused-stale-heartbeat", "command_or_check": "CGO_ENABLED=0 go test -count=1 -v ./internal/polecat -run 'TestIsSessionProcessDead_Heartbeat(Fresh|StaleUsesAgentLiveness|StaleWithoutTmuxFailsClosed)'", "outcome": "pass", "artifact_ref": "verification-focused", "reason": "Fresh, stale/live, stale/not-live, stale/query-error, and stale/no-tmux fail-closed regressions passed."},
+      {"name": "tmux-focused-checked-liveness", "command_or_check": "CGO_ENABLED=0 go test -count=1 -v ./internal/tmux -run '^(TestIsRuntimeRunning|TestIsRuntimeRunningChecked_NonexistentSessionErrors|TestIsRuntimeRunning_AgentNameRequiresCursorSession|TestIsRuntimeRunning_ShellWithNodeChild|TestIsAgentRunning_NonexistentSession)$'", "outcome": "pass", "artifact_ref": "verification-focused", "reason": "Checked liveness, bool wrapper compatibility, and runtime detection regressions passed."},
+      {"name": "polecat-package", "command_or_check": "CGO_ENABLED=0 go test -count=1 ./internal/polecat", "outcome": "pass", "artifact_ref": "verification-focused", "reason": "Full touched polecat package passed with CGO disabled for local ICU constraint."},
+      {"name": "build", "command_or_check": "CGO_ENABLED=0 go build ./cmd/gt", "outcome": "pass", "artifact_ref": "verification-focused", "reason": "CLI builds with CGO disabled in local environment."},
+      {"name": "local-baseline-tmux", "command_or_check": "CGO_ENABLED=0 go test -count=1 -v ./internal/tmux -run '^(TestNewSessionWithCommand_ExecEnvSuccess|TestGetPaneCommand_MultiPane)$' on upstream/main 62fc77c7", "outcome": "pass", "artifact_ref": "local-baseline-proof", "reason": "Baseline proof passed as unrelatedness evidence: the same two local failures reproduce on clean upstream/main."}
+    ],
+    "ci_checks": []
+  },
+  "baseline_red_waiver": {
+    "requested": false,
+    "approved": false,
+    "approved_by": null,
+    "approver_role": null,
+    "approved_at": null,
+    "approval_ref": null,
+    "failing_checks": [],
+    "unrelated_rationale": "",
+    "evidence_refs": []
+  },
+  "replacement_flow": {
+    "required": true,
+    "mode": "replacement_pr",
+    "state": "ready",
+    "original_change_url": "https://github.com/gastownhall/gastown/pull/4468",
+    "replacement_change_url": "https://github.com/Bella-Giraffety/gastown/tree/polecat/mirelurk/gt-4468fx-pr4468-stale-heartbeat",
+    "replacement_branch": "polecat/mirelurk/gt-4468fx-pr4468-stale-heartbeat",
+    "replacement_commit_refs": ["d3858c3c91c3bee3252b1095551af5579bc07f34"],
+    "original_author": "marvincris / Marvin Cris Andrade",
+    "evidence_reuse": {
+      "reused_artifact_refs": ["original-pr-4468", "research-01", "research-06"],
+      "fresh_artifact_refs": ["final-head", "verification-focused", "post-01", "post-02", "post-03", "post-04", "post-05"],
+      "rationale": "The valid bug intent from PR #4468 was carried forward, but final checked liveness semantics, tests, and current-main verification are fresh on upstream/main 62fc77c7."
+    },
+    "attribution": {
+      "required": true,
+      "required_reason": "Replacement preserves the accepted stale-heartbeat live-agent safety intent from PR #4468 by marvincris.",
+      "preserved": true,
+      "method": "co_authored_by",
+      "artifact_refs": ["original-pr-4468", "final-head", "research-06"]
+    },
+    "superseded_closure": {
+      "required": true,
+      "state": "deferred_until_replacement_merge",
+      "closure_intent_ref": "original-pr-4468",
+      "replacement_merge_ref": null,
+      "closure_ref": null
+    }
+  },
+  "blocker_scan": {
+    "scanned_sources": ["labels", "pr_comments", "review_comments", "ci_checks", "beads_notes", "local_reviews", "verification"],
+    "unresolved_blockers_found": false,
+    "blocker_refs": [],
+    "resolution_refs": ["post-01", "post-02", "post-03", "post-04", "post-05", "verification-focused", "final-head"],
+    "scanned_at": "2026-07-13T20:25:00Z",
+    "summary": "Original PR #4468 remains blocked for merge-as-is by status/needs-review, no approval, stale original head, missing tests, and bool query-error semantics. Replacement head d3858c3c resolves the implementation/test/query-error blockers, is current-main based, and has no unresolved blockers after final post-review and verification."
+  },
+  "gates": [],
+  "final": {
+    "verdict": "merge_replacement",
+    "decision_valid": true,
+    "merge_path_allowed": true,
+    "blocking_gates": [],
+    "target_change_url": "https://github.com/Bella-Giraffety/gastown/tree/polecat/mirelurk/gt-4468fx-pr4468-stale-heartbeat",
+    "target_head_sha": "d3858c3c91c3bee3252b1095551af5579bc07f34",
+    "decided_by": "gastown/polecats/mirelurk",
+    "decided_at": "2026-07-13T20:25:00Z",
+    "reason": "Original PR #4468 is not mergeable as-is. The current-main replacement passes 15 research legs, 5 pre-implementation reviews, 5 final-head post-implementation reviews, cleanup-first, attribution, blocker scan, focused verification, and build gates.",
+    "required_actions": ["Do not close PR #4468 as superseded until the replacement lands with attribution evidence."]
+  }
+}

--- a/pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/merge-gate-check.txt
+++ b/pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/merge-gate-check.txt
@@ -1,0 +1,10 @@
+command: gt-pr-sheriff-check --evidence pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/evidence.json --merge-gate
+exit_code: 0
+
+stdout:
+PR Sheriff: PASS
+merge_path_allowed: true
+verdict: merge_replacement
+gates: 12 pass, 2 not_applicable, 0 waived, 0 fail
+
+stderr:

--- a/pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/report.md
+++ b/pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/report.md
@@ -1,0 +1,26 @@
+PR Sheriff Report
+Subject: gastownhall/gastown PR #4468 "fix(polecat): require agent-process death before reconcile-killing stale-heartbeat sessions" https://github.com/gastownhall/gastown/pull/4468
+Mode: replacement_fixup + merge_decision
+Author: marvincris / Marvin Cris Andrade (known)
+Base/Head: upstream/main@62fc77c7ecd262461802cd55fcadcd69f5393209 -> d3858c3c91c3bee3252b1095551af5579bc07f34
+Repo config used: pr-sheriff default policy v1.1
+Labels: status=merge-ready priority=p1 kind=bug for replacement target; original PR remains status/needs-review priority/p1 kind/bug
+Triage category: needs_replacement_or_fixup_analysis
+Action mode: replacement_pr
+Research legs: 15/15
+Pre-implementation reviews: 5/5
+Post-implementation reviews: 5/5
+Cleanup-first: acceptable_minimal
+Human approvals: not_required for kind/bug implementation; original PR has no merge approval
+Verification: focused polecat stale-heartbeat tests pass; focused tmux checked-liveness tests pass; CGO_ENABLED=0 go test ./internal/polecat passes; CGO_ENABLED=0 go build ./cmd/gt passes; git diff --check passes; default CGO blocked by missing local ICU header; broad internal/tmux sleep/coreutils failures reproduce on upstream/main baseline
+Baseline-red waiver: not_applicable
+Replacement/fixup: original PR #4468 carried forward on current-main branch polecat/mirelurk/gt-4468fx-pr4468-stale-heartbeat at d3858c3c91c3bee3252b1095551af5579bc07f34
+Contributor attribution: preserved via commit Refs to PR #4468 and original commit plus Co-authored-by: mayor <marvincris@outlook.com>
+Superseded closure: deferred_until_replacement_merge
+Blocker scan: original PR merge-as-is blockers resolved by replacement; no unresolved replacement blockers
+Gate summary: 12 pass, 2 not_applicable, 0 waived, 0 fail
+Blocking gates: none for replacement merge gate
+Final verdict: merge_replacement
+Merge path allowed: true
+Required next actions: do not close PR #4468 as superseded until replacement lands with attribution evidence
+Evidence refs: pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/evidence.json; pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/merge-gate-check.txt


### PR DESCRIPTION
## Summary
- carry forward #4468 while preserving tmux/process liveness query errors instead of collapsing them to `false`
- treat a stale heartbeat as confirmed dead only after a successful not-live result
- fail closed when the tmux manager is unavailable or liveness is uncertain
- add focused stale-heartbeat live, not-live, nil-manager, and query-error regressions

## Disposition
PR #4468 has valid narrow intent but its liveness helper treated query failure as process death. This current-main replacement converges the decision on the existing liveness predicate with checked error semantics rather than adding retries, timeouts, or a second liveness layer. Keep #4468 open until this replacement merges, then close it as superseded.

## Attribution
The implementation commit references #4468 and its original commit and includes a co-author trailer using Marvin Cris Andrade's original commit email.

## Validation
- focused `CGO_ENABLED=0` polecat stale-heartbeat tests
- focused `CGO_ENABLED=0` tmux checked-liveness tests
- `CGO_ENABLED=0 go test ./internal/polecat`
- `CGO_ENABLED=0 go build ./cmd/gt`
- `git diff --check`
- broader tmux sleep/coreutils failures reproduced on clean current-main baseline and are not waived as branch-specific checks

## Review Evidence
The PR Sheriff workflow completed 15 independent research legs, 5 approving pre-implementation reviews, and 5 approving final-head post-implementation reviews. `gt-pr-sheriff-check --merge-gate` passed with `merge_path_allowed=true`, `verdict=merge_replacement`, and 12 passing gates. Durable evidence is included under `pr-sheriff-evidence/gt-4468fx-pr4468-stale-heartbeat/`.