### PR TITLE
docs: fix messaging config paths

### DIFF
--- a/internal/cmd/mail.go
+++ b/internal/cmd/mail.go
@@ -107,7 +107,7 @@ Addresses:
   <rig>/           - Broadcast to a rig
   list:<name>      - Send to a mailing list (fans out to all members)
 
-Mailing lists are defined in ~/gt/config/messaging.json and allow
+Mailing lists are defined in <town-root>/config/messaging.json and allow
 sending to multiple recipients at once. Each recipient gets their
 own copy of the message.
 
@@ -434,7 +434,7 @@ SYNTAX:
   gt mail announces              # List all announce channels
   gt mail announces <channel>    # Read messages from a channel
 
-Announce channels are bulletin boards defined in ~/gt/config/messaging.json.
+Announce channels are bulletin boards defined in <town-root>/config/messaging.json.
 Messages are broadcast to readers and persist until retention limit is reached.
 Unlike regular mail, announce messages are NOT removed when read.
 

--- a/internal/cmd/mail_test.go
+++ b/internal/cmd/mail_test.go
@@ -9,6 +9,27 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 )
 
+func TestMailHelpUsesTownRootMessagingConfig(t *testing.T) {
+	const want = "<town-root>/config/messaging.json"
+
+	for _, command := range []struct {
+		name string
+		long string
+	}{
+		{name: "send", long: mailSendCmd.Long},
+		{name: "announces", long: mailAnnouncesCmd.Long},
+	} {
+		t.Run(command.name, func(t *testing.T) {
+			if !strings.Contains(command.long, want) {
+				t.Fatalf("help should document %q:\n%s", want, command.long)
+			}
+			if strings.Contains(command.long, "~/gt/config/messaging.json") {
+				t.Fatalf("help should not document the obsolete home-relative path:\n%s", command.long)
+			}
+		})
+	}
+}
+
 // TestClaimPatternMatching tests claim pattern matching via the beads package.
 // This verifies that the pattern matching used for queue eligibility works correctly.
 func TestClaimPatternMatching(t *testing.T) {

--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -106,7 +106,7 @@ Role shortcuts (expand to session names):
 
 Channel syntax:
   channel:<name>  Nudges all members of a named channel defined in
-                  ~/gt/config/messaging.json under "nudge_channels".
+                  <town-root>/config/messaging.json under "nudge_channels".
                   Patterns like "gastown/polecats/*" are expanded.
 
 DND (Do Not Disturb):

--- a/internal/cmd/nudge_test.go
+++ b/internal/cmd/nudge_test.go
@@ -21,6 +21,17 @@ func setupNudgeTestRegistry(t *testing.T) {
 	t.Cleanup(func() { session.SetDefaultRegistry(old) })
 }
 
+func TestNudgeHelpUsesTownRootMessagingConfig(t *testing.T) {
+	const want = "<town-root>/config/messaging.json"
+
+	if !strings.Contains(nudgeCmd.Long, want) {
+		t.Fatalf("help should document %q:\n%s", want, nudgeCmd.Long)
+	}
+	if strings.Contains(nudgeCmd.Long, "~/gt/config/messaging.json") {
+		t.Fatalf("help should not document the obsolete home-relative path:\n%s", nudgeCmd.Long)
+	}
+}
+
 func TestNudgeStdinConflict(t *testing.T) {
 	// Save and restore package-level flags
 	origMessage := nudgeMessageFlag


### PR DESCRIPTION
## Summary

Correct the `gt mail send`, `gt mail announces`, and `gt nudge` help text so it points to the active town's messaging configuration instead of assuming the town lives at `~/gt`.

The old strings hard-coded the default town location even though Gas Town supports configurable town roots. The updated wording uses `<town-root>/config/messaging.json`, which matches the actual configuration lookup.

## Related Issue

Fixes #4336

## Changes

- update all three user-facing messaging configuration paths
- add focused regression tests for the mail and nudge help text
- guard against reintroducing the obsolete home-relative path

## Testing

- [ ] Unit tests pass (`go test ./...`)
  - The full suite was run. It still has unrelated macOS/environment failures that reproduce on clean `main`, including existing `/var` vs. `/private/var` expectations and missing `bd`/Docker integration dependencies.
- [x] Manual testing performed
  - `go test ./internal/cmd -run 'Test(MailHelpUsesTownRootMessagingConfig|NudgeHelpUsesTownRootMessagingConfig)$' -count=1`
  - `make build BUILD_DIR=/tmp/gastown-build`
  - verified the built CLI output for `mail send --help`, `mail announces --help`, and `nudge --help`
  - `go vet ./...`

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
