### PR TITLE
fix(dolt): re-enable non-blocking auto_gc

### DIFF
--- a/docs/design/dolt-storage.md
+++ b/docs/design/dolt-storage.md
@@ -239,9 +239,9 @@ but insufficient. DELETE + rebase + gc is the full pipeline.
 
 **Critical update** (Tim Sehn, 2026-02-28): All compaction operations —
 `DOLT_RESET --soft`, `DOLT_REBASE()`, `dolt_gc()` — are **safe on a
-running server**. No downtime or maintenance window is needed. Auto-GC
-has been ON by default since Dolt 1.75.0. Flatten is trivially cheap
-(pointer moves, not data writes). Can run daily or more frequently.
+running server**. Routine compaction does not need downtime. Auto-GC has
+been ON by default since Dolt 1.75.0. Flatten is trivially cheap (pointer
+moves, not data writes). Can run daily or more frequently.
 
 Reference: https://www.dolthub.com/blog/2026-01-28-everybody-rebase/
 
@@ -393,6 +393,19 @@ first, gc second.
 **Automatic GC is ON by default** since Dolt 1.75.0 (October 2025). It
 triggers when the journal file (`.dolt/noms/vvvv...`) reaches 50MB. No
 manual gc or server stop is required — the server handles it.
+
+Gas Town managed Dolt configs should keep `auto_gc_behavior` enabled with
+`archive_level: 1` so the sql-server does not retain every old chunk index
+and grow RSS indefinitely. The config is regenerated only when the managed
+Dolt server starts; a deployed change takes effect on the next Dolt restart.
+Set `GT_DOLT_AUTO_GC=off` before that restart to emit `enable: false` and
+`archive_level: 0` as an operational rollback switch.
+
+If auto-GC was disabled long enough for a database to bloat, schedule one
+explicit `dolt gc --full --archive-level=1` in a maintenance window to reset
+the storage/RSS baseline. That one-time reclaim is an operator action, not a
+hidden daemon task; after it completes, auto-GC handles ongoing chunk
+reclamation.
 
 ```sql
 -- Manual gc (safe on a running server, no need to stop)

--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -868,6 +868,15 @@ func writeDaemonDoltConfig(cfg *DoltServerConfig, configPath string) error {
 			systemVariablesBlock = fmt.Sprintf("\nsystem_variables:\n  dolt_stats_enabled: %s\n", strings.TrimSpace(stats))
 		}
 	}
+	// Non-blocking storage GC bounds the sql-server's RSS (hq-excy9g); on by
+	// default. GT_DOLT_AUTO_GC=off (or false/0/disabled) disables it at the next
+	// Dolt restart without a source revert+rebuild — the runtime escape hatch.
+	autoGcBlock := "  auto_gc_behavior:\n    enable: true\n    archive_level: 1\n"
+	if v, ok := os.LookupEnv("GT_DOLT_AUTO_GC"); ok {
+		if vv := strings.ToLower(strings.TrimSpace(v)); vv == "off" || vv == "false" || vv == "0" || vv == "disabled" {
+			autoGcBlock = "  auto_gc_behavior:\n    enable: false\n    archive_level: 0\n"
+		}
+	}
 	content := fmt.Sprintf(`# Dolt SQL server configuration — managed by Gas Town daemon
 # Do not edit manually; overwritten on each daemon-managed server start.
 
@@ -883,14 +892,12 @@ data_dir: %q
 
 behavior:
   dolt_transaction_commit: false
-%s  auto_gc_behavior:
-    enable: false
-    archive_level: 0
-%s`,
+%s%s%s`,
 		cfg.Port,
 		hostLine,
 		cfg.DataDir,
 		eventSchedulerLine,
+		autoGcBlock,
 		systemVariablesBlock,
 	)
 	return os.WriteFile(configPath, []byte(content), 0600)

--- a/internal/daemon/dolt_endpoint_config_test.go
+++ b/internal/daemon/dolt_endpoint_config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestNewDoltServerManagerNormalizesManagedEndpointFromTownConfig(t *testing.T) {
@@ -121,6 +123,32 @@ func TestApplyConfiguredDoltHostEnvClearsManagedConfigWithoutHost(t *testing.T) 
 	}
 }
 
+func TestWriteDaemonDoltConfigAutoGC(t *testing.T) {
+	t.Run("default enabled", func(t *testing.T) {
+		unsetEnv(t, "GT_DOLT_AUTO_GC")
+
+		got := writeAndReadDaemonAutoGC(t)
+		if !got.Enable {
+			t.Fatalf("auto_gc_behavior.enable = false, want true")
+		}
+		if got.ArchiveLevel != 1 {
+			t.Fatalf("auto_gc_behavior.archive_level = %d, want 1", got.ArchiveLevel)
+		}
+	})
+
+	t.Run("kill switch disabled", func(t *testing.T) {
+		t.Setenv("GT_DOLT_AUTO_GC", "disabled")
+
+		got := writeAndReadDaemonAutoGC(t)
+		if got.Enable {
+			t.Fatalf("GT_DOLT_AUTO_GC=disabled: auto_gc_behavior.enable = true, want false")
+		}
+		if got.ArchiveLevel != 0 {
+			t.Fatalf("GT_DOLT_AUTO_GC=disabled: auto_gc_behavior.archive_level = %d, want 0", got.ArchiveLevel)
+		}
+	})
+}
+
 func writeManagedDoltConfig(t *testing.T, townRoot, content string) {
 	t.Helper()
 	doltDataDir := filepath.Join(townRoot, ".dolt-data")
@@ -130,6 +158,53 @@ func writeManagedDoltConfig(t *testing.T, townRoot, content string) {
 	if err := os.WriteFile(filepath.Join(doltDataDir, "config.yaml"), []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func writeAndReadDaemonAutoGC(t *testing.T) struct {
+	Enable       bool `yaml:"enable"`
+	ArchiveLevel int  `yaml:"archive_level"`
+} {
+	t.Helper()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	cfg := &DoltServerConfig{Port: 3307, DataDir: dir}
+	if err := writeDaemonDoltConfig(cfg, configPath); err != nil {
+		t.Fatalf("writeDaemonDoltConfig: %v", err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading daemon Dolt config: %v", err)
+	}
+
+	var parsed struct {
+		Behavior struct {
+			AutoGCBehavior struct {
+				Enable       bool `yaml:"enable"`
+				ArchiveLevel int  `yaml:"archive_level"`
+			} `yaml:"auto_gc_behavior"`
+		} `yaml:"behavior"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("generated daemon config is invalid YAML: %v\n%s", err, data)
+	}
+	return parsed.Behavior.AutoGCBehavior
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+
+	old, hadOld := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if hadOld {
+			_ = os.Setenv(key, old)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
 }
 
 func assertProcessEnv(t *testing.T, key, want string) {

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -266,6 +266,12 @@ type Config struct {
 	// config. Default is "0" to avoid background stats workers during high-churn
 	// agent workloads. Set to "omit" to leave the variable out of config.yaml.
 	DoltStatsEnabled string
+
+	// AutoGC controls Dolt's non-blocking storage GC (auto_gc_behavior) in managed
+	// config. Default "on" keeps the sql-server's RSS bounded (hq-excy9g). Set to
+	// "off" (or false/0/disabled), typically via GT_DOLT_AUTO_GC, to disable it
+	// without a source revert+rebuild — a runtime escape hatch.
+	AutoGC string
 }
 
 // DefaultConfig returns the default Dolt server configuration.
@@ -296,6 +302,7 @@ func DefaultConfig(townRoot string) *Config {
 		LogLevel:         "warning",
 		EventScheduler:   "OFF",
 		DoltStatsEnabled: "0",
+		AutoGC:           "on",
 	}
 
 	// Optional override for the idle-session timeout. Negative values disable
@@ -328,6 +335,9 @@ func DefaultConfig(townRoot string) *Config {
 	}
 	if stats, ok := os.LookupEnv("GT_DOLT_STATS_ENABLED"); ok {
 		config.DoltStatsEnabled = stats
+	}
+	if autoGc, ok := os.LookupEnv("GT_DOLT_AUTO_GC"); ok {
+		config.AutoGC = autoGc
 	}
 
 	if u := os.Getenv("GT_DOLT_USER"); u != "" {
@@ -1627,11 +1637,22 @@ func writeServerConfig(config *Config, configPath string) error {
 		systemVariablesBlock = fmt.Sprintf("\nsystem_variables:\n  dolt_stats_enabled: %s\n", strings.TrimSpace(config.DoltStatsEnabled))
 	}
 
+	// Non-blocking storage GC keeps the managed sql-server's RSS bounded (hq-excy9g);
+	// enabled by default. GT_DOLT_AUTO_GC=off (or false/0/disabled) turns it off at
+	// runtime (next Dolt restart) without a source revert+rebuild — the escape hatch
+	// given the old blocking-GC lockup history. Dolt's non-blocking auto-GC is
+	// default-on since 1.75.
+	autoGcBlock := "  auto_gc_behavior:\n    enable: true\n    archive_level: 1\n"
+	if v := strings.ToLower(strings.TrimSpace(config.AutoGC)); v == "off" || v == "false" || v == "0" || v == "disabled" {
+		autoGcBlock = "  auto_gc_behavior:\n    enable: false\n    archive_level: 0\n"
+	}
+
 	content := fmt.Sprintf(`# Dolt SQL server configuration — managed by Gas Town (gt dolt start)
 # Do not edit manually; changes are overwritten on each server start.
 # To customize, set Gas Town environment variables:
 #   GT_DOLT_PORT, GT_DOLT_HOST, GT_DOLT_USER, GT_DOLT_PASSWORD, GT_DOLT_LOGLEVEL
 #   GT_DOLT_EVENT_SCHEDULER (OFF, ON, omit), GT_DOLT_STATS_ENABLED (0, 1, omit)
+#   GT_DOLT_AUTO_GC (on, off)
 
 log_level: %s
 
@@ -1642,10 +1663,7 @@ data_dir: "%s"
 
 behavior:
   dolt_transaction_commit: false
-%s  auto_gc_behavior:
-    enable: false
-    archive_level: 0
-%s`,
+%s%s%s`,
 		config.LogLevel,
 		config.Port,
 		hostLine,
@@ -1654,6 +1672,7 @@ behavior:
 		writeTimeoutLine,
 		filepath.ToSlash(config.DataDir),
 		eventSchedulerLine,
+		autoGcBlock,
 		systemVariablesBlock,
 	)
 

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -4001,6 +4001,9 @@ func TestDefaultConfig_IgnoreConfigUsesEnvPort(t *testing.T) {
 func TestDefaultConfig_ManagedDefaultsAndEnvOverrides(t *testing.T) {
 	townRoot := t.TempDir()
 	t.Setenv("GT_DOLT_PORT", "")
+	unsetEnv(t, "GT_DOLT_STATS_ENABLED")
+	unsetEnv(t, "GT_DOLT_EVENT_SCHEDULER")
+	unsetEnv(t, "GT_DOLT_AUTO_GC")
 
 	config := DefaultConfig(townRoot)
 	if config.EventScheduler != "OFF" {

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -4009,15 +4009,22 @@ func TestDefaultConfig_ManagedDefaultsAndEnvOverrides(t *testing.T) {
 	if config.DoltStatsEnabled != "0" {
 		t.Errorf("DoltStatsEnabled = %q, want 0", config.DoltStatsEnabled)
 	}
+	if config.AutoGC != "on" {
+		t.Errorf("AutoGC = %q, want on", config.AutoGC)
+	}
 
 	t.Setenv("GT_DOLT_STATS_ENABLED", "omit")
 	t.Setenv("GT_DOLT_EVENT_SCHEDULER", "omit")
+	t.Setenv("GT_DOLT_AUTO_GC", "off")
 	config = DefaultConfig(townRoot)
 	if config.DoltStatsEnabled != "omit" {
 		t.Errorf("DoltStatsEnabled = %q, want omit", config.DoltStatsEnabled)
 	}
 	if config.EventScheduler != "omit" {
 		t.Errorf("EventScheduler = %q, want omit", config.EventScheduler)
+	}
+	if config.AutoGC != "off" {
+		t.Errorf("AutoGC = %q, want off", config.AutoGC)
 	}
 }
 

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -4522,14 +4522,58 @@ func TestWriteServerConfig_Defaults(t *testing.T) {
 	if parsed.Behavior.EventScheduler == nil || *parsed.Behavior.EventScheduler != "OFF" {
 		t.Fatalf("behavior.event_scheduler = %v, want OFF", parsed.Behavior.EventScheduler)
 	}
-	if parsed.Behavior.AutoGCBehavior.Enable {
-		t.Error("behavior.auto_gc_behavior.enable = true, want false")
+	if !parsed.Behavior.AutoGCBehavior.Enable {
+		t.Error("behavior.auto_gc_behavior.enable = false, want true (non-blocking auto_gc re-enabled, hq-excy9g)")
 	}
-	if parsed.Behavior.AutoGCBehavior.ArchiveLevel != 0 {
-		t.Errorf("behavior.auto_gc_behavior.archive_level = %d, want 0", parsed.Behavior.AutoGCBehavior.ArchiveLevel)
+	if parsed.Behavior.AutoGCBehavior.ArchiveLevel != 1 {
+		t.Errorf("behavior.auto_gc_behavior.archive_level = %d, want 1", parsed.Behavior.AutoGCBehavior.ArchiveLevel)
 	}
 	if parsed.SystemVariables.DoltStatsEnabled == nil || *parsed.SystemVariables.DoltStatsEnabled != 0 {
 		t.Fatalf("system_variables.dolt_stats_enabled = %v, want 0", parsed.SystemVariables.DoltStatsEnabled)
+	}
+}
+
+// TestWriteServerConfig_AutoGCDisabled verifies the GT_DOLT_AUTO_GC kill-switch:
+// AutoGC="off" emits auto_gc_behavior {enable:false, archive_level:0} so auto_gc can
+// be disabled at runtime without a source revert+rebuild (hq-excy9g escape hatch).
+func TestWriteServerConfig_AutoGCDisabled(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	config := &Config{
+		Port:           3307,
+		DataDir:        dir,
+		MaxConnections: 1000,
+		ReadTimeoutMs:  DefaultReadTimeoutMs,
+		WriteTimeoutMs: DefaultWriteTimeoutMs,
+		LogLevel:       "warning",
+		AutoGC:         "off",
+	}
+
+	if err := writeServerConfig(config, configPath); err != nil {
+		t.Fatalf("writeServerConfig: %v", err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+
+	var parsed struct {
+		Behavior struct {
+			AutoGCBehavior struct {
+				Enable       bool `yaml:"enable"`
+				ArchiveLevel int  `yaml:"archive_level"`
+			} `yaml:"auto_gc_behavior"`
+		} `yaml:"behavior"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("generated config is invalid YAML: %v\n%s", err, data)
+	}
+	if parsed.Behavior.AutoGCBehavior.Enable {
+		t.Error("AutoGC=off: auto_gc_behavior.enable = true, want false")
+	}
+	if parsed.Behavior.AutoGCBehavior.ArchiveLevel != 0 {
+		t.Errorf("AutoGC=off: archive_level = %d, want 0", parsed.Behavior.AutoGCBehavior.ArchiveLevel)
 	}
 }
 


### PR DESCRIPTION
Replacement for #4509 carrying forward Sean Bearden's scoped Dolt auto-GC fix on current main.\n\nOriginal PR: #4509\nOriginal author: @seanbearden\nReplacement branch: Bella-Giraffety:polecat/railroad/gt-pr-4509+de77bd\nHead: 6a02d50565f0ca93ff92071eac2e6a196d1984a6\nBase: 3126a5753b064a3b2d49bdae5e587b59ef3c6073\n\nPR Sheriff evidence on bead gt-pr-4509: 15 research legs, 5 pre-implementation reviews, 5 exact-final-head post reviews, focused verification, blocker scan, and gt-pr-sheriff-check --merge-gate PASS.\n\nFocused verification passed:\n- GT_DOLT_AUTO_GC=off CGO_ENABLED=0 go test ./internal/doltserver -run 'TestDefaultConfig_ManagedDefaultsAndEnvOverrides' -count=1\n- CGO_ENABLED=0 go test ./internal/doltserver -run 'TestDefaultConfig_ManagedDefaultsAndEnvOverrides|TestWriteServerConfig_Defaults|TestWriteServerConfig_AutoGCDisabled' -count=1\n- CGO_ENABLED=0 go test -v ./internal/daemon -run 'TestWriteDaemonDoltConfigAutoGC' -count=1\n- git diff --check upstream/main...HEAD\n- gofmt -l changed Go test files\n\nCleanup-first rationale: re-enables Dolt's existing managed auto_gc boundary instead of adding watchdog restarts, retry loops, or manual-GC-only workarounds. Excludes unrelated stacked dog_molecule work from the original PR.