### PR TITLE
test(daemon): cover children parser error branches

### DIFF
--- a/internal/daemon/dog_molecule_test.go
+++ b/internal/daemon/dog_molecule_test.go
@@ -119,6 +119,21 @@ func TestParseChildrenJSON(t *testing.T) {
 			wantIDs: []string{},
 		},
 		{
+			name:    "empty input",
+			input:   `   `,
+			wantErr: true,
+		},
+		{
+			name:    "malformed bare array",
+			input:   `[`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed object envelope",
+			input:   `{"hq-wisp-root":[`,
+			wantErr: true,
+		},
+		{
 			name:    "invalid json",
 			input:   `not json`,
 			wantErr: true,


### PR DESCRIPTION
Test-only follow-up for merged PR #4507 and attribution repair before closing superseded originals #4498/#4327/#4143/#4449.

This adds focused `parseChildrenJSON` regression coverage for trimmed empty input, malformed bare-array JSON, and malformed object-envelope JSON. It does not change production semantics.

Evidence is recorded on bead `gt-4507-credit`:
- 15 independent research legs complete
- 5 approving pre-implementation reviews complete
- 5 exact-final-head post-implementation reviews complete for `9aed9af7d9369b51222e53b6ded4c4f126a70e80`
- `gt-pr-sheriff-check --evidence /tmp/opencode/gt-4507-credit-pr-sheriff-evidence.json --merge-gate` passed

Verification recorded on `gt-4507-credit`:
- `CGO_ENABLED=0 go test ./internal/daemon -run TestParseChildrenJSON -count=1`
- `CGO_ENABLED=0 go test ./internal/daemon -count=1`
- `git diff --check upstream/main...HEAD`

Full local `CGO_ENABLED=0 go test ./...` was attempted; unrelated environment-sensitive failures occurred outside `internal/daemon`.

Follow-up-to: #4507
Original PR: #4498
Related PRs: #4327, #4143, #4449

Required trailers are present in the commit for Sean Bearden, Anthony Wong, and Claude.