### PR TITLE
fix(daemon): execute plugin run.sh directly — exit code gates the AI agent step

### DIFF
--- a/docs/design/plugin-system.md
+++ b/docs/design/plugin-system.md
@@ -91,6 +91,31 @@ Benefits:
 - Plugin failures don't stall patrol
 - Consistent with Dogs' purpose (infrastructure work)
 
+### Execution Model: run.sh Script Contract (op-omcx)
+
+When a plugin directory contains a `run.sh` alongside `plugin.md`, the daemon
+executes the script DIRECTLY (background goroutine; working directory = the
+plugin directory; `GT_TOWN_ROOT` set; `execution.timeout` enforced, default
+5m). The AI dog dispatch above becomes conditional on the script's exit code:
+
+| exit code | meaning | agent step |
+|-----------|---------|------------|
+| `0` | script completed the plugin run | NOT dispatched |
+| `10` | pre-checks passed; plugin requests AI judgment | dispatched with plugin.md instructions + script output tail |
+| other / timeout | failure (recorded as `result:failure`) | NOT dispatched (fail-safe) |
+
+**Why**: instruction placement must match the execution layer. A correct code
+guard in `run.sh` protected nothing for two days because the dispatch path
+only ever fed `plugin.md` to a dog as a prompt — the dog "ran" the plugin by
+reading about it, and six RESTART_POLECAT false fires resulted (op-omcx).
+Deterministic logic and guards belong in `run.sh`, which code executes;
+`plugin.md` is the AI-facing layer and is only authoritative for plugins with
+no script.
+
+Overlap protection: the daemon keeps an in-flight set per plugin name, so a
+slow script is never re-launched by the next heartbeat; the dispatch receipt
+is recorded at launch so the cooldown gate holds while the script runs.
+
 ### State Tracking: Wisps on the Ledger
 
 Each plugin run creates a wisp:
@@ -138,7 +163,8 @@ This keeps the ledger clean while preserving audit history.
 
 ```
 rebuild-gt/
-└── plugin.md      # Definition with TOML frontmatter
+├── plugin.md      # Definition with TOML frontmatter
+└── run.sh         # Optional: deterministic script, executed directly by the daemon
 ```
 
 ### plugin.md Format

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -71,6 +71,14 @@ type Daemon struct {
 	deathsMu     sync.Mutex
 	recentDeaths []sessionDeath
 
+	// Script-plugin execution tracking (op-omcx): plugins with a run.sh are
+	// executed directly by the daemon in background goroutines. The in-flight
+	// set prevents overlapping runs of the same plugin across heartbeats; the
+	// WaitGroup lets shutdown (and tests) wait for completions.
+	scriptPluginMu      sync.Mutex
+	scriptPluginRunning map[string]bool
+	scriptPluginWG      sync.WaitGroup
+
 	// Deacon startup tracking: prevents race condition where newly started
 	// sessions are immediately killed by the heartbeat check.
 	// See: https://github.com/steveyegge/gastown/issues/567

--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -284,6 +285,17 @@ func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsC
 			}
 		}
 
+		// Plugins that ship a run.sh get the script executed by the daemon
+		// itself — code guards must run in code, not depend on an AI dog
+		// following prompt instructions (op-omcx: six RESTART_POLECAT false
+		// fires because the dog dispatch path only ever fed plugin.md to the
+		// dog as a prompt, so the run.sh guard never executed). The script's
+		// exit code gates whether the AI agent step dispatches at all.
+		if p.HasRunScript {
+			d.startScriptPlugin(p, recorder, mgr, sm, router)
+			continue
+		}
+
 		// Find an idle dog that doesn't already have a live tmux session.
 		// A leaked session (dog marked idle before its tmux terminated) would
 		// cause sm.Start to fail with "session already running", and since
@@ -297,44 +309,10 @@ func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsC
 			return
 		}
 
-		// Assign work and start session.
-		workDesc := fmt.Sprintf("plugin:%s", p.Name)
-		if err := mgr.AssignWork(idleDog.Name, workDesc); err != nil {
-			d.logger.Printf("Handler: failed to assign work to dog %s: %v", idleDog.Name, err)
+		if err := d.dispatchPluginToDog(p, idleDog, p.FormatMailBody(), mgr, sm, router); err != nil {
+			d.logger.Printf("Handler: %v", err)
 			continue
 		}
-
-		// Send mail with plugin instructions BEFORE starting the session
-		// so the dog finds work in its inbox on first check.
-		msg := mail.NewMessage(
-			"daemon",
-			fmt.Sprintf("deacon/dogs/%s", idleDog.Name),
-			fmt.Sprintf("Plugin: %s", p.Name),
-			p.FormatMailBody(),
-		)
-		msg.Type = mail.TypeTask
-		msg.Timestamp = time.Now()
-		if err := router.Send(msg); err != nil {
-			d.logger.Printf("Handler: failed to send mail to dog %s: %v", idleDog.Name, err)
-			// Roll back assignment — no point starting a session without instructions.
-			if clearErr := mgr.ClearWork(idleDog.Name); clearErr != nil {
-				d.logger.Printf("Handler: failed to clear work after mail failure for dog %s: %v", idleDog.Name, clearErr)
-			}
-			continue
-		}
-
-		if err := sm.Start(idleDog.Name, dog.SessionStartOptions{
-			WorkDesc: workDesc,
-		}); err != nil {
-			d.logger.Printf("Handler: failed to start session for dog %s: %v", idleDog.Name, err)
-			// Roll back assignment on session start failure.
-			if clearErr := mgr.ClearWork(idleDog.Name); clearErr != nil {
-				d.logger.Printf("Handler: failed to clear work after start failure for dog %s: %v", idleDog.Name, clearErr)
-			}
-			continue
-		}
-
-		d.logger.Printf("Handler: dispatched plugin %s to dog %s", p.Name, idleDog.Name)
 
 		// Record the dispatch immediately so the cooldown gate is satisfied
 		// for the next 1h regardless of what the dog does. Dogs create their
@@ -347,6 +325,136 @@ func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsC
 		}); err != nil {
 			d.logger.Printf("Handler: failed to record dispatch for plugin %s: %v", p.Name, err)
 		}
+	}
+}
+
+// dispatchPluginToDog assigns plugin work to the given dog, mails it the
+// instruction body, and starts its session. On mail or session failure the
+// work assignment is rolled back so the dog returns to idle.
+func (d *Daemon) dispatchPluginToDog(p *plugin.Plugin, idleDog *dog.Dog, body string, mgr *dog.Manager, sm *dog.SessionManager, router *mail.Router) error {
+	workDesc := fmt.Sprintf("plugin:%s", p.Name)
+	if err := mgr.AssignWork(idleDog.Name, workDesc); err != nil {
+		return fmt.Errorf("failed to assign work to dog %s: %w", idleDog.Name, err)
+	}
+
+	// Send mail with plugin instructions BEFORE starting the session
+	// so the dog finds work in its inbox on first check.
+	msg := mail.NewMessage(
+		"daemon",
+		fmt.Sprintf("deacon/dogs/%s", idleDog.Name),
+		fmt.Sprintf("Plugin: %s", p.Name),
+		body,
+	)
+	msg.Type = mail.TypeTask
+	msg.Timestamp = time.Now()
+	if err := router.Send(msg); err != nil {
+		// Roll back assignment — no point starting a session without instructions.
+		if clearErr := mgr.ClearWork(idleDog.Name); clearErr != nil {
+			d.logger.Printf("Handler: failed to clear work after mail failure for dog %s: %v", idleDog.Name, clearErr)
+		}
+		return fmt.Errorf("failed to send mail to dog %s: %w", idleDog.Name, err)
+	}
+
+	if err := sm.Start(idleDog.Name, dog.SessionStartOptions{
+		WorkDesc: workDesc,
+	}); err != nil {
+		// Roll back assignment on session start failure.
+		if clearErr := mgr.ClearWork(idleDog.Name); clearErr != nil {
+			d.logger.Printf("Handler: failed to clear work after start failure for dog %s: %v", idleDog.Name, clearErr)
+		}
+		return fmt.Errorf("failed to start session for dog %s: %w", idleDog.Name, err)
+	}
+
+	d.logger.Printf("Handler: dispatched plugin %s to dog %s", p.Name, idleDog.Name)
+	return nil
+}
+
+// startScriptPlugin executes a plugin's run.sh asynchronously (the patrol
+// loop must not block behind a script's multi-minute timeout). Overlapping
+// runs of the same plugin are prevented with an in-flight set, and the
+// dispatch receipt is recorded up front — same as the dog path — so the
+// cooldown gate holds while the script runs.
+func (d *Daemon) startScriptPlugin(p *plugin.Plugin, recorder *plugin.Recorder, mgr *dog.Manager, sm *dog.SessionManager, router *mail.Router) {
+	d.scriptPluginMu.Lock()
+	if d.scriptPluginRunning == nil {
+		d.scriptPluginRunning = make(map[string]bool)
+	}
+	if d.scriptPluginRunning[p.Name] {
+		d.scriptPluginMu.Unlock()
+		d.logger.Printf("Handler: plugin %s run.sh still in flight, skipping", p.Name)
+		return
+	}
+	d.scriptPluginRunning[p.Name] = true
+	d.scriptPluginMu.Unlock()
+
+	if _, err := recorder.RecordRun(plugin.PluginRunRecord{
+		PluginName: p.Name,
+		RigName:    p.RigName,
+		Result:     plugin.ResultSuccess,
+		Body:       "run.sh executed directly by daemon (script contract, op-omcx)",
+	}); err != nil {
+		d.logger.Printf("Handler: failed to record script dispatch for plugin %s: %v", p.Name, err)
+	}
+
+	d.scriptPluginWG.Add(1)
+	go func() {
+		defer d.scriptPluginWG.Done()
+		defer func() {
+			d.scriptPluginMu.Lock()
+			delete(d.scriptPluginRunning, p.Name)
+			d.scriptPluginMu.Unlock()
+		}()
+		d.runScriptPlugin(p, recorder, mgr, sm, router)
+	}()
+}
+
+// runScriptPlugin runs a plugin's run.sh synchronously and acts on the exit
+// code per the script contract (see internal/plugin/runner.go): 0 completes
+// the run, ScriptExitNeedsAgent dispatches the AI agent step, anything else
+// (including timeout) fails safe with NO agent dispatch.
+func (d *Daemon) runScriptPlugin(p *plugin.Plugin, recorder *plugin.Recorder, mgr *dog.Manager, sm *dog.SessionManager, router *mail.Router) {
+	ctx := d.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	result, err := plugin.RunScript(ctx, p, d.config.TownRoot)
+	switch {
+	case err != nil:
+		d.logger.Printf("Handler: plugin %s run.sh could not execute: %v", p.Name, err)
+		d.recordScriptFailure(p, recorder, fmt.Sprintf("run.sh could not execute: %v", err))
+	case result.TimedOut:
+		d.logger.Printf("Handler: plugin %s run.sh timed out after %v; agent step NOT dispatched (fail-safe)\n--- output tail ---\n%s", p.Name, p.ScriptTimeout(), result.Output)
+		d.recordScriptFailure(p, recorder, fmt.Sprintf("run.sh timed out after %v", p.ScriptTimeout()))
+	case result.Success():
+		d.logger.Printf("Handler: plugin %s run.sh completed (exit 0); no agent step needed", p.Name)
+	case result.NeedsAgent():
+		d.logger.Printf("Handler: plugin %s run.sh requested agent step (exit %d)", p.Name, result.ExitCode)
+		idleDog := findDispatchableDog(mgr, sm, d.logger)
+		if idleDog == nil {
+			d.logger.Printf("Handler: no dispatchable idle dog for agent step of plugin %s; will retry after cooldown", p.Name)
+			return
+		}
+		if dispatchErr := d.dispatchPluginToDog(p, idleDog, p.FormatAgentStepMailBody(result.Output), mgr, sm, router); dispatchErr != nil {
+			d.logger.Printf("Handler: agent step for plugin %s: %v", p.Name, dispatchErr)
+		}
+	default:
+		d.logger.Printf("Handler: plugin %s run.sh FAILED (exit %d); agent step NOT dispatched (fail-safe)\n--- output tail ---\n%s", p.Name, result.ExitCode, result.Output)
+		d.recordScriptFailure(p, recorder, fmt.Sprintf("run.sh failed with exit %d", result.ExitCode))
+	}
+}
+
+// recordScriptFailure writes a failure receipt for a script run. Best-effort:
+// the dispatch receipt already satisfied the cooldown gate, this one exists
+// for plugin history/audit.
+func (d *Daemon) recordScriptFailure(p *plugin.Plugin, recorder *plugin.Recorder, body string) {
+	if _, err := recorder.RecordRun(plugin.PluginRunRecord{
+		PluginName: p.Name,
+		RigName:    p.RigName,
+		Result:     plugin.ResultFailure,
+		Body:       body,
+	}); err != nil {
+		d.logger.Printf("Handler: failed to record script failure for plugin %s: %v", p.Name, err)
 	}
 }
 

--- a/internal/daemon/handler_script_plugin_test.go
+++ b/internal/daemon/handler_script_plugin_test.go
@@ -1,0 +1,169 @@
+package daemon
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/dog"
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// testScriptPluginDaemon builds a Daemon whose log output is captured so
+// tests can assert on the script-contract decisions.
+func testScriptPluginDaemon(t *testing.T, townRoot string) (*Daemon, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		logger: log.New(&syncWriter{buf: &buf}, "test: ", log.LstdFlags),
+	}
+	return d, &buf
+}
+
+// syncWriter serializes writes: the script goroutine and the test goroutine
+// both touch the log buffer.
+type syncWriter struct {
+	mu  sync.Mutex
+	buf *bytes.Buffer
+}
+
+func (w *syncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+// writeScriptPlugin creates a town-level cooldown plugin with a run.sh.
+// The gate has no duration so dispatchPlugins skips the bd-backed cooldown
+// query (unavailable in unit tests).
+func writeScriptPlugin(t *testing.T, townRoot, name, script string) {
+	t.Helper()
+	dir := filepath.Join(townRoot, "plugins", name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	pluginMD := "+++\nname = \"" + name + "\"\ndescription = \"script plugin\"\n\n[gate]\ntype = \"cooldown\"\n+++\n\n# Instructions\n"
+	if err := os.WriteFile(filepath.Join(dir, "plugin.md"), []byte(pluginMD), 0644); err != nil {
+		t.Fatalf("WriteFile plugin.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "run.sh"), []byte("#!/usr/bin/env bash\n"+script+"\n"), 0755); err != nil {
+		t.Fatalf("WriteFile run.sh: %v", err)
+	}
+}
+
+func runDispatchPlugins(t *testing.T, d *Daemon, townRoot string) *dog.Manager {
+	t.Helper()
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	sm := dog.NewSessionManager(tmux.NewTmux(), townRoot, mgr)
+	d.dispatchPlugins(mgr, sm, rigsConfig)
+	d.scriptPluginWG.Wait()
+	return mgr
+}
+
+func TestDispatchPlugins_ScriptExecutesInsteadOfDog(t *testing.T) {
+	townRoot := t.TempDir()
+	d, logs := testScriptPluginDaemon(t, townRoot)
+
+	marker := filepath.Join(townRoot, "script-ran")
+	writeScriptPlugin(t, townRoot, "test-script", "touch '"+marker+"'; exit 0")
+	testSetupDogState(t, townRoot, "idle-dog", dog.StateIdle, time.Now().Add(-10*time.Minute))
+
+	mgr := runDispatchPlugins(t, d, townRoot)
+
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("run.sh did not execute: %v", err)
+	}
+	dg, err := mgr.Get("idle-dog")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if dg.State != dog.StateIdle || dg.Work != "" {
+		t.Errorf("dog = state %q work %q, want idle/empty (exit 0 must not dispatch the agent step)", dg.State, dg.Work)
+	}
+	if !strings.Contains(logs.String(), "no agent step needed") {
+		t.Errorf("logs missing success decision:\n%s", logs.String())
+	}
+}
+
+func TestDispatchPlugins_ScriptFailureFailsSafe(t *testing.T) {
+	townRoot := t.TempDir()
+	d, logs := testScriptPluginDaemon(t, townRoot)
+
+	writeScriptPlugin(t, townRoot, "failing-script", "echo guard says no; exit 3")
+	testSetupDogState(t, townRoot, "idle-dog", dog.StateIdle, time.Now().Add(-10*time.Minute))
+
+	mgr := runDispatchPlugins(t, d, townRoot)
+
+	dg, err := mgr.Get("idle-dog")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if dg.State != dog.StateIdle || dg.Work != "" {
+		t.Errorf("dog = state %q work %q, want idle/empty (failure must not dispatch the agent step)", dg.State, dg.Work)
+	}
+	got := logs.String()
+	if !strings.Contains(got, "FAILED (exit 3)") || !strings.Contains(got, "NOT dispatched") {
+		t.Errorf("logs missing fail-safe decision:\n%s", got)
+	}
+	if !strings.Contains(got, "guard says no") {
+		t.Errorf("logs missing script output tail:\n%s", got)
+	}
+}
+
+func TestDispatchPlugins_ScriptNeedsAgentAttemptsDogDispatch(t *testing.T) {
+	townRoot := t.TempDir()
+	d, logs := testScriptPluginDaemon(t, townRoot)
+
+	writeScriptPlugin(t, townRoot, "needs-agent", "echo judgment required; exit 10")
+	testSetupDogState(t, townRoot, "idle-dog", dog.StateIdle, time.Now().Add(-10*time.Minute))
+
+	runDispatchPlugins(t, d, townRoot)
+
+	got := logs.String()
+	if !strings.Contains(got, "requested agent step (exit 10)") {
+		t.Errorf("logs missing needs-agent decision:\n%s", got)
+	}
+	// The temp town has no mail infrastructure, so the dispatch itself is
+	// expected to fail and roll back — what matters is that exit 10 is the
+	// one path that tries the agent step at all.
+	if strings.Contains(got, "NOT dispatched") {
+		t.Errorf("exit 10 must not take the fail-safe path:\n%s", got)
+	}
+}
+
+func TestDispatchPlugins_ScriptInFlightNotRelaunched(t *testing.T) {
+	townRoot := t.TempDir()
+	d, logs := testScriptPluginDaemon(t, townRoot)
+
+	counter := filepath.Join(townRoot, "run-count")
+	// Slow enough that the second dispatch tick lands while in flight.
+	writeScriptPlugin(t, townRoot, "slow-script",
+		"echo x >> '"+counter+"'; sleep 1; exit 0")
+
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	sm := dog.NewSessionManager(tmux.NewTmux(), townRoot, mgr)
+
+	d.dispatchPlugins(mgr, sm, rigsConfig)
+	d.dispatchPlugins(mgr, sm, rigsConfig)
+	d.scriptPluginWG.Wait()
+
+	data, err := os.ReadFile(counter)
+	if err != nil {
+		t.Fatalf("script never ran: %v", err)
+	}
+	if runs := strings.Count(string(data), "x"); runs != 1 {
+		t.Errorf("script ran %d times, want 1 (in-flight guard)", runs)
+	}
+	if !strings.Contains(logs.String(), "still in flight") {
+		t.Errorf("logs missing in-flight skip:\n%s", logs.String())
+	}
+}

--- a/internal/plugin/runner.go
+++ b/internal/plugin/runner.go
@@ -1,0 +1,166 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/util"
+)
+
+// Script execution contract (op-omcx).
+//
+// When a plugin directory contains a run.sh alongside plugin.md, the daemon
+// executes the script DIRECTLY instead of asking an AI dog to run it. Code
+// guards must run in code: six RESTART_POLECAT false fires happened because
+// a correct guard lived in run.sh while the dog dispatch path only ever fed
+// plugin.md to the dog as a prompt, so the guard never executed.
+//
+// The script's exit code gates whether the AI agent step dispatches at all:
+//
+//	0                     — script completed the plugin run; no agent step.
+//	ScriptExitNeedsAgent  — script pre-checks passed and the plugin wants the
+//	                        AI agent step; the daemon dispatches a dog with
+//	                        the plugin.md instructions (plus the script's
+//	                        output tail as context).
+//	anything else/timeout — failure; recorded and logged; the agent step is
+//	                        NOT dispatched (fail-safe).
+const (
+	// ScriptExitNeedsAgent is the documented run.sh exit code that requests
+	// the AI agent step after the script's own checks complete.
+	ScriptExitNeedsAgent = 10
+
+	// DefaultScriptTimeout bounds run.sh execution when the plugin does not
+	// declare execution.timeout in its frontmatter.
+	DefaultScriptTimeout = 5 * time.Minute
+
+	// scriptOutputTailLimit caps how much combined stdout/stderr is retained
+	// from a script run (the tail is what carries the failure context).
+	scriptOutputTailLimit = 8 * 1024
+)
+
+// ScriptResult is the outcome of executing a plugin's run.sh.
+type ScriptResult struct {
+	// ExitCode is the script's exit status (-1 when it timed out).
+	ExitCode int
+
+	// TimedOut is true when the script was killed at the execution timeout.
+	TimedOut bool
+
+	// Output is the tail of the script's combined stdout+stderr.
+	Output string
+}
+
+// Success reports whether the script completed the plugin run on its own.
+func (r *ScriptResult) Success() bool {
+	return r != nil && !r.TimedOut && r.ExitCode == 0
+}
+
+// NeedsAgent reports whether the script requested the AI agent step.
+func (r *ScriptResult) NeedsAgent() bool {
+	return r != nil && !r.TimedOut && r.ExitCode == ScriptExitNeedsAgent
+}
+
+// ScriptTimeout returns the execution budget for this plugin's run.sh,
+// from execution.timeout in the frontmatter or DefaultScriptTimeout.
+func (p *Plugin) ScriptTimeout() time.Duration {
+	if p.Execution != nil && p.Execution.Timeout != "" {
+		if d, err := time.ParseDuration(p.Execution.Timeout); err == nil && d > 0 {
+			return d
+		}
+	}
+	return DefaultScriptTimeout
+}
+
+// RunScript executes the plugin's run.sh with the plugin directory as the
+// working directory and GT_TOWN_ROOT set. Non-zero exit codes are returned
+// in the ScriptResult, not as an error; the error return is reserved for
+// failures to execute the script at all (missing file, spawn failure).
+func RunScript(ctx context.Context, p *Plugin, townRoot string) (*ScriptResult, error) {
+	scriptPath := filepath.Join(p.Path, "run.sh")
+	if _, err := os.Stat(scriptPath); err != nil {
+		return nil, fmt.Errorf("plugin %s: stat run.sh: %w", p.Name, err)
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, p.ScriptTimeout())
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, "bash", scriptPath)
+	cmd.Dir = p.Path
+	cmd.Env = append(os.Environ(), "GT_TOWN_ROOT="+townRoot)
+	// Kill the whole process group on timeout — otherwise a child holding
+	// the output pipe keeps Run() blocked long past the deadline.
+	util.SetProcessGroup(cmd)
+	cmd.WaitDelay = 5 * time.Second
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	runErr := cmd.Run()
+	result := &ScriptResult{Output: outputTail(buf.String(), scriptOutputTailLimit)}
+
+	if runCtx.Err() != nil {
+		result.TimedOut = true
+		result.ExitCode = -1
+		return result, nil
+	}
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			result.ExitCode = exitErr.ExitCode()
+			return result, nil
+		}
+		return nil, fmt.Errorf("plugin %s: running run.sh: %w", p.Name, runErr)
+	}
+	return result, nil
+}
+
+// FormatAgentStepMailBody formats dog instructions for the AI agent step of
+// a plugin whose run.sh pre-check already ran and requested the agent step
+// (exit ScriptExitNeedsAgent). Unlike FormatMailBody, it must NOT tell the
+// dog to execute run.sh again — the daemon already did.
+func (p *Plugin) FormatAgentStepMailBody(scriptOutput string) string {
+	var sb bytes.Buffer
+
+	sb.WriteString("Execute the following plugin (AI agent step):\n\n")
+	sb.WriteString(fmt.Sprintf("**Plugin**: %s\n", p.Name))
+	sb.WriteString(fmt.Sprintf("**Description**: %s\n", p.Description))
+	if p.RigName != "" {
+		sb.WriteString(fmt.Sprintf("**Rig**: %s\n", p.RigName))
+	}
+	sb.WriteString(fmt.Sprintf(
+		"\nThe daemon already executed this plugin's run.sh pre-check; it exited with code %d, requesting the AI agent step. Do NOT re-run run.sh.\n",
+		ScriptExitNeedsAgent))
+	if scriptOutput != "" {
+		sb.WriteString("\n**run.sh output tail**:\n\n```\n")
+		sb.WriteString(scriptOutput)
+		sb.WriteString("\n```\n")
+	}
+	sb.WriteString("\n---\n\n## Instructions\n\n")
+	sb.WriteString(p.Instructions)
+	sb.WriteString("\n\n---\n\n")
+	sb.WriteString("After completion:\n")
+	sb.WriteString("1. Follow the plugin's recording instructions above. If none are provided, run `gt plugin record-run --plugin " + p.Name + " --result <outcome> --title \"Plugin run: " + p.Name + "\"`.\n")
+	sb.WriteString("2. Run `gt dog done` — this clears your work and auto-terminates the session. Run this even if recording fails.\n")
+
+	return sb.String()
+}
+
+// outputTail returns the last max bytes of s, trimmed to start after the
+// first newline inside the cut window so partial lines aren't shown.
+func outputTail(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	cut := s[len(s)-max:]
+	if idx := bytes.IndexByte([]byte(cut), '\n'); idx >= 0 && idx+1 < len(cut) {
+		cut = cut[idx+1:]
+	}
+	return cut
+}

--- a/internal/plugin/runner_test.go
+++ b/internal/plugin/runner_test.go
@@ -1,0 +1,193 @@
+package plugin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testScriptPlugin creates a plugin directory with the given run.sh body and
+// returns a Plugin pointing at it.
+func testScriptPlugin(t *testing.T, script, timeout string) *Plugin {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "run.sh"), []byte("#!/usr/bin/env bash\n"+script+"\n"), 0755); err != nil {
+		t.Fatalf("writing run.sh: %v", err)
+	}
+	p := &Plugin{
+		Name:         "test-script",
+		Description:  "script contract test plugin",
+		Path:         dir,
+		HasRunScript: true,
+		Instructions: "Do the thing.",
+	}
+	if timeout != "" {
+		p.Execution = &Execution{Timeout: timeout}
+	}
+	return p
+}
+
+func TestRunScript_SuccessCompletesRun(t *testing.T) {
+	p := testScriptPlugin(t, "echo guard-ran; exit 0", "")
+
+	res, err := RunScript(context.Background(), p, t.TempDir())
+	if err != nil {
+		t.Fatalf("RunScript: %v", err)
+	}
+	if !res.Success() {
+		t.Errorf("Success() = false, want true (exit=%d timedOut=%v)", res.ExitCode, res.TimedOut)
+	}
+	if res.NeedsAgent() {
+		t.Error("NeedsAgent() = true, want false for exit 0")
+	}
+	if !strings.Contains(res.Output, "guard-ran") {
+		t.Errorf("Output = %q, want it to contain script stdout", res.Output)
+	}
+}
+
+func TestRunScript_NeedsAgentExitCode(t *testing.T) {
+	p := testScriptPlugin(t, "echo pre-checks passed; exit 10", "")
+
+	res, err := RunScript(context.Background(), p, t.TempDir())
+	if err != nil {
+		t.Fatalf("RunScript: %v", err)
+	}
+	if !res.NeedsAgent() {
+		t.Errorf("NeedsAgent() = false, want true for exit %d (got exit %d)", ScriptExitNeedsAgent, res.ExitCode)
+	}
+	if res.Success() {
+		t.Error("Success() = true, want false for the needs-agent exit code")
+	}
+}
+
+func TestRunScript_FailureIsNotAgentDispatch(t *testing.T) {
+	p := testScriptPlugin(t, "echo boom >&2; exit 7", "")
+
+	res, err := RunScript(context.Background(), p, t.TempDir())
+	if err != nil {
+		t.Fatalf("RunScript: %v", err)
+	}
+	if res.ExitCode != 7 {
+		t.Errorf("ExitCode = %d, want 7", res.ExitCode)
+	}
+	if res.Success() || res.NeedsAgent() {
+		t.Error("failure exit must be neither Success nor NeedsAgent (fail-safe)")
+	}
+	if !strings.Contains(res.Output, "boom") {
+		t.Errorf("Output = %q, want stderr captured", res.Output)
+	}
+}
+
+func TestRunScript_TimeoutFailsSafe(t *testing.T) {
+	// Exit code 10 after the deadline must NOT count as a needs-agent run.
+	p := testScriptPlugin(t, "sleep 5; exit 10", "150ms")
+
+	start := time.Now()
+	res, err := RunScript(context.Background(), p, t.TempDir())
+	if err != nil {
+		t.Fatalf("RunScript: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("RunScript took %v, want timeout enforcement near 150ms", elapsed)
+	}
+	if !res.TimedOut {
+		t.Error("TimedOut = false, want true")
+	}
+	if res.Success() || res.NeedsAgent() {
+		t.Error("timed-out run must be neither Success nor NeedsAgent (fail-safe)")
+	}
+}
+
+func TestRunScript_RunsInPluginDirWithTownRoot(t *testing.T) {
+	p := testScriptPlugin(t, `printf 'cwd=%s town=%s' "$(pwd -P)" "$GT_TOWN_ROOT"`, "")
+	townRoot := t.TempDir()
+
+	res, err := RunScript(context.Background(), p, townRoot)
+	if err != nil {
+		t.Fatalf("RunScript: %v", err)
+	}
+	wantDir, _ := filepath.EvalSymlinks(p.Path)
+	if !strings.Contains(res.Output, "cwd="+wantDir) {
+		t.Errorf("Output = %q, want cwd %q (plugin dir)", res.Output, wantDir)
+	}
+	if !strings.Contains(res.Output, "town="+townRoot) {
+		t.Errorf("Output = %q, want GT_TOWN_ROOT %q", res.Output, townRoot)
+	}
+}
+
+func TestRunScript_MissingScriptErrors(t *testing.T) {
+	p := &Plugin{Name: "no-script", Path: t.TempDir()}
+
+	if _, err := RunScript(context.Background(), p, t.TempDir()); err == nil {
+		t.Fatal("RunScript with no run.sh: got nil error, want error")
+	}
+}
+
+func TestScriptTimeout(t *testing.T) {
+	cases := []struct {
+		name   string
+		plugin *Plugin
+		want   time.Duration
+	}{
+		{"default when no execution block", &Plugin{}, DefaultScriptTimeout},
+		{"default when empty timeout", &Plugin{Execution: &Execution{}}, DefaultScriptTimeout},
+		{"parses declared timeout", &Plugin{Execution: &Execution{Timeout: "2m"}}, 2 * time.Minute},
+		{"default on unparseable timeout", &Plugin{Execution: &Execution{Timeout: "soon"}}, DefaultScriptTimeout},
+		{"default on non-positive timeout", &Plugin{Execution: &Execution{Timeout: "-5s"}}, DefaultScriptTimeout},
+	}
+	for _, tc := range cases {
+		if got := tc.plugin.ScriptTimeout(); got != tc.want {
+			t.Errorf("%s: ScriptTimeout() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestScriptResult_NilSafe(t *testing.T) {
+	var r *ScriptResult
+	if r.Success() || r.NeedsAgent() {
+		t.Error("nil ScriptResult must be neither Success nor NeedsAgent")
+	}
+}
+
+func TestFormatAgentStepMailBody(t *testing.T) {
+	p := &Plugin{
+		Name:         "check-thing",
+		Description:  "checks the thing",
+		RigName:      "gastown",
+		Instructions: "Inspect the pane output and decide.",
+	}
+
+	body := p.FormatAgentStepMailBody("[check-thing] 2 candidates need judgment")
+
+	for _, want := range []string{
+		"Do NOT re-run run.sh",
+		"exited with code 10",
+		"Inspect the pane output and decide.",
+		"[check-thing] 2 candidates need judgment",
+		"gt dog done",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("FormatAgentStepMailBody missing %q\nbody:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "bash run.sh") {
+		t.Error("FormatAgentStepMailBody must not instruct the dog to run the script again")
+	}
+}
+
+func TestOutputTail(t *testing.T) {
+	long := strings.Repeat("x", 100) + "\nline-two\n" + strings.Repeat("y", 50)
+	got := outputTail(long, 60)
+	if len(got) > 60 {
+		t.Errorf("outputTail returned %d bytes, want <= 60", len(got))
+	}
+	if !strings.HasSuffix(got, strings.Repeat("y", 50)) {
+		t.Errorf("outputTail = %q, want the tail preserved", got)
+	}
+	if short := outputTail("short", 60); short != "short" {
+		t.Errorf("outputTail(short) = %q, want unchanged", short)
+	}
+}

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -1945,6 +1945,21 @@ This directory contains town-level plugins that run during Deacon patrol cycles.
 
 Each plugin is a directory containing:
 - plugin.md - Plugin definition with TOML frontmatter
+- run.sh (optional) - Deterministic script executed DIRECTLY by the daemon
+
+## run.sh Contract
+
+When run.sh exists, the daemon executes it itself (working dir = plugin dir,
+GT_TOWN_ROOT set, execution.timeout enforced). plugin.md is NOT sent to an AI
+dog unless the script asks for it. The exit code gates the AI agent step:
+
+- 0:  script completed the plugin run; no agent step
+- 10: pre-checks passed, dispatch an AI dog with the plugin.md instructions
+- anything else / timeout: failure; recorded; agent step NOT dispatched
+
+Put guards and anything that must run deterministically in run.sh — prompt
+instructions in plugin.md are advisory to the AI and MUST NOT be the only
+enforcement layer.
 
 ## Gate Types
 

--- a/plugins/stuck-agent-dog/plugin.md
+++ b/plugins/stuck-agent-dog/plugin.md
@@ -19,6 +19,15 @@ severity = "high"
 
 # Stuck Agent Dog
 
+> **EXECUTION NOTE:** the daemon executes `run.sh` in this directory DIRECTLY
+> (script contract, op-omcx) — NOT the bash blocks in this file. This doc is
+> reference/AI-facing only; an AI dog only sees it if `run.sh` exits with the
+> needs-agent code (10), which this plugin never does. Any behavior change
+> MUST be made in `run.sh` (and mirrored here). A fix applied only to this
+> doc once left the old `run.sh` firing false mass-death CRITICALs for two
+> extra cycles, and six RESTART_POLECAT false fires happened while the code
+> guard lived only in a script no execution layer ever ran.
+
 Detects stuck or crashed polecats and deacons by inspecting tmux session context
 before taking action. Unlike the daemon's blind kill-and-restart approach, this
 plugin checks whether an agent is truly unresponsive before restarting.
@@ -101,6 +110,16 @@ For each rig, enumerate polecats and check their session status.
 A polecat is a concern if:
 - It has hooked work (hook_bead is set)
 - Its central runtime-aware health is `session-dead` OR `agent-dead`
+
+**DEFERRED-TRACKER exclusion** (2026-07-12, capital/witness hq-wisp-l4zal): a
+hook bead whose comments contain the marker `DEFERRED-TRACKER` belongs to a
+polecat that was deliberately stopped while its bead stays OPEN as a long-lived
+tracker (e.g. awaiting an epic close or a human gate sign-off). `bead_restartable`
+in `run.sh` checks plain `bd show` output for the marker (comments are not in
+the `--json` issue object) and treats such beads as not restartable — they never
+enter `CRASHED[]`/`STUCK[]` and never count toward mass death. The
+RESTART_POLECAT mailer loops re-check the marker immediately before sending
+mail (defense-in-depth, op-omcx) — the mailer is where every past bypass fired.
 
 Polecat liveness must use `gt session health`, which wraps the central
 `tmux.CheckSessionHealth` path. That path reads `GT_PROCESS_NAMES`, `GT_AGENT`,
@@ -252,6 +271,14 @@ For DEACON stuck (stale heartbeat):
   for stale-heartbeat events; do not include the age seconds in the fingerprint.
 
 **Decision framework:**
+0. **MANDATORY FIRST CHECK — DEFERRED-TRACKER.** Before requesting ANY restart,
+   run `bd show <hook_bead> | grep DEFERRED-TRACKER` (plain output — the marker
+   is in comments, NOT in `--json`). If it matches, the polecat was STOPPED
+   DELIBERATELY and its bead stays open as a tracker: do NOT request restart,
+   do NOT mail the witness, count it healthy, and move on. This is not
+   optional and overrides every rule below. If `bd show` errors, treat as
+   NON-restartable (fail safe). (6 false fires on cap-hhu/cap-kgp happened
+   because dogs skipped this — hq-wisp-l4zal, hq-wisp-ctor5, hq-wisp-0flh3.)
 1. If central health is `session-dead` and hook status is actionable → request restart
 2. If central health is `agent-dead` and hook status is actionable → clear zombie, request restart
 3. If central health is `agent-hung` → observe/report only; do not restart polecat research sessions
@@ -276,6 +303,12 @@ fi
 ```
 
 ## Step 6: Take action
+
+**GATE (repeat of framework rule 0): before sending ANY RESTART_POLECAT mail
+below, re-check `bd show <hook_bead> | grep DEFERRED-TRACKER`. Marker present
+→ SKIP that agent entirely, no mail.** Duplicate on purpose: this mailer step
+is where every past bypass actually fired. `run.sh` enforces this in code in
+both RESTART_POLECAT loops.
 
 For each agent requiring restart:
 

--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -121,13 +121,35 @@ rig_bead_status() {
     | jq -r '.[0].status // empty' 2>/dev/null || true
 }
 
+# DEFERRED-TRACKER convention (2026-07-12, capital/witness request hq-wisp-l4zal):
+# some polecats are deliberately stopped while their hook bead stays OPEN as a
+# long-lived tracker (e.g. awaiting an epic close or a human gate sign-off).
+# The witness marks such beads with a comment containing "DEFERRED-TRACKER".
+# The marker is visible in plain `bd show` output (comments section), NOT in
+# the --json issue object. Such beads are never restartable.
+bead_deferred_tracker() {
+  local rig="$1" bead="$2" dir=""
+
+  if ! dir=$(rig_workdir "$rig"); then
+    return 1
+  fi
+
+  ( cd "$dir" 2>/dev/null && bd show "$bead" 2>/dev/null ) \
+    | grep -q "DEFERRED-TRACKER"
+}
+
 bead_restartable() {
   local session="$1" rig="$2" bead="$3" status=""
 
   status=$(rig_bead_status "$rig" "$bead")
 
   case "$status" in
-    open|hooked|in_progress) return 0 ;;
+    open|hooked|in_progress)
+      if bead_deferred_tracker "$rig" "$bead"; then
+        log "  DEFERRED-TRACKER: $session hook=$bead deliberately stopped, bead open as tracker — not restartable"
+        return 1
+      fi
+      return 0 ;;
     closed) log "  SKIP $session: bead closed (completed normally)" ;;
     "") log "  SKIP $session: hook=$bead status unavailable" ;;
     *) log "  SKIP $session: hook=$bead status=$status not actionable" ;;
@@ -304,6 +326,13 @@ else
   # `${arr[@]+"${arr[@]}"}` form expands to nothing when the array is empty.
   for ENTRY in ${CRASHED[@]+"${CRASHED[@]}"}; do
     IFS='|' read -r SESSION RIG PCAT HOOK <<< "$ENTRY"
+    # Mailer-time re-check (op-omcx, defense-in-depth): the marker can land
+    # between detection and action, and this mailer is where every historical
+    # bypass actually fired. Refuse DEFERRED-TRACKER beads here too.
+    if bead_deferred_tracker "$RIG" "$HOOK"; then
+      log "  MAILER-GATE: $SESSION hook=$HOOK carries DEFERRED-TRACKER — refusing RESTART_POLECAT mail"
+      continue
+    fi
     log "Requesting restart for $RIG/polecats/$PCAT (hook=$HOOK)"
     gt mail send "$RIG/witness" -s "RESTART_POLECAT: $RIG/$PCAT" --stdin <<BODY || log "  WARN: restart mail failed for $RIG/$PCAT"
 Polecat $PCAT crash confirmed by stuck-agent-dog plugin.
@@ -315,6 +344,11 @@ BODY
   # Zombie polecats: kill zombie session, then request restart
   for ENTRY in ${STUCK[@]+"${STUCK[@]}"}; do
     IFS='|' read -r SESSION RIG PCAT HOOK REASON <<< "$ENTRY"
+    # Mailer-time re-check (op-omcx): see the CRASHED loop above.
+    if bead_deferred_tracker "$RIG" "$HOOK"; then
+      log "  MAILER-GATE: $SESSION hook=$HOOK carries DEFERRED-TRACKER — refusing RESTART_POLECAT mail (zombie session left untouched)"
+      continue
+    fi
     log "Killing zombie session $SESSION and requesting restart"
     tmux kill-session -t "$SESSION" 2>/dev/null || true
     gt mail send "$RIG/witness" -s "RESTART_POLECAT: $RIG/$PCAT (zombie cleared)" --stdin <<BODY || log "  WARN: restart mail failed for $RIG/$PCAT"

--- a/plugins/stuck-agent-dog/run_test.sh
+++ b/plugins/stuck-agent-dog/run_test.sh
@@ -196,7 +196,33 @@ case "${1:-}" in
     if [ -f "$TEST_STATE/status/$bead" ]; then
       status=$(tr -d '\n' < "$TEST_STATE/status/$bead")
     fi
-    printf '[{"status":"%s"}]\n' "$status"
+    json=false
+    for arg in "$@"; do
+      [ "$arg" = "--json" ] && json=true
+    done
+    if [ "$json" = true ]; then
+      printf '[{"status":"%s"}]\n' "$status"
+    else
+      # Plain `bd show` renders comments; that's where the DEFERRED-TRACKER
+      # marker lives. Track plain-show call counts per bead so tests can
+      # make the marker appear only from the Nth call (mailer-gate race).
+      count_file="$TEST_STATE/plainshow/$bead"
+      count=0
+      [ -f "$count_file" ] && count=$(tr -d '\n' < "$count_file")
+      count=$((count + 1))
+      printf '%s\n' "$count" > "$count_file"
+      printf 'status: %s\n' "$status"
+      emit_marker=false
+      if [ -f "$TEST_STATE/deferred/$bead" ]; then
+        emit_marker=true
+      elif [ -f "$TEST_STATE/deferred_after/$bead" ]; then
+        after=$(tr -d '\n' < "$TEST_STATE/deferred_after/$bead")
+        [ "$count" -gt "$after" ] && emit_marker=true
+      fi
+      if [ "$emit_marker" = true ]; then
+        printf 'comment: DEFERRED-TRACKER — deliberately stopped, bead stays open as tracker\n'
+      fi
+    fi
     ;;
   list)
     printf '[]\n'
@@ -235,6 +261,7 @@ setup_case() {
   local bin_dir="$TEST_TMP/bin"
 
   mkdir -p "$TEST_STATE/health" "$TEST_STATE/nohook" "$TEST_STATE/sessions" "$TEST_STATE/status" "$bin_dir"
+  mkdir -p "$TEST_STATE/plainshow" "$TEST_STATE/deferred" "$TEST_STATE/deferred_after"
   mkdir -p "$GT_TOWN_ROOT/gastown/polecats" "$GT_TOWN_ROOT/deacon"
   printf '{"rigs":{"gastown":{"beads":{"prefix":"gt"}}}}\n' > "$GT_TOWN_ROOT/rigs.json"
   : > "$TEST_STATE/mail.log"
@@ -337,6 +364,53 @@ test_mass_death_skips_actions() {
   assert_file_contains "$TEST_STATE/output.log" "Skipping per-agent restart/kill actions" "mass death: action loops skipped"
 }
 
+test_deferred_tracker_skips_crashed_restart() {
+  setup_case
+  add_polecat delta session-dead
+  touch "$TEST_STATE/deferred/gt-hook-delta"
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "deferred tracker (crashed): no session kill"
+  assert_file_empty "$TEST_STATE/mail.log" "deferred tracker (crashed): no restart mail"
+  assert_file_empty "$TEST_STATE/escalate.log" "deferred tracker (crashed): no escalation"
+  assert_file_contains "$TEST_STATE/output.log" "DEFERRED-TRACKER: gt-delta" "deferred tracker (crashed): detection-time guard logged"
+}
+
+test_deferred_tracker_skips_zombie_restart() {
+  setup_case
+  add_polecat epsilon agent-dead
+  touch "$TEST_STATE/deferred/gt-hook-epsilon"
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "deferred tracker (zombie): no session kill"
+  assert_file_empty "$TEST_STATE/mail.log" "deferred tracker (zombie): no restart mail"
+  assert_file_contains "$TEST_STATE/output.log" "DEFERRED-TRACKER: gt-epsilon" "deferred tracker (zombie): detection-time guard logged"
+}
+
+test_deferred_tracker_mailer_gate_crashed() {
+  # Marker lands AFTER detection (plain-show call 1) but BEFORE the mailer
+  # re-check (plain-show call 2) — the exact window where every historical
+  # bypass fired. The mailer must refuse the RESTART_POLECAT mail.
+  setup_case
+  add_polecat zeta session-dead
+  printf '1\n' > "$TEST_STATE/deferred_after/gt-hook-zeta"
+  run_script
+
+  assert_file_empty "$TEST_STATE/mail.log" "mailer gate (crashed): no restart mail"
+  assert_file_contains "$TEST_STATE/output.log" "MAILER-GATE: gt-zeta" "mailer gate (crashed): refusal logged"
+}
+
+test_deferred_tracker_mailer_gate_zombie() {
+  setup_case
+  add_polecat eta agent-dead
+  printf '1\n' > "$TEST_STATE/deferred_after/gt-hook-eta"
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "mailer gate (zombie): zombie session left untouched"
+  assert_file_empty "$TEST_STATE/mail.log" "mailer gate (zombie): no restart mail"
+  assert_file_contains "$TEST_STATE/output.log" "MAILER-GATE: gt-eta" "mailer gate (zombie): refusal logged"
+}
+
 test_healthy_runtime opencode
 test_healthy_runtime bun
 test_healthy_runtime node
@@ -346,6 +420,10 @@ test_dead_agent_restarts_one
 test_dead_session_restarts_one
 test_closed_hook_skips_restart
 test_mass_death_skips_actions
+test_deferred_tracker_skips_crashed_restart
+test_deferred_tracker_skips_zombie_restart
+test_deferred_tracker_mailer_gate_crashed
+test_deferred_tracker_mailer_gate_zombie
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Problem

When a plugin ships a `run.sh`, the daemon's dog dispatch path never executes it — it only feeds `plugin.md` to an AI dog as a prompt (with `FormatMailBody` asking the dog to run the script). In practice dogs skim past that instruction: a correct code guard added to `plugins/stuck-agent-dog/run.sh` protected nothing for two days, and six false RESTART_POLECAT notifications fired on deliberately-stopped polecats across two prompt-level fix attempts. Instruction placement must match the execution layer: code guards need a code execution path.

## Fix

**The daemon executes `run.sh` itself; the exit code gates the AI agent step.**

- `internal/plugin/runner.go` (new): `RunScript()` executes `plugins/<name>/run.sh` — cwd = plugin dir, `GT_TOWN_ROOT` set, `execution.timeout` enforced (default 5m, process-group kill so children can't hold the output pipe past the deadline).
- Exit-code contract (documented in the plugins README template, `docs/design/plugin-system.md`, and the stuck-agent-dog EXECUTION NOTE):
  - `0` — script completed the plugin run; no agent step
  - `10` — pre-checks passed; dispatch an AI dog with the plugin.md instructions + script output tail
  - anything else / timeout — failure, recorded `result:failure`; agent step NOT dispatched (fail-safe)
- `internal/daemon/handler.go`: `dispatchPlugins` routes `HasRunScript` plugins through `startScriptPlugin` — async so the patrol loop never blocks behind a script; a per-plugin in-flight set prevents overlap across heartbeats; the dispatch receipt is recorded at launch so the cooldown gate holds while the script runs. `dispatchPluginToDog` is extracted and shared with the post-script agent step; `FormatAgentStepMailBody` tells the dog the script already ran and must not be re-run.
- Defense-in-depth in `plugins/stuck-agent-dog/run.sh`: both RESTART_POLECAT mailer loops re-check the hook bead's DEFERRED-TRACKER marker immediately before mailing and refuse it — the mailer step is where every historical bypass fired (the detection-time guard already upstream stays as the first layer).

## Tests

- 10 new tests in `internal/plugin/runner_test.go` (exit-code contract, timeout fail-safe, cwd/env, agent-step mail body).
- 4 new tests in `internal/daemon/handler_script_plugin_test.go` (script-instead-of-dog, fail-safe on nonzero exit, exit-10 agent-step attempt, in-flight dedupe).
- 4 new cases in `plugins/stuck-agent-dog/run_test.sh` (detection-time guard crashed+zombie; mailer-gate race crashed+zombie via plain-`bd show` call counting in the fake).

Gates: `go build ./...` + `go vet` clean; `internal/plugin`, `internal/rig`, `internal/daemon` (217s) suites pass; `run_test.sh` 49/49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)