### PR TITLE
fix(patrol): rebuild heartbeat and root-wisp flow

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -1912,6 +1912,7 @@ func (b *Beads) Update(id string, opts UpdateOptions) error {
 	}
 
 	args := []string{"update", id}
+	var stdinData []byte
 
 	if opts.Title != nil {
 		args = append(args, "--title="+*opts.Title)
@@ -1923,7 +1924,12 @@ func (b *Beads) Update(id string, opts UpdateOptions) error {
 		args = append(args, fmt.Sprintf("--priority=%d", *opts.Priority))
 	}
 	if opts.Description != nil {
-		args = append(args, "--description="+*opts.Description)
+		args = append(args, "--body-file=-")
+		stdinData = []byte(*opts.Description)
+		if *opts.Description == "" {
+			args = append(args, "--allow-empty-description")
+			stdinData = []byte{}
+		}
 	}
 	if opts.Assignee != nil {
 		args = append(args, "--assignee="+*opts.Assignee)
@@ -1942,7 +1948,7 @@ func (b *Beads) Update(id string, opts UpdateOptions) error {
 		}
 	}
 
-	_, err := b.run(args...)
+	_, err := b.runWithStdin(stdinData, args...)
 	return err
 }
 

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -1578,6 +1578,153 @@ func TestUpdateOptions(t *testing.T) {
 	}
 }
 
+func TestUpdateDescriptionUsesBodyFileStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script bd stub")
+	}
+
+	ResetBdAllowStaleCacheForTest()
+	stubDir := t.TempDir()
+	argsPath := filepath.Join(stubDir, "args.txt")
+	stdinPath := filepath.Join(stubDir, "stdin.txt")
+	stubPath := filepath.Join(stubDir, "bd")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--allow-stale" ]; then
+  echo "Error: unknown flag: --allow-stale" >&2
+  exit 0
+fi
+for a in "$@"; do
+  printf '%%s\n' "$a" >> %q
+done
+cat > %q
+exit 0
+`, argsPath, stdinPath)
+	if err := os.WriteFile(stubPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	desc := "line one\nline two"
+	status := "hooked"
+	if err := New(t.TempDir()).Update("gt-test", UpdateOptions{Status: &status, Description: &desc}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	argsData, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	args := string(argsData)
+	for _, want := range []string{"update", "gt-test", "--status=hooked", "--body-file=-"} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("args missing %q:\n%s", want, args)
+		}
+	}
+	for _, line := range strings.Split(args, "\n") {
+		if strings.HasPrefix(line, "--description=") {
+			t.Fatalf("description must not be passed through argv, got %q", line)
+		}
+	}
+	stdinData, err := os.ReadFile(stdinPath)
+	if err != nil {
+		t.Fatalf("read stdin: %v", err)
+	}
+	if got := string(stdinData); got != desc {
+		t.Fatalf("stdin = %q, want %q", got, desc)
+	}
+}
+
+func TestUpdateEmptyDescriptionAllowsEmptyBodyFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script bd stub")
+	}
+
+	ResetBdAllowStaleCacheForTest()
+	stubDir := t.TempDir()
+	argsPath := filepath.Join(stubDir, "args.txt")
+	stdinPath := filepath.Join(stubDir, "stdin.txt")
+	stubPath := filepath.Join(stubDir, "bd")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--allow-stale" ]; then
+  echo "Error: unknown flag: --allow-stale" >&2
+  exit 0
+fi
+for a in "$@"; do
+  printf '%%s\n' "$a" >> %q
+done
+cat > %q
+exit 0
+`, argsPath, stdinPath)
+	if err := os.WriteFile(stubPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	desc := ""
+	if err := New(t.TempDir()).Update("gt-test", UpdateOptions{Description: &desc}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	argsData, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	args := string(argsData)
+	for _, want := range []string{"--body-file=-", "--allow-empty-description"} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("args missing %q:\n%s", want, args)
+		}
+	}
+	stdinData, err := os.ReadFile(stdinPath)
+	if err != nil {
+		t.Fatalf("read stdin: %v", err)
+	}
+	if len(stdinData) != 0 {
+		t.Fatalf("stdin = %q, want empty", string(stdinData))
+	}
+}
+
+func TestUpdateNilDescriptionDoesNotUseBodyFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script bd stub")
+	}
+
+	ResetBdAllowStaleCacheForTest()
+	stubDir := t.TempDir()
+	argsPath := filepath.Join(stubDir, "args.txt")
+	stubPath := filepath.Join(stubDir, "bd")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--allow-stale" ]; then
+  echo "Error: unknown flag: --allow-stale" >&2
+  exit 0
+fi
+for a in "$@"; do
+  printf '%%s\n' "$a" >> %q
+done
+exit 0
+`, argsPath)
+	if err := os.WriteFile(stubPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	status := "hooked"
+	if err := New(t.TempDir()).Update("gt-test", UpdateOptions{Status: &status}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	argsData, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	args := string(argsData)
+	for _, forbidden := range []string{"--body-file=-", "--allow-empty-description", "--description="} {
+		if strings.Contains(args, forbidden) {
+			t.Fatalf("args contained %q:\n%s", forbidden, args)
+		}
+	}
+}
+
 // TestIsBeadsRepo tests repository detection.
 func TestIsBeadsRepo(t *testing.T) {
 	// Test with a non-beads directory

--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -22,6 +22,7 @@ type bdCmd struct {
 	args       []string
 	dir        string
 	env        []string
+	stdin      io.Reader
 	stderr     io.Writer
 	autoCommit bool
 	allowStale bool
@@ -111,6 +112,12 @@ func (b *bdCmd) Stderr(w io.Writer) *bdCmd {
 	return b
 }
 
+// Stdin sets the stdin reader for the command.
+func (b *bdCmd) Stdin(r io.Reader) *bdCmd {
+	b.stdin = r
+	return b
+}
+
 // filterEnvKey removes all entries matching the given key from the env slice.
 // This ensures appended values aren't shadowed by existing entries, since
 // glibc getenv() returns the first match in the environment array.
@@ -163,6 +170,7 @@ func (b *bdCmd) Build() *exec.Cmd {
 	cmd := exec.Command("bd", args...)
 	cmd.Dir = b.dir
 	cmd.Env = b.buildEnv()
+	cmd.Stdin = b.stdin
 	cmd.Stderr = b.stderr
 	return cmd
 }
@@ -182,6 +190,7 @@ func (b *bdCmd) buildContextCommand(ctx context.Context) *exec.Cmd {
 	util.SetProcessGroup(cmd)
 	cmd.Dir = b.dir
 	cmd.Env = b.buildEnv()
+	cmd.Stdin = b.stdin
 	cmd.Stderr = b.stderr
 	return cmd
 }
@@ -277,6 +286,7 @@ func (b *bdCmd) CombinedOutput() ([]byte, error) {
 	util.SetProcessGroup(cmd)
 	cmd.Dir = b.dir
 	cmd.Env = b.buildEnv()
+	cmd.Stdin = b.stdin
 	out, err := cmd.CombinedOutput()
 	return out, b.wrapCommandError(ctx, err, deadline)
 }

--- a/internal/cmd/bd_helpers_test.go
+++ b/internal/cmd/bd_helpers_test.go
@@ -123,6 +123,34 @@ func TestBdCmd_Stderr(t *testing.T) {
 	}
 }
 
+func TestBdCmd_Stdin(t *testing.T) {
+	binDir := t.TempDir()
+	writeBDStub(t, binDir, `#!/usr/bin/env sh
+printf 'args:%s\n' "$*"
+printf 'stdin:'
+cat
+`, `@echo off
+echo args:%*
+set /p stdin=
+echo stdin:%stdin%
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := BdCmd("update", "gt-wisp-test", "--body-file=-").
+		Stdin(strings.NewReader("line one\nline two")).
+		Output()
+	if err != nil {
+		t.Fatalf("Output: %v", err)
+	}
+	text := string(out)
+	if !strings.Contains(text, "args:update gt-wisp-test --body-file=-") {
+		t.Fatalf("missing args in output: %q", text)
+	}
+	if !strings.Contains(text, "stdin:line one\nline two") {
+		t.Fatalf("stdin was not passed through: %q", text)
+	}
+}
+
 func TestBdCmd_DefaultStderr(t *testing.T) {
 	bdc := BdCmd("list")
 	cmd := bdc.Build()
@@ -241,6 +269,9 @@ func TestBdCmd_Chaining(t *testing.T) {
 	}
 	if bdc.Stderr(os.Stdout) != bdc {
 		t.Error("Stderr() should return receiver for chaining")
+	}
+	if bdc.Stdin(strings.NewReader("")) != bdc {
+		t.Error("Stdin() should return receiver for chaining")
 	}
 }
 

--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -791,13 +791,12 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 			stepArgs = append(stepArgs, "--force")
 		}
 
-		createCmd := BdCmd(stepArgs...).
+		if err := BdCmd(stepArgs...).
+			Stdin(strings.NewReader(stepDescription)).
 			WithAutoCommit().
 			Dir(rigBeadsDir).
 			Stderr(os.Stderr).
-			Build()
-		createCmd.Stdin = strings.NewReader(stepDescription)
-		if err := createCmd.Run(); err != nil {
+			Run(); err != nil {
 			fmt.Printf("%s Failed to create step bead for %s: %v\n",
 				style.Dim.Render("Warning:"), step.ID, err)
 			continue

--- a/internal/cmd/heartbeat.go
+++ b/internal/cmd/heartbeat.go
@@ -86,6 +86,8 @@ func runHeartbeat(cmd *cobra.Command, args []string) error {
 // stale enough to matter to watchers.
 const deaconBeadHeartbeatSyncThreshold = deacon.HeartbeatStaleThreshold / 2
 
+var deaconAgentBeadHeartbeatSync = syncDeaconAgentBeadHeartbeat
+
 func syncDeaconHeartbeatStores(townRoot, action string) error {
 	var err error
 	if action != "" {
@@ -93,7 +95,7 @@ func syncDeaconHeartbeatStores(townRoot, action string) error {
 	} else {
 		err = deacon.Touch(townRoot)
 	}
-	syncDeaconAgentBeadHeartbeat(townRoot)
+	deaconAgentBeadHeartbeatSync(townRoot)
 	return err
 }
 

--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/cli"
+	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/refinery"
 	"github.com/steveyegge/gastown/internal/style"
 	"golang.org/x/text/cases"
@@ -299,7 +300,49 @@ func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
 		return patrolID, fmt.Errorf("created wisp %s but failed to hook", patrolID)
 	}
 
+	desc, err := renderPatrolWispDescription(cfg)
+	if err != nil {
+		style.PrintWarning("could not render patrol description for %s: %v", patrolID, err)
+	} else if err := updatePatrolWispDescription(cfg, resolvedBeadsDir, patrolID, desc); err != nil {
+		style.PrintWarning("could not write patrol description for %s: %v", patrolID, err)
+	}
+
 	return patrolID, nil
+}
+
+func renderPatrolWispDescription(cfg PatrolConfig) (string, error) {
+	rigName := patrolRigName(cfg)
+	ctx := RoleContext{TownRoot: cfg.BeadsDir, Rig: rigName}
+	var vars []string
+	switch cfg.PatrolMolName {
+	case constants.MolWitnessPatrol:
+		vars = buildWitnessPatrolVars(ctx)
+	case constants.MolRefineryPatrol:
+		vars = buildRefineryPatrolVars(ctx)
+	}
+	vars = append(vars, cfg.ExtraVars...)
+	return renderFormulaRootAndStepsFull(cfg.PatrolMolName, cfg.BeadsDir, rigName, vars)
+}
+
+func patrolRigName(cfg PatrolConfig) string {
+	rigName, _, ok := strings.Cut(cfg.Assignee, "/")
+	if !ok {
+		return ""
+	}
+	return rigName
+}
+
+func updatePatrolWispDescription(cfg PatrolConfig, resolvedBeadsDir, patrolID, desc string) error {
+	desc = strings.TrimSpace(desc)
+	if desc == "" {
+		return nil
+	}
+	return BdCmd("update", patrolID, "--body-file=-").
+		Stdin(strings.NewReader(desc)).
+		WithAutoCommit().
+		WithBeadsDir(resolvedBeadsDir).
+		Dir(cfg.BeadsDir).
+		Run()
 }
 
 // outputPatrolContext is the main function that handles patrol display logic.

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -81,9 +81,9 @@ func TestBuildRefineryPatrolVars_MissingSettings(t *testing.T) {
 		Rig:      "testrig",
 	}
 	vars := buildRefineryPatrolVars(ctx)
-	// target_branch should always be present (falls back to "main" without rig config)
-	if len(vars) != 1 {
-		t.Errorf("expected 1 var (target_branch) when settings file missing, got %v", vars)
+	// rig and target_branch should always be present.
+	if len(vars) != 2 {
+		t.Errorf("expected 2 vars (rig, target_branch) when settings file missing, got %v", vars)
 	}
 	varMap := make(map[string]string)
 	for _, v := range vars {
@@ -91,6 +91,9 @@ func TestBuildRefineryPatrolVars_MissingSettings(t *testing.T) {
 		if len(parts) == 2 {
 			varMap[parts[0]] = parts[1]
 		}
+	}
+	if got := varMap["rig"]; got != "testrig" {
+		t.Errorf("rig = %q, want %q", got, "testrig")
 	}
 	if got := varMap["target_branch"]; got != "main" {
 		t.Errorf("target_branch = %q, want %q", got, "main")
@@ -192,9 +195,9 @@ func TestBuildRefineryPatrolVars_NilMergeQueue(t *testing.T) {
 		Rig:      "testrig",
 	}
 	vars := buildRefineryPatrolVars(ctx)
-	// target_branch should always be present (falls back to "main" without rig config)
-	if len(vars) != 1 {
-		t.Errorf("expected 1 var (target_branch) when merge_queue is nil, got %v", vars)
+	// rig and target_branch should always be present.
+	if len(vars) != 2 {
+		t.Errorf("expected 2 vars (rig, target_branch) when merge_queue is nil, got %v", vars)
 	}
 	varMap := make(map[string]string)
 	for _, v := range vars {
@@ -202,6 +205,9 @@ func TestBuildRefineryPatrolVars_NilMergeQueue(t *testing.T) {
 		if len(parts) == 2 {
 			varMap[parts[0]] = parts[1]
 		}
+	}
+	if got := varMap["rig"]; got != "testrig" {
+		t.Errorf("rig = %q, want %q", got, "testrig")
 	}
 	if got := varMap["target_branch"]; got != "main" {
 		t.Errorf("target_branch = %q, want %q", got, "main")
@@ -247,6 +253,7 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 	// New commands (setup, typecheck, lint, build) default to empty = omitted
 	// judgment_enabled defaults to false, review_depth defaults to "standard"
 	expected := map[string]string{
+		"rig":                                 "testrig",
 		"integration_branch_refinery_enabled": "true",
 		"integration_branch_auto_land":        "false",
 		"run_tests":                           "true",
@@ -505,9 +512,9 @@ func TestBuildRefineryPatrolVars_DefaultBranchWithoutMQ(t *testing.T) {
 	}
 	vars := buildRefineryPatrolVars(ctx)
 
-	// target_branch must be "gastown" even without merge_queue settings
-	if len(vars) != 1 {
-		t.Errorf("expected 1 var (target_branch), got %d: %v", len(vars), vars)
+	// rig and target_branch must be present even without merge_queue settings.
+	if len(vars) != 2 {
+		t.Errorf("expected 2 vars (rig, target_branch), got %d: %v", len(vars), vars)
 	}
 	varMap := make(map[string]string)
 	for _, v := range vars {
@@ -515,6 +522,9 @@ func TestBuildRefineryPatrolVars_DefaultBranchWithoutMQ(t *testing.T) {
 		if len(parts) == 2 {
 			varMap[parts[0]] = parts[1]
 		}
+	}
+	if got := varMap["rig"]; got != "testrig" {
+		t.Errorf("rig = %q, want %q", got, "testrig")
 	}
 	if got := varMap["target_branch"]; got != "gastown" {
 		t.Errorf("target_branch = %q, want %q (should read rig config even without MQ settings)", got, "gastown")
@@ -657,6 +667,137 @@ func splitFirstEquals(s string) []string {
 		return []string{s}
 	}
 	return []string{s[:idx], s[idx+1:]}
+}
+
+func TestPatrolRigName(t *testing.T) {
+	if got := patrolRigName(PatrolConfig{Assignee: "gastown/refinery"}); got != "gastown" {
+		t.Fatalf("patrolRigName = %q, want gastown", got)
+	}
+	if got := patrolRigName(PatrolConfig{Assignee: "deacon"}); got != "" {
+		t.Fatalf("patrolRigName without rig = %q, want empty", got)
+	}
+}
+
+func TestRenderPatrolWispDescription_DeaconInlinesStepsAndVars(t *testing.T) {
+	desc, err := renderPatrolWispDescription(PatrolConfig{
+		PatrolMolName: "mol-deacon-patrol",
+		BeadsDir:      t.TempDir(),
+		Assignee:      "deacon",
+		ExtraVars:     []string{"idle_effort_threshold=7"},
+	})
+	if err != nil {
+		t.Fatalf("renderPatrolWispDescription: %v", err)
+	}
+	for _, want := range []string{
+		"Mayor's daemon patrol loop.",
+		"**Formula Checklist**",
+		"gt deacon heartbeat \"starting patrol cycle\"",
+		"idle_cycles >= 7",
+	} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("description missing %q:\n%s", want, desc)
+		}
+	}
+}
+
+func TestRenderPatrolWispDescription_AppliesOverlay(t *testing.T) {
+	townRoot := t.TempDir()
+	overlayDir := filepath.Join(townRoot, "formula-overlays")
+	if err := os.MkdirAll(overlayDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "mol-deacon-patrol.toml"), []byte(`[[step-overrides]]
+step_id = "heartbeat"
+mode = "append"
+description = "overlay heartbeat note"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	desc, err := renderPatrolWispDescription(PatrolConfig{
+		PatrolMolName: "mol-deacon-patrol",
+		BeadsDir:      townRoot,
+		Assignee:      "deacon",
+	})
+	if err != nil {
+		t.Fatalf("renderPatrolWispDescription: %v", err)
+	}
+	if !strings.Contains(desc, "overlay heartbeat note") {
+		t.Fatalf("description did not include overlay text:\n%s", desc)
+	}
+}
+
+func TestRenderPatrolWispDescription_RefinerySubstitutesRigAndEmptyDefaults(t *testing.T) {
+	desc, err := renderPatrolWispDescription(PatrolConfig{
+		PatrolMolName: "mol-refinery-patrol",
+		BeadsDir:      t.TempDir(),
+		Assignee:      "gastown/refinery",
+	})
+	if err != nil {
+		t.Fatalf("renderPatrolWispDescription: %v", err)
+	}
+	if strings.Contains(desc, "{{") {
+		t.Fatalf("description contains unresolved placeholder:\n%s", desc)
+	}
+	if !strings.Contains(desc, "gt agents resolve --role refinery --rig gastown") {
+		t.Fatalf("description did not substitute refinery rig:\n%s", desc)
+	}
+}
+
+func TestRenderPatrolWispDescription_ExtraVarsOverrideRoleVars(t *testing.T) {
+	desc, err := renderPatrolWispDescription(PatrolConfig{
+		PatrolMolName: constants.MolRefineryPatrol,
+		BeadsDir:      t.TempDir(),
+		Assignee:      "gastown/refinery",
+		ExtraVars:     []string{"rig=override"},
+	})
+	if err != nil {
+		t.Fatalf("renderPatrolWispDescription: %v", err)
+	}
+	if !strings.Contains(desc, "gt agents resolve --role refinery --rig override") {
+		t.Fatalf("description did not use ExtraVars override:\n%s", desc)
+	}
+	if strings.Contains(desc, "gt agents resolve --role refinery --rig gastown") {
+		t.Fatalf("description used role var instead of ExtraVars override:\n%s", desc)
+	}
+}
+
+func TestUpdatePatrolWispDescriptionUsesBodyFileStdin(t *testing.T) {
+	binDir := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "bd.log")
+	writeBDStub(t, binDir, `#!/usr/bin/env sh
+{
+  printf 'args:%s\n' "$*"
+  printf 'stdin:'
+  cat
+  printf '\n'
+} >> "$BD_STUB_LOG"
+`, `@echo off
+echo args:%* >> %BD_STUB_LOG%
+set /p stdin=
+echo stdin:%stdin% >> %BD_STUB_LOG%
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_STUB_LOG", logFile)
+
+	err := updatePatrolWispDescription(PatrolConfig{BeadsDir: t.TempDir()}, filepath.Join(t.TempDir(), ".beads"), "gt-wisp-test", "line one\nline two")
+	if err != nil {
+		t.Fatalf("updatePatrolWispDescription: %v", err)
+	}
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "args:update gt-wisp-test --body-file=-") {
+		t.Fatalf("expected body-file update args, got:\n%s", log)
+	}
+	if strings.Contains(log, "--description=") {
+		t.Fatalf("description must not be passed through argv:\n%s", log)
+	}
+	if !strings.Contains(log, "stdin:line one\nline two") {
+		t.Fatalf("expected multiline description on stdin, got:\n%s", log)
+	}
 }
 
 // --- Patrol discovery tests (findActivePatrol) ---

--- a/internal/cmd/patrol_report.go
+++ b/internal/cmd/patrol_report.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/deacon"
 	"github.com/steveyegge/gastown/internal/formula"
 	"github.com/steveyegge/gastown/internal/style"
 )
@@ -91,7 +92,10 @@ func runPatrolReport(cmd *cobra.Command, args []string) error {
 	}
 
 	// Close the current patrol root with the summary
-	b := beads.New(cfg.BeadsDir)
+	b := cfg.Beads
+	if b == nil {
+		b = beads.New(cfg.BeadsDir)
+	}
 
 	// Build step audit checklist
 	stepAudit := buildStepAudit(cfg.PatrolMolName, patrolReportSteps)
@@ -134,7 +138,29 @@ func runPatrolReport(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("%s Started new patrol: %s\n", style.Success.Render("✓"), newPatrolID)
+	if cfg.RoleName == "deacon" {
+		stampDeaconHeartbeatOnReport(cfg.BeadsDir, patrolReportSummary)
+	}
 	return nil
+}
+
+func stampDeaconHeartbeatOnReport(townRoot, summary string) {
+	paused, _, err := deacon.IsPaused(townRoot)
+	if err != nil {
+		style.PrintWarning("not stamping deacon heartbeat: pause state unreadable: %v", err)
+		return
+	}
+	if paused {
+		return
+	}
+
+	action := "patrol report"
+	if summary = strings.TrimSpace(summary); summary != "" {
+		action += ": " + summary
+	}
+	if err := syncDeaconHeartbeatStores(townRoot, action); err != nil {
+		style.PrintWarning("could not stamp deacon heartbeat: %v", err)
+	}
 }
 
 // buildStepAudit builds a step checklist from the formula's steps and the

--- a/internal/cmd/patrol_report_heartbeat_test.go
+++ b/internal/cmd/patrol_report_heartbeat_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/deacon"
+)
+
+func TestStampDeaconHeartbeatOnReport_StampsAllStores(t *testing.T) {
+	townRoot := t.TempDir()
+	syncs := 0
+	oldSync := deaconAgentBeadHeartbeatSync
+	deaconAgentBeadHeartbeatSync = func(string) { syncs++ }
+	t.Cleanup(func() { deaconAgentBeadHeartbeatSync = oldSync })
+
+	stampDeaconHeartbeatOnReport(townRoot, "all clear")
+
+	hb := deacon.ReadHeartbeat(townRoot)
+	if hb == nil {
+		t.Fatal("expected heartbeat file")
+	}
+	if hb.LastAction != "patrol report: all clear" {
+		t.Fatalf("LastAction = %q, want patrol report summary", hb.LastAction)
+	}
+	if _, err := os.Stat(filepath.Join(townRoot, "deacon", ".deacon-heartbeat")); err != nil {
+		t.Fatalf("expected legacy heartbeat file: %v", err)
+	}
+	if syncs != 1 {
+		t.Fatalf("agent bead syncs = %d, want 1", syncs)
+	}
+}
+
+func TestStampDeaconHeartbeatOnReport_SkipsWhenPaused(t *testing.T) {
+	townRoot := t.TempDir()
+	syncs := 0
+	oldSync := deaconAgentBeadHeartbeatSync
+	deaconAgentBeadHeartbeatSync = func(string) { syncs++ }
+	t.Cleanup(func() { deaconAgentBeadHeartbeatSync = oldSync })
+	if err := deacon.Pause(townRoot, "maintenance", "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	stampDeaconHeartbeatOnReport(townRoot, "paused")
+
+	if hb := deacon.ReadHeartbeat(townRoot); hb != nil {
+		t.Fatalf("expected no heartbeat when paused, got %+v", hb)
+	}
+	if syncs != 0 {
+		t.Fatalf("agent bead syncs = %d, want 0", syncs)
+	}
+}
+
+func TestStampDeaconHeartbeatOnReport_SkipsOnCorruptPauseFile(t *testing.T) {
+	townRoot := t.TempDir()
+	syncs := 0
+	oldSync := deaconAgentBeadHeartbeatSync
+	deaconAgentBeadHeartbeatSync = func(string) { syncs++ }
+	t.Cleanup(func() { deaconAgentBeadHeartbeatSync = oldSync })
+	pauseFile := deacon.GetPauseFile(townRoot)
+	if err := os.MkdirAll(filepath.Dir(pauseFile), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pauseFile, []byte("not-json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	stampDeaconHeartbeatOnReport(townRoot, "corrupt")
+
+	if hb := deacon.ReadHeartbeat(townRoot); hb != nil {
+		t.Fatalf("expected no heartbeat on corrupt pause state, got %+v", hb)
+	}
+	if syncs != 0 {
+		t.Fatalf("agent bead syncs = %d, want 0", syncs)
+	}
+}

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -114,30 +114,15 @@ func showMoleculeExecutionPrompt(workDir, moleculeID string) {
 // extraVars is an optional list of "key=value" overrides that are substituted into
 // step descriptions before rendering, taking precedence over formula defaults.
 func showFormulaSteps(formulaName, label, townRoot, rigName string, extraVars ...[]string) {
-	content, err := formula.ResolveFormulaContent(formulaName, townRoot, rigName)
+	f, varMap, err := resolveFormulaForRendering(formulaName, townRoot, rigName, firstFormulaVars(extraVars))
 	if err != nil {
-		style.PrintWarning("could not load formula %s: %v", formulaName, err)
-		return
-	}
-
-	f, err := formula.Parse(content)
-	if err != nil {
-		style.PrintWarning("could not parse formula %s: %v", formulaName, err)
+		style.PrintWarning("%v", err)
 		return
 	}
 
 	if len(f.Steps) == 0 {
 		return
 	}
-
-	// Apply formula overlays if townRoot is available.
-	applyFormulaOverlays(f, formulaName, townRoot, rigName)
-
-	var vars []string
-	if len(extraVars) > 0 {
-		vars = extraVars[0]
-	}
-	varMap := buildFormulaVarMap(f, vars)
 
 	fmt.Println()
 	fmt.Printf("**%s** (%d steps from %s):\n", label, len(f.Steps), formulaName)
@@ -162,28 +147,53 @@ func showFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...[]
 }
 
 func renderFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...[]string) (string, error) {
+	f, varMap, err := resolveFormulaForRendering(formulaName, townRoot, rigName, firstFormulaVars(extraVars))
+	if err != nil {
+		return "", err
+	}
+	return renderFormulaStepsFullParsed(formulaName, f, varMap), nil
+}
+
+func renderFormulaRootAndStepsFull(formulaName, townRoot, rigName string, extraVars ...[]string) (string, error) {
+	f, varMap, err := resolveFormulaForRendering(formulaName, townRoot, rigName, firstFormulaVars(extraVars))
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	if desc := strings.TrimSpace(applyFormulaVars(f.Description, varMap)); desc != "" {
+		sb.WriteString(desc)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString(strings.TrimLeft(renderFormulaStepsFullParsed(formulaName, f, varMap), "\n"))
+	return strings.TrimSpace(sb.String()), nil
+}
+
+func resolveFormulaForRendering(formulaName, townRoot, rigName string, vars []string) (*formula.Formula, map[string]string, error) {
 	content, err := formula.ResolveFormulaContent(formulaName, townRoot, rigName)
 	if err != nil {
-		return "", fmt.Errorf("could not load formula %s: %w", formulaName, err)
+		return nil, nil, fmt.Errorf("could not load formula %s: %w", formulaName, err)
 	}
 
 	f, err := formula.Parse(content)
 	if err != nil {
-		return "", fmt.Errorf("could not parse formula %s: %w", formulaName, err)
+		return nil, nil, fmt.Errorf("could not parse formula %s: %w", formulaName, err)
 	}
-
-	if len(f.Steps) == 0 {
-		return "", nil
-	}
-
-	// Apply formula overlays if townRoot is available.
 	applyFormulaOverlays(f, formulaName, townRoot, rigName)
+	return f, buildFormulaVarMap(f, vars), nil
+}
 
-	var vars []string
-	if len(extraVars) > 0 {
-		vars = extraVars[0]
+func firstFormulaVars(extraVars [][]string) []string {
+	if len(extraVars) == 0 {
+		return nil
 	}
-	varMap := buildFormulaVarMap(f, vars)
+	return extraVars[0]
+}
+
+func renderFormulaStepsFullParsed(formulaName string, f *formula.Formula, varMap map[string]string) string {
+	if len(f.Steps) == 0 {
+		return ""
+	}
 
 	var sb strings.Builder
 	sb.WriteString("\n")
@@ -196,7 +206,7 @@ func renderFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...
 			sb.WriteString("\n\n")
 		}
 	}
-	return sb.String(), nil
+	return sb.String()
 }
 
 // buildFormulaVarMap builds a map of variable name → value for substitution.
@@ -204,7 +214,7 @@ func renderFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...
 func buildFormulaVarMap(f *formula.Formula, extraVars []string) map[string]string {
 	m := make(map[string]string, len(f.Vars))
 	for k, v := range f.Vars {
-		if v.Default != "" {
+		if v.Default != "" || !v.Required {
 			m[k] = v.Default
 		}
 	}
@@ -338,7 +348,7 @@ func outputDeaconPatrolContext(ctx RoleContext) {
 		},
 	}
 	outputPatrolContext(cfg)
-	showFormulaSteps(constants.MolDeaconPatrol, "Patrol Steps", ctx.TownRoot, ctx.Rig)
+	showFormulaStepsFull(constants.MolDeaconPatrol, ctx.TownRoot, ctx.Rig)
 }
 
 // outputWitnessPatrolContext shows patrol molecule status for the Witness.
@@ -430,6 +440,7 @@ func buildRefineryPatrolVars(ctx RoleContext) []string {
 	if err == nil && rigCfg != nil && rigCfg.DefaultBranch != "" {
 		defaultBranch = rigCfg.DefaultBranch
 	}
+	vars = append(vars, fmt.Sprintf("rig=%s", ctx.Rig))
 	vars = append(vars, fmt.Sprintf("target_branch=%s", defaultBranch))
 
 	// MQ-specific vars: try settings/config.json first (legacy format), then

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -58,6 +58,22 @@ func writeTestRoutes(t *testing.T, townRoot string, routes []beads.Route) {
 	}
 }
 
+func TestRenderFormulaStepsFull_DeaconIncludesHeartbeatCommand(t *testing.T) {
+	out, err := renderFormulaStepsFull(constants.MolDeaconPatrol, t.TempDir(), "")
+	if err != nil {
+		t.Fatalf("renderFormulaStepsFull: %v", err)
+	}
+	for _, want := range []string{
+		"### Step 1: Refresh heartbeat",
+		"gt deacon heartbeat \"starting patrol cycle\"",
+		"This MUST run before any other step.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("rendered deacon patrol missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestGetAgentBeadID_UsesRigPrefix(t *testing.T) {
 	townRoot := t.TempDir()
 	writeTestRoutes(t, townRoot, []beads.Route{


### PR DESCRIPTION
## Summary

Rebuild the valid intent of PR #4463 from current `main` without carrying its stale WIP history.

- fail closed when Deacon pause state cannot be read before patrol-report heartbeat stamping
- render root patrol-wisp descriptions through the shared formula path
- keep critical hook updates authoritative while making description persistence best-effort
- route multiline bead updates through stdin/body-file support

## Attribution

Carries forward PR #4463 by nux/blairsilverberg. The commit preserves `Co-authored-by: nux <blair@humcapital.com>` and the original Claude co-author. Keep #4463 open until this replacement lands.

## Verification

- 15 fresh independent research legs
- 5 approving pre-implementation reviews
- 5 approving final-head post-implementation reviews
- focused `internal/beads` and `internal/cmd` tests passed
- `git diff --check` passed
- `CGO_ENABLED=0 make build` passed
- `gt-pr-sheriff-check --merge-gate` passed for head `4cdb3104914d39be6047bcb83e106e9594997b6b`

Evidence is persisted on Bead `gt-wfcl`.