### PR TITLE
fix(done): route source validation and runtime cleanup

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -239,6 +239,68 @@ func HasLabel(issue *Issue, label string) bool {
 	return false
 }
 
+// ConcreteWorkIssueRejectReason returns why issue is not a concrete source/work
+// issue suitable for completion or merge-request source tracking. Empty means OK.
+func ConcreteWorkIssueRejectReason(issue *Issue) string {
+	if issue == nil || strings.TrimSpace(issue.ID) == "" {
+		return "source-missing"
+	}
+	if issue.Ephemeral {
+		return "ephemeral"
+	}
+	issueID := strings.ToLower(strings.TrimSpace(issue.ID))
+	if strings.Contains(issueID, "-wisp-") {
+		return "wisp-id"
+	}
+	if strings.HasPrefix(issueID, "mol-") {
+		return "formula-id"
+	}
+	if InternalIssueType(issue.Type) {
+		return "internal-type:" + strings.ToLower(strings.TrimSpace(issue.Type))
+	}
+	for _, label := range issue.Labels {
+		if InternalIssueLabel(label) {
+			return "internal-label:" + strings.ToLower(strings.TrimSpace(label))
+		}
+		if ProtectedIssueLabel(label) {
+			return "protected-label:" + strings.ToLower(strings.TrimSpace(label))
+		}
+	}
+	return ""
+}
+
+// InternalIssueType reports whether an issue type represents Gas Town runtime
+// state rather than user/code work.
+func InternalIssueType(issueType string) bool {
+	switch strings.ToLower(strings.TrimSpace(issueType)) {
+	case "wisp", "message", "handoff", "merge-request", "agent", "queue", "convoy", "formula":
+		return true
+	default:
+		return false
+	}
+}
+
+// InternalIssueLabel reports whether a label marks Gas Town runtime state.
+func InternalIssueLabel(label string) bool {
+	switch strings.ToLower(strings.TrimSpace(label)) {
+	case "gt:wisp", "gt:message", "gt:handoff", "gt:merge-request", "gt:agent", "gt:queue", "gt:convoy", "gt:formula":
+		return true
+	default:
+		return false
+	}
+}
+
+// ProtectedIssueLabel reports whether a label marks a bead that automated
+// completion paths must not close as ordinary work.
+func ProtectedIssueLabel(label string) bool {
+	switch strings.ToLower(strings.TrimSpace(label)) {
+	case "gt:standing-orders", "gt:keep", "gt:role", "gt:rig":
+		return true
+	default:
+		return false
+	}
+}
+
 // HasUncheckedCriteria checks if an issue has acceptance criteria with unchecked items.
 // Returns the count of unchecked items (0 means all checked or no criteria).
 func HasUncheckedCriteria(issue *Issue) int {
@@ -278,8 +340,7 @@ func IsProtectedBead(issue *Issue) bool {
 		return false
 	}
 	for _, l := range issue.Labels {
-		switch l {
-		case "gt:standing-orders", "gt:keep", "gt:role", "gt:rig":
+		if ProtectedIssueLabel(l) {
 			return true
 		}
 	}
@@ -646,12 +707,12 @@ func (b *Beads) forIssueID(id string) *Beads {
 		return b
 	}
 	return &Beads{
-		workDir:    b.workDir,
+		workDir:    filepath.Dir(resolved),
 		beadsDir:   resolved,
 		isolated:   b.isolated,
 		serverPort: b.serverPort,
-		store:      b.store,
 		townRoot:   b.townRoot,
+		noRoute:    true,
 	}
 }
 
@@ -1493,13 +1554,8 @@ func (b *Beads) ReadyWithType(issueType string) ([]*Issue, error) {
 
 // Show returns detailed information about an issue.
 func (b *Beads) Show(id string) (*Issue, error) {
-	// Route cross-rig queries via routes.jsonl so that rig-level bead IDs
-	// (e.g., "gt-abc123") resolve to the correct rig database.
-	// noRoute (see ForAgentBead) bypasses this for agent-bead lookups.
 	if !b.noRoute {
-		targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
-		if targetDir != b.getResolvedBeadsDir() {
-			target := NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
+		if target := b.forIssueID(id); target != b {
 			return target.Show(id)
 		}
 	}
@@ -1907,6 +1963,12 @@ func normalizeBugTitle(title string) string {
 
 // Update updates an existing issue.
 func (b *Beads) Update(id string, opts UpdateOptions) error {
+	if !b.noRoute {
+		if target := b.forIssueID(id); target != b {
+			return target.Update(id, opts)
+		}
+	}
+
 	if b.store != nil {
 		return b.storeUpdate(id, opts)
 	}
@@ -1952,77 +2014,129 @@ func (b *Beads) Update(id string, opts UpdateOptions) error {
 	return err
 }
 
+// AddComment appends a comment to an issue, routing by issue ID when needed.
+func (b *Beads) AddComment(id, comment string) error {
+	if !b.noRoute {
+		if target := b.forIssueID(id); target != b {
+			return target.AddComment(id, comment)
+		}
+	}
+
+	_, err := b.run("comments", "add", id, comment)
+	return err
+}
+
+// Comments returns comments for an issue, routing by issue ID when needed.
+func (b *Beads) Comments(id string) ([]Comment, error) {
+	if !b.noRoute {
+		if target := b.forIssueID(id); target != b {
+			return target.Comments(id)
+		}
+	}
+
+	if b.store != nil {
+		comments, err := b.store.GetIssueComments(context.Background(), id)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]Comment, 0, len(comments))
+		for _, comment := range comments {
+			converted, ok := sdkCommentToComment(comment)
+			if ok {
+				out = append(out, converted)
+			}
+		}
+		return out, nil
+	}
+
+	out, err := b.run("comments", id, "--json")
+	if err != nil {
+		return nil, err
+	}
+	var comments []Comment
+	if err := json.Unmarshal(out, &comments); err != nil {
+		return nil, fmt.Errorf("parsing comments: %w", err)
+	}
+	return comments, nil
+}
+
 func (b *Beads) deleteBead(id string) error {
 	_, err := b.run("delete", id, "--force")
 	return err
+}
+
+type closeOptions struct {
+	reason     string
+	withReason bool
+	force      bool
 }
 
 // Close closes one or more issues.
 // If a runtime session ID is set in the environment, it is passed to bd close
 // for work attribution tracking (see decision 009-session-events-architecture.md).
 func (b *Beads) Close(ids ...string) error {
-	if len(ids) == 0 {
-		return nil
-	}
-
-	if b.store != nil {
-		return b.storeClose("", runtime.SessionIDFromEnv(), ids...)
-	}
-
-	args := append([]string{"close"}, ids...)
-
-	// Pass session ID for work attribution if available
-	if sessionID := runtime.SessionIDFromEnv(); sessionID != "" {
-		args = append(args, "--session="+sessionID)
-	}
-
-	_, err := b.run(args...)
-	return err
+	return b.closeWithOptions(closeOptions{}, ids...)
 }
 
 // CloseWithReason closes one or more issues with a reason.
 // If a runtime session ID is set in the environment, it is passed to bd close
 // for work attribution tracking (see decision 009-session-events-architecture.md).
 func (b *Beads) CloseWithReason(reason string, ids ...string) error {
-	if len(ids) == 0 {
-		return nil
-	}
-
-	if b.store != nil {
-		return b.storeClose(reason, runtime.SessionIDFromEnv(), ids...)
-	}
-
-	args := append([]string{"close"}, ids...)
-	args = append(args, "--reason="+reason)
-
-	// Pass session ID for work attribution if available
-	if sessionID := runtime.SessionIDFromEnv(); sessionID != "" {
-		args = append(args, "--session="+sessionID)
-	}
-
-	_, err := b.run(args...)
-	return err
+	return b.closeWithOptions(closeOptions{reason: reason, withReason: true}, ids...)
 }
 
 // ForceCloseWithReason closes one or more issues with --force, bypassing
 // dependency checks. Used by gt done where the polecat is about to be nuked
 // and open molecule wisps should not block issue closure.
 func (b *Beads) ForceCloseWithReason(reason string, ids ...string) error {
+	return b.closeWithOptions(closeOptions{reason: reason, withReason: true, force: true}, ids...)
+}
+
+func (b *Beads) closeWithOptions(opts closeOptions, ids ...string) error {
 	if len(ids) == 0 {
 		return nil
 	}
 
+	if !b.noRoute {
+		groups := make(map[string][]string)
+		targets := make(map[string]*Beads)
+		currentDir := b.getResolvedBeadsDir()
+		for _, id := range ids {
+			target := b.forIssueID(id)
+			targetDir := target.getResolvedBeadsDir()
+			groups[targetDir] = append(groups[targetDir], id)
+			targets[targetDir] = target
+		}
+		if len(groups) > 1 || groups[currentDir] == nil {
+			for targetDir, groupIDs := range groups {
+				if err := targets[targetDir].closeInCurrentDB(opts, groupIDs...); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
+
+	return b.closeInCurrentDB(opts, ids...)
+}
+
+func (b *Beads) closeInCurrentDB(opts closeOptions, ids ...string) error {
 	// In-process store close doesn't enforce dependency checks (no --force
 	// needed). Note: this means the store path bypasses the dependency
 	// validation that the CLI's --force flag overrides. Callers relying on
 	// ForceCloseWithReason (e.g., gt done nuking polecat wisps) are already
 	// accepting that deps may remain dangling, so this is intentional.
 	if b.store != nil {
-		return b.storeClose(reason, runtime.SessionIDFromEnv(), ids...)
+		return b.storeClose(opts.reason, runtime.SessionIDFromEnv(), ids...)
 	}
 
 	args := append([]string{"close"}, ids...)
-	args = append(args, "--reason="+reason, "--force")
+	if opts.withReason {
+		args = append(args, "--reason="+opts.reason)
+	}
+	if opts.force {
+		args = append(args, "--force")
+	}
 
 	// Pass session ID for work attribution if available
 	if sessionID := runtime.SessionIDFromEnv(); sessionID != "" {

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -951,6 +951,112 @@ exit 0
 	}
 }
 
+func TestMutationsRouteIDsByResolvedBeadsDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+
+	townRoot := t.TempDir()
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor"),
+		filepath.Join(townRoot, ".beads"),
+		filepath.Join(townRoot, "gastown", ".beads"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+	if err := WriteRoutes(filepath.Join(townRoot, ".beads"), []Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: "gt-", Path: "gastown"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	stubDir := t.TempDir()
+	logPath := filepath.Join(stubDir, "bd.log")
+	stubPath := filepath.Join(stubDir, "bd")
+	script := `#!/bin/sh
+if [ "$1" = "--allow-stale" ] && [ "$2" = "version" ]; then
+  exit 1
+fi
+printf '%s|%s\n' "${BEADS_DIR:-}" "$*" >> "$MOCK_BD_LOG"
+if [ "$1" = "comments" ] && [ "$3" = "--json" ]; then
+  printf '[]\n'
+fi
+exit 0
+`
+	if err := os.WriteFile(stubPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("MOCK_BD_LOG", logPath)
+	ResetBdAllowStaleCacheForTest()
+
+	bd := NewWithBeadsDir(filepath.Join(townRoot, "gastown"), filepath.Join(townRoot, "gastown", ".beads"))
+	status := "in_progress"
+	if err := bd.Update("hq-source", UpdateOptions{Status: &status}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if err := bd.AddComment("hq-source", "MR created: gt-mr"); err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	if _, err := bd.Comments("hq-source"); err != nil {
+		t.Fatalf("Comments: %v", err)
+	}
+	if err := bd.CloseWithReason("done", "hq-source", "gt-work"); err != nil {
+		t.Fatalf("CloseWithReason: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	log := string(data)
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	rigBeadsDir := filepath.Join(townRoot, "gastown", ".beads")
+	for _, want := range []string{
+		townBeadsDir + "|update hq-source --status=in_progress",
+		townBeadsDir + "|comments add hq-source MR created: gt-mr",
+		townBeadsDir + "|comments hq-source --json",
+		townBeadsDir + "|close hq-source --reason=done",
+		rigBeadsDir + "|close gt-work --reason=done",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("bd log missing %q:\n%s", want, log)
+		}
+	}
+}
+
+func TestConcreteWorkIssueRejectReason(t *testing.T) {
+	tests := []struct {
+		name  string
+		issue *Issue
+		want  string
+	}{
+		{name: "nil", issue: nil, want: "source-missing"},
+		{name: "empty id", issue: &Issue{}, want: "source-missing"},
+		{name: "ephemeral", issue: &Issue{ID: "gt-work", Ephemeral: true}, want: "ephemeral"},
+		{name: "wisp id", issue: &Issue{ID: "gt-wisp-123"}, want: "wisp-id"},
+		{name: "formula id", issue: &Issue{ID: "mol-polecat-work"}, want: "formula-id"},
+		{name: "internal type", issue: &Issue{ID: "gt-mr", Type: "merge-request"}, want: "internal-type:merge-request"},
+		{name: "internal label", issue: &Issue{ID: "gt-mr", Labels: []string{"gt:merge-request"}}, want: "internal-label:gt:merge-request"},
+		{name: "protected label", issue: &Issue{ID: "gt-rig", Labels: []string{"gt:rig"}}, want: "protected-label:gt:rig"},
+		{name: "concrete", issue: &Issue{ID: "gt-work", Type: "task"}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConcreteWorkIssueRejectReason(tt.issue); got != tt.want {
+				t.Fatalf("ConcreteWorkIssueRejectReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCreateWithRigRepairsTargetConfigPrefix(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses Unix shell script mock for bd")

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -177,31 +177,31 @@ func doneSourceCloseSkipReason(bd *beads.Beads, issueID string, issue *beads.Iss
 	return doneSourceCloseSkipReasonForHead(bd, issueID, issue, currentHead)
 }
 
-func doneDirectMergeSkipReason(bd *beads.Beads, issueID string, issue *beads.Issue, targetBranch string) (string, bool) {
+func doneDirectMergeSkipReason(bd *beads.Beads, issueID string, issue *beads.Issue, targetBranch string) string {
 	if strings.TrimSpace(issueID) == "" {
-		return "source issue is required for direct merge", true
+		return "source issue is required for direct merge"
 	}
-	issue, skipReason, fatal := loadDoneSourceIssue(bd, issueID, issue)
+	issue, skipReason, _ := loadDoneSourceIssue(bd, issueID, issue)
 	if skipReason != "" {
-		return skipReason, fatal
+		return skipReason
 	}
 	if err := validateConcreteSourceIssue(issueID, issue); err != nil {
-		return err.Error(), true
+		return err.Error()
 	}
 	if attachment := beads.ParseAttachmentFields(issue); attachment != nil {
 		switch {
 		case attachment.NoMerge:
-			return fmt.Sprintf("source_issue %s has no_merge=true", issueID), true
+			return fmt.Sprintf("source_issue %s has no_merge=true", issueID)
 		case attachment.ReviewOnly:
-			return fmt.Sprintf("review-only issue %s cannot be direct-merged to %s", issueID, targetBranch), true
+			return fmt.Sprintf("review-only issue %s cannot be direct-merged to %s", issueID, targetBranch)
 		case strings.EqualFold(strings.TrimSpace(attachment.MergeStrategy), "local"):
-			return fmt.Sprintf("source_issue %s has merge_strategy=local", issueID), true
+			return fmt.Sprintf("source_issue %s has merge_strategy=local", issueID)
 		}
 	}
 	if unchecked := beads.HasUncheckedCriteria(issue); unchecked > 0 {
-		return fmt.Sprintf("issue %s has %d unchecked acceptance criteria — skipping direct merge", issueID, unchecked), false
+		return fmt.Sprintf("issue %s has %d unchecked acceptance criteria — skipping direct merge", issueID, unchecked)
 	}
-	return "", false
+	return ""
 }
 
 func doneSourceCloseSkipReasonForHead(bd *beads.Beads, issueID string, issue *beads.Issue, currentHead string) (string, bool) {
@@ -1077,7 +1077,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		if convoyInfo != nil && convoyInfo.MergeStrategy == "direct" {
 			fmt.Printf("%s Direct merge strategy: pushing to %s\n", style.Bold.Render("→"), defaultBranch)
 			directBd := beads.New(cwd)
-			if skipReason, _ := doneDirectMergeSkipReason(directBd, issueID, nil, defaultBranch); skipReason != "" {
+			if skipReason := doneDirectMergeSkipReason(directBd, issueID, nil, defaultBranch); skipReason != "" {
 				style.PrintWarning("%s", skipReason)
 				notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
 				return fmt.Errorf("cannot complete direct-merge work: %s", skipReason)
@@ -1189,7 +1189,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		if convoyInfo != nil && convoyInfo.MergeStrategy == "direct" {
 			fmt.Printf("%s Late-detected direct merge strategy: pushing to %s\n", style.Bold.Render("→"), defaultBranch)
 			fmt.Printf("  Convoy: %s\n", convoyInfo.ID)
-			if skipReason, _ := doneDirectMergeSkipReason(bd, issueID, sourceIssueForNoMerge, defaultBranch); skipReason != "" {
+			if skipReason := doneDirectMergeSkipReason(bd, issueID, sourceIssueForNoMerge, defaultBranch); skipReason != "" {
 				style.PrintWarning("%s", skipReason)
 				notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
 				return fmt.Errorf("cannot complete direct-merge work: %s", skipReason)

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -141,6 +140,22 @@ func cleanupStatusAfterSuccessfulPush(status string) string {
 	return status
 }
 
+func cleanupStatusFromWorkState(workStatus *git.UncommittedWorkStatus, branchPushed bool, unpushedCount int, branchPushedErr error) string {
+	if workStatus == nil {
+		return "unknown"
+	}
+	if workStatus.HasUncommittedChanges && !workStatus.CleanExcludingRuntime() {
+		return "uncommitted"
+	}
+	if workStatus.StashCount > 0 {
+		return "stash"
+	}
+	if branchPushedErr != nil || !branchPushed || unpushedCount > 0 {
+		return "unpushed"
+	}
+	return "clean"
+}
+
 var reviewEvidencePrefixes = []string{
 	"report:",
 	"findings:",
@@ -162,10 +177,43 @@ func doneSourceCloseSkipReason(bd *beads.Beads, issueID string, issue *beads.Iss
 	return doneSourceCloseSkipReasonForHead(bd, issueID, issue, currentHead)
 }
 
+func doneDirectMergeSkipReason(bd *beads.Beads, issueID string, issue *beads.Issue, targetBranch string) (string, bool) {
+	if strings.TrimSpace(issueID) == "" {
+		return "source issue is required for direct merge", true
+	}
+	issue, skipReason, fatal := loadDoneSourceIssue(bd, issueID, issue)
+	if skipReason != "" {
+		return skipReason, fatal
+	}
+	if err := validateConcreteSourceIssue(issueID, issue); err != nil {
+		return err.Error(), true
+	}
+	if attachment := beads.ParseAttachmentFields(issue); attachment != nil {
+		switch {
+		case attachment.NoMerge:
+			return fmt.Sprintf("source_issue %s has no_merge=true", issueID), true
+		case attachment.ReviewOnly:
+			return fmt.Sprintf("review-only issue %s cannot be direct-merged to %s", issueID, targetBranch), true
+		case strings.EqualFold(strings.TrimSpace(attachment.MergeStrategy), "local"):
+			return fmt.Sprintf("source_issue %s has merge_strategy=local", issueID), true
+		}
+	}
+	if unchecked := beads.HasUncheckedCriteria(issue); unchecked > 0 {
+		return fmt.Sprintf("issue %s has %d unchecked acceptance criteria — skipping direct merge", issueID, unchecked), false
+	}
+	return "", false
+}
+
 func doneSourceCloseSkipReasonForHead(bd *beads.Beads, issueID string, issue *beads.Issue, currentHead string) (string, bool) {
 	issue, skipReason, fatal := loadDoneSourceIssue(bd, issueID, issue)
 	if skipReason != "" {
 		return skipReason, fatal
+	}
+	if err := validateConcreteSourceIssue(issueID, issue); err != nil {
+		return err.Error(), true
+	}
+	if attachment := beads.ParseAttachmentFields(issue); attachment != nil && strings.EqualFold(strings.TrimSpace(attachment.MergeStrategy), "local") {
+		return fmt.Sprintf("issue %s has merge_strategy=local — skipping close", issueID), false
 	}
 	if skipReason, fatal := doneReviewOnlyCloseSkipReasonForHead(bd, issueID, issue, currentHead); skipReason != "" {
 		return skipReason, fatal
@@ -257,33 +305,9 @@ func hasFreshReviewReportEvidence(bd *beads.Beads, issueID string, issue *beads.
 	if bd == nil || issueID == "" {
 		return false, nil
 	}
-	if store := bd.Store(); store != nil {
-		comments, err := store.GetIssueComments(context.Background(), issueID)
-		if err != nil {
-			return false, err
-		}
-		for _, comment := range comments {
-			if comment == nil {
-				continue
-			}
-			candidate := beads.Comment{
-				Author:    comment.Author,
-				Text:      comment.Text,
-				CreatedAt: comment.CreatedAt.Format(time.RFC3339Nano),
-			}
-			if hasFreshReviewEvidenceComment([]beads.Comment{candidate}, assignmentAt, assignee, currentHead) {
-				return true, nil
-			}
-		}
-		return false, nil
-	}
-	out, err := bd.Run("comments", issueID, "--json")
+	comments, err := bd.Comments(issueID)
 	if err != nil {
 		return false, err
-	}
-	var comments []beads.Comment
-	if err := json.Unmarshal(out, &comments); err != nil {
-		return false, fmt.Errorf("parsing comments: %w", err)
 	}
 	if hasFreshReviewEvidenceComment(comments, assignmentAt, assignee, currentHead) {
 		return true, nil
@@ -545,25 +569,14 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			if err != nil {
 				style.PrintWarning("could not auto-detect cleanup status: %v", err)
 			} else {
-				switch {
-				case workStatus.HasUncommittedChanges:
-					doneCleanupStatus = "uncommitted"
-				case workStatus.StashCount > 0:
-					doneCleanupStatus = "stash"
-				default:
-					// CheckUncommittedWork.UnpushedCommits doesn't work for branches
-					// without upstream tracking (common for polecats). Use the more
-					// robust BranchPushedToRemote which compares against origin/main.
-					pushed, unpushedCount, err := g.BranchPushedToRemote(branch, "origin")
-					if err != nil {
-						style.PrintWarning("could not check if branch is pushed: %v", err)
-						doneCleanupStatus = "unpushed" // err on side of caution
-					} else if !pushed || unpushedCount > 0 {
-						doneCleanupStatus = "unpushed"
-					} else {
-						doneCleanupStatus = "clean"
-					}
+				// CheckUncommittedWork.UnpushedCommits doesn't work for branches
+				// without upstream tracking (common for polecats). Use the more
+				// robust BranchPushedToRemote which compares against origin/main.
+				pushed, unpushedCount, pushErr := g.BranchPushedToRemote(branch, "origin")
+				if pushErr != nil {
+					style.PrintWarning("could not check if branch is pushed: %v", pushErr)
 				}
+				doneCleanupStatus = cleanupStatusFromWorkState(workStatus, pushed, unpushedCount, pushErr)
 			}
 		}
 	}
@@ -1063,6 +1076,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// Handle "direct" strategy: push to target branch, skip MR
 		if convoyInfo != nil && convoyInfo.MergeStrategy == "direct" {
 			fmt.Printf("%s Direct merge strategy: pushing to %s\n", style.Bold.Render("→"), defaultBranch)
+			directBd := beads.New(cwd)
+			if skipReason, _ := doneDirectMergeSkipReason(directBd, issueID, nil, defaultBranch); skipReason != "" {
+				style.PrintWarning("%s", skipReason)
+				notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
+				return fmt.Errorf("cannot complete direct-merge work: %s", skipReason)
+			}
 			// Push submodule changes before direct push (gt-dzs)
 			pushSubmoduleChanges(g, baseRef)
 			directRefspec := branch + ":" + defaultBranch
@@ -1090,12 +1109,11 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 			// Close the base issue — no MR/refinery will close it
 			if issueID != "" {
-				directBd := beads.New(cwd)
-				if skipReason, fatal := doneReviewOnlyCloseSkipReason(directBd, issueID, nil); skipReason != "" {
+				if skipReason, fatal := doneSourceCloseSkipReason(directBd, issueID, nil); skipReason != "" {
 					style.PrintWarning("%s", skipReason)
 					notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
 					if fatal {
-						return fmt.Errorf("cannot complete review-only work: %s", skipReason)
+						return fmt.Errorf("cannot complete direct-merge work: %s", skipReason)
 					}
 				} else {
 					closeReason := fmt.Sprintf("Direct merge to %s (convoy strategy)", defaultBranch)
@@ -1121,6 +1139,113 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		}
 
 		// Default: "mr" strategy (or no convoy) — push branch, create MR bead
+
+		if issueID == "" {
+			return fmt.Errorf("cannot determine source issue from branch '%s'; use --issue to specify", branch)
+		}
+
+		// Initialize beads and validate the source before any remote mutation.
+		// Without a redirect, MR beads are invisible to the Refinery.
+		resolvedBeads := beads.ResolveBeadsDir(cwd)
+		if beads.IsLocalBeadsDir(cwd, resolvedBeads) {
+			fmt.Fprintf(os.Stderr, "WARNING: beads resolved to local dir %s (no shared-beads redirect)\n", resolvedBeads)
+			fmt.Fprintf(os.Stderr, "  MR beads written here will be invisible to the Refinery — run 'gt polecat repair' to fix\n")
+		}
+		bd := beads.NewWithBeadsDir(cwd, resolvedBeads)
+
+		sourceIssueForNoMerge, err := bd.Show(issueID)
+		if err != nil {
+			mrFailed = true
+			errMsg := fmt.Sprintf("source issue validation failed: source_issue %s could not be resolved: %v", issueID, err)
+			doneErrors = append(doneErrors, errMsg)
+			style.PrintWarning("%s\nBranch is not pushed and MR bead not created. Witness will be notified.", errMsg)
+			goto notifyWitness
+		}
+		if err := validateConcreteSourceIssue(issueID, sourceIssueForNoMerge); err != nil {
+			mrFailed = true
+			errMsg := fmt.Sprintf("source issue validation failed: %v", err)
+			doneErrors = append(doneErrors, errMsg)
+			style.PrintWarning("%s\nBranch is not pushed and MR bead not created. Witness will be notified.", errMsg)
+			goto notifyWitness
+		}
+		if attachmentFields := beads.ParseAttachmentFields(sourceIssueForNoMerge); attachmentFields != nil && strings.EqualFold(strings.TrimSpace(attachmentFields.MergeStrategy), "local") {
+			fmt.Printf("%s Local merge strategy: skipping push and merge queue\n", style.Bold.Render("→"))
+			fmt.Printf("  Branch: %s\n", branch)
+			fmt.Printf("  Issue: %s\n", issueID)
+			fmt.Println()
+			fmt.Printf("%s\n", style.Dim.Render("Work stays on local feature branch."))
+			goto notifyWitness
+		}
+
+		// Fallback: check if issue belongs to a direct-merge convoy that the
+		// primary check missed — e.g., issues dispatched before the attachment-field
+		// fix, or where dep-based lookup failed at that point. This must happen
+		// before the generic branch/submodule push because direct mode has no MR or
+		// refinery recheck.
+		convoyInfo = getConvoyInfoFromIssue(issueID, cwd)
+		if convoyInfo == nil {
+			convoyInfo = getConvoyInfoForIssue(issueID)
+		}
+		if convoyInfo != nil && convoyInfo.MergeStrategy == "direct" {
+			fmt.Printf("%s Late-detected direct merge strategy: pushing to %s\n", style.Bold.Render("→"), defaultBranch)
+			fmt.Printf("  Convoy: %s\n", convoyInfo.ID)
+			if skipReason, _ := doneDirectMergeSkipReason(bd, issueID, sourceIssueForNoMerge, defaultBranch); skipReason != "" {
+				style.PrintWarning("%s", skipReason)
+				notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
+				return fmt.Errorf("cannot complete direct-merge work: %s", skipReason)
+			}
+
+			pushSubmoduleChanges(g, baseRef)
+			directRefspec := branch + ":" + defaultBranch
+			directPushErr := g.Push("origin", directRefspec, false)
+			if directPushErr != nil {
+				pushFailed = true
+				errMsg := fmt.Sprintf("direct push to %s failed: %v", defaultBranch, directPushErr)
+				doneErrors = append(doneErrors, errMsg)
+				style.PrintWarning("%s", errMsg)
+				goto notifyWitness
+			}
+			directCommitSHA, _ := g.Rev("HEAD")
+			if doneSkipVerify {
+				noteVerifiedPushSkipped(cwd, issueID, defaultBranch, directCommitSHA, "--skip-verify on late direct merge")
+			} else if verifyErr := g.VerifyPushedCommitReachableFromPushTarget("origin", defaultBranch, directCommitSHA); verifyErr != nil {
+				pushFailed = true
+				errMsg := verifyErr.Error()
+				doneErrors = append(doneErrors, errMsg)
+				noteVerifiedPushFailure(cwd, issueID, defaultBranch, directCommitSHA, verifyErr)
+				style.PrintWarning("%s\nLate direct merge pushed but remote verification failed. Source bead will remain in progress.", errMsg)
+				goto notifyWitness
+			}
+			fmt.Printf("%s Branch pushed directly to %s\n", style.Bold.Render("✓"), defaultBranch)
+			doneCleanupStatus = cleanupStatusAfterSuccessfulPush(doneCleanupStatus)
+
+			if skipReason, fatal := doneSourceCloseSkipReason(bd, issueID, sourceIssueForNoMerge); skipReason != "" {
+				style.PrintWarning("%s", skipReason)
+				notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
+				if fatal {
+					return fmt.Errorf("cannot complete direct-merge work: %s", skipReason)
+				}
+			} else {
+				var closeErr error
+				for attempt := 1; attempt <= 3; attempt++ {
+					closeErr = bd.ForceCloseWithReason(
+						fmt.Sprintf("Direct merge to %s (convoy strategy, late detection)", defaultBranch), issueID)
+					if closeErr == nil {
+						fmt.Printf("%s Issue %s closed (direct merge)\n", style.Bold.Render("✓"), issueID)
+						break
+					}
+					if attempt < 3 {
+						style.PrintWarning("close attempt %d/3 failed: %v (retrying in %ds)", attempt, closeErr, attempt*2)
+						time.Sleep(time.Duration(attempt*2) * time.Second)
+					}
+				}
+				if closeErr != nil {
+					style.PrintWarning("could not close issue %s after 3 attempts: %v", issueID, closeErr)
+				}
+			}
+
+			goto notifyWitness
+		}
 
 		// Pre-declare push variables for checkpoint goto (gt-aufru)
 		var refspec string
@@ -1230,22 +1355,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 	afterPush:
 
-		if issueID == "" {
-			return fmt.Errorf("cannot determine source issue from branch '%s'; use --issue to specify", branch)
-		}
-
-		// Initialize beads — warn if resolved to a local .beads/ (no redirect).
-		// Without a redirect, MR beads are invisible to the Refinery.
-		resolvedBeads := beads.ResolveBeadsDir(cwd)
-		if beads.IsLocalBeadsDir(cwd, resolvedBeads) {
-			fmt.Fprintf(os.Stderr, "WARNING: beads resolved to local dir %s (no shared-beads redirect)\n", resolvedBeads)
-			fmt.Fprintf(os.Stderr, "  MR beads written here will be invisible to the Refinery — run 'gt polecat repair' to fix\n")
-		}
-		bd := beads.NewWithBeadsDir(cwd, resolvedBeads)
-
 		// Check for no_merge flag - if set, skip merge queue and notify for review
-		sourceIssueForNoMerge, err := bd.Show(issueID)
-		if err == nil {
+		{
 			attachmentFields := beads.ParseAttachmentFields(sourceIssueForNoMerge)
 			if attachmentFields != nil && attachmentFields.NoMerge {
 				fmt.Printf("%s No-merge mode: skipping merge queue\n", style.Bold.Render("→"))
@@ -1336,7 +1447,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				// here after notifying the dispatcher. Otherwise hooked work remains open.
 				if issueID != "" {
 					canCloseIssue := true
-					if skipReason, fatal := doneReviewOnlyCloseSkipReason(bd, issueID, sourceIssueForNoMerge); skipReason != "" {
+					if skipReason, fatal := doneSourceCloseSkipReason(bd, issueID, sourceIssueForNoMerge); skipReason != "" {
 						style.PrintWarning("%s", skipReason)
 						notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
 						if fatal {
@@ -1380,72 +1491,6 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			}
 		}
 
-		// Fallback: check if issue belongs to a direct-merge convoy that the
-		// primary check (line ~483) missed — e.g., issues dispatched before the
-		// attachment-field fix, or where dep-based lookup failed at that point.
-		// At this stage the branch was pushed to origin/<branch> (feature branch),
-		// NOT to main. So we must push to main now before skipping MR creation.
-		convoyInfo = getConvoyInfoFromIssue(issueID, cwd)
-		if convoyInfo == nil {
-			convoyInfo = getConvoyInfoForIssue(issueID)
-		}
-		if convoyInfo != nil && convoyInfo.MergeStrategy == "direct" {
-			fmt.Printf("%s Late-detected direct merge strategy: pushing to %s\n", style.Bold.Render("→"), defaultBranch)
-			fmt.Printf("  Convoy: %s\n", convoyInfo.ID)
-
-			// Push branch directly to main (the earlier push went to origin/<branch>)
-			directRefspec := branch + ":" + defaultBranch
-			directPushErr := g.Push("origin", directRefspec, false)
-			if directPushErr != nil {
-				// Direct push failed — fall through to normal MR creation
-				style.PrintWarning("late direct push to %s failed: %v — falling through to MR", defaultBranch, directPushErr)
-			} else {
-				lateDirectCommitSHA, _ := g.Rev("HEAD")
-				if doneSkipVerify {
-					noteVerifiedPushSkipped(cwd, issueID, defaultBranch, lateDirectCommitSHA, "--skip-verify on late direct merge")
-				} else if verifyErr := g.VerifyPushedCommitReachableFromPushTarget("origin", defaultBranch, lateDirectCommitSHA); verifyErr != nil {
-					pushFailed = true
-					errMsg := verifyErr.Error()
-					doneErrors = append(doneErrors, errMsg)
-					noteVerifiedPushFailure(cwd, issueID, defaultBranch, lateDirectCommitSHA, verifyErr)
-					style.PrintWarning("%s\nLate direct merge pushed but remote verification failed. Source bead will remain in progress.", errMsg)
-					goto notifyWitness
-				}
-				fmt.Printf("%s Branch pushed directly to %s\n", style.Bold.Render("✓"), defaultBranch)
-				doneCleanupStatus = cleanupStatusAfterSuccessfulPush(doneCleanupStatus)
-
-				// Close the issue directly — refinery won't process it.
-				if issueID != "" {
-					if skipReason, fatal := doneReviewOnlyCloseSkipReason(bd, issueID, nil); skipReason != "" {
-						style.PrintWarning("%s", skipReason)
-						notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
-						if fatal {
-							return fmt.Errorf("cannot complete review-only work: %s", skipReason)
-						}
-					} else {
-						var closeErr error
-						for attempt := 1; attempt <= 3; attempt++ {
-							closeErr = bd.ForceCloseWithReason(
-								fmt.Sprintf("Direct merge to %s (convoy strategy, late detection)", defaultBranch), issueID)
-							if closeErr == nil {
-								fmt.Printf("%s Issue %s closed (direct merge)\n", style.Bold.Render("✓"), issueID)
-								break
-							}
-							if attempt < 3 {
-								style.PrintWarning("close attempt %d/3 failed: %v (retrying in %ds)", attempt, closeErr, attempt*2)
-								time.Sleep(time.Duration(attempt*2) * time.Second)
-							}
-						}
-						if closeErr != nil {
-							style.PrintWarning("could not close issue %s after 3 attempts: %v", issueID, closeErr)
-						}
-					}
-				}
-
-				goto notifyWitness
-			}
-		}
-
 		// Determine target branch for the MR.
 		// Priority: explicit --target flag > formula_vars base_branch > integration branch auto-detect > rig default.
 		target := defaultBranch
@@ -1470,11 +1515,6 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 					fmt.Printf("  Target branch override: %s (from formula_vars)\n", target)
 				}
 			}
-		} else if !explicitTarget && target == defaultBranch && sourceIssueForNoMerge == nil && issueID != "" {
-			// sourceIssueForNoMerge is nil — bd.Show(issueID) failed earlier.
-			// This is the silent failure path that caused 150+ procedure beads to
-			// target main instead of feat/contract-review-procedure.
-			style.PrintWarning("could not load source issue %s for target branch detection (Dolt/beads lookup failed) — using default branch %s", issueID, defaultBranch)
 		}
 
 		// 3. Auto-detect integration branch from epic hierarchy (if enabled).
@@ -1498,12 +1538,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		if donePriority >= 0 {
 			priority = donePriority
 		} else {
-			sourceIssue, err := bd.Show(issueID)
-			if err != nil {
-				priority = 2 // Default
-			} else {
-				priority = sourceIssue.Priority
-			}
+			priority = sourceIssueForNoMerge.Priority
 		}
 
 		// Pre-declare for checkpoint goto (gt-aufru)
@@ -1526,6 +1561,13 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			if cpMR, cpErr := bd.Show(cpMRID); cpErr == nil && cpMR != nil {
 				branchPrefix := "branch: " + branch + "\n"
 				if strings.HasPrefix(cpMR.Description, branchPrefix) {
+					if err := validateMergeRequestSource(bd, cpMR, issueID); err != nil {
+						mrFailed = true
+						errMsg := fmt.Sprintf("checkpoint MR validation failed: %v", err)
+						doneErrors = append(doneErrors, errMsg)
+						style.PrintWarning("%s\nBranch is pushed but MR bead not trusted. Witness will be notified.", errMsg)
+						goto notifyWitness
+					}
 					mrID = cpMRID
 					fmt.Printf("%s MR already created (resumed from checkpoint: %s)\n", style.Bold.Render("✓"), mrID)
 					goto afterMR
@@ -1549,6 +1591,13 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 		if existingMR != nil {
 			// MR already exists with same branch AND commit — true idempotent retry
+			if err := validateMergeRequestSource(bd, existingMR, issueID); err != nil {
+				mrFailed = true
+				errMsg := fmt.Sprintf("existing MR validation failed: %v", err)
+				doneErrors = append(doneErrors, errMsg)
+				style.PrintWarning("%s\nBranch is pushed but existing MR bead not trusted. Witness will be notified.", errMsg)
+				goto notifyWitness
+			}
 			mrID = existingMR.ID
 			fmt.Printf("%s MR already exists (idempotent)\n", style.Bold.Render("✓"))
 			fmt.Printf("  MR ID: %s\n", style.Bold.Render(mrID))
@@ -1673,7 +1722,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			// GH#2599: Back-link source issue to MR bead for discoverability.
 			if issueID != "" {
 				comment := fmt.Sprintf("MR created: %s", mrID)
-				if _, err := bd.Run("comments", "add", issueID, comment); err != nil {
+				if err := bd.AddComment(issueID, comment); err != nil {
 					style.PrintWarning("could not back-link source issue %s to MR %s: %v", issueID, mrID, err)
 				}
 			}
@@ -1896,7 +1945,7 @@ func noteVerifiedPushFailure(cwd, issueID, branch, commit string, verifyErr erro
 	inProgress := "in_progress"
 	_ = bd.Update(issueID, beads.UpdateOptions{Status: &inProgress})
 	msg := fmt.Sprintf("verified_push_failed: commit %s not verified on origin/%s: %v", commit, branch, verifyErr)
-	_, _ = bd.Run("comments", "add", issueID, msg)
+	_ = bd.AddComment(issueID, msg)
 }
 
 func noteVerifiedPushSkipped(cwd, issueID, branch, commit, reason string) {
@@ -1904,7 +1953,7 @@ func noteVerifiedPushSkipped(cwd, issueID, branch, commit, reason string) {
 		return
 	}
 	msg := fmt.Sprintf("verified_push_skipped: commit %s branch origin/%s reason=%s", commit, branch, reason)
-	_, _ = beads.New(cwd).Run("comments", "add", issueID, msg)
+	_ = beads.New(cwd).AddComment(issueID, msg)
 }
 
 func verifyPushedCommitWithBareFallback(g *git.Git, townRoot, rigName, branch, commit string) error {
@@ -2169,12 +2218,12 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 				goto doneStateUpdate
 			}
 
-			if skipReason, fatal := doneReviewOnlyCloseSkipReason(bd, hookedBeadID, hookedBead); skipReason != "" {
+			if skipReason, fatal := doneSourceCloseSkipReason(bd, hookedBeadID, hookedBead); skipReason != "" {
 				style.PrintWarning("%s", skipReason)
 				fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
 				notifyDoneCloseSkipped(townRoot, ctx.Rig, detectSender(), hookedBeadID, skipReason)
 				if fatal {
-					return fmt.Errorf("cannot complete review-only work: %s", skipReason)
+					return fmt.Errorf("cannot complete hooked work: %s", skipReason)
 				}
 				goto doneStateUpdate
 			}

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -314,6 +314,143 @@ func TestNonReviewOnlyReviewGateDoesNotChangeCriteriaHandling(t *testing.T) {
 	}
 }
 
+func TestSourceCloseRejectsNonConcreteIssue(t *testing.T) {
+	issue := &beads.Issue{
+		ID:     "gt-mr",
+		Labels: []string{"gt:merge-request"},
+	}
+
+	reason, fatal := doneSourceCloseSkipReason(nil, issue.ID, issue)
+	if reason == "" || !fatal {
+		t.Fatalf("source close gate = %q, %v; want fatal non-concrete rejection", reason, fatal)
+	}
+	if !strings.Contains(reason, "not concrete") {
+		t.Fatalf("reason = %q, want non-concrete reason", reason)
+	}
+}
+
+func TestSourceCloseRejectsLocalMergeStrategy(t *testing.T) {
+	issue := &beads.Issue{
+		ID:          "gt-work",
+		Type:        "task",
+		Description: "merge_strategy: local\n",
+	}
+
+	reason, fatal := doneSourceCloseSkipReason(nil, issue.ID, issue)
+	if reason == "" || fatal {
+		t.Fatalf("local source close gate = %q, %v; want non-fatal skip", reason, fatal)
+	}
+	if !strings.Contains(reason, "merge_strategy=local") {
+		t.Fatalf("reason = %q, want local merge strategy reason", reason)
+	}
+}
+
+func TestDirectMergeRejectsUnsafeSourceBeforePush(t *testing.T) {
+	freshEvidenceReviewOnly := &beads.Issue{
+		ID:          "gt-review",
+		Type:        "task",
+		Description: "review_only: true\nattached_at: 2026-07-01T12:00:00Z\n",
+		Assignee:    "gastown/polecats/toast",
+		Comments: []beads.Comment{{
+			Author:    "gastown/polecats/toast",
+			CreatedAt: "2026-07-01T12:05:00Z",
+			Text:      "PR-SHERIFF-EVIDENCE: pass\nhead_sha: abc123",
+		}},
+	}
+	tests := []struct {
+		name        string
+		issueID     string
+		issue       *beads.Issue
+		wantReason  string
+		wantFatal   bool
+		wantAllowed bool
+	}{
+		{
+			name:       "missing source id",
+			issue:      &beads.Issue{ID: "gt-work", Type: "task"},
+			wantReason: "source issue is required",
+			wantFatal:  true,
+		},
+		{
+			name:       "non concrete source",
+			issueID:    "gt-mr",
+			issue:      &beads.Issue{ID: "gt-mr", Labels: []string{"gt:merge-request"}},
+			wantReason: "not concrete",
+			wantFatal:  true,
+		},
+		{
+			name:       "review only source",
+			issueID:    "gt-review",
+			issue:      freshEvidenceReviewOnly,
+			wantReason: "review-only issue gt-review cannot be direct-merged",
+			wantFatal:  true,
+		},
+		{
+			name:       "no merge source",
+			issueID:    "gt-work",
+			issue:      &beads.Issue{ID: "gt-work", Type: "task", Description: "no_merge: true\n"},
+			wantReason: "no_merge=true",
+			wantFatal:  true,
+		},
+		{
+			name:       "local merge strategy source",
+			issueID:    "gt-work",
+			issue:      &beads.Issue{ID: "gt-work", Type: "task", Description: "merge_strategy: local\n"},
+			wantReason: "merge_strategy=local",
+			wantFatal:  true,
+		},
+		{
+			name:       "unchecked criteria",
+			issueID:    "gt-work",
+			issue:      &beads.Issue{ID: "gt-work", Type: "task", AcceptanceCriteria: "- [ ] still open\n"},
+			wantReason: "unchecked acceptance criteria",
+			wantFatal:  false,
+		},
+		{
+			name:        "eligible source",
+			issueID:     "gt-work",
+			issue:       &beads.Issue{ID: "gt-work", Type: "task"},
+			wantAllowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, fatal := doneDirectMergeSkipReason(nil, tt.issueID, tt.issue, "main")
+			if tt.wantAllowed {
+				if reason != "" || fatal {
+					t.Fatalf("direct merge gate = %q, %v; want allowed", reason, fatal)
+				}
+				return
+			}
+			if reason == "" || !strings.Contains(reason, tt.wantReason) || fatal != tt.wantFatal {
+				t.Fatalf("direct merge gate = %q, %v; want reason containing %q fatal=%v", reason, fatal, tt.wantReason, tt.wantFatal)
+			}
+		})
+	}
+}
+
+func TestSourceValidationRejectsInternalIssues(t *testing.T) {
+	if err := validateConcreteSourceIssue("gt-work", &beads.Issue{ID: "gt-work", Type: "task"}); err != nil {
+		t.Fatalf("concrete source rejected: %v", err)
+	}
+	if err := validateConcreteSourceIssue("gt-mr", &beads.Issue{ID: "gt-mr", Labels: []string{"gt:merge-request"}}); err == nil {
+		t.Fatal("internal source accepted; want rejection")
+	}
+}
+
+func TestValidateMergeRequestSourceRejectsMissingAndMismatchedSource(t *testing.T) {
+	missing := &beads.Issue{ID: "gt-mr", Description: "branch: polecat/test/gt-work\n"}
+	if err := validateMergeRequestSource(nil, missing, "gt-work"); err == nil || !strings.Contains(err.Error(), "missing source_issue") {
+		t.Fatalf("missing source validation error = %v, want missing source_issue", err)
+	}
+
+	mismatched := &beads.Issue{ID: "gt-mr", Description: "source_issue: gt-other\n"}
+	if err := validateMergeRequestSource(nil, mismatched, "gt-work"); err == nil || !strings.Contains(err.Error(), "does not match expected") {
+		t.Fatalf("mismatched source validation error = %v, want mismatch", err)
+	}
+}
+
 // TestDoneBeadsInitWithoutRedirect verifies that beads initialization works
 // normally when no redirect file exists.
 func TestDoneBeadsInitWithoutRedirect(t *testing.T) {
@@ -935,6 +1072,66 @@ func TestCleanupStatusAfterSuccessfulPush(t *testing.T) {
 		t.Run(tt.status, func(t *testing.T) {
 			if got := cleanupStatusAfterSuccessfulPush(tt.status); got != tt.want {
 				t.Errorf("cleanupStatusAfterSuccessfulPush(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanupStatusFromWorkState(t *testing.T) {
+	pushErr := errors.New("remote unavailable")
+	tests := []struct {
+		name          string
+		status        *gitpkg.UncommittedWorkStatus
+		branchPushed  bool
+		unpushedCount int
+		pushErr       error
+		want          string
+	}{
+		{name: "nil", status: nil, branchPushed: true, want: "unknown"},
+		{
+			name:         "runtime only pushed",
+			status:       &gitpkg.UncommittedWorkStatus{HasUncommittedChanges: true, ModifiedFiles: []string{".opencode/plugins/gastown.js"}},
+			branchPushed: true,
+			want:         "clean",
+		},
+		{
+			name:         "runtime plus source",
+			status:       &gitpkg.UncommittedWorkStatus{HasUncommittedChanges: true, ModifiedFiles: []string{".opencode/plugins/gastown.js", "internal/cmd/done.go"}},
+			branchPushed: true,
+			want:         "uncommitted",
+		},
+		{
+			name:         "runtime plus stash",
+			status:       &gitpkg.UncommittedWorkStatus{HasUncommittedChanges: true, ModifiedFiles: []string{".opencode/plugins/gastown.js"}, StashCount: 1},
+			branchPushed: true,
+			want:         "stash",
+		},
+		{
+			name:          "runtime plus unpushed",
+			status:        &gitpkg.UncommittedWorkStatus{HasUncommittedChanges: true, ModifiedFiles: []string{".opencode/plugins/gastown.js"}},
+			branchPushed:  true,
+			unpushedCount: 1,
+			want:          "unpushed",
+		},
+		{
+			name:         "runtime plus push error",
+			status:       &gitpkg.UncommittedWorkStatus{HasUncommittedChanges: true, ModifiedFiles: []string{".opencode/plugins/gastown.js"}},
+			branchPushed: true,
+			pushErr:      pushErr,
+			want:         "unpushed",
+		},
+		{
+			name:         "runtime conflict",
+			status:       &gitpkg.UncommittedWorkStatus{HasUncommittedChanges: true, UnmergedFiles: []string{".opencode/plugins/gastown.js"}},
+			branchPushed: true,
+			want:         "uncommitted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cleanupStatusFromWorkState(tt.status, tt.branchPushed, tt.unpushedCount, tt.pushErr); got != tt.want {
+				t.Fatalf("cleanupStatusFromWorkState() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -362,49 +362,42 @@ func TestDirectMergeRejectsUnsafeSourceBeforePush(t *testing.T) {
 		issueID     string
 		issue       *beads.Issue
 		wantReason  string
-		wantFatal   bool
 		wantAllowed bool
 	}{
 		{
 			name:       "missing source id",
 			issue:      &beads.Issue{ID: "gt-work", Type: "task"},
 			wantReason: "source issue is required",
-			wantFatal:  true,
 		},
 		{
 			name:       "non concrete source",
 			issueID:    "gt-mr",
 			issue:      &beads.Issue{ID: "gt-mr", Labels: []string{"gt:merge-request"}},
 			wantReason: "not concrete",
-			wantFatal:  true,
 		},
 		{
 			name:       "review only source",
 			issueID:    "gt-review",
 			issue:      freshEvidenceReviewOnly,
 			wantReason: "review-only issue gt-review cannot be direct-merged",
-			wantFatal:  true,
 		},
 		{
 			name:       "no merge source",
 			issueID:    "gt-work",
 			issue:      &beads.Issue{ID: "gt-work", Type: "task", Description: "no_merge: true\n"},
 			wantReason: "no_merge=true",
-			wantFatal:  true,
 		},
 		{
 			name:       "local merge strategy source",
 			issueID:    "gt-work",
 			issue:      &beads.Issue{ID: "gt-work", Type: "task", Description: "merge_strategy: local\n"},
 			wantReason: "merge_strategy=local",
-			wantFatal:  true,
 		},
 		{
 			name:       "unchecked criteria",
 			issueID:    "gt-work",
 			issue:      &beads.Issue{ID: "gt-work", Type: "task", AcceptanceCriteria: "- [ ] still open\n"},
 			wantReason: "unchecked acceptance criteria",
-			wantFatal:  false,
 		},
 		{
 			name:        "eligible source",
@@ -416,15 +409,15 @@ func TestDirectMergeRejectsUnsafeSourceBeforePush(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reason, fatal := doneDirectMergeSkipReason(nil, tt.issueID, tt.issue, "main")
+			reason := doneDirectMergeSkipReason(nil, tt.issueID, tt.issue, "main")
 			if tt.wantAllowed {
-				if reason != "" || fatal {
-					t.Fatalf("direct merge gate = %q, %v; want allowed", reason, fatal)
+				if reason != "" {
+					t.Fatalf("direct merge gate = %q; want allowed", reason)
 				}
 				return
 			}
-			if reason == "" || !strings.Contains(reason, tt.wantReason) || fatal != tt.wantFatal {
-				t.Fatalf("direct merge gate = %q, %v; want reason containing %q fatal=%v", reason, fatal, tt.wantReason, tt.wantFatal)
+			if reason == "" || !strings.Contains(reason, tt.wantReason) {
+				t.Fatalf("direct merge gate = %q; want reason containing %q", reason, tt.wantReason)
 			}
 		})
 	}

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -141,6 +141,13 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 
 	// Initialize beads for looking up source issue
 	bd := beads.New(cwd)
+	sourceIssue, err := bd.Show(issueID)
+	if err != nil {
+		return fmt.Errorf("source issue validation failed: source_issue %s could not be resolved: %w", issueID, err)
+	}
+	if err := validateConcreteSourceIssue(issueID, sourceIssue); err != nil {
+		return fmt.Errorf("source issue validation failed: %w", err)
+	}
 
 	// Determine target branch
 	// Priority: explicit --epic > formula_vars base_branch > integration branch auto-detect > rig default.
@@ -155,12 +162,10 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		// the bead's formula_vars field. Without this check, MRs created via
 		// gt mq submit always target the rig's default branch (usually main),
 		// even when the polecat was working against a feature branch.
-		if sourceIssue, showErr := bd.Show(issueID); showErr == nil {
-			if af := beads.ParseAttachmentFields(sourceIssue); af != nil {
-				if bb := extractFormulaVar(af.FormulaVars, "base_branch"); bb != "" && bb != defaultBranch {
-					target = bb
-					fmt.Printf("  Target branch override: %s (from formula_vars)\n", target)
-				}
+		if af := beads.ParseAttachmentFields(sourceIssue); af != nil {
+			if bb := extractFormulaVar(af.FormulaVars, "base_branch"); bb != "" && bb != defaultBranch {
+				target = bb
+				fmt.Printf("  Target branch override: %s (from formula_vars)\n", target)
 			}
 		}
 
@@ -187,20 +192,10 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 
 	// Get source issue for priority inheritance and dependency check
 	var priority int
-	var sourceIssue *beads.Issue
 	if mqSubmitPriority >= 0 {
 		priority = mqSubmitPriority
-	}
-	// Always try to fetch source issue (needed for both priority and dep check)
-	sourceIssue, err = bd.Show(issueID)
-	if err != nil {
-		if mqSubmitPriority < 0 {
-			priority = 2
-		}
 	} else {
-		if mqSubmitPriority < 0 {
-			priority = sourceIssue.Priority
-		}
+		priority = sourceIssue.Priority
 	}
 
 	// Enforce molecule step dependencies before allowing submit.
@@ -252,6 +247,9 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 	}
 
 	if existingMR != nil {
+		if err := validateMergeRequestSource(bd, existingMR, issueID); err != nil {
+			return fmt.Errorf("existing merge request validation failed: %w", err)
+		}
 		mrIssue = existingMR
 		fmt.Printf("%s MR already exists (idempotent)\n", style.Bold.Render("✓"))
 	} else {
@@ -279,7 +277,7 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		// GH#2599: Back-link source issue to MR bead for discoverability.
 		if issueID != "" {
 			comment := fmt.Sprintf("MR created: %s", mrIssue.ID)
-			if _, err := bd.Run("comments", "add", issueID, comment); err != nil {
+			if err := bd.AddComment(issueID, comment); err != nil {
 				style.PrintWarning("could not back-link source issue %s to MR %s: %v", issueID, mrIssue.ID, err)
 			}
 		}

--- a/internal/cmd/source_validation.go
+++ b/internal/cmd/source_validation.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func validateConcreteSourceIssue(issueID string, issue *beads.Issue) error {
+	if reason := beads.ConcreteWorkIssueRejectReason(issue); reason != "" {
+		return fmt.Errorf("source_issue %s is not concrete (%s)", issueID, reason)
+	}
+	return nil
+}
+
+func validateMergeRequestSource(bd *beads.Beads, mr *beads.Issue, expectedIssueID string) error {
+	if mr == nil {
+		return fmt.Errorf("merge request is missing")
+	}
+	fields := beads.ParseMRFields(mr)
+	if fields == nil || strings.TrimSpace(fields.SourceIssue) == "" {
+		return fmt.Errorf("merge request %s has missing source_issue", mr.ID)
+	}
+	sourceIssueID := strings.TrimSpace(fields.SourceIssue)
+	if sourceIssueID != strings.TrimSpace(expectedIssueID) {
+		return fmt.Errorf("merge request %s source_issue %s does not match expected %s", mr.ID, sourceIssueID, expectedIssueID)
+	}
+	sourceIssue, err := bd.Show(sourceIssueID)
+	if err != nil {
+		return fmt.Errorf("source_issue %s could not be resolved: %w", sourceIssueID, err)
+	}
+	return validateConcreteSourceIssue(sourceIssueID, sourceIssue)
+}

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -969,8 +969,11 @@ func (e *Engineer) recheckMRSourceStillMergeable(mr *MRInfo, sourceIssue string)
 	if beads.IssueStatus(issue.Status).IsTerminal() {
 		return e.rejectMRBeforeMerge(mr, fmt.Sprintf("source_issue %s status is %s", sourceIssue, issue.Status))
 	}
-	if reason := refinerySourceIssueConcreteReason(issue); reason != "" {
+	if reason := beads.ConcreteWorkIssueRejectReason(issue); reason != "" {
 		return e.rejectMRBeforeMerge(mr, fmt.Sprintf("source_issue %s is not concrete (%s)", sourceIssue, reason))
+	}
+	if unchecked := beads.HasUncheckedCriteria(issue); unchecked > 0 {
+		return e.rejectMRBeforeMerge(mr, fmt.Sprintf("source_issue %s has %d unchecked acceptance criteria", sourceIssue, unchecked))
 	}
 	if af := beads.ParseAttachmentFields(issue); af != nil {
 		switch {
@@ -983,48 +986,6 @@ func (e *Engineer) recheckMRSourceStillMergeable(mr *MRInfo, sourceIssue string)
 		}
 	}
 	return ProcessResult{Success: true}
-}
-
-func refinerySourceIssueConcreteReason(issue *beads.Issue) string {
-	if issue == nil || strings.TrimSpace(issue.ID) == "" {
-		return "source-missing"
-	}
-	if issue.Ephemeral {
-		return "ephemeral"
-	}
-	if strings.Contains(strings.ToLower(issue.ID), "-wisp-") {
-		return "wisp-id"
-	}
-	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(issue.ID)), "mol-") {
-		return "formula-id"
-	}
-	if refineryInternalIssueType(issue.Type) {
-		return "internal-type:" + strings.ToLower(strings.TrimSpace(issue.Type))
-	}
-	for _, label := range issue.Labels {
-		if refineryInternalIssueLabel(label) {
-			return "internal-label:" + strings.ToLower(strings.TrimSpace(label))
-		}
-	}
-	return ""
-}
-
-func refineryInternalIssueType(issueType string) bool {
-	switch strings.ToLower(strings.TrimSpace(issueType)) {
-	case "wisp", "message", "handoff", "merge-request", "agent", "queue", "convoy", "formula":
-		return true
-	default:
-		return false
-	}
-}
-
-func refineryInternalIssueLabel(label string) bool {
-	switch strings.ToLower(strings.TrimSpace(label)) {
-	case "gt:wisp", "gt:message", "gt:handoff", "gt:merge-request", "gt:agent", "gt:queue", "gt:convoy", "gt:formula":
-		return true
-	default:
-		return false
-	}
 }
 
 func (e *Engineer) acquireMainPushSlot(ctx context.Context) (string, error) {

--- a/internal/refinery/prepush_recheck_test.go
+++ b/internal/refinery/prepush_recheck_test.go
@@ -247,6 +247,24 @@ func TestRecheckMRStillMergeable_RejectsClosedSource(t *testing.T) {
 	}
 }
 
+func TestRecheckMRStillMergeable_RejectsUncheckedSourceCriteria(t *testing.T) {
+	workDir, _, cleanup := testGitRepo(t)
+	defer cleanup()
+	source := prepushIssue("gt-src", "")
+	source.AcceptanceCriteria = "- [ ] still open\n"
+	store := newPrepushStore(source, prepushMRIssue("gt-mr", "feature", "main", "gt-src"))
+	e := newPrepushEngineer(t, workDir, store)
+
+	mr := &MRInfo{ID: "gt-mr", Branch: "feature", Target: "main", SourceIssue: "gt-src"}
+	result := e.recheckMRStillMergeable(mr, "main")
+	if result.Success || !result.NoMerge {
+		t.Fatalf("unchecked source criteria should be rejected, got: %+v", result)
+	}
+	if got := store.closeReasons["gt-mr"]; got != "rejected: source_issue gt-src has 1 unchecked acceptance criteria" {
+		t.Fatalf("MR close reason = %q, want unchecked criteria rejection", got)
+	}
+}
+
 func TestDoMerge_RechecksSourceFlagsBeforeDirectPush(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/refinery/work_bead_close.go
+++ b/internal/refinery/work_bead_close.go
@@ -58,7 +58,7 @@ func closeMergedWorkBead(work workBeadCloser, agent issueReader, out io.Writer, 
 		result.NotFound = true
 		return result
 	}
-	if reason := refinerySourceIssueConcreteReason(issue); reason != "" {
+	if reason := beads.ConcreteWorkIssueRejectReason(issue); reason != "" {
 		logf("[Refinery] Warning: refusing to close non-concrete work bead %s (%s)\n", workBeadID, reason)
 		result.NotFound = true
 		return result
@@ -81,7 +81,7 @@ func closeMergedWorkBead(work workBeadCloser, agent issueReader, out io.Writer, 
 
 	if err := work.ForceCloseWithReason(closeReason, workBeadID); err != nil {
 		if issue, showErr := work.Show(workBeadID); showErr == nil && issue != nil &&
-			refinerySourceIssueConcreteReason(issue) == "" &&
+			beads.ConcreteWorkIssueRejectReason(issue) == "" &&
 			beads.IssueStatus(strings.TrimSpace(issue.Status)).IsTerminal() {
 			logf("[Refinery] Work bead already closed: %s\n", workBeadID)
 			result.Closed = true


### PR DESCRIPTION
## Summary

Rebuild the routed `gt done` completion fix from current `main` without carrying the polluted Thunder/fork history.

- resolve and validate the concrete source bead before remote mutation or MR reuse
- route source comments and closure through the authoritative Beads client
- enforce source eligibility before direct merge paths
- classify generated `.opencode` runtime artifacts separately from real uncommitted work
- preserve fail-closed behavior for mismatched or unresolved source work

Closes #4410.

## Attribution

Carries forward the accepted source-identity intent from PR #3893, commit `77932ad2b1379831cd0c5f62a7d765346e256ddd`, by anthonybyrnes/AJBcoding. The commit preserves both the original contributor and Claude co-author trailers.

## Verification

- 15 fresh independent research legs
- 5 approving pre-implementation reviews
- 5 fresh approving final-head reviews for `e615d3d993533ea76857187d330c5b1fa7fa88a5`
- focused `internal/beads`, `internal/cmd`, `internal/git`, and `internal/refinery` tests passed with `CGO_ENABLED=0`
- `gt-pr-sheriff-check --merge-gate` passed for the exact attributed head
- attributed tree is identical to reviewed head `da0918aab5a2ad0532244ebb4ea29274439b22e1`

Evidence is persisted on Bead `gt-dfix`.