### PR TITLE
fix(polecat): route identities to their rig database

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	beadsdk "github.com/steveyegge/beads"
+	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/telemetry"
 	"github.com/steveyegge/gastown/internal/util"
@@ -640,6 +641,17 @@ func (b *Beads) ForRoutedAgentBead() *Beads {
 		townRoot:   b.getTownRoot(),
 		noRoute:    true,
 	}
+}
+
+// ForAgentBeadID returns the storage wrapper for an agent identity. Polecat
+// identities are stored in their rig database; all other agent identities
+// retain the town-database behavior of ForAgentBead.
+func (b *Beads) ForAgentBeadID(id string) *Beads {
+	_, role, _, ok := ParseAgentBeadID(id)
+	if ok && role == constants.RolePolecat {
+		return b.ForRoutedAgentBead()
+	}
+	return b.ForAgentBead()
 }
 
 func (b *Beads) agentBeadTarget() *Beads {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -632,9 +632,13 @@ func (b *Beads) ForAgentBead() *Beads {
 // routed database. Polecat identities live alongside their rig's work beads,
 // so their rig-prefixed IDs must not be redirected to the town database.
 func (b *Beads) ForRoutedAgentBead() *Beads {
+	return b.forRoutedAgentBeadsDir(b.getResolvedBeadsDir())
+}
+
+func (b *Beads) forRoutedAgentBeadsDir(beadsDir string) *Beads {
 	return &Beads{
 		workDir:    b.workDir,
-		beadsDir:   b.getResolvedBeadsDir(),
+		beadsDir:   beadsDir,
 		isolated:   b.isolated,
 		serverPort: b.serverPort,
 		store:      b.store,
@@ -647,6 +651,13 @@ func (b *Beads) ForRoutedAgentBead() *Beads {
 // identities are stored in their rig database; all other agent identities
 // retain the town-database behavior of ForAgentBead.
 func (b *Beads) ForAgentBeadID(id string) *Beads {
+	if b.noRoute {
+		return b
+	}
+	if beadsDir := b.routedPolecatBeadsDir(id); beadsDir != "" {
+		return b.forRoutedAgentBeadsDir(beadsDir)
+	}
+
 	_, role, _, ok := ParseAgentBeadID(id)
 	if ok && role == constants.RolePolecat {
 		// Resolve the owning rig before disabling ID routing. Callers such as
@@ -655,6 +666,45 @@ func (b *Beads) ForAgentBeadID(id string) *Beads {
 		return b.forIssueID(id).ForRoutedAgentBead()
 	}
 	return b.ForAgentBead()
+}
+
+// routedPolecatBeadsDir resolves a polecat identity using the town's configured
+// routes. Agent ID parsing normally treats the first hyphen-delimited segment
+// as the prefix, but valid configured prefixes may themselves contain hyphens.
+func (b *Beads) routedPolecatBeadsDir(id string) string {
+	townRoot := b.getTownRoot()
+	if townRoot == "" {
+		return ""
+	}
+
+	routes, err := LoadRoutes(filepath.Join(townRoot, ".beads"))
+	if err != nil {
+		return ""
+	}
+
+	var targetPath string
+	longestPrefix := 0
+	for _, route := range routes {
+		if route.Path == "." || len(route.Prefix) <= longestPrefix || !strings.HasPrefix(id, route.Prefix) {
+			continue
+		}
+
+		// Parse the portion after the configured prefix with a known-safe
+		// synthetic prefix. This preserves ParseAgentBeadID's compatibility
+		// contract while recognizing route prefixes such as "long-prefix-".
+		_, role, _, ok := ParseAgentBeadID("gt-" + strings.TrimPrefix(id, route.Prefix))
+		if !ok || role != constants.RolePolecat {
+			continue
+		}
+
+		targetPath = route.Path
+		longestPrefix = len(route.Prefix)
+	}
+	if targetPath == "" {
+		return ""
+	}
+
+	return ResolveBeadsDir(filepath.Join(townRoot, targetPath))
 }
 
 func (b *Beads) agentBeadTarget() *Beads {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -649,7 +649,10 @@ func (b *Beads) ForRoutedAgentBead() *Beads {
 func (b *Beads) ForAgentBeadID(id string) *Beads {
 	_, role, _, ok := ParseAgentBeadID(id)
 	if ok && role == constants.RolePolecat {
-		return b.ForRoutedAgentBead()
+		// Resolve the owning rig before disabling ID routing. Callers such as
+		// patrol start at the town root, where pinning first would incorrectly
+		// target the town database.
+		return b.forIssueID(id).ForRoutedAgentBead()
 	}
 	return b.ForAgentBead()
 }

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -551,7 +551,10 @@ type Beads struct {
 	// bypass the bd subprocess and use the store directly. Follows the
 	// pattern in internal/daemon/convoy_manager.go. Callers are responsible
 	// for closing the store.
-	store beadsdk.Storage
+	store         beadsdk.Storage
+	storeBeadsDir string // Resolved directory for store; required before sharing it with a routed wrapper.
+	storeErr      error  // Failed routed-store binding; prevents an incorrect CLI fallback.
+	storeOpener   func(context.Context, string) (beadsdk.Storage, error)
 
 	// Lazy-cached town root for routing resolution.
 	// Populated on first call to getTownRoot() to avoid filesystem walk on every operation.
@@ -617,15 +620,7 @@ func (b *Beads) ForAgentBead() *Beads {
 		return b
 	}
 	townBeadsDir := filepath.Join(townRoot, ".beads")
-	return &Beads{
-		workDir:    townRoot,
-		beadsDir:   townBeadsDir,
-		isolated:   b.isolated,
-		serverPort: b.serverPort,
-		store:      b.store,
-		townRoot:   townRoot,
-		noRoute:    true,
-	}
+	return b.forAgentBeadsDir(townRoot, townBeadsDir)
 }
 
 // ForRoutedAgentBead returns a wrapper for agent beads stored in the current
@@ -636,15 +631,30 @@ func (b *Beads) ForRoutedAgentBead() *Beads {
 }
 
 func (b *Beads) forRoutedAgentBeadsDir(beadsDir string) *Beads {
-	return &Beads{
-		workDir:    b.workDir,
-		beadsDir:   beadsDir,
-		isolated:   b.isolated,
-		serverPort: b.serverPort,
-		store:      b.store,
-		townRoot:   b.getTownRoot(),
-		noRoute:    true,
+	return b.forAgentBeadsDir(b.workDir, beadsDir)
+}
+
+func (b *Beads) forAgentBeadsDir(workDir, beadsDir string) *Beads {
+	target := &Beads{
+		workDir:     workDir,
+		beadsDir:    beadsDir,
+		isolated:    b.isolated,
+		serverPort:  b.serverPort,
+		storeOpener: b.storeOpener,
+		townRoot:    b.getTownRoot(),
+		noRoute:     true,
 	}
+
+	store, err := b.rebindStore(beadsDir)
+	if err != nil {
+		target.storeErr = err
+		return target
+	}
+	target.store = store
+	if store != nil {
+		target.storeBeadsDir = target.getResolvedBeadsDir()
+	}
+	return target
 }
 
 // ForAgentBeadID returns the storage wrapper for an agent identity. Polecat
@@ -844,6 +854,10 @@ func (b *Beads) run(args ...string) ([]byte, error) {
 // --body-file=- that read multi-line content from stdin (avoids embedding
 // newlines in --description, which bd 1.0.3+ rejects).
 func (b *Beads) runWithStdin(stdinData []byte, args ...string) (_ []byte, retErr error) {
+	if b.storeErr != nil {
+		return nil, b.storeErr
+	}
+
 	start := time.Now()
 	// Declare buffers before defer so the closure captures them after cmd.Run.
 	var stdout, stderr bytes.Buffer
@@ -931,6 +945,10 @@ func (b *Beads) runWithStdin(stdinData []byte, args ...string) (_ []byte, retErr
 // (e.g., setting an hq-* hook bead on a gt-* agent bead).
 // See: sling_helpers.go verifyBeadExists/hookBeadWithRetry for the same pattern.
 func (b *Beads) runWithRouting(args ...string) (_ []byte, retErr error) { //nolint:unparam // mirrors run() signature for consistency
+	if b.storeErr != nil {
+		return nil, b.storeErr
+	}
+
 	start := time.Now()
 	var stdout, stderr bytes.Buffer
 	defer func() {
@@ -1634,6 +1652,13 @@ func (b *Beads) ReadyWithType(issueType string) ([]*Issue, error) {
 
 // Show returns detailed information about an issue.
 func (b *Beads) Show(id string) (*Issue, error) {
+	if b.storeErr != nil {
+		return nil, b.storeErr
+	}
+
+	// Route cross-rig queries via routes.jsonl so that rig-level bead IDs
+	// (e.g., "gt-abc123") resolve to the correct rig database.
+	// noRoute (see ForAgentBead) bypasses this for agent-bead lookups.
 	if !b.noRoute {
 		if target := b.forIssueID(id); target != b {
 			return target.Show(id)
@@ -2043,6 +2068,10 @@ func normalizeBugTitle(title string) string {
 
 // Update updates an existing issue.
 func (b *Beads) Update(id string, opts UpdateOptions) error {
+	if b.storeErr != nil {
+		return b.storeErr
+	}
+
 	if !b.noRoute {
 		if target := b.forIssueID(id); target != b {
 			return target.Update(id, opts)

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -627,6 +627,21 @@ func (b *Beads) ForAgentBead() *Beads {
 	}
 }
 
+// ForRoutedAgentBead returns a wrapper for agent beads stored in the current
+// routed database. Polecat identities live alongside their rig's work beads,
+// so their rig-prefixed IDs must not be redirected to the town database.
+func (b *Beads) ForRoutedAgentBead() *Beads {
+	return &Beads{
+		workDir:    b.workDir,
+		beadsDir:   b.getResolvedBeadsDir(),
+		isolated:   b.isolated,
+		serverPort: b.serverPort,
+		store:      b.store,
+		townRoot:   b.getTownRoot(),
+		noRoute:    true,
+	}
+}
+
 func (b *Beads) agentBeadTarget() *Beads {
 	if b.noRoute {
 		return b

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -555,6 +555,7 @@ type Beads struct {
 	storeBeadsDir string // Resolved directory for store; required before sharing it with a routed wrapper.
 	storeErr      error  // Failed routed-store binding; prevents an incorrect CLI fallback.
 	storeOpener   func(context.Context, string) (beadsdk.Storage, error)
+	storeOwner    *storeOwnership
 
 	// Lazy-cached town root for routing resolution.
 	// Populated on first call to getTownRoot() to avoid filesystem walk on every operation.
@@ -645,12 +646,13 @@ func (b *Beads) forAgentBeadsDir(workDir, beadsDir string) *Beads {
 		noRoute:     true,
 	}
 
-	store, err := b.rebindStore(beadsDir)
+	store, storeOwner, err := b.rebindStore(beadsDir)
 	if err != nil {
 		target.storeErr = err
 		return target
 	}
 	target.store = store
+	target.storeOwner = storeOwner
 	if store != nil {
 		target.storeBeadsDir = target.getResolvedBeadsDir()
 	}

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -1,6 +1,7 @@
 package beads
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	beadsdk "github.com/steveyegge/beads"
 )
 
 func installMockBDFixedShowOutput(t *testing.T, showOutput string) {
@@ -346,6 +349,95 @@ func TestForAgentBeadIDRoutesLongHyphenatedPrefixPolecatToRig(t *testing.T) {
 	}
 	if strings.Contains(logOutput, "BEADS_DIR="+townBeadsDir+" update "+polecatID) {
 		t.Fatalf("polecat lifecycle operation targeted town beads:\n%s", logOutput)
+	}
+}
+
+func TestForAgentBeadIDRebindsStoreToRoutedPolecatRig(t *testing.T) {
+	const polecatID = "long-hyphen-prefix-gastown-polecat-nux"
+
+	for _, tc := range []struct {
+		name  string
+		build func(string, beadsdk.Storage) *Beads
+	}{
+		{
+			name: "NewWithStore",
+			build: func(townRoot string, store beadsdk.Storage) *Beads {
+				return NewWithStore(townRoot, store)
+			},
+		},
+		{
+			name: "SetStore",
+			build: func(townRoot string, store beadsdk.Storage) *Beads {
+				b := New(townRoot)
+				b.SetStore(store)
+				return b
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			townRoot := t.TempDir()
+			rigPath := filepath.Join(townRoot, "gastown")
+			townBeadsDir := filepath.Join(townRoot, ".beads")
+			rigBeadsDir := filepath.Join(rigPath, ".beads")
+			if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+				t.Fatalf("mkdir mayor: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+				t.Fatalf("write town marker: %v", err)
+			}
+			for _, dir := range []string{townBeadsDir, rigBeadsDir} {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					t.Fatalf("mkdir %s: %v", dir, err)
+				}
+			}
+			if err := os.WriteFile(filepath.Join(townBeadsDir, "routes.jsonl"), []byte(`{"prefix":"long-hyphen-prefix-","path":"gastown"}
+{"prefix":"hq-","path":"."}
+`), 0644); err != nil {
+				t.Fatalf("write routes: %v", err)
+			}
+
+			hqStore := newMockStorage()
+			rigStore := newMockStorage()
+			hqStore.issues[polecatID] = &beadsdk.Issue{ID: polecatID, Title: "town polecat"}
+			rigStore.issues[polecatID] = &beadsdk.Issue{ID: polecatID, Title: "rig polecat"}
+
+			b := tc.build(townRoot, hqStore)
+			var opened []string
+			b.storeOpener = func(_ context.Context, beadsDir string) (beadsdk.Storage, error) {
+				opened = append(opened, filepath.Clean(beadsDir))
+				if filepath.Clean(beadsDir) != filepath.Clean(rigBeadsDir) {
+					t.Fatalf("opened store for %q, want %q", beadsDir, rigBeadsDir)
+				}
+				return rigStore, nil
+			}
+
+			routed := b.ForAgentBeadID(polecatID)
+			if routed.Store() != rigStore {
+				t.Fatal("routed polecat wrapper retained the town store instead of binding the rig store")
+			}
+			if len(opened) != 1 || opened[0] != filepath.Clean(rigBeadsDir) {
+				t.Fatalf("opened stores = %v, want only %q", opened, rigBeadsDir)
+			}
+
+			issue, err := routed.Show(polecatID)
+			if err != nil {
+				t.Fatalf("Show: %v", err)
+			}
+			if issue.Title != "rig polecat" {
+				t.Fatalf("Show title = %q, want rig store issue", issue.Title)
+			}
+
+			title := "updated rig polecat"
+			if err := routed.Update(polecatID, UpdateOptions{Title: &title}); err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+			if rigStore.issues[polecatID].Title != title {
+				t.Fatalf("rig store title = %q, want %q", rigStore.issues[polecatID].Title, title)
+			}
+			if hqStore.issues[polecatID].Title != "town polecat" {
+				t.Fatalf("town store was modified: %q", hqStore.issues[polecatID].Title)
+			}
+		})
 	}
 }
 

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -256,10 +256,15 @@ func TestForAgentBeadIDRoutesPolecatLifecycleWritesToRig(t *testing.T) {
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
 	}
+	if err := os.WriteFile(filepath.Join(townBeadsDir, "routes.jsonl"), []byte(`{"prefix":"gst-","path":"gastown"}
+{"prefix":"hq-","path":"."}
+`), 0644); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
 
 	const polecatID = "gst-gastown-polecat-nux"
 	logPath := installMockBDShowRecorder(t, `[{"id":"gst-gastown-polecat-nux","title":"Polecat nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: working\nactive_mr: gst-wisp-1"}]`)
-	lifecycleBeads := New(rigPath).ForAgentBeadID(polecatID)
+	lifecycleBeads := New(townRoot).ForAgentBeadID(polecatID)
 
 	if err := lifecycleBeads.UpdateAgentActiveMR(polecatID, "gst-wisp-1"); err != nil {
 		t.Fatalf("UpdateAgentActiveMR: %v", err)

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -3,6 +3,7 @@ package beads
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -437,7 +438,64 @@ func TestForAgentBeadIDRebindsStoreToRoutedPolecatRig(t *testing.T) {
 			if hqStore.issues[polecatID].Title != "town polecat" {
 				t.Fatalf("town store was modified: %q", hqStore.issues[polecatID].Title)
 			}
+			if err := routed.CloseStore(); err != nil {
+				t.Fatalf("CloseStore: %v", err)
+			}
+			if err := routed.CloseStore(); err != nil {
+				t.Fatalf("second CloseStore: %v", err)
+			}
+			if rigStore.storeCloseCalls != 1 {
+				t.Fatalf("rig store close calls = %d, want 1", rigStore.storeCloseCalls)
+			}
+			if hqStore.storeCloseCalls != 0 {
+				t.Fatalf("caller-provided store close calls = %d, want 0", hqStore.storeCloseCalls)
+			}
 		})
+	}
+}
+
+func TestRoutedStoreCloseSurfacesError(t *testing.T) {
+	source := newMockStorage()
+	target := newMockStorage()
+	target.storeCloseErr = errors.New("close target store")
+
+	b := NewWithStore(t.TempDir(), source)
+	b.storeOpener = func(_ context.Context, _ string) (beadsdk.Storage, error) {
+		return target, nil
+	}
+	routed := b.forAgentBeadsDir(t.TempDir(), t.TempDir())
+
+	if err := routed.CloseStore(); !errors.Is(err, target.storeCloseErr) {
+		t.Fatalf("CloseStore error = %v, want %v", err, target.storeCloseErr)
+	}
+	if err := routed.CloseStore(); !errors.Is(err, target.storeCloseErr) {
+		t.Fatalf("second CloseStore error = %v, want %v", err, target.storeCloseErr)
+	}
+	if target.storeCloseCalls != 1 {
+		t.Fatalf("target store close calls = %d, want 1", target.storeCloseCalls)
+	}
+	if source.storeCloseCalls != 0 {
+		t.Fatalf("source store close calls = %d, want 0", source.storeCloseCalls)
+	}
+}
+
+func TestSameStoreRouteDoesNotTakeOwnership(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
+	}
+	source := newMockStorage()
+	b := NewWithBeadsDirAndStore(filepath.Dir(beadsDir), beadsDir, source)
+
+	routed := b.forAgentBeadsDir(filepath.Dir(beadsDir), beadsDir)
+	if routed.Store() != source {
+		t.Fatal("same-database route did not retain caller-provided store")
+	}
+	if err := routed.CloseStore(); err != nil {
+		t.Fatalf("CloseStore: %v", err)
+	}
+	if source.storeCloseCalls != 0 {
+		t.Fatalf("source store close calls = %d, want 0", source.storeCloseCalls)
 	}
 }
 

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -81,7 +81,7 @@ func installMockBDShowRecorder(t *testing.T, showOutput string) string {
 
 	script := `#!/bin/sh
 LOG_FILE='` + logPath + `'
-printf '%s\n' "$*" >> "$LOG_FILE"
+printf 'BEADS_DIR=%s %s\n' "$BEADS_DIR" "$*" >> "$LOG_FILE"
 
 cmd=""
 for arg in "$@"; do
@@ -233,6 +233,62 @@ func TestUpdateAgentState_UsesUpdateDescriptionPath(t *testing.T) {
 	// Should NOT use the obsolete bd agent state or bd set-state path
 	if strings.Contains(logOutput, "agent state") || strings.Contains(logOutput, "set-state") {
 		t.Fatalf("mock bd log %q unexpectedly used obsolete bd agent state / set-state path", logOutput)
+	}
+}
+
+func TestForAgentBeadIDRoutesPolecatLifecycleWritesToRig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for bd")
+	}
+
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "gastown")
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	rigBeadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	for _, dir := range []string{townBeadsDir, rigBeadsDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	const polecatID = "gst-gastown-polecat-nux"
+	logPath := installMockBDShowRecorder(t, `[{"id":"gst-gastown-polecat-nux","title":"Polecat nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: working\nactive_mr: gst-wisp-1"}]`)
+	lifecycleBeads := New(rigPath).ForAgentBeadID(polecatID)
+
+	if err := lifecycleBeads.UpdateAgentActiveMR(polecatID, "gst-wisp-1"); err != nil {
+		t.Fatalf("UpdateAgentActiveMR: %v", err)
+	}
+	if err := lifecycleBeads.UpdateAgentCompletion(polecatID, &CompletionMetadata{ExitType: "COMPLETED", MRID: "gst-wisp-1"}); err != nil {
+		t.Fatalf("UpdateAgentCompletion: %v", err)
+	}
+	if err := lifecycleBeads.UpdateAgentState(polecatID, "done"); err != nil {
+		t.Fatalf("UpdateAgentState: %v", err)
+	}
+	if err := lifecycleBeads.UpdateAgentCleanupStatus(polecatID, "clean"); err != nil {
+		t.Fatalf("UpdateAgentCleanupStatus: %v", err)
+	}
+
+	logOutput := readMockBDLog(t, logPath)
+	if strings.Contains(logOutput, "BEADS_DIR="+townBeadsDir) {
+		t.Fatalf("polecat lifecycle operation targeted town beads instead of rig beads:\n%s", logOutput)
+	}
+	if writes := strings.Count(logOutput, "BEADS_DIR="+rigBeadsDir+" update "+polecatID); writes != 4 {
+		t.Fatalf("rig lifecycle writes = %d, want 4:\n%s", writes, logOutput)
+	}
+
+	crewID := "gst-gastown-crew-max"
+	if err := New(rigPath).ForAgentBeadID(crewID).UpdateAgentState(crewID, "done"); err != nil {
+		t.Fatalf("UpdateAgentState crew: %v", err)
+	}
+	logOutput = readMockBDLog(t, logPath)
+	if !strings.Contains(logOutput, "BEADS_DIR="+townBeadsDir+" update "+crewID) {
+		t.Fatalf("crew lifecycle operation did not retain town beads target:\n%s", logOutput)
 	}
 }
 

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -297,6 +297,58 @@ func TestForAgentBeadIDRoutesPolecatLifecycleWritesToRig(t *testing.T) {
 	}
 }
 
+func TestForAgentBeadIDRoutesLongHyphenatedPrefixPolecatToRig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for bd")
+	}
+
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "gastown")
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	rigBeadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	for _, dir := range []string{townBeadsDir, rigBeadsDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townBeadsDir, "routes.jsonl"), []byte(`{"prefix":"long-hyphen-prefix-","path":"gastown"}
+{"prefix":"hq-","path":"."}
+`), 0644); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	const polecatID = "long-hyphen-prefix-gastown-polecat-nux"
+	logPath := installMockBDShowRecorder(t, `[{"id":"long-hyphen-prefix-gastown-polecat-nux","title":"Polecat nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: working"}]`)
+	lifecycleBeads := New(townRoot).ForAgentBeadID(polecatID)
+
+	if !lifecycleBeads.noRoute {
+		t.Fatal("polecat lifecycle wrapper must disable further ID routing")
+	}
+	if lifecycleBeads.beadsDir != rigBeadsDir {
+		t.Fatalf("polecat lifecycle beads dir = %q, want %q", lifecycleBeads.beadsDir, rigBeadsDir)
+	}
+	if got := lifecycleBeads.ForAgentBeadID(polecatID); got != lifecycleBeads {
+		t.Fatal("noRoute polecat wrapper must not be re-routed")
+	}
+	if err := lifecycleBeads.UpdateAgentState(polecatID, "done"); err != nil {
+		t.Fatalf("UpdateAgentState: %v", err)
+	}
+
+	logOutput := readMockBDLog(t, logPath)
+	if !strings.Contains(logOutput, "BEADS_DIR="+rigBeadsDir+" update "+polecatID) {
+		t.Fatalf("polecat lifecycle operation did not target rig beads:\n%s", logOutput)
+	}
+	if strings.Contains(logOutput, "BEADS_DIR="+townBeadsDir+" update "+polecatID) {
+		t.Fatalf("polecat lifecycle operation targeted town beads:\n%s", logOutput)
+	}
+}
+
 func TestClearAgentActiveMRIfMatchesClearsExactMatch(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses Unix shell script mocks for bd")

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -24,6 +25,11 @@ import (
 // Callers are responsible for closing the store when done.
 func (b *Beads) SetStore(store beadsdk.Storage) {
 	b.store = store
+	if store == nil {
+		b.storeBeadsDir = ""
+		return
+	}
+	b.storeBeadsDir = b.getResolvedBeadsDir()
 }
 
 // Store returns the in-process beadsdk.Storage, or nil if not set.
@@ -35,13 +41,21 @@ func (b *Beads) Store() beadsdk.Storage {
 // The store is used for direct SDK calls, bypassing bd subprocess spawning.
 // Callers are responsible for closing the store when done.
 func NewWithStore(workDir string, store beadsdk.Storage) *Beads {
-	return &Beads{workDir: workDir, store: store}
+	b := &Beads{workDir: workDir, store: store}
+	if store != nil {
+		b.storeBeadsDir = b.getResolvedBeadsDir()
+	}
+	return b
 }
 
 // NewWithBeadsDirAndStore creates a Beads wrapper with an explicit BEADS_DIR
 // and an in-process store. Used for cross-database access from polecat worktrees.
 func NewWithBeadsDirAndStore(workDir, beadsDir string, store beadsdk.Storage) *Beads {
-	return &Beads{workDir: workDir, beadsDir: beadsDir, store: store}
+	b := &Beads{workDir: workDir, beadsDir: beadsDir, store: store}
+	if store != nil {
+		b.storeBeadsDir = b.getResolvedBeadsDir()
+	}
+	return b
 }
 
 // OpenStore opens a beadsdk.Storage for the resolved beads directory.
@@ -55,6 +69,10 @@ func NewWithBeadsDirAndStore(workDir, beadsDir string, store beadsdk.Storage) *B
 //	if err != nil { /* fall back to subprocess */ }
 //	defer cleanup()
 func (b *Beads) OpenStore(ctx context.Context) (beadsdk.Storage, func(), error) {
+	if b.storeErr != nil {
+		return nil, nil, b.storeErr
+	}
+
 	beadsDir := b.beadsDir
 	if beadsDir == "" {
 		beadsDir = ResolveBeadsDir(b.workDir)
@@ -63,7 +81,7 @@ func (b *Beads) OpenStore(ctx context.Context) (beadsdk.Storage, func(), error) 
 		return nil, nil, fmt.Errorf("no beads directory found")
 	}
 
-	store, err := beadsdk.OpenFromConfig(ctx, beadsDir)
+	store, err := b.openStore(ctx, beadsDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening beads store: %w", err)
 	}
@@ -72,6 +90,38 @@ func (b *Beads) OpenStore(ctx context.Context) (beadsdk.Storage, func(), error) 
 		_ = store.Close()
 	}
 	return store, cleanup, nil
+}
+
+// rebindStore returns the source store only when its directory is known to be
+// the requested target. A routed wrapper otherwise opens a distinct target
+// store, so in-process operations cannot write through the source database.
+func (b *Beads) rebindStore(beadsDir string) (beadsdk.Storage, error) {
+	if b.store == nil {
+		return nil, nil
+	}
+	if sameBeadsDir(b.storeBeadsDir, beadsDir) {
+		return b.store, nil
+	}
+
+	store, err := b.openStore(context.Background(), beadsDir)
+	if err != nil {
+		return nil, fmt.Errorf("opening routed beads store for %s: %w", beadsDir, err)
+	}
+	return store, nil
+}
+
+func (b *Beads) openStore(ctx context.Context, beadsDir string) (beadsdk.Storage, error) {
+	if b.storeOpener != nil {
+		return b.storeOpener(ctx, beadsDir)
+	}
+	return beadsdk.OpenFromConfig(ctx, beadsDir)
+}
+
+func sameBeadsDir(left, right string) bool {
+	if left == "" || right == "" {
+		return false
+	}
+	return filepath.Clean(ResolveBeadsDir(left)) == filepath.Clean(ResolveBeadsDir(right))
 }
 
 // storeCtx returns a context with a standard timeout for store operations.

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -12,10 +12,24 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	beadsdk "github.com/steveyegge/beads"
 )
+
+type storeOwnership struct {
+	close func() error
+	once  sync.Once
+	err   error
+}
+
+func (o *storeOwnership) Close() error {
+	o.once.Do(func() {
+		o.err = o.close()
+	})
+	return o.err
+}
 
 // SetStore configures an in-process beadsdk.Storage for this Beads instance.
 // When set, methods that have in-process implementations will use the store
@@ -35,6 +49,19 @@ func (b *Beads) SetStore(store beadsdk.Storage) {
 // Store returns the in-process beadsdk.Storage, or nil if not set.
 func (b *Beads) Store() beadsdk.Storage {
 	return b.store
+}
+
+// CloseStore releases a store opened for a routed Beads wrapper.
+//
+// It is a no-op for caller-provided stores, including stores supplied through
+// NewWithStore and SetStore. Call it when done with a wrapper returned by
+// ForAgentBead, ForRoutedAgentBead, or ForAgentBeadID; repeated calls close
+// an owned store only once and return the original close error.
+func (b *Beads) CloseStore() error {
+	if b.storeOwner == nil {
+		return nil
+	}
+	return b.storeOwner.Close()
 }
 
 // NewWithStore creates a new Beads wrapper backed by an in-process store.
@@ -95,19 +122,20 @@ func (b *Beads) OpenStore(ctx context.Context) (beadsdk.Storage, func(), error) 
 // rebindStore returns the source store only when its directory is known to be
 // the requested target. A routed wrapper otherwise opens a distinct target
 // store, so in-process operations cannot write through the source database.
-func (b *Beads) rebindStore(beadsDir string) (beadsdk.Storage, error) {
+// The caller owns a newly opened store and must release it with CloseStore.
+func (b *Beads) rebindStore(beadsDir string) (beadsdk.Storage, *storeOwnership, error) {
 	if b.store == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if sameBeadsDir(b.storeBeadsDir, beadsDir) {
-		return b.store, nil
+		return b.store, nil, nil
 	}
 
 	store, err := b.openStore(context.Background(), beadsDir)
 	if err != nil {
-		return nil, fmt.Errorf("opening routed beads store for %s: %w", beadsDir, err)
+		return nil, nil, fmt.Errorf("opening routed beads store for %s: %w", beadsDir, err)
 	}
-	return store, nil
+	return store, &storeOwnership{close: store.Close}, nil
 }
 
 func (b *Beads) openStore(ctx context.Context, beadsDir string) (beadsdk.Storage, error) {

--- a/internal/beads/store_test.go
+++ b/internal/beads/store_test.go
@@ -30,6 +30,8 @@ type mockStorage struct {
 	addDepErr       error
 	removeDepErr    error
 	getLabelsErr    error
+	storeCloseErr   error
+	storeCloseCalls int
 }
 
 func newMockStorage() *mockStorage {
@@ -291,7 +293,10 @@ func (m *mockStorage) GetReadyWork(_ context.Context, filter beadsdk.WorkFilter)
 	return result, nil
 }
 
-func (m *mockStorage) Close() error { return nil }
+func (m *mockStorage) Close() error {
+	m.storeCloseCalls++
+	return m.storeCloseErr
+}
 
 // --- Tests ---
 

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -734,7 +734,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// every write fails 'issue not found' and witness zombie detection +
 		// done-resume silently degrade. Best-effort: a failed recreate just
 		// leaves the existing warnings.
-		ensureAgentBeadExists(beads.New(cwd).ForAgentBead(), agentBeadID, ctx)
+		ensureAgentBeadExists(beads.New(cwd).ForAgentBeadID(agentBeadID), agentBeadID, ctx)
 
 		// Completion now exits the live polecat session after durable handoff.
 		// The agent bead keeps lifecycle metadata for witness/refinery cleanup.
@@ -791,8 +791,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	// skip those stages to avoid repeating work or hitting errors.
 	checkpoints := map[DoneCheckpoint]string{}
 	if agentBeadID != "" {
-		// Agent bead lives in town DB despite rig prefix — bypass routing.
-		bd := beads.New(cwd).ForAgentBead()
+		bd := beads.New(cwd).ForAgentBeadID(agentBeadID)
 		setDoneIntentLabel(bd, agentBeadID, exitType)
 		checkpoints = readDoneCheckpoints(bd, agentBeadID)
 		if len(checkpoints) > 0 {
@@ -1348,8 +1347,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 		// Write push checkpoint for resume (gt-aufru)
 		if agentBeadID != "" {
-			// Agent bead lives in town DB despite rig prefix — bypass routing.
-			cpBd := beads.New(cwd).ForAgentBead()
+			cpBd := beads.New(cwd).ForAgentBeadID(agentBeadID)
 			writeDoneCheckpoint(cpBd, agentBeadID, CheckpointPushed, branch)
 		}
 
@@ -1710,11 +1708,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			}
 
 			// Update agent bead with active_mr reference (for traceability).
-			// Agent beads live in HQ regardless of rig prefix — bypass routing
-			// via ForAgentBead() to avoid the "issue not found" warning that
-			// leaves active_mr null after every gt done (hq-e73z).
 			if agentBeadID != "" {
-				if err := bd.ForAgentBead().UpdateAgentActiveMR(agentBeadID, mrID); err != nil {
+				if err := bd.ForAgentBeadID(agentBeadID).UpdateAgentActiveMR(agentBeadID, mrID); err != nil {
 					style.PrintWarning("could not update agent bead with active_mr: %v", err)
 				}
 			}
@@ -1739,8 +1734,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 		// Write MR checkpoint for resume (gt-aufru)
 		if mrID != "" && agentBeadID != "" {
-			// Agent bead lives in town DB despite rig prefix — bypass routing.
-			cpBd := beads.New(cwd).ForAgentBead()
+			cpBd := beads.New(cwd).ForAgentBeadID(agentBeadID)
 			writeDoneCheckpoint(cpBd, agentBeadID, CheckpointMRCreated, mrID)
 		}
 
@@ -1775,8 +1769,7 @@ notifyWitness:
 	// longer processes routine completions from these fields.
 	fmt.Printf("\nNotifying Witness...\n")
 	if agentBeadID != "" {
-		// Agent bead lives in town DB despite rig prefix — bypass routing.
-		completionBd := beads.New(cwd).ForAgentBead()
+		completionBd := beads.New(cwd).ForAgentBeadID(agentBeadID)
 		meta := &beads.CompletionMetadata{
 			ExitType:       exitType,
 			MRID:           mrID,
@@ -1793,8 +1786,7 @@ notifyWitness:
 
 	// Write witness notification checkpoint for resume (gt-aufru)
 	if agentBeadID != "" {
-		// Agent bead lives in town DB despite rig prefix — bypass routing.
-		cpBd := beads.New(cwd).ForAgentBead()
+		cpBd := beads.New(cwd).ForAgentBeadID(agentBeadID)
 		writeDoneCheckpoint(cpBd, agentBeadID, CheckpointWitnessNotified, "ok")
 	}
 
@@ -2177,11 +2169,7 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 		beadsPath = filepath.Join(townRoot, ctx.Rig)
 	}
 	bd := beads.New(beadsPath)
-	// agentBd bypasses prefix routing — agent beads (gt:agent label) live in
-	// the town DB regardless of their ID prefix, but the rig-prefix routing
-	// would otherwise misroute them to the rig DB and silently fail with
-	// "issue not found". See beads.ForAgentBead docstring for details.
-	agentBd := bd.ForAgentBead()
+	agentBd := bd.ForAgentBeadID(agentBeadID)
 
 	// Find the hooked bead to close. Use issueID directly instead of reading
 	// agent bead's hook_bead slot (hq-l6mm5: direct bead tracking).

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1052,7 +1052,7 @@ func runPolecatCheckRecovery(cmd *cobra.Command, args []string) error {
 	rigPath := r.Path
 	bd := beads.New(rigPath)
 	agentBeadID := polecatBeadIDForRig(r, rigName, polecatName)
-	agentIssue, fields, err := bd.GetAgentBead(agentBeadID)
+	agentIssue, fields, err := bd.ForRoutedAgentBead().GetAgentBead(agentBeadID)
 
 	status := RecoveryStatus{
 		Rig:     rigName,
@@ -1980,7 +1980,7 @@ func checkNukeActiveMRSafety(checker activeMRRemovalChecker, polecatName, rigNam
 func resetPolecatAgentBeadForReuse(r *rig.Rig, rigName, polecatName string) {
 	agentBeadID := polecatBeadIDForRig(r, rigName, polecatName)
 	bd := beads.New(r.Path)
-	if err := bd.ForAgentBead().ResetAgentBeadForReuse(agentBeadID, "nuked"); err != nil {
+	if err := bd.ForRoutedAgentBead().ResetAgentBeadForReuse(agentBeadID, "nuked"); err != nil {
 		fmt.Printf("  %s agent bead not found or already cleaned\n", style.Dim.Render("○"))
 	} else {
 		fmt.Printf("  %s reset agent bead %s\n", style.Success.Render("✓"), agentBeadID)

--- a/internal/cmd/polecat_helpers.go
+++ b/internal/cmd/polecat_helpers.go
@@ -109,7 +109,7 @@ func checkPolecatSafety(target polecatTarget) *SafetyCheckResult {
 	// Check 1: Unpushed commits via cleanup_status or git state
 	bd := beads.New(target.r.Path)
 	agentBeadID := polecatBeadIDForRig(target.r, target.rigName, target.polecatName)
-	agentIssue, fields, err := bd.GetAgentBead(agentBeadID)
+	agentIssue, fields, err := bd.ForRoutedAgentBead().GetAgentBead(agentBeadID)
 
 	if err != nil || fields == nil {
 		// No agent bead - fall back to git check
@@ -229,6 +229,10 @@ func polecatBeadIDForRig(r *rig.Rig, rigName, polecatName string) string {
 	return beads.PolecatBeadIDWithPrefix(rigPrefix(r), rigName, polecatName)
 }
 
+func polecatIdentityBeads(r *rig.Rig) *beads.Beads {
+	return beads.New(r.Path).ForRoutedAgentBead()
+}
+
 // displaySafetyCheckBlocked prints blocked polecats and guidance.
 func displaySafetyCheckBlocked(blocked []*SafetyCheckResult) {
 	displaySafetyCheckBlockedTo(os.Stderr, blocked)
@@ -269,7 +273,7 @@ func displayDryRunSafetyCheck(target polecatTarget) bool {
 	polecatInfo, infoErr := target.mgr.Get(target.polecatName)
 	bd := beads.New(target.r.Path)
 	agentBeadID := polecatBeadIDForRig(target.r, target.rigName, target.polecatName)
-	agentIssue, fields, err := bd.GetAgentBead(agentBeadID)
+	agentIssue, fields, err := bd.ForRoutedAgentBead().GetAgentBead(agentBeadID)
 
 	// Check 1: cleanup status or fallback git state
 	if err != nil || fields == nil {

--- a/internal/cmd/polecat_identity.go
+++ b/internal/cmd/polecat_identity.go
@@ -232,7 +232,7 @@ func runPolecatIdentityAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check if identity already exists
-	bd := beads.New(r.Path)
+	bd := polecatIdentityBeads(r)
 	beadID := polecatBeadIDForRig(r, rigName, polecatName)
 	existingIssue, _, _ := bd.GetAgentBead(beadID)
 	if existingIssue != nil && existingIssue.Status != "closed" {
@@ -269,7 +269,7 @@ func runPolecatIdentityList(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get all agent beads
-	bd := beads.New(r.Path)
+	bd := polecatIdentityBeads(r)
 	agentBeads, err := bd.ListAgentBeads()
 	if err != nil {
 		return fmt.Errorf("listing agent beads: %w", err)
@@ -385,7 +385,7 @@ func runPolecatIdentityShow(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get identity bead
-	bd := beads.New(r.Path)
+	bd := polecatIdentityBeads(r)
 	beadID := polecatBeadIDForRig(r, rigName, polecatName)
 	issue, fields, err := bd.GetAgentBead(beadID)
 	if err != nil {
@@ -563,7 +563,7 @@ func runPolecatIdentityRename(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	bd := beads.New(r.Path)
+	bd := polecatIdentityBeads(r)
 	oldBeadID := polecatBeadIDForRig(r, rigName, oldName)
 	newBeadID := polecatBeadIDForRig(r, rigName, newName)
 
@@ -634,7 +634,7 @@ func runPolecatIdentityRemove(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	bd := beads.New(r.Path)
+	bd := polecatIdentityBeads(r)
 	beadID := polecatBeadIDForRig(r, rigName, polecatName)
 
 	// Check identity exists
@@ -725,7 +725,7 @@ func buildCVSummary(rigPath, rigName, polecatName, identityBeadID, clonePath str
 	}
 
 	// Get agent bead info for creation date
-	bd := beads.New(beadsQueryPath)
+	bd := beads.New(beadsQueryPath).ForRoutedAgentBead()
 	agentBead, _, err := bd.GetAgentBead(identityBeadID)
 	if err == nil && agentBead != nil {
 		if agentBead.CreatedAt != "" && len(agentBead.CreatedAt) >= 10 {

--- a/internal/cmd/polecat_identity.go
+++ b/internal/cmd/polecat_identity.go
@@ -17,6 +17,7 @@ import (
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/polecat"
+	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
@@ -281,9 +282,9 @@ func runPolecatIdentityList(cmd *cobra.Command, args []string) error {
 	polecatMgr := polecat.NewSessionManager(t, r)
 
 	for id, issue := range agentBeads {
-		// Parse the bead ID to check if it's a polecat for this rig
-		beadRig, role, name, ok := beads.ParseAgentBeadID(id)
-		if !ok || role != constants.RolePolecat || beadRig != rigName {
+		fields := beads.ParseAgentFields(issue.Description)
+		name, ok := polecatIdentityName(r, rigName, id, fields)
+		if !ok {
 			continue
 		}
 
@@ -291,8 +292,6 @@ func runPolecatIdentityList(cmd *cobra.Command, args []string) error {
 		if issue.Status == "closed" {
 			continue
 		}
-
-		fields := beads.ParseAgentFields(issue.Description)
 
 		// Check if worktree exists
 		worktreeExists := false
@@ -372,6 +371,22 @@ func runPolecatIdentityList(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("\n%d identity bead(s)\n", len(identities))
 	return nil
+}
+
+// polecatIdentityName verifies that an agent bead is a polecat identity in the
+// given rig and extracts its name. Identity fields establish the role and rig;
+// the configured rig prefix establishes the ID shape without relying on the
+// legacy fixed-width agent ID parser.
+func polecatIdentityName(r *rig.Rig, rigName, id string, fields *beads.AgentFields) (string, bool) {
+	if fields.RoleType != constants.RolePolecat || fields.Rig != rigName {
+		return "", false
+	}
+
+	name, ok := strings.CutPrefix(id, polecatBeadIDForRig(r, rigName, "")+"-")
+	if !ok || name == "" {
+		return "", false
+	}
+	return name, true
 }
 
 func runPolecatIdentityShow(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/polecat_identity_test.go
+++ b/internal/cmd/polecat_identity_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -8,7 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
 )
@@ -235,6 +238,86 @@ func TestPolecatIdentityUsesRigDatabaseAndPrimeFindsHookedWork(t *testing.T) {
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
 	}
+
+	t.Run("identity list includes long hyphenated prefix", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("test uses a Unix shell mock for bd")
+		}
+
+		townRoot := t.TempDir()
+		rigName := "gastown"
+		rigPath := filepath.Join(townRoot, rigName)
+		for _, dir := range []string{
+			filepath.Join(townRoot, "mayor"),
+			filepath.Join(townRoot, ".beads"),
+			filepath.Join(rigPath, ".beads"),
+		} {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatalf("mkdir %s: %v", dir, err)
+			}
+		}
+		if err := config.SaveTownConfig(filepath.Join(townRoot, "mayor", "town.json"), &config.TownConfig{
+			Type:      "town",
+			Version:   config.CurrentTownVersion,
+			Name:      "test-town",
+			CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("save town config: %v", err)
+		}
+		if err := config.SaveRigsConfig(filepath.Join(townRoot, "mayor", "rigs.json"), &config.RigsConfig{
+			Version: config.CurrentRigsVersion,
+			Rigs: map[string]config.RigEntry{
+				rigName: {GitURL: "https://example.com/gastown.git", AddedAt: time.Now()},
+			},
+		}); err != nil {
+			t.Fatalf("save rigs config: %v", err)
+		}
+		writeTestRoutes(t, townRoot, []beads.Route{
+			{Prefix: "long-hyphenated-prefix-", Path: rigName},
+			{Prefix: "hq-", Path: "."},
+		})
+
+		binDir := t.TempDir()
+		script := `#!/bin/sh
+	case "$*" in
+	  *list*)
+	    printf '%s\n' '[{"id":"long-hyphenated-prefix-gastown-polecat-furiosa","title":"Polecat furiosa","issue_type":"agent","labels":["gt:agent"],"status":"open","description":"role_type: polecat\nrig: gastown\nagent_state: idle"},{"id":"hq-polecat-furiosa","title":"HQ polecat","issue_type":"agent","labels":["gt:agent"],"status":"open","description":"role_type: polecat\nrig: gastown\nagent_state: idle"},{"id":"long-hyphenated-prefix-gastown-crew-furiosa","title":"Crew furiosa","issue_type":"agent","labels":["gt:agent"],"status":"open","description":"role_type: crew\nrig: gastown\nagent_state: idle"},{"id":"long-hyphenated-prefix-other-rig-polecat-furiosa","title":"Other rig polecat","issue_type":"agent","labels":["gt:agent"],"status":"open","description":"role_type: polecat\nrig: other-rig\nagent_state: idle"},{"id":"long-hyphenated-prefix-gastown-polecat-closed","title":"Closed polecat","issue_type":"agent","labels":["gt:agent"],"status":"closed","description":"role_type: polecat\nrig: gastown\nagent_state: idle"}]'
+	    ;;
+	esac
+	`
+		if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+			t.Fatalf("write mock bd: %v", err)
+		}
+		t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+		oldWD, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("get working directory: %v", err)
+		}
+		if err := os.Chdir(townRoot); err != nil {
+			t.Fatalf("change to town root: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+		polecatIdentityListJSON = true
+		t.Cleanup(func() { polecatIdentityListJSON = false })
+		output := captureStdout(t, func() {
+			if err := runPolecatIdentityList(&cobra.Command{}, []string{rigName}); err != nil {
+				t.Fatalf("run polecat identity list: %v", err)
+			}
+		})
+
+		var identities []IdentityInfo
+		if err := json.Unmarshal([]byte(output), &identities); err != nil {
+			t.Fatalf("decode identity list: %v\noutput: %s", err, output)
+		}
+		if len(identities) != 1 {
+			t.Fatalf("identity list returned %d records, want 1: %#v", len(identities), identities)
+		}
+		if identities[0].Name != "furiosa" || identities[0].BeadID != "long-hyphenated-prefix-gastown-polecat-furiosa" {
+			t.Fatalf("identity list record = %#v, want long-prefix polecat identity", identities[0])
+		}
+	})
 	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
 		t.Fatalf("write town config: %v", err)
 	}

--- a/internal/cmd/polecat_identity_test.go
+++ b/internal/cmd/polecat_identity_test.go
@@ -1,9 +1,15 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
 )
 
@@ -209,3 +215,101 @@ func TestFormatCountStyled(t *testing.T) {
 	}
 }
 
+func TestPolecatIdentityUsesRigDatabaseAndPrimeFindsHookedWork(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a Unix shell mock for bd")
+	}
+
+	townRoot := t.TempDir()
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	rigPath := filepath.Join(townRoot, "gastown")
+	rigBeadsDir := filepath.Join(rigPath, "mayor", "rig", ".beads")
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor"),
+		townBeadsDir,
+		filepath.Join(rigPath, ".beads"),
+		rigBeadsDir,
+		filepath.Join(rigPath, "polecats", "furiosa"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatalf("write town config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigPath, ".beads", "redirect"), []byte("mayor/rig/.beads\n"), 0644); err != nil {
+		t.Fatalf("write rig redirect: %v", err)
+	}
+	if err := beads.WriteRoutes(townBeadsDir, []beads.Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: "gst-", Path: "gastown/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "bd.log")
+	script := `#!/bin/sh
+printf 'beads_dir=%s args=%s\n' "$BEADS_DIR" "$*" >> "$MOCK_BD_LOG"
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+case "$cmd" in
+  version) exit 0 ;;
+  create) printf '%s\n' '{"id":"gst-gastown-polecat-furiosa","title":"Polecat furiosa","status":"open"}' ;;
+  show) printf '%s\n' '[{"id":"gst-gastown-polecat-furiosa","title":"Polecat furiosa","issue_type":"task","labels":["gt:agent"],"status":"open","description":"role_type: polecat\nrig: gastown\nagent_state: idle\nhook_bead: null"}]' ;;
+  list) printf '%s\n' '[{"id":"gst-work","title":"Routed work","status":"hooked","assignee":"gastown/polecats/furiosa"}]' ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write mock bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("MOCK_BD_LOG", logPath)
+
+	r := &rig.Rig{Name: "gastown", Path: rigPath}
+	identityID := polecatBeadIDForRig(r, r.Name, "furiosa")
+	identityBeads := polecatIdentityBeads(r)
+	if _, err := identityBeads.CreateAgentBead(identityID, "Polecat furiosa", &beads.AgentFields{
+		RoleType: "polecat", Rig: r.Name, AgentState: "idle",
+	}); err != nil {
+		t.Fatalf("create routed polecat identity: %v", err)
+	}
+	if issue, _, err := identityBeads.GetAgentBead(identityID); err != nil || issue == nil {
+		t.Fatalf("resolve routed polecat identity: issue=%v err=%v", issue, err)
+	}
+
+	hooked, err := findAgentWorkOnce(RoleContext{
+		Role:     RolePolecat,
+		Rig:      r.Name,
+		Polecat:  "furiosa",
+		TownRoot: townRoot,
+		WorkDir:  filepath.Join(rigPath, "polecats", "furiosa"),
+	}, "gastown/polecats/furiosa")
+	if err != nil {
+		t.Fatalf("find hooked work: %v", err)
+	}
+	if hooked == nil || hooked.ID != "gst-work" {
+		t.Fatalf("findAgentWorkOnce() = %#v, want routed hooked work", hooked)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read mock bd log: %v", err)
+	}
+	logOutput := string(logData)
+	if strings.Contains(logOutput, "beads_dir="+townBeadsDir) {
+		t.Fatalf("polecat identity accessed town beads instead of rig beads:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "beads_dir="+rigBeadsDir) ||
+		!strings.Contains(logOutput, "args=create") ||
+		!strings.Contains(logOutput, "args=show") ||
+		!strings.Contains(logOutput, "args=list") {
+		t.Fatalf("polecat identity and hook lookup did not use rig beads:\n%s", logOutput)
+	}
+}

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -1477,7 +1477,9 @@ func updateAgentMode(agentID, mode, workDir, townBeadsDir string) {
 
 	agentWorkDir := beads.ResolveHookDir(townRoot, agentBeadID, workDir)
 	bd := beads.New(agentWorkDir)
-	if err := bd.UpdateAgentDescriptionFields(agentBeadID, beads.AgentFieldUpdates{Mode: &mode}); err != nil {
+	agentBd := bd.ForAgentBeadID(agentBeadID)
+	defer func() { _ = agentBd.CloseStore() }()
+	if err := agentBd.UpdateAgentDescriptionFields(agentBeadID, beads.AgentFieldUpdates{Mode: &mode}); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: couldn't set agent %s mode: %v\n", agentBeadID, err)
 	}
 }

--- a/internal/cmd/sling_helpers_test.go
+++ b/internal/cmd/sling_helpers_test.go
@@ -81,6 +81,100 @@ func TestNudgeRefinerySessionName(t *testing.T) {
 	}
 }
 
+func TestUpdateAgentModeRoutesPrefixedPolecatToRig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX bd stub")
+	}
+
+	townRoot := t.TempDir()
+	hqBeadsDir := filepath.Join(townRoot, ".beads")
+	rigDir := filepath.Join(townRoot, "gastown")
+	rigBeadsDir := filepath.Join(rigDir, ".beads")
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor"),
+		hqBeadsDir,
+		rigBeadsDir,
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hqBeadsDir, "routes.jsonl"), []byte(`{"prefix":"gt-","path":"gastown"}
+{"prefix":"hq-","path":"."}
+`), 0o644); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+set -eu
+printf 'BEADS_DIR=%s %s\n' "$BEADS_DIR" "$*" >> "$BD_LOG"
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+case "$cmd" in
+  version) exit 0 ;;
+  show) printf '[{"id":"gt-gastown-polecat-nux","title":"Nux","status":"open","description":""}]\n' ;;
+  update)
+    body=$(cat)
+    case "$body" in
+      *"mode: ralph"*) printf 'mode=ralph\n' >> "$BD_LOG" ;;
+      *) printf 'mode=missing\n' >> "$BD_LOG" ;;
+    esac
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0o755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir town root: %v", err)
+	}
+
+	updateAgentMode("gastown/polecats/nux", "ralph", "", "")
+
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	logOutput := string(log)
+	resolvedRigBeadsDir, err := filepath.EvalSymlinks(rigBeadsDir)
+	if err != nil {
+		t.Fatalf("resolve rig beads directory: %v", err)
+	}
+	resolvedHQBeadsDir, err := filepath.EvalSymlinks(hqBeadsDir)
+	if err != nil {
+		t.Fatalf("resolve HQ beads directory: %v", err)
+	}
+	if !strings.Contains(logOutput, "BEADS_DIR="+resolvedRigBeadsDir+" update gt-gastown-polecat-nux") {
+		t.Fatalf("mode update did not target rig beads:\n%s", logOutput)
+	}
+	if strings.Contains(logOutput, "BEADS_DIR="+resolvedHQBeadsDir+" update gt-gastown-polecat-nux") {
+		t.Fatalf("mode update targeted HQ beads:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "mode=ralph") {
+		t.Fatalf("ralph mode metadata was not written:\n%s", logOutput)
+	}
+}
+
 // TestWakeRigAgentsDoesNotNudgeRefinery verifies that wakeRigAgents only
 // nudges the witness, not the refinery. The refinery should only be nudged
 // when an MR is actually created (via nudgeRefinery), not at polecat dispatch time.

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -355,7 +355,7 @@ func (m *Manager) createAgentBeadWithRetry(agentID string, fields *beads.AgentFi
 }
 
 func (m *Manager) agentBeads() *beads.Beads {
-	return m.beads.ForAgentBead()
+	return m.beads.ForRoutedAgentBead()
 }
 
 func (m *Manager) resetAgentBeadForReuse(agentID, reason string) error {
@@ -410,7 +410,7 @@ func (m *Manager) agentBeadID(name string) string {
 // ZFC #10: This is the ZFC-compliant way to check if removal is safe.
 func (m *Manager) getCleanupStatusFromBead(name string) CleanupStatus {
 	agentID := m.agentBeadID(name)
-	_, fields, err := m.beads.GetAgentBead(agentID)
+	_, fields, err := m.agentBeads().GetAgentBead(agentID)
 	if err != nil || fields == nil {
 		return CleanupUnknown
 	}
@@ -1305,7 +1305,7 @@ func (m *Manager) removeWithOptionsLocked(name string, force, nuclear, selfNuke 
 }
 
 // ActiveMRRemovalBlocker returns the pending active-MR reason that should block
-// non-force polecat removal. It reads agent metadata from the town agent-bead
+// non-force polecat removal. It reads agent metadata from the rig agent-bead
 // store, then classifies the MR/source through the normal rig beads reader.
 func (m *Manager) ActiveMRRemovalBlocker(name string) (string, string) {
 	agentID := m.agentBeadID(name)
@@ -1928,7 +1928,7 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 	// The column stays stale (e.g., "idle" from previous gt done) until
 	// StartSession sets it to "working". Without this, the column and
 	// description diverge, causing dashboards to show incorrect state.
-	// Agent beads live in town DB — bypass prefix routing.
+	// Polecat identities live in the rig DB; retain that target for updates.
 	if err := m.agentBeads().UpdateAgentState(agentID, "spawning"); err != nil {
 		style.PrintWarning("could not sync agent_state column to spawning: %v", err)
 	}
@@ -2565,8 +2565,7 @@ func (m *Manager) Get(name string) (*Polecat, error) {
 // Valid states: "spawning", "working", "done", "stuck", "idle"
 func (m *Manager) SetAgentState(name string, state string) error {
 	agentID := m.agentBeadID(name)
-	// Agent beads live in the town DB — bypass prefix routing that would
-	// otherwise misroute "za-*" / "my-*" agent IDs to a rig DB.
+	// Polecat identities live in the rig DB; retain that target for updates.
 	return m.agentBeads().UpdateAgentState(agentID, state)
 }
 
@@ -2780,7 +2779,7 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 	// it resolves to a currently hooked bead for this assignee. This avoids stale
 	// issue reporting when hook_bead diverges from the work bead state.
 	agentID := m.agentBeadID(name)
-	_, fields, agentErr := m.beads.GetAgentBead(agentID)
+	_, fields, agentErr := m.agentBeads().GetAgentBead(agentID)
 	if agentErr == nil && fields != nil && fields.HookBead != "" {
 		if hookIssue, err := m.beads.Show(fields.HookBead); err == nil &&
 			isCurrentHookedIssueForAssignee(hookIssue, assignee) {
@@ -3079,7 +3078,7 @@ func (m *Manager) DetectStalePolecats(threshold int) ([]*StalenessInfo, error) {
 
 		// Check agent bead state
 		agentID := m.agentBeadID(p.Name)
-		_, fields, err := m.beads.GetAgentBead(agentID)
+		_, fields, err := m.agentBeads().GetAgentBead(agentID)
 		if err == nil && fields != nil {
 			info.AgentState = fields.AgentState
 		}

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -2451,7 +2451,7 @@ esac
 	}
 }
 
-func TestManagerAgentLifecycleUsesTownBeadsDir(t *testing.T) {
+func TestManagerAgentLifecycleUsesRigBeadsDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses Unix shell script mock for bd")
 	}
@@ -2522,7 +2522,7 @@ case "$cmd" in
     exit 0
     ;;
 esac
-`, logPath, townBeadsDir)
+`, logPath, rigBeadsDir)
 	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
 		t.Fatalf("write mock bd: %v", err)
 	}
@@ -2542,14 +2542,14 @@ esac
 		t.Fatalf("read mock log: %v", err)
 	}
 	logOutput := string(logBytes)
-	if strings.Contains(logOutput, "env="+rigBeadsDir) {
-		t.Fatalf("manager agent lifecycle used rig BEADS_DIR; log:\n%s", logOutput)
+	if strings.Contains(logOutput, "env="+townBeadsDir) {
+		t.Fatalf("manager agent lifecycle used town BEADS_DIR; log:\n%s", logOutput)
 	}
-	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, "args=create") {
-		t.Fatalf("manager create did not use town BEADS_DIR; log:\n%s", logOutput)
+	if !strings.Contains(logOutput, "env="+rigBeadsDir+" args=") || !strings.Contains(logOutput, "args=create") {
+		t.Fatalf("manager create did not use rig BEADS_DIR; log:\n%s", logOutput)
 	}
-	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, "args=show") || !strings.Contains(logOutput, "args=update") {
-		t.Fatalf("manager reset did not use town BEADS_DIR for show/update; log:\n%s", logOutput)
+	if !strings.Contains(logOutput, "env="+rigBeadsDir+" args=") || !strings.Contains(logOutput, "args=show") || !strings.Contains(logOutput, "args=update") {
+		t.Fatalf("manager reset did not use rig BEADS_DIR for show/update; log:\n%s", logOutput)
 	}
 }
 

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1312,7 +1312,7 @@ func (e *Engineer) ProcessMRInfo(ctx context.Context, mr *MRInfo) ProcessResult 
 
 // HandleMRInfoSuccess handles a successful merge from MRInfo.
 func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
-	workBeadID := resolveMergedWorkBead(e.beads.ForAgentBead(), mergedWorkBeadCloseRequest{
+	workBeadID := resolveMergedWorkBead(e.beads.ForAgentBeadID(mr.AgentBead), mergedWorkBeadCloseRequest{
 		MRID:        mr.ID,
 		Branch:      mr.Branch,
 		SourceIssue: mr.SourceIssue,

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -119,7 +119,7 @@ func TestEngineerFirstOpenBlockerUsesDependencySemantics(t *testing.T) {
 	}
 }
 
-func TestEngineerTerminalCloseClearsAgentActiveMRUsesTownBeadsDir(t *testing.T) {
+func TestEngineerTerminalCloseClearsPolecatActiveMRUsesRigBeadsDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses Unix shell script mock for bd")
 	}
@@ -202,12 +202,12 @@ esac
 	}
 	logOutput := string(logBytes)
 	for _, line := range strings.Split(strings.TrimSpace(logOutput), "\n") {
-		if strings.Contains(line, "gt-gastown-polecat-rust") && strings.Contains(line, "env="+rigBeadsDir) {
-			t.Fatalf("refinery active_mr cleanup used rig BEADS_DIR; log:\n%s", logOutput)
+		if strings.Contains(line, "gt-gastown-polecat-rust") && strings.Contains(line, "env="+townBeadsDir) {
+			t.Fatalf("refinery polecat active_mr cleanup used town BEADS_DIR; log:\n%s", logOutput)
 		}
 	}
-	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=show gt-gastown-polecat-rust") || !strings.Contains(logOutput, "env="+townBeadsDir+" args=update gt-gastown-polecat-rust") {
-		t.Fatalf("refinery active_mr cleanup did not use town BEADS_DIR; log:\n%s", logOutput)
+	if !strings.Contains(logOutput, "env="+rigBeadsDir+" args=show gt-gastown-polecat-rust") || !strings.Contains(logOutput, "env="+rigBeadsDir+" args=update gt-gastown-polecat-rust") {
+		t.Fatalf("refinery polecat active_mr cleanup did not use rig BEADS_DIR; log:\n%s", logOutput)
 	}
 }
 

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -742,7 +742,7 @@ func (m *Manager) PostMerge(idOrBranch string) (*PostMergeResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	workBeadID := resolveMergedWorkBead(b.ForAgentBead(), mergedWorkBeadCloseRequest{
+	workBeadID := resolveMergedWorkBead(b.ForAgentBeadID(mr.AgentBead), mergedWorkBeadCloseRequest{
 		MRID:        mr.ID,
 		Branch:      mr.Branch,
 		SourceIssue: mr.IssueID,

--- a/internal/refinery/terminal_mr.go
+++ b/internal/refinery/terminal_mr.go
@@ -78,7 +78,7 @@ func closeTerminalMR(b *beads.Beads, mrID string, opts terminalMRCloseOptions) (
 	}
 
 	if result.AgentBead != "" {
-		cleared, clearErr := b.ForAgentBead().ClearAgentActiveMRIfMatches(result.AgentBead, mrID)
+		cleared, clearErr := b.ForAgentBeadID(result.AgentBead).ClearAgentActiveMRIfMatches(result.AgentBead, mrID)
 		result.AgentActiveMRCleared = cleared
 		result.AgentActiveMRClearErr = clearErr
 	}

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1004,7 +1004,7 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 	prefix := beads.GetPrefixForRig(townRoot, rigName)
 	agentID := beads.PolecatBeadIDWithPrefix(prefix, rigName, polecatName)
 	rigBeads := beads.New(workDir)
-	_, fields, err := rigBeads.ForAgentBead().GetAgentBead(agentID)
+	_, fields, err := rigBeads.ForAgentBeadID(agentID).GetAgentBead(agentID)
 	input := polecat.SlotReuseInput{State: polecat.StateIdle, CleanupStatus: polecat.CleanupUnknown, GitCheckFailed: err != nil || fields == nil}
 	issueID := ""
 	hookSafe := true

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -181,6 +181,72 @@ func TestNotifyMayorSlotOpen_BlocksNonCompletedExit(t *testing.T) {
 	}
 }
 
+func TestSlotOpenDecisionFromTownRootReadsRigPolecatIdentity(t *testing.T) {
+	const (
+		rigName     = "gastown"
+		polecatName = "nux"
+	)
+	townRoot := setupActiveMRGitSafeWorkDir(t, rigName, polecatName)
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hqBeadsDir := filepath.Join(townRoot, ".beads")
+	rigBeadsDir := filepath.Join(townRoot, rigName, "mayor", "rig", ".beads")
+	for _, dir := range []string{hqBeadsDir, rigBeadsDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(hqBeadsDir, "routes.jsonl"), []byte(`{"prefix":"gst-","path":"gastown/mayor/rig"}
+{"prefix":"hq-","path":"."}
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	installSlotOpenIdentityBD(t, rigBeadsDir)
+
+	decision := slotOpenDecision(townRoot, townRoot, rigName, polecatName, string(ExitTypeCompleted))
+	if !decision.Reusable {
+		t.Fatalf("slotOpenDecision from town root = %+v, want reusable after reading rig identity", decision)
+	}
+}
+
+func installSlotOpenIdentityBD(t *testing.T, rigBeadsDir string) {
+	t.Helper()
+	binDir := t.TempDir()
+	scriptPath := filepath.Join(binDir, "bd")
+	script := `#!/bin/sh
+cmd=""
+for arg in "$@"; do
+	case "$arg" in
+		--*) ;;
+		*) cmd="$arg"; break ;;
+	esac
+done
+
+case "$cmd" in
+	show)
+		if [ "$BEADS_DIR" = "$MOCK_RIG_BEADS_DIR" ]; then
+			printf '%s\n' '[{"id":"gst-gastown-polecat-nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: idle\ncleanup_status: clean"}]'
+		else
+			printf '%s\n' '[]'
+		fi
+		;;
+	*) printf '%s\n' '[]' ;;
+esac
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("MOCK_RIG_BEADS_DIR", rigBeadsDir)
+	beads.ResetBdAllowStaleCacheForTest()
+	t.Cleanup(beads.ResetBdAllowStaleCacheForTest)
+}
+
 func TestNotifyMayorSlotOpen_SchedulerDispatchSuppressesMayor(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	townRoot, workDir := setupSlotOpenTestTown(t)


### PR DESCRIPTION
## Summary
- route prefixed polecat identities to the configured rig database rather than HQ
- apply consistent routing to hooks, completion metadata, Ralph mode, Witness patrol, Refinery cleanup, and identity listing
- support configured long and hyphenated prefixes, and correctly bind and close routed in-process stores

## Reproduction
A `gst-*` polecat task could be hooked in its rig database while the polecat identity was created or read from HQ. `gt hook show` and `gt prime --hook` then reported no work, causing the polecat to run `gt done` prematurely.

## Validation
- focused routing, lifecycle, Witness, Refinery, Ralph mode, store ownership, and identity-list regression tests
- `gofmt`
- `git diff --check`
- `CGO_ENABLED=0 go vet ./...`
- attempted `CGO_ENABLED=0 go test ./...`; unrelated baseline/environment-sensitive failures remain (including missing ICU `unicode/regex.h` and existing integration/tmux failures)