### PR TITLE
fix(scheduler): use authoritative dispatch plan

### DIFF
--- a/internal/cmd/capacity_dispatch.go
+++ b/internal/cmd/capacity_dispatch.go
@@ -73,9 +73,95 @@ var fireCrossRigEscalation = func(rig, prefix, beadID string) {
 // before a sling context is closed as circuit-broken.
 const maxDispatchFailures = 3
 
+type schedulerDispatchPlan struct {
+	State       *capacity.SchedulerState
+	MaxPolecats int
+	BatchSize   int
+	SpawnDelay  time.Duration
+	Capacity    polecatCapacitySnapshot
+	Scheduled   []scheduledBeadInfo
+	Ready       []capacity.PendingBead
+	Plan        capacity.DispatchPlan
+}
+
+func buildSchedulerDispatchPlan(townRoot string, batchOverride int, cleanup bool) (*schedulerDispatchPlan, error) {
+	state, err := capacity.LoadState(townRoot)
+	if err != nil {
+		return nil, fmt.Errorf("loading scheduler state: %w", err)
+	}
+
+	settingsPath := config.TownSettingsPath(townRoot)
+	settings, err := config.LoadOrCreateTownSettings(settingsPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading town settings: %w", err)
+	}
+	schedulerCfg := settings.Scheduler
+	if schedulerCfg == nil {
+		schedulerCfg = capacity.DefaultSchedulerConfig()
+	}
+
+	maxPolecats := schedulerCfg.GetMaxPolecats()
+	batchSize := schedulerCfg.GetBatchSize()
+	if batchOverride > 0 {
+		batchSize = batchOverride
+	}
+	spawnDelay := schedulerCfg.GetSpawnDelay()
+
+	if cleanup && !state.Paused && maxPolecats > 0 {
+		if err := cleanupStaleContexts(townRoot); err != nil {
+			return nil, fmt.Errorf("cleaning stale scheduler contexts: %w", err)
+		}
+	}
+
+	assessments, blockedErr := assessScheduledContexts(townRoot)
+	if blockedErr != nil {
+		return nil, blockedErr
+	}
+
+	snapshot, err := polecatCapacitySnapshotForTownNoCleanup(townRoot)
+	if cleanup {
+		snapshot, err = polecatCapacitySnapshotForTown(townRoot)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("loading polecat capacity: %w", err)
+	}
+
+	ready := readySlingContextsFromAssessments(assessments)
+	dispatchPlan := capacity.PlanDispatch(snapshot.Free, batchSize, ready)
+	if len(ready) > 0 {
+		switch {
+		case state.Paused:
+			dispatchPlan = capacity.DispatchPlan{Skipped: len(ready), Reason: "paused"}
+		case maxPolecats <= 0:
+			dispatchPlan = capacity.DispatchPlan{Skipped: len(ready), Reason: "direct-mode"}
+		}
+	}
+
+	return &schedulerDispatchPlan{
+		State:       state,
+		MaxPolecats: maxPolecats,
+		BatchSize:   batchSize,
+		SpawnDelay:  spawnDelay,
+		Capacity:    snapshot,
+		Scheduled:   scheduledBeadInfosFromAssessments(assessments),
+		Ready:       ready,
+		Plan:        dispatchPlan,
+	}, nil
+}
+
 // dispatchScheduledWork is the main dispatch loop for the capacity scheduler.
 // Called by both `gt scheduler run` and the daemon heartbeat.
 func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun bool) (int, error) {
+	if dryRun {
+		dispatchPlan, err := buildSchedulerDispatchPlan(townRoot, batchOverride, false)
+		if err != nil {
+			return 0, fmt.Errorf("planning dispatch: %w", err)
+		}
+		dispatchPlan.Plan = validateDryRunDispatchPlan(townRoot, dispatchPlan.Plan)
+		printSchedulerDryRunPlan(dispatchPlan)
+		return 0, nil
+	}
+
 	// Acquire exclusive lock to prevent concurrent dispatch
 	runtimeDir := filepath.Join(townRoot, ".runtime")
 	_ = os.MkdirAll(runtimeDir, 0755)
@@ -86,83 +172,46 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 		return 0, fmt.Errorf("acquiring dispatch lock: %w", err)
 	}
 	if !locked {
-		return 0, nil
+		if isDaemonDispatch() {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("scheduler dispatch already in progress (lock held: %s)", lockFile)
 	}
 	defer func() { _ = fileLock.Unlock() }()
 
-	// Load scheduler state
-	state, err := capacity.LoadState(townRoot)
+	dispatchPlan, err := buildSchedulerDispatchPlan(townRoot, batchOverride, true)
 	if err != nil {
-		return 0, fmt.Errorf("loading scheduler state: %w", err)
+		return 0, fmt.Errorf("planning dispatch: %w", err)
 	}
 
-	if state.Paused {
-		if !dryRun {
-			fmt.Printf("%s Scheduler is paused (by %s), skipping dispatch\n", style.Dim.Render("⏸"), state.PausedBy)
+	if dispatchPlan.State.Paused {
+		if !isDaemonDispatch() {
+			fmt.Printf("%s Scheduler is paused (by %s), skipping %d ready bead(s)\n",
+				style.Dim.Render("⏸"), dispatchPlan.State.PausedBy, len(dispatchPlan.Ready))
 		}
 		return 0, nil
-	}
-
-	// Load town settings for scheduler config
-	settingsPath := config.TownSettingsPath(townRoot)
-	settings, err := config.LoadOrCreateTownSettings(settingsPath)
-	if err != nil {
-		return 0, fmt.Errorf("loading town settings: %w", err)
-	}
-
-	schedulerCfg := settings.Scheduler
-	if schedulerCfg == nil {
-		schedulerCfg = capacity.DefaultSchedulerConfig()
 	}
 
 	// Nothing to dispatch when scheduler is in direct dispatch or disabled mode.
-	maxPolecats := schedulerCfg.GetMaxPolecats()
-	if maxPolecats <= 0 {
-		if !dryRun && !isDaemonDispatch() {
-			staleBeads, _ := getReadySlingContexts(townRoot)
-			if len(staleBeads) > 0 {
+	if dispatchPlan.MaxPolecats <= 0 {
+		if !isDaemonDispatch() {
+			if len(dispatchPlan.Scheduled) > 0 {
 				fmt.Printf("%s %d context bead(s) still open from a previous deferred mode\n",
-					style.Warning.Render("⚠"), len(staleBeads))
+					style.Warning.Render("⚠"), len(dispatchPlan.Scheduled))
 				fmt.Printf("  Use: gt scheduler clear  (close all sling context beads)\n")
 				fmt.Printf("  Or:  gt config set scheduler.max_polecats N  (re-enable deferred dispatch)\n")
+			} else {
+				fmt.Println("No ready beads scheduled for dispatch")
 			}
 		}
 		return 0, nil
-	}
-
-	// Determine limits
-	batchSize := schedulerCfg.GetBatchSize()
-	if batchOverride > 0 {
-		batchSize = batchOverride
-	}
-	spawnDelay := schedulerCfg.GetSpawnDelay()
-
-	// Clean up invalid/stale contexts before querying for ready beads.
-	// Skip during dry-run to avoid mutating state.
-	if !dryRun {
-		cleanupStaleContexts(townRoot)
 	}
 
 	// Wire up the DispatchCycle
 	successfulRigs := make(map[string]bool)
 	// Track polecat names from dispatch results, keyed by context bead ID.
 	polecatNames := make(map[string]string)
-	lastCapacitySnapshot := polecatCapacitySnapshot{Max: maxPolecats}
 	cycle := &capacity.DispatchCycle{
-		AvailableCapacity: func() (int, error) {
-			snapshot, err := polecatCapacitySnapshotForTown(townRoot)
-			if err != nil {
-				return 0, err
-			}
-			lastCapacitySnapshot = snapshot
-			if snapshot.Free <= 0 {
-				return 0, nil // No free slots — PlanDispatch treats <= 0 as no capacity
-			}
-			return snapshot.Free, nil
-		},
-		QueryPending: func() ([]capacity.PendingBead, error) {
-			return getReadySlingContexts(townRoot)
-		},
 		Validate: func(b capacity.PendingBead) error {
 			return validatePendingBeadForDispatch(townRoot, b, true)
 		},
@@ -219,23 +268,15 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 			}
 			recordDispatchFailure(beadsForPendingContext(townRoot, b), b, err)
 		},
-		BatchSize:  batchSize,
-		SpawnDelay: spawnDelay,
+		SpawnDelay: dispatchPlan.SpawnDelay,
 	}
 
-	if dryRun {
-		plan, planErr := cycle.Plan()
-		if planErr != nil {
-			return 0, fmt.Errorf("planning dispatch: %w", planErr)
-		}
-		plan = validateDryRunDispatchPlan(townRoot, plan)
-		printDryRunPlan(plan, lastCapacitySnapshot, batchSize)
-		return 0, nil
-	}
-
-	report, err := cycle.Run()
+	report, err := cycle.RunPlan(dispatchPlan.Plan)
 	if err != nil {
 		return 0, fmt.Errorf("dispatch cycle failed: %w", err)
+	}
+	if len(dispatchPlan.Plan.ToDispatch) > 0 && report.Dispatched == 0 && report.Failed == 0 {
+		return 0, fmt.Errorf("scheduler dispatch invariant violation: plan had %d dispatchable bead(s) but no dispatch result", len(dispatchPlan.Plan.ToDispatch))
 	}
 
 	// Wake rig agents for each unique rig that had successful dispatches.
@@ -260,15 +301,43 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 		fmt.Printf("\n%s Dispatched %d, failed %d (reason: %s)\n",
 			style.Bold.Render("✓"), report.Dispatched, report.Failed, report.Reason)
 	} else if report.Skipped > 0 {
-		snapshot, err := polecatCapacitySnapshotForTown(townRoot)
-		if err != nil {
-			snapshot = lastCapacitySnapshot
-		}
-		fmt.Printf("\n%s Skipped %d bead(s) — zero capacity (working: %d recovery_blocked: %d reservations: %d reusable_idle: %d pending_mr: %d)\n",
-			style.Dim.Render("○"), report.Skipped, snapshot.Working, snapshot.RecoveryBlocked, snapshot.Reservations, snapshot.ReusableIdle, snapshot.PendingMR)
+		printDispatchNoOp(report, dispatchPlan.Capacity)
+	} else if !isDaemonDispatch() {
+		printDispatchNoOp(report, dispatchPlan.Capacity)
 	}
 
 	return report.Dispatched, nil
+}
+
+func printSchedulerDryRunPlan(dispatchPlan *schedulerDispatchPlan) {
+	if dispatchPlan.State.Paused {
+		fmt.Printf("Scheduler is paused (by %s); %d ready bead(s) not dispatched\n",
+			dispatchPlan.State.PausedBy, len(dispatchPlan.Ready))
+		return
+	}
+	if dispatchPlan.MaxPolecats <= 0 {
+		if len(dispatchPlan.Scheduled) == 0 {
+			fmt.Println("No ready beads scheduled for dispatch")
+			return
+		}
+		fmt.Printf("Scheduler is in direct dispatch mode (scheduler.max_polecats=%d); %d open context bead(s) will not dispatch\n",
+			dispatchPlan.MaxPolecats, len(dispatchPlan.Scheduled))
+		return
+	}
+	printDryRunPlan(dispatchPlan.Plan, dispatchPlan.Capacity, dispatchPlan.BatchSize)
+}
+
+func printDispatchNoOp(report capacity.DispatchReport, snapshot polecatCapacitySnapshot) {
+	switch report.Reason {
+	case "none":
+		fmt.Println("No ready beads scheduled for dispatch")
+	case "capacity":
+		fmt.Printf("\n%s No capacity: %d ready bead(s) waiting (working: %d recovery_blocked: %d reservations: %d reusable_idle: %d pending_mr: %d)\n",
+			style.Dim.Render("○"), report.Skipped, snapshot.Working, snapshot.RecoveryBlocked, snapshot.Reservations, snapshot.ReusableIdle, snapshot.PendingMR)
+	default:
+		fmt.Printf("\n%s No dispatchable beads (reason: %s, skipped: %d)\n",
+			style.Dim.Render("○"), report.Reason, report.Skipped)
+	}
 }
 
 // printDryRunPlan displays a dry-run dispatch plan.
@@ -286,7 +355,14 @@ func printDryRunPlan(plan capacity.DispatchPlan, snapshot polecatCapacitySnapsho
 
 	totalReady := len(plan.ToDispatch) + plan.Skipped
 	if len(plan.ToDispatch) == 0 {
-		fmt.Printf("No capacity: %s, %d ready bead(s) waiting\n", capStr, totalReady)
+		switch plan.Reason {
+		case "capacity":
+			fmt.Printf("No capacity: %s, %d ready bead(s) waiting\n", capStr, totalReady)
+		case "validation":
+			fmt.Printf("No dispatchable beads: validation failed for %d candidate(s)\n", totalReady)
+		default:
+			fmt.Printf("No dispatchable beads: reason=%s, %d candidate(s) skipped\n", plan.Reason, totalReady)
+		}
 		return
 	}
 
@@ -345,8 +421,11 @@ func beadsForContextRecord(rec slingContextRecord) *beads.Beads {
 
 // cleanupStaleContexts closes invalid and stale sling context beads.
 // Called explicitly before the dispatch cycle to separate cleanup from querying.
-func cleanupStaleContexts(townRoot string) {
-	contexts := listAllSlingContextRecords(townRoot)
+func cleanupStaleContexts(townRoot string) error {
+	contexts, err := listAllSlingContextRecords(townRoot)
+	if err != nil {
+		return err
+	}
 
 	// First pass: close invalid and circuit-broken contexts, collect work bead IDs
 	// that need status checks for stale detection.
@@ -367,7 +446,7 @@ func cleanupStaleContexts(townRoot string) {
 	}
 
 	if len(staleCheckContexts) == 0 {
-		return
+		return nil
 	}
 
 	// Collect work bead IDs to fetch
@@ -391,6 +470,7 @@ func cleanupStaleContexts(townRoot string) {
 			_ = beadsForContextRecord(ctx).CloseSlingContext(ctx.issue.ID, "stale-work-bead")
 		}
 	}
+	return nil
 }
 
 // beadStatusInfo holds batch-fetched bead status, title, and labels.
@@ -498,7 +578,10 @@ func groupBeadIDsByResolvedBeadsDir(townRoot string, ids []string) map[string][]
 }
 
 func assessScheduledContexts(townRoot string) ([]scheduledContextAssessment, error) {
-	contexts := listAllSlingContextRecords(townRoot)
+	contexts, err := listAllSlingContextRecords(townRoot)
+	if err != nil {
+		return nil, err
+	}
 	if len(contexts) == 0 {
 		return nil, nil
 	}
@@ -564,7 +647,10 @@ func getReadySlingContexts(townRoot string) ([]capacity.PendingBead, error) {
 	if blockedErr != nil {
 		return nil, blockedErr
 	}
+	return readySlingContextsFromAssessments(assessments), nil
+}
 
+func readySlingContextsFromAssessments(assessments []scheduledContextAssessment) []capacity.PendingBead {
 	var result []capacity.PendingBead
 	for _, assessment := range assessments {
 		if !assessment.ready {
@@ -590,7 +676,7 @@ func getReadySlingContexts(townRoot string) ([]capacity.PendingBead, error) {
 		})
 	}
 
-	return result, nil
+	return result
 }
 
 // dispatchSingleBead dispatches one scheduled bead via executeSling.
@@ -737,24 +823,31 @@ func recordDispatchFailure(townBeads *beads.Beads, b capacity.PendingBead, dispa
 // Deduplicates by context ID: different search dirs can resolve to the same
 // underlying beads DB (e.g., when a rig's top-level .beads is a redirect to
 // mayor/rig/.beads), and both paths would otherwise return the same contexts.
-func listAllSlingContexts(townRoot string) []*beads.Issue {
-	records := listAllSlingContextRecords(townRoot)
+func listAllSlingContexts(townRoot string) ([]*beads.Issue, error) {
+	records, err := listAllSlingContextRecords(townRoot)
+	if err != nil {
+		return nil, err
+	}
 	all := make([]*beads.Issue, 0, len(records))
 	for _, rec := range records {
 		all = append(all, rec.issue)
 	}
-	return all
+	return all, nil
 }
 
-func listAllSlingContextRecords(townRoot string) []slingContextRecord {
+func listAllSlingContextRecords(townRoot string) ([]slingContextRecord, error) {
 	var records []slingContextRecord
 	seen := make(map[string]bool)
-	for _, dir := range beadsSearchDirs(townRoot) {
+	dirs, err := beadsSearchDirs(townRoot)
+	if err != nil {
+		return nil, err
+	}
+	for _, dir := range dirs {
 		beadsDir := beads.ResolveBeadsDir(dir)
 		b := beads.NewWithBeadsDir(dir, beadsDir)
 		contexts, err := b.ListOpenSlingContexts()
 		if err != nil {
-			continue // Partial failure is acceptable — skip unavailable dirs
+			return nil, fmt.Errorf("listing sling contexts in %s: %w", beadsDir, err)
 		}
 		for _, ctx := range contexts {
 			key := beadsDir + "\x00" + ctx.ID
@@ -765,7 +858,7 @@ func listAllSlingContextRecords(townRoot string) []slingContextRecord {
 			records = append(records, slingContextRecord{issue: ctx, workDir: dir, beadsDir: beadsDir})
 		}
 	}
-	return records
+	return records, nil
 }
 
 type blockedWorkQuery func(beadsDir string, groupedIDs []string) ([]byte, error)

--- a/internal/cmd/polecat_capacity_test.go
+++ b/internal/cmd/polecat_capacity_test.go
@@ -375,6 +375,37 @@ func TestPrintDryRunPlanUsesCapacitySnapshot(t *testing.T) {
 	}
 }
 
+func TestPrintDryRunPlanValidationReasonNotCapacity(t *testing.T) {
+	out := captureStdout(t, func() {
+		printDryRunPlan(capacity.DispatchPlan{
+			Skipped: 2,
+			Reason:  "validation",
+		}, polecatCapacitySnapshot{Max: 2, Free: 2}, 5)
+	})
+	if !strings.Contains(out, "validation failed for 2 candidate") {
+		t.Fatalf("dry-run output %q missing validation reason", out)
+	}
+	if strings.Contains(out, "No capacity") {
+		t.Fatalf("dry-run output %q should not report capacity for validation failures", out)
+	}
+}
+
+func TestPrintDispatchNoOpReportsExplicitReason(t *testing.T) {
+	out := captureStdout(t, func() {
+		printDispatchNoOp(capacity.DispatchReport{Reason: "none"}, polecatCapacitySnapshot{})
+	})
+	if !strings.Contains(out, "No ready beads scheduled for dispatch") {
+		t.Fatalf("none output = %q", out)
+	}
+
+	out = captureStdout(t, func() {
+		printDispatchNoOp(capacity.DispatchReport{Reason: "validation", Skipped: 1}, polecatCapacitySnapshot{})
+	})
+	if !strings.Contains(out, "No dispatchable beads") || !strings.Contains(out, "validation") {
+		t.Fatalf("validation output = %q", out)
+	}
+}
+
 func TestResolveTargetRigPassesHeldAdmissionToSpawn(t *testing.T) {
 	townRoot := setupPolecatCapacityRig(t, 1)
 	oldSpawn := spawnPolecatForSling

--- a/internal/cmd/scheduler.go
+++ b/internal/cmd/scheduler.go
@@ -137,7 +137,10 @@ func runSchedulerStatus(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("loading scheduler state: %w", err)
 	}
 
-	scheduled := listScheduledBeads(townRoot)
+	scheduled, err := listScheduledBeads(townRoot)
+	if err != nil {
+		return fmt.Errorf("listing scheduled beads: %w", err)
+	}
 
 	capacitySnapshot, err := polecatCapacitySnapshotForTown(townRoot)
 	if err != nil {
@@ -214,7 +217,10 @@ func runSchedulerList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	scheduled := listScheduledBeads(townRoot)
+	scheduled, err := listScheduledBeads(townRoot)
+	if err != nil {
+		return fmt.Errorf("listing scheduled beads: %w", err)
+	}
 
 	if schedulerListJSON {
 		enc := json.NewEncoder(os.Stdout)
@@ -310,7 +316,10 @@ func runSchedulerClear(cmd *cobra.Command, args []string) error {
 		// Close ALL sling contexts for this specific work bead (there may be
 		// duplicates if concurrent scheduleBead calls raced past idempotency).
 		// Scan all rig dirs since contexts live in target rig beads. (GH#3468)
-		contexts := listAllSlingContextRecords(townRoot)
+		contexts, err := listAllSlingContextRecords(townRoot)
+		if err != nil {
+			return fmt.Errorf("listing sling contexts: %w", err)
+		}
 
 		closed := 0
 		for _, ctx := range contexts {
@@ -334,7 +343,10 @@ func runSchedulerClear(cmd *cobra.Command, args []string) error {
 	}
 
 	// Close all open sling contexts across all dirs
-	allContexts := listAllSlingContextRecords(townRoot)
+	allContexts, err := listAllSlingContextRecords(townRoot)
+	if err != nil {
+		return fmt.Errorf("listing sling contexts: %w", err)
+	}
 
 	if len(allContexts) == 0 {
 		fmt.Println("Scheduler is already empty.")
@@ -367,8 +379,15 @@ func runSchedulerRun(cmd *cobra.Command, args []string) error {
 // listScheduledBeads returns info about all scheduled beads for display.
 // Reconciles sling context beads with work bead readiness to mark blocked status.
 // Uses batch fetch for work bead info to avoid N+1 subprocess spawns.
-func listScheduledBeads(townRoot string) []scheduledBeadInfo {
-	assessments, _ := assessScheduledContexts(townRoot)
+func listScheduledBeads(townRoot string) ([]scheduledBeadInfo, error) {
+	assessments, err := assessScheduledContexts(townRoot)
+	if err != nil {
+		return nil, err
+	}
+	return scheduledBeadInfosFromAssessments(assessments), nil
+}
+
+func scheduledBeadInfosFromAssessments(assessments []scheduledContextAssessment) []scheduledBeadInfo {
 	var result []scheduledBeadInfo
 	for _, assessment := range assessments {
 		bead, ok := scheduledBeadInfoFromWork(assessment.context.issue.Title, assessment.fields, assessment.info, assessment.found, assessment.ready)
@@ -405,12 +424,12 @@ func scheduledBeadInfoFromWork(ctxTitle string, fields *capacity.SlingContextFie
 
 // beadsSearchDirs returns directories to scan for scheduled beads:
 // the town root plus any rig directories that have a .beads/ subdirectory.
-func beadsSearchDirs(townRoot string) []string {
+func beadsSearchDirs(townRoot string) ([]string, error) {
 	dirs := []string{townRoot}
 	seen := map[string]bool{townRoot: true}
 	entries, err := os.ReadDir(townRoot)
 	if err != nil {
-		return dirs
+		return nil, fmt.Errorf("discovering scheduler beads search dirs: %w", err)
 	}
 	for _, e := range entries {
 		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") || e.Name() == "mayor" || e.Name() == "settings" {
@@ -429,7 +448,7 @@ func beadsSearchDirs(townRoot string) []string {
 			seen[mayorRigDir] = true
 		}
 	}
-	return dirs
+	return dirs, nil
 }
 
 // countActivePolecats counts all running polecat tmux sessions across all rigs.

--- a/internal/cmd/scheduler_dispatch_test.go
+++ b/internal/cmd/scheduler_dispatch_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gofrs/flock"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/scheduler/capacity"
+)
+
+func installFakeBD(t *testing.T, script string) {
+	t.Helper()
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir fake bd bin: %v", err)
+	}
+	fakeBD := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(fakeBD, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func setupSchedulerScanFailureTown(t *testing.T) string {
+	t.Helper()
+	townRoot := t.TempDir()
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor"),
+		filepath.Join(townRoot, ".beads"),
+		filepath.Join(townRoot, "rig", ".beads"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	installFakeBD(t, `#!/bin/sh
+case "$BEADS_DIR" in
+  */rig/.beads) echo "scan failed" >&2; exit 7 ;;
+  *) printf '[]\n'; exit 0 ;;
+esac
+`)
+	return townRoot
+}
+
+func TestDispatchScheduledWorkReportsHeldLock(t *testing.T) {
+	townRoot := t.TempDir()
+	runtimeDir := filepath.Join(townRoot, ".runtime")
+	if err := os.MkdirAll(runtimeDir, 0755); err != nil {
+		t.Fatalf("mkdir runtime: %v", err)
+	}
+	lockFile := filepath.Join(runtimeDir, "scheduler-dispatch.lock")
+	lock := flock.New(lockFile)
+	locked, err := lock.TryLock()
+	if err != nil {
+		t.Fatalf("TryLock: %v", err)
+	}
+	if !locked {
+		t.Fatal("test could not acquire scheduler dispatch lock")
+	}
+	t.Cleanup(func() { _ = lock.Unlock() })
+
+	_, err = dispatchScheduledWork(townRoot, "test", 1, false)
+	if err == nil {
+		t.Fatal("dispatchScheduledWork succeeded with held scheduler lock")
+	}
+	if !strings.Contains(err.Error(), "scheduler dispatch already in progress") || !strings.Contains(err.Error(), lockFile) {
+		t.Fatalf("error = %q, want explicit held lock reason with path", err.Error())
+	}
+}
+
+func TestValidateDryRunDispatchPlanMarksAllInvalidAsValidation(t *testing.T) {
+	townRoot := t.TempDir()
+	writeJSONFile(t, filepath.Join(townRoot, "mayor", "rigs.json"), &config.RigsConfig{
+		Version: config.CurrentRigsVersion,
+		Rigs: map[string]config.RigEntry{
+			"testrig": {BeadsConfig: &config.BeadsConfig{Prefix: "gt"}},
+		},
+	})
+
+	plan := validateDryRunDispatchPlan(townRoot, capacity.DispatchPlan{
+		ToDispatch: []capacity.PendingBead{{ID: "ctx-1", WorkBeadID: "hq-one", TargetRig: "testrig"}},
+		Reason:     "ready",
+	})
+
+	if len(plan.ToDispatch) != 0 || plan.Skipped != 1 || plan.Reason != "validation" {
+		t.Fatalf("validated plan = %+v, want no dispatch, skipped=1, reason=validation", plan)
+	}
+}
+
+func TestListAllSlingContextRecordsFailsOnPartialScanFailure(t *testing.T) {
+	townRoot := setupSchedulerScanFailureTown(t)
+
+	_, err := listAllSlingContextRecords(townRoot)
+	if err == nil {
+		t.Fatal("partial sling-context scan failure should fail closed")
+	}
+	if !strings.Contains(err.Error(), "listing sling contexts") || !strings.Contains(err.Error(), filepath.Join("rig", ".beads")) {
+		t.Fatalf("error = %q, want explicit context scan failure", err.Error())
+	}
+}
+
+func TestAreScheduledFailsClosedOnContextScanFailure(t *testing.T) {
+	townRoot := setupSchedulerScanFailureTown(t)
+	oldCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCWD) })
+
+	got := areScheduled([]string{"gt-one", "gt-two"})
+	if !got["gt-one"] || !got["gt-two"] {
+		t.Fatalf("areScheduled on scan failure = %+v, want all requested IDs marked scheduled", got)
+	}
+}
+
+func TestRunSchedulerClearFailsOnContextScanFailure(t *testing.T) {
+	townRoot := setupSchedulerScanFailureTown(t)
+	oldCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCWD) })
+	oldClearBead := schedulerClearBead
+	schedulerClearBead = ""
+	t.Cleanup(func() { schedulerClearBead = oldClearBead })
+
+	err = runSchedulerClear(nil, nil)
+	if err == nil {
+		t.Fatal("scheduler clear succeeded with incomplete context scan")
+	}
+	if !strings.Contains(err.Error(), "listing sling contexts") {
+		t.Fatalf("error = %q, want sling context scan failure", err.Error())
+	}
+}

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -302,7 +302,11 @@ func createSlingContext(t *testing.T, hqPath string, fields *capacity.SlingConte
 // Returns nil if none found.
 func findSlingContext(t *testing.T, hqPath, workBeadID string) *capacity.SlingContextFields {
 	t.Helper()
-	for _, ctx := range listAllSlingContexts(hqPath) {
+	contexts, err := listAllSlingContexts(hqPath)
+	if err != nil {
+		t.Fatalf("listAllSlingContexts: %v", err)
+	}
+	for _, ctx := range contexts {
 		fields := beads.ParseSlingContextFields(ctx.Description)
 		if fields != nil && fields.WorkBeadID == workBeadID {
 			return fields
@@ -535,7 +539,11 @@ func TestSchedulerBlockedStatusReporting(t *testing.T) {
 		t.Fatalf("unblocked queued bead %s not found in scheduler list", blockedID)
 	}
 	contextCount := 0
-	for _, ctx := range listAllSlingContexts(hqPath) {
+	contexts, err := listAllSlingContexts(hqPath)
+	if err != nil {
+		t.Fatalf("listAllSlingContexts: %v", err)
+	}
+	for _, ctx := range contexts {
 		fields := beads.ParseSlingContextFields(ctx.Description)
 		if fields != nil && fields.WorkBeadID == blockedID {
 			contextCount++
@@ -752,7 +760,11 @@ func TestSchedulerSlingContextIdempotency(t *testing.T) {
 	// Verify: only one sling context exists across all rig dirs
 	// (sling contexts live in the target rig's beads dir per dee628d3).
 	count := 0
-	for _, ctx := range listAllSlingContexts(hqPath) {
+	contexts, err := listAllSlingContexts(hqPath)
+	if err != nil {
+		t.Fatalf("listAllSlingContexts: %v", err)
+	}
+	for _, ctx := range contexts {
 		fields := beads.ParseSlingContextFields(ctx.Description)
 		if fields != nil && fields.WorkBeadID == beadID {
 			count++

--- a/internal/cmd/sling_schedule.go
+++ b/internal/cmd/sling_schedule.go
@@ -340,7 +340,13 @@ func areScheduled(beadIDs []string) map[string]bool {
 	}
 
 	// Scan all rig beads dirs (sling contexts live in target rig's DB). (GH#3468)
-	contexts := listAllSlingContexts(townRoot)
+	contexts, err := listAllSlingContexts(townRoot)
+	if err != nil {
+		for _, id := range beadIDs {
+			result[id] = true
+		}
+		return result
+	}
 
 	// Build lookup of work bead IDs from open contexts. Cleanup owns stale-state
 	// closure; idempotency must not use a different definition of scheduled.

--- a/internal/scheduler/capacity/dispatch.go
+++ b/internal/scheduler/capacity/dispatch.go
@@ -111,7 +111,12 @@ func (c *DispatchCycle) Run() (DispatchReport, error) {
 	if err != nil {
 		return DispatchReport{}, err
 	}
+	return c.RunPlan(plan)
+}
 
+// RunPlan executes a precomputed dispatch plan. Used when callers need one
+// authoritative plan for rendering, validation, and dispatch.
+func (c *DispatchCycle) RunPlan(plan DispatchPlan) (DispatchReport, error) {
 	report := DispatchReport{
 		Skipped: plan.Skipped,
 		Reason:  plan.Reason,

--- a/internal/scheduler/capacity/dispatch_test.go
+++ b/internal/scheduler/capacity/dispatch_test.go
@@ -141,6 +141,59 @@ func TestDispatchCycle_Run_WithFailures(t *testing.T) {
 	}
 }
 
+func TestDispatchCycle_RunPlan_DoesNotRequery(t *testing.T) {
+	queried := false
+	checkedCapacity := false
+	dispatched := []string{}
+	successCalled := []string{}
+
+	cycle := &DispatchCycle{
+		AvailableCapacity: func() (int, error) {
+			checkedCapacity = true
+			return 0, nil
+		},
+		QueryPending: func() ([]PendingBead, error) {
+			queried = true
+			return nil, nil
+		},
+		Validate: func(b PendingBead) error {
+			if b.ID == "blocked" {
+				return errors.New("blocked")
+			}
+			return nil
+		},
+		Execute: func(b PendingBead) error {
+			dispatched = append(dispatched, b.ID)
+			return nil
+		},
+		OnSuccess: func(b PendingBead) error {
+			successCalled = append(successCalled, b.ID)
+			return nil
+		},
+		BatchSize: 10,
+	}
+
+	report, err := cycle.RunPlan(DispatchPlan{
+		ToDispatch: []PendingBead{{ID: "planned"}, {ID: "blocked"}},
+		Reason:     "ready",
+	})
+	if err != nil {
+		t.Fatalf("RunPlan() error: %v", err)
+	}
+	if queried || checkedCapacity {
+		t.Fatalf("RunPlan re-queried: queried=%v checkedCapacity=%v", queried, checkedCapacity)
+	}
+	if report.Dispatched != 1 || report.Failed != 1 || report.Reason != "ready" {
+		t.Fatalf("report = %+v, want dispatched=1 failed=1 reason=ready", report)
+	}
+	if len(dispatched) != 1 || dispatched[0] != "planned" {
+		t.Fatalf("dispatched = %v, want [planned]", dispatched)
+	}
+	if len(successCalled) != 1 || successCalled[0] != "planned" {
+		t.Fatalf("successCalled = %v, want [planned]", successCalled)
+	}
+}
+
 func TestDispatchCycle_Run_NoBeads(t *testing.T) {
 	cycle := &DispatchCycle{
 		AvailableCapacity: func() (int, error) { return 5, nil },


### PR DESCRIPTION
Replacement for PR #4515, which remains dirty/status merge-failed.

This carries forward the accepted scheduler no-op fix on current `main` as one clean attributed commit. It collapses scheduler dry-run/live execution onto one authoritative dispatch plan, executes that exact plan without re-query drift, and fails closed when sling-context scans are incomplete.

Evidence is recorded on bead `gt-pr-4515-repair`:
- 15 independent research legs complete before code changes
- 5 approving pre-implementation reviews complete before code changes
- 5 exact-final-head post reviews complete or implementation-approved, with final checker evidence resolving durable-evidence blockers
- `gt-pr-sheriff-check --evidence /tmp/opencode/gt-pr-4515-evidence.json --merge-gate` passed for head `0a2df14af283eba9fde2320d178880684d4db34c`

Focused verification recorded on `gt-pr-4515-repair`:
- `CGO_ENABLED=0 go test ./internal/scheduler/capacity -count=1`
- focused `CGO_ENABLED=0 go test ./internal/cmd ... -count=1 -timeout=60s`
- `CGO_ENABLED=0 go test -run ^ ./cmd/gt ./internal/cmd ./internal/scheduler/capacity -count=1`
- `git diff --check upstream/main...HEAD`

Known environment note: broad `CGO_ENABLED=0 go test ./internal/cmd -count=1 -timeout=3m` timed out in unrelated `TestPrimeFlagCombinations`; focused scheduler gates passed.

Original PR: #4515
Original head: `0d2bb819ef66b506c151626c51ba520106244964`
Replacement head: `0a2df14af283eba9fde2320d178880684d4db34c`