### PR TITLE
fix(polecat): let StateDone through check-recovery predicates

### DIFF
--- a/internal/cmd/polecat_inventory_test.go
+++ b/internal/cmd/polecat_inventory_test.go
@@ -107,9 +107,17 @@ func TestBuildPolecatInventoryItem(t *testing.T) {
 			wantVerdict: polecat.WorkstateVerdictPendingMR,
 		},
 		{
-			name:         "done without active mr is not reusable",
+			name:         "done without active mr and clean cleanup is reusable",
 			polecatName:  "done",
 			fields:       &beads.AgentFields{AgentState: string(beads.AgentStateDone), CleanupStatus: string(polecat.CleanupClean)},
+			wantState:    polecat.StateDone,
+			wantVerdict:  polecat.WorkstateVerdictSafeToNuke,
+			wantReusable: true,
+		},
+		{
+			name:         "done without active mr blocks reuse when cleanup is dirty",
+			polecatName:  "donedirty",
+			fields:       &beads.AgentFields{AgentState: string(beads.AgentStateDone), CleanupStatus: string(polecat.CleanupUnpushed)},
 			wantState:    polecat.StateDone,
 			wantVerdict:  polecat.WorkstateVerdictNeedsRecovery,
 			wantRecovery: true,

--- a/internal/polecat/workstate.go
+++ b/internal/polecat/workstate.go
@@ -66,7 +66,11 @@ func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
 		}
 	}
 
-	if in.State != StateIdle {
+	// StateDone (agent_state=done, seen before a polecat's own idle transition
+	// lands) falls through to the real predicate checks below instead of
+	// bailing out here — otherwise a merged/clean polecat gets NEEDS_RECOVERY
+	// with no blockers, disagreeing with git-state for no reason (gt-check-recovery-bug).
+	if in.State != StateIdle && in.State != StateDone {
 		verdict := WorkstateVerdictNeedsRecovery
 		needsRecovery := true
 		if in.State == StateWorking {

--- a/internal/polecat/workstate_test.go
+++ b/internal/polecat/workstate_test.go
@@ -104,9 +104,14 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 			want: WorkstateDisposition{Verdict: WorkstateVerdictPendingMR, Reason: "active-mr-open", ReuseStatus: "idle-pr-open", Blockers: []string{"active_mr=gt-mr-open status=open"}},
 		},
 		{
-			name: "done without mr blocks reuse until cleanup",
+			name: "done without mr and clean cleanup is reusable and safe",
 			in:   WorkstateInput{State: StateDone, CleanupStatus: CleanupClean},
-			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "not-idle", NeedsRecovery: true, CountsTowardCapacity: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictSafeToNuke, Reason: "reusable", Reusable: true, SafeToNuke: true, ReuseStatus: "idle-clean"},
+		},
+		{
+			name: "done without mr blocks reuse when cleanup is dirty",
+			in:   WorkstateInput{State: StateDone, CleanupStatus: CleanupUnpushed},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "cleanup-has_unpushed", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed", Blockers: []string{"cleanup_status=has_unpushed"}},
 		},
 		{
 			name: "working counts as working capacity",


### PR DESCRIPTION
## Summary

- `gt polecat check-recovery` always returned `NEEDS_RECOVERY` / "Cleanup refused by an unknown recovery predicate" for merged, clean polecats — disagreeing with `gt polecat git-state`, which independently reported CLEAN/safe-to-kill.
- Root cause: `DecideWorkstate` (`internal/polecat/workstate.go`) short-circuited **any** non-idle `State` — including `StateDone` — straight to `NEEDS_RECOVERY` with no blockers set, before ever evaluating cleanup/git/MQ facts. A polecat can carry `agent_state=done` briefly before its own idle transition lands (self-managed completion, gt-1qlg), so it hit this dead-end path even when everything was actually clean.
- Fix: `StateDone` now falls through to the same predicate checks `StateIdle` gets, instead of bailing out blind. A clean/merged polecat now resolves to `SAFE_TO_NUKE`; a genuinely dirty one still blocks, but with a real blocker message instead of an empty one.
- Updated two existing unit tests that had encoded the buggy behavior as expected (`workstate_test.go`, `polecat_inventory_test.go`).

## Test plan

- [x] `CGO_ENABLED=0 go test ./internal/polecat/...` — 389 passed
- [x] `CGO_ENABLED=0 go test ./internal/cmd/... -run TestBuildPolecatInventoryItem` — 12 passed
- [x] Confirmed the remaining 13 `internal/cmd` failures (macOS tmpdir symlink path mismatches) reproduce identically on unmodified `main`, unrelated to this change