### PR TITLE
fix(sling): route formula bond to target bead's beads dir so rig-prefixed beads dispatch

### DIFF
--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -1088,8 +1088,17 @@ func bondFormulaDirect(bondTarget, formulaName, beadID, formulaWorkDir, townRoot
 	for _, variable := range vars {
 		bondArgs = append(bondArgs, "--var", variable)
 	}
+	// FIX (hq-t9v): route bd to the TARGET BEAD's beads database. Running the bond
+	// only in the polecat worktree (formulaWorkDir) does not give bd the rig's
+	// beads routing, so native rig-prefixed beads (e.g. vo-*) cannot be
+	// resolved/written and the bond exits 1 ("no polecat work can dispatch in any
+	// rig"). Resolve the beads dir from the bead's prefix — the town .beads for
+	// hq-*, the rig's own .beads for rig-prefixed beads — mirroring how the town
+	// beads dir already keeps hq-* working.
+	bondBeadsDir := beads.ResolveBeadsDirForID(filepath.Join(townRoot, ".beads"), beadID)
 	bondOut, err := BdCmd(bondArgs...).
 		Dir(formulaWorkDir).
+		WithBeadsDir(bondBeadsDir).
 		WithAutoCommit().
 		WithGTRoot(townRoot).
 		Output()


### PR DESCRIPTION
## Problem

`gt sling <bead> <rig>` fails at formula instantiation for beads that live in a rig's own beads database (native rig-prefixed beads, e.g. `vo-*`):

```
bonding formula to bead: exit status 1 (direct formula bond fallback failed: exit status 1 (args: mol bond mol-polecat-work ...))
```

Town-root (`hq-*`) beads are unaffected. In practice this blocks **all** polecat dispatch in any rig that uses rig-prefixed beads.

## Root cause

`bondFormulaDirect` (`internal/cmd/sling_helpers.go`) runs `bd mol bond ...` with `.Dir(formulaWorkDir).WithGTRoot(townRoot)` but never sets the beads database for the target bead. `formulaWorkDir` is the fresh polecat worktree (resolved via `ResolveHookDir`), which does not carry the rig's beads routing, so `bd` cannot resolve/write the rig-prefixed bead and exits 1.

The verify path in the same file (`BdCmd("show", beadID, ...)`) already uses `.WithBeadsDir(...)`; only the bond path was missing it.

## Fix

Add `.WithBeadsDir(beads.ResolveBeadsDirForID(filepath.Join(townRoot, ".beads"), beadID))` to the bond command. `ResolveBeadsDirForID` resolves from the bead's prefix — the town `.beads` for `hq-*`, the rig's own `.beads` for rig-prefixed beads — mirroring the existing verify path and the `townBeadsDir` wiring in `sling.go`. `hq-*` behavior is unchanged (it still resolves to the town dir).

## Verification

Built with `make build`; `gt sling <vo-bead> vorena` now spawns a polecat and prints `Formula bonded to <bead>` where it previously exited 1. Existing `hq-*` dispatch is unaffected.
