### PR TITLE
fix(daemon): converge children schema envelope parsing

### DIFF
--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -262,25 +263,66 @@ type childInfo struct {
 }
 
 // parseChildrenJSON parses the output of `bd show <id> --children --json`.
-// bd returns a map keyed by parent ID: {"hq-wisp-abc": [{...}, ...]}.
-// For forward compatibility, a bare array is also accepted.
+// bd returns a map keyed by parent ID plus envelope metadata:
+// {"hq-wisp-abc": [{...}, ...], "schema_version": 1}.
+// For legacy compatibility, a bare array is also accepted.
 func parseChildrenJSON(raw string) ([]childInfo, error) {
-	data := []byte(raw)
+	data := bytes.TrimSpace([]byte(raw))
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty children JSON")
+	}
 
 	var arr []childInfo
-	if err := json.Unmarshal(data, &arr); err == nil {
+	if data[0] == '[' {
+		if err := json.Unmarshal(data, &arr); err != nil {
+			return nil, err
+		}
 		return arr, nil
 	}
 
-	var wrapped map[string][]childInfo
-	if err := json.Unmarshal(data, &wrapped); err == nil {
-		for _, children := range wrapped {
-			return children, nil
-		}
-		return nil, nil
+	if data[0] != '{' {
+		return nil, fmt.Errorf("unrecognized JSON shape: %.200s", raw)
 	}
 
-	return nil, fmt.Errorf("unrecognized JSON shape: %.200s", raw)
+	var wrapped map[string]json.RawMessage
+	if err := json.Unmarshal(data, &wrapped); err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(wrapped))
+	for key := range wrapped {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var children []childInfo
+	sawChildArray := false
+	for _, key := range keys {
+		if key == "schema_version" {
+			continue
+		}
+
+		value := bytes.TrimSpace(wrapped[key])
+		if len(value) == 0 {
+			return nil, fmt.Errorf("empty child payload for key %q", key)
+		}
+		if value[0] != '[' {
+			return nil, fmt.Errorf("non-array child payload for key %q", key)
+		}
+
+		var group []childInfo
+		if err := json.Unmarshal(value, &group); err != nil {
+			return nil, fmt.Errorf("parse child array for key %q: %w", key, err)
+		}
+		children = append(children, group...)
+		sawChildArray = true
+	}
+
+	if !sawChildArray {
+		return nil, fmt.Errorf("children JSON object has no child arrays")
+	}
+
+	return children, nil
 }
 
 // knownSteps returns the list of known step slugs for debugging.

--- a/internal/daemon/dog_molecule_test.go
+++ b/internal/daemon/dog_molecule_test.go
@@ -1,6 +1,9 @@
 package daemon
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestParseWispID(t *testing.T) {
 	tests := []struct {
@@ -70,34 +73,74 @@ func TestStripANSI(t *testing.T) {
 
 func TestParseChildrenJSON(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		wantCount int
-		wantErr   bool
+		name    string
+		input   string
+		wantIDs []string
+		wantErr bool
 	}{
 		{
-			name:      "bare array",
-			input:     `[{"id":"a","title":"Probe","status":"open"}]`,
-			wantCount: 1,
+			name:    "bare array",
+			input:   `[{"id":"a","title":"Probe","status":"open"}]`,
+			wantIDs: []string{"a"},
 		},
 		{
-			name:      "map wrapper from bd show",
-			input:     `{"hq-wisp-root":[{"id":"hq-wisp-a","title":"Probe","status":"open"},{"id":"hq-wisp-b","title":"Report","status":"open"}]}`,
-			wantCount: 2,
+			name:    "map wrapper from bd show",
+			input:   `{"hq-wisp-root":[{"id":"hq-wisp-a","title":"Probe","status":"open"},{"id":"hq-wisp-b","title":"Report","status":"open"}]}`,
+			wantIDs: []string{"hq-wisp-a", "hq-wisp-b"},
 		},
 		{
-			name:      "empty map wrapper",
-			input:     `{"hq-wisp-root":[]}`,
-			wantCount: 0,
+			name:    "empty map wrapper",
+			input:   `{"hq-wisp-root":[]}`,
+			wantIDs: []string{},
 		},
 		{
-			name:      "empty array",
-			input:     `[]`,
-			wantCount: 0,
+			name:    "schema metadata with children",
+			input:   `{"hq-wisp-root":[{"id":"hq-wisp-a","title":"Probe","status":"open"}],"schema_version":1}`,
+			wantIDs: []string{"hq-wisp-a"},
+		},
+		{
+			name:    "schema metadata with empty children",
+			input:   `{"hq-wisp-root":[],"schema_version":1}`,
+			wantIDs: []string{},
+		},
+		{
+			name:    "multiple child arrays are deterministic",
+			input:   `{"hq-wisp-b":[{"id":"b-step","title":"Report","status":"open"}],"schema_version":1,"hq-wisp-a":[{"id":"a-step","title":"Probe","status":"open"}]}`,
+			wantIDs: []string{"a-step", "b-step"},
+		},
+		{
+			name:    "schema key is metadata even if array-valued",
+			input:   `{"schema_version":[{"id":"metadata","title":"Ignore","status":"open"}],"hq-wisp-root":[{"id":"hq-wisp-a","title":"Probe","status":"open"}]}`,
+			wantIDs: []string{"hq-wisp-a"},
+		},
+		{
+			name:    "empty array",
+			input:   `[]`,
+			wantIDs: []string{},
 		},
 		{
 			name:    "invalid json",
 			input:   `not json`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed child array",
+			input:   `{"hq-wisp-root":[{"id":1}],"schema_version":1}`,
+			wantErr: true,
+		},
+		{
+			name:    "non-array child payload",
+			input:   `{"hq-wisp-root":1,"schema_version":1}`,
+			wantErr: true,
+		},
+		{
+			name:    "metadata only is not silent skip-all",
+			input:   `{"schema_version":1}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty object is not silent skip-all",
+			input:   `{}`,
 			wantErr: true,
 		},
 	}
@@ -115,8 +158,13 @@ func TestParseChildrenJSON(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
-			if len(got) != tt.wantCount {
-				t.Errorf("got %d children, want %d", len(got), tt.wantCount)
+
+			gotIDs := make([]string, 0, len(got))
+			for _, child := range got {
+				gotIDs = append(gotIDs, child.ID)
+			}
+			if !reflect.DeepEqual(gotIDs, tt.wantIDs) {
+				t.Errorf("got child IDs %v, want %v", gotIDs, tt.wantIDs)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- replace the typed children wrapper with one canonical RawMessage envelope decoder
- ignore only shipped schema_version metadata and flatten child arrays deterministically
- fail closed on malformed, unexpected non-array, metadata-only, and empty object payloads

## Verification
- CGO_ENABLED=0 go test ./internal/daemon -run '^TestParseChildrenJSON$|^TestDogMolGracefulDegradation$' -count=1
- CGO_ENABLED=0 go test ./internal/formula -run '^TestParseRealFormulas$|^TestAllDogFormulas_CanBeWisped$|^TestDeaconPatrolHasHeartbeatSteps$' -count=1
- CGO_ENABLED=0 go test ./internal/cmd -run '^TestBuildStepAudit$' -count=1
- git diff --check upstream/main...HEAD
- PR Sheriff 15 research + 5 pre + 5 exact-head post reviews
- gt-pr-sheriff-check --merge-gate: PASS, merge_replacement

Carries forward PR #4498 with attribution. Related prior work: #4327, #4143, #4449. Keep those PRs open until this replacement is merged and verified.