### PR TITLE
fix(daemon): tolerate schema_version metadata key in children JSON

### DIFF
--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -272,12 +272,25 @@ func parseChildrenJSON(raw string) ([]childInfo, error) {
 		return arr, nil
 	}
 
-	var wrapped map[string][]childInfo
-	if err := json.Unmarshal(data, &wrapped); err == nil {
-		for _, children := range wrapped {
-			return children, nil
+	// Map form keyed by parent ID: {"hq-wisp-abc": [{...}, ...]}. bd may also
+	// include non-array metadata keys (e.g. "schema_version": 1), so decode into
+	// RawMessage and skip any value that is not a JSON array — otherwise the typed
+	// unmarshal into map[string][]childInfo fails on the metadata key and the whole
+	// parse is lost, pouring a 0-step molecule (gt-dep3).
+	var rawMap map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMap); err == nil {
+		var children []childInfo
+		for _, v := range rawMap {
+			if trimmed := bytes.TrimSpace(v); len(trimmed) == 0 || trimmed[0] != '[' {
+				continue // skip metadata keys (schema_version, future fields)
+			}
+			var group []childInfo
+			if err := json.Unmarshal(v, &group); err != nil {
+				return nil, fmt.Errorf("parse children group: %w", err)
+			}
+			children = append(children, group...)
 		}
-		return nil, nil
+		return children, nil
 	}
 
 	return nil, fmt.Errorf("unrecognized JSON shape: %.200s", raw)

--- a/internal/daemon/dog_molecule_test.go
+++ b/internal/daemon/dog_molecule_test.go
@@ -96,6 +96,19 @@ func TestParseChildrenJSON(t *testing.T) {
 			wantCount: 0,
 		},
 		{
+			// gt-dep3: bd added a non-array "schema_version" metadata key to the
+			// children output; the strict map[string][]childInfo unmarshal used to
+			// fail on it and pour a 0-step molecule. The metadata key must be skipped.
+			name:      "map wrapper with schema_version metadata and children",
+			input:     `{"hq-wisp-root":[{"id":"hq-wisp-a","title":"Probe","status":"open"},{"id":"hq-wisp-b","title":"Report","status":"open"}],"schema_version":1}`,
+			wantCount: 2,
+		},
+		{
+			name:      "map wrapper with schema_version metadata, no children",
+			input:     `{"hq-yfdpy8":[],"schema_version":1}`,
+			wantCount: 0,
+		},
+		{
 			name:    "invalid json",
 			input:   `not json`,
 			wantErr: true,


### PR DESCRIPTION
## Problem

bd v1.1.0 added a non-array `schema_version` metadata key to `bd show <id> --children --json`:

```json
{ "hq-yfdpy8": [], "schema_version": 1 }
```

`parseChildrenJSON` (internal/daemon/dog_molecule.go) decodes into `map[string][]childInfo`. The int-valued `schema_version` key can't unmarshal into `[]childInfo`, so the **entire** object unmarshal fails and the parse falls through to `unrecognized JSON shape`. The daemon then pours a **0-step dog molecule**:

- reaper dogs (charlie/delta) receive no work and escalate HIGH repeatedly, and
- un-closeable molecule step-wisps pile up (hq breached the wisp threshold).

An earlier map-form fix (c54b5f04) is insufficient — it doesn't tolerate the metadata key.

## Fix

Decode into `map[string]json.RawMessage` and skip any value that isn't a JSON array (the `schema_version` key and any future metadata), parsing the array-valued keys as `[]childInfo`. This also fixes a latent bug where the old branch returned only the *first* key's children (nondeterministic map order).

## Test

Extended `TestParseChildrenJSON` with the exact failing shapes (metadata key with and without children). Verified against real bd v1.1.0 output. `go test ./internal/daemon/ -run TestParseChildrenJSON` passes.

Fixes gt-dep3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)