### PR TITLE
fix: clear bd target selectors from agent env

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -362,6 +362,80 @@ func TestBuildBDEnvConnectionOverridesAndDoesNotRestoreDataDir(t *testing.T) {
 	}
 }
 
+func TestBuildBDEnvDoesNotRestoreGTDoltDataDir(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":4407}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := []string{
+		"PATH=/usr/bin",
+		"GT_DOLT_DATA=/town/.dolt-data",
+		"GT_DOLT_PORT=5507",
+		"BEADS_DOLT_DATA_DIR=/wrong/data",
+		"BEADS_DOLT_SERVER_DATABASE=hq",
+		"BEADS_DOLT_AUTO_START=0",
+	}
+
+	tests := []struct {
+		name           string
+		env            []string
+		wantBeadsDir   string
+		wantDB         string
+		wantConnection bool
+	}{
+		{name: "pinned", env: BuildPinnedBDEnv(base, beadsDir), wantBeadsDir: beadsDir, wantDB: "rigdb", wantConnection: true},
+		{name: "routing", env: BuildRoutingBDEnv(base, beadsDir), wantConnection: true},
+		{name: "read only pinned", env: BuildReadOnlyPinnedBDEnv(base, beadsDir), wantBeadsDir: beadsDir, wantDB: "rigdb", wantConnection: true},
+		{name: "read only routing", env: BuildReadOnlyRoutingBDEnv(base, beadsDir), wantConnection: true},
+		{name: "mutation pinned", env: BuildMutationPinnedBDEnv(base, beadsDir), wantBeadsDir: beadsDir, wantDB: "rigdb", wantConnection: true},
+		{name: "mutation routing", env: BuildMutationRoutingBDEnv(base, beadsDir), wantConnection: true},
+		{name: "mutation neutral", env: BuildMutationNeutralBDEnv(base)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := envMap(tc.env)
+			for _, key := range []string{"BEADS_DOLT_DATA_DIR", "GT_DOLT_DATA"} {
+				if value, ok := got[key]; ok {
+					t.Fatalf("%s should be stripped, got %q in %v", key, value, tc.env)
+				}
+			}
+			if got["BEADS_DOLT_AUTO_START"] != "0" {
+				t.Fatalf("BEADS_DOLT_AUTO_START should be preserved, got %q in %v", got["BEADS_DOLT_AUTO_START"], tc.env)
+			}
+			if got["BEADS_DIR"] != tc.wantBeadsDir {
+				t.Fatalf("BEADS_DIR = %q, want %q in %v", got["BEADS_DIR"], tc.wantBeadsDir, tc.env)
+			}
+			if tc.wantDB == "" {
+				if value, ok := got["BEADS_DOLT_SERVER_DATABASE"]; ok {
+					t.Fatalf("BEADS_DOLT_SERVER_DATABASE should be stripped, got %q in %v", value, tc.env)
+				}
+			} else if got["BEADS_DOLT_SERVER_DATABASE"] != tc.wantDB {
+				t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want %q in %v", got["BEADS_DOLT_SERVER_DATABASE"], tc.wantDB, tc.env)
+			}
+			if tc.wantConnection {
+				if got["BEADS_DOLT_SERVER_HOST"] != "127.0.0.1" {
+					t.Fatalf("BEADS_DOLT_SERVER_HOST = %q, want metadata host in %v", got["BEADS_DOLT_SERVER_HOST"], tc.env)
+				}
+				if got["BEADS_DOLT_SERVER_PORT"] != "5507" || got["BEADS_DOLT_PORT"] != "5507" {
+					t.Fatalf("ports = server:%q legacy:%q, want 5507 in %v", got["BEADS_DOLT_SERVER_PORT"], got["BEADS_DOLT_PORT"], tc.env)
+				}
+			} else {
+				for _, key := range []string{"BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT"} {
+					if value, ok := got[key]; ok {
+						t.Fatalf("neutral env should not add %s, got %q in %v", key, value, tc.env)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestBuildPinnedBDEnvStripsCaseVariantTargetEnvWhenKeysAreCaseInsensitive(t *testing.T) {
 	withCaseInsensitiveEnvKeys(t)
 
@@ -376,6 +450,7 @@ func TestBuildPinnedBDEnvStripsCaseVariantTargetEnvWhenKeysAreCaseInsensitive(t 
 
 	env := BuildPinnedBDEnv([]string{
 		"PATH=/usr/bin",
+		"gt_dolt_data=/wrong/.dolt-data",
 		"beads_dir=/wrong",
 		"beads_db=/wrong.db",
 		"bd_db=/wrong.bd",
@@ -390,6 +465,7 @@ func TestBuildPinnedBDEnvStripsCaseVariantTargetEnvWhenKeysAreCaseInsensitive(t 
 	got := envMap(env)
 
 	for _, key := range []string{
+		"gt_dolt_data",
 		"beads_dir",
 		"beads_db",
 		"bd_db",
@@ -5187,7 +5263,7 @@ func TestBuildRunEnv_OverridesStaleDoltPortFromBeadsDir(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.port"), []byte("43113\n"), 0644); err != nil {
 		t.Fatalf("write dolt-server.port: %v", err)
 	}
-
+	t.Setenv("GT_DOLT_HOST", "")
 	t.Setenv("GT_DOLT_PORT", "")
 	t.Setenv("BEADS_DOLT_PORT", "3307")
 
@@ -5216,7 +5292,7 @@ func TestBuildRoutingEnv_OverridesStaleDoltPortFromBeadsDir(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.port"), []byte("43113\n"), 0644); err != nil {
 		t.Fatalf("write dolt-server.port: %v", err)
 	}
-
+	t.Setenv("GT_DOLT_HOST", "")
 	t.Setenv("GT_DOLT_PORT", "")
 	t.Setenv("BEADS_DOLT_PORT", "3307")
 
@@ -5274,6 +5350,7 @@ fi
 {
   printf 'BEADS_DIR=%s\n' "${BEADS_DIR:-}"
   printf 'BEADS_DOLT_DATA_DIR=%s\n' "${BEADS_DOLT_DATA_DIR:-}"
+  printf 'GT_DOLT_DATA=%s\n' "${GT_DOLT_DATA:-}"
   printf 'BEADS_DOLT_HOST=%s\n' "${BEADS_DOLT_HOST:-}"
   printf 'BEADS_DOLT_PORT=%s\n' "${BEADS_DOLT_PORT:-}"
   printf 'BEADS_DOLT_SERVER_HOST=%s\n' "${BEADS_DOLT_SERVER_HOST:-}"
@@ -5295,9 +5372,9 @@ printf 'unknown\n'
 	}
 	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("MOCK_BD_LOG", logPath)
+	t.Setenv("GT_DOLT_DATA", "/home/coder/gt/.dolt-data")
 	t.Setenv("BEADS_DOLT_DATA_DIR", "/home/coder/gt/.dolt-data")
 	t.Setenv("BEADS_DOLT_HOST", "127.0.0.1")
-	t.Setenv("GT_DOLT_DATA", "")
 	t.Setenv("GT_DOLT_PORT", "")
 	t.Setenv("BEADS_DOLT_PORT", "3307")
 	t.Setenv("BEADS_DOLT_SERVER_HOST", "127.0.0.1")
@@ -5319,6 +5396,7 @@ printf 'unknown\n'
 	log := string(data)
 	for _, forbidden := range []string{
 		"BEADS_DOLT_DATA_DIR=/home/coder/gt/.dolt-data",
+		"GT_DOLT_DATA=/home/coder/gt/.dolt-data",
 		"BEADS_DOLT_HOST=127.0.0.1",
 		"BEADS_DOLT_SERVER_DATABASE=hq",
 	} {

--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -974,6 +974,7 @@ func buildRestartCommandWithOpts(sessionName string, opts buildRestartCommandOpt
 	if _, hasNodeOpts := agentEnv["NODE_OPTIONS"]; !hasNodeOpts {
 		envMap["NODE_OPTIONS"] = ""
 	}
+	config.SanitizeAgentEnv(envMap, agentEnv)
 
 	// Build the full command with OS-appropriate env prefix
 	var cdPrefix string

--- a/internal/cmd/handoff_test.go
+++ b/internal/cmd/handoff_test.go
@@ -266,6 +266,86 @@ func TestBuildRestartCommand_MergesAgentPresetEnv(t *testing.T) {
 	}
 }
 
+func TestBuildRestartCommand_ClearsBDTargetSelectors(t *testing.T) {
+	setupHandoffTestRegistry(t)
+
+	origCwd, _ := os.Getwd()
+	origGTAgent := os.Getenv("GT_AGENT")
+	origTownRoot := os.Getenv("GT_TOWN_ROOT")
+	origRoot := os.Getenv("GT_ROOT")
+	t.Cleanup(func() {
+		_ = os.Chdir(origCwd)
+		_ = os.Setenv("GT_AGENT", origGTAgent)
+		_ = os.Setenv("GT_TOWN_ROOT", origTownRoot)
+		_ = os.Setenv("GT_ROOT", origRoot)
+	})
+
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "gastown")
+	witnessDir := filepath.Join(rigPath, "witness")
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"gastown"}`), 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+	if err := os.MkdirAll(witnessDir, 0755); err != nil {
+		t.Fatalf("mkdir witness dir: %v", err)
+	}
+
+	townSettings := config.NewTownSettings()
+	townSettings.DefaultAgent = "target-cleaner"
+	townSettings.Agents = map[string]*config.RuntimeConfig{
+		"target-cleaner": {
+			Command: "claude",
+			Args:    []string{"--dangerously-skip-permissions"},
+			Env: map[string]string{
+				"BEADS_DIR":                  "/agent/beads",
+				"BEADS_DOLT_DATA_DIR":        "/agent/data",
+				"BEADS_DOLT_SERVER_DATABASE": "agentdb",
+				"BEADS_DOLT_SERVER_SOCKET":   "/agent/socket",
+				"GT_DOLT_DATA":               "/agent/data",
+				"GT_DOLT_PORT":               "1555",
+				"GT_DOLT_HOST":               "agent-host",
+			},
+		},
+	}
+	if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatalf("SaveTownSettings: %v", err)
+	}
+	if err := config.SaveRigSettings(config.RigSettingsPath(rigPath), config.NewRigSettings()); err != nil {
+		t.Fatalf("SaveRigSettings: %v", err)
+	}
+
+	_ = os.Setenv("GT_AGENT", "target-cleaner")
+	_ = os.Setenv("GT_TOWN_ROOT", "")
+	_ = os.Setenv("GT_ROOT", "")
+	if err := os.Chdir(witnessDir); err != nil {
+		t.Fatalf("chdir witness dir: %v", err)
+	}
+
+	cmd, err := buildRestartCommand("gt-witness")
+	if err != nil {
+		t.Fatalf("buildRestartCommand: %v", err)
+	}
+
+	for _, key := range []string{"BEADS_DIR", "BEADS_DOLT_DATA_DIR", "BEADS_DOLT_SERVER_DATABASE", "BEADS_DOLT_SERVER_SOCKET", "GT_DOLT_DATA"} {
+		if !strings.Contains(cmd, key+"=") {
+			t.Fatalf("restart command missing cleared %s assignment: %q", key, cmd)
+		}
+	}
+	for _, stale := range []string{"/agent/beads", "/agent/data", "agentdb", "/agent/socket"} {
+		if strings.Contains(cmd, stale) {
+			t.Fatalf("restart command leaked stale bd selector value %q: %q", stale, cmd)
+		}
+	}
+	for _, want := range []string{"GT_DOLT_PORT=1555", "GT_DOLT_HOST=agent-host"} {
+		if !strings.Contains(cmd, want) {
+			t.Fatalf("restart command missing preserved connection env %q: %q", want, cmd)
+		}
+	}
+}
+
 func TestBuildRestartCommandWithOpts_ContinuePrompt(t *testing.T) {
 	setupHandoffTestRegistry(t)
 

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -1171,7 +1171,7 @@ if [ "$1" = "--allow-stale" ] && [ "${2:-}" = "version" ]; then
   echo 'bd version 1.0.0'
   exit 0
 fi
-printf '%s|%s|%s|%s|%s\n' "$*" "$(pwd)" "${BEADS_DIR:-}" "${BEADS_DOLT_DATA_DIR:-}" "${BEADS_DOLT_SERVER_DATABASE:-}" >> "${BD_LOG}"
+printf '%s|%s|%s|%s|%s|%s\n' "$*" "$(pwd)" "${BEADS_DIR:-}" "${BEADS_DOLT_DATA_DIR:-}" "${GT_DOLT_DATA:-}" "${BEADS_DOLT_SERVER_DATABASE:-}" >> "${BD_LOG}"
 cmd="$1"
 shift || true
 if [ "$cmd" = "--allow-stale" ]; then
@@ -1206,7 +1206,7 @@ esac
 	}
 	line := strings.TrimSpace(string(logBytes))
 	parts := strings.Split(line, "|")
-	if len(parts) != 5 {
+	if len(parts) != 6 {
 		t.Fatalf("malformed bd log: %q", line)
 	}
 	if !strings.Contains(parts[0], "show gt-hq-oy83-cleanup --json") {
@@ -1221,8 +1221,11 @@ esac
 	if parts[3] != "" {
 		t.Fatalf("BEADS_DOLT_DATA_DIR leaked: %q", parts[3])
 	}
-	if parts[4] != "gastown" {
-		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want gastown", parts[4])
+	if parts[4] != "" {
+		t.Fatalf("GT_DOLT_DATA leaked: %q", parts[4])
+	}
+	if parts[5] != "gastown" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want gastown", parts[5])
 	}
 }
 

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -23,6 +23,21 @@ var IdentityEnvVars = []string{
 	"GT_SESSION", "GT_AGENT", "BD_ACTOR", "GIT_AUTHOR_NAME", "BEADS_AGENT_NAME",
 }
 
+var bdTargetSelectorEnvVars = []string{
+	"BEADS_DIR",
+	"BEADS_DB",
+	"BD_DB",
+	"BEADS_SHARED_SERVER_DIR",
+	"BEADS_DOLT_DATA_DIR",
+	"BEADS_DOLT_DATABASE",
+	"BEADS_DOLT_SERVER_DATABASE",
+	"BEADS_DOLT_HOST",
+	"BEADS_DOLT_SHARED_SERVER",
+	"BEADS_DOLT_SERVER_MODE",
+	"BEADS_DOLT_SERVER_SOCKET",
+	"GT_DOLT_DATA",
+}
+
 // AgentEnvConfig specifies the configuration for generating agent environment variables.
 // This is the single source of truth for all agent environment configuration.
 type AgentEnvConfig struct {
@@ -222,6 +237,8 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 	// See: https://github.com/steveyegge/gastown/issues/1666
 	env["CLAUDECODE"] = ""
 
+	clearBDTargetSelectorEnv(env)
+
 	// Propagate Claude Code's own OTEL telemetry when GT telemetry is enabled.
 	// Reuses the same VictoriaMetrics endpoint as gastown's telemetry so all
 	// metrics (gt + claude) land in the same store.
@@ -392,6 +409,12 @@ func setDoltPortEnv(env map[string]string, port string) {
 	env["GT_DOLT_PORT"] = port
 	env["BEADS_DOLT_SERVER_PORT"] = port
 	env["BEADS_DOLT_PORT"] = port
+}
+
+func clearBDTargetSelectorEnv(env map[string]string) {
+	for _, key := range bdTargetSelectorEnvVars {
+		env[key] = ""
+	}
 }
 
 // sanitizeOTELAttrValue prepares a string for use as a value in OTEL_RESOURCE_ATTRIBUTES.

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -764,6 +764,37 @@ func TestSanitizeAgentEnv_ClearsClaudeCode(t *testing.T) {
 	}
 }
 
+func TestSanitizeAgentEnv_ClearsBDTargetSelectors(t *testing.T) {
+	t.Parallel()
+
+	resolvedEnv := map[string]string{
+		"GT_DOLT_PORT":             "13307",
+		"GT_DOLT_HOST":             "dolt.example",
+		"BEADS_DOLT_PORT":          "13307",
+		"BEADS_DOLT_SERVER_PORT":   "13307",
+		"BEADS_DOLT_SERVER_HOST":   "dolt.example",
+		"BEADS_DOLT_AUTO_START":    "0",
+		"BEADS_DOLT_SERVER_SOCKET": "/tmp/stale.sock",
+	}
+	callerEnv := map[string]string{}
+	for _, key := range bdTargetSelectorEnvVars {
+		resolvedEnv[key] = "stale"
+		callerEnv[key] = "caller-stale"
+	}
+
+	SanitizeAgentEnv(resolvedEnv, callerEnv)
+
+	for _, key := range bdTargetSelectorEnvVars {
+		assertEnv(t, resolvedEnv, key, "")
+	}
+	assertEnv(t, resolvedEnv, "GT_DOLT_PORT", "13307")
+	assertEnv(t, resolvedEnv, "GT_DOLT_HOST", "dolt.example")
+	assertEnv(t, resolvedEnv, "BEADS_DOLT_PORT", "13307")
+	assertEnv(t, resolvedEnv, "BEADS_DOLT_SERVER_PORT", "13307")
+	assertEnv(t, resolvedEnv, "BEADS_DOLT_SERVER_HOST", "dolt.example")
+	assertEnv(t, resolvedEnv, "BEADS_DOLT_AUTO_START", "0")
+}
+
 func TestAgentEnv_ExcludesAnthropicBaseURL(t *testing.T) {
 	// Not parallel — t.Setenv modifies process environment.
 
@@ -839,6 +870,31 @@ func TestAgentEnv_IncludesClaudeCodeClearing(t *testing.T) {
 			assertEnv(t, env, "CLAUDECODE", "")
 		})
 	}
+}
+
+func TestAgentEnv_ClearsBDTargetSelectors(t *testing.T) {
+	// Not parallel: t.Setenv modifies process environment.
+	for _, key := range bdTargetSelectorEnvVars {
+		t.Setenv(key, "stale")
+	}
+	t.Setenv("GT_DOLT_PORT", "13307")
+	t.Setenv("GT_DOLT_HOST", "dolt.example")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+
+	env := AgentEnv(AgentEnvConfig{
+		Role:      "polecat",
+		Rig:       "myrig",
+		AgentName: "Toast",
+		TownRoot:  "/town",
+	})
+	for _, key := range bdTargetSelectorEnvVars {
+		assertEnv(t, env, key, "")
+	}
+	assertEnv(t, env, "GT_DOLT_PORT", "13307")
+	assertEnv(t, env, "BEADS_DOLT_PORT", "13307")
+	assertEnv(t, env, "BEADS_DOLT_SERVER_PORT", "13307")
+	assertEnv(t, env, "BEADS_DOLT_SERVER_HOST", "dolt.example")
+	assertEnv(t, env, "BEADS_DOLT_AUTO_START", "0")
 }
 
 func TestAgentEnv_DisablesBdBackup(t *testing.T) {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -2404,6 +2404,8 @@ func SanitizeAgentEnv(resolvedEnv, callerEnv map[string]string) {
 	if _, ok := callerEnv["CLAUDECODE"]; !ok {
 		resolvedEnv["CLAUDECODE"] = ""
 	}
+
+	clearBDTargetSelectorEnv(resolvedEnv)
 }
 
 // PrependEnv prepends export statements to a command string.

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1492,6 +1492,72 @@ func TestBuildStartupCommand_UsesRigAgentWhenRigPathProvided(t *testing.T) {
 	}
 }
 
+func TestBuildStartupCommand_ClearsBDTargetSelectors(t *testing.T) {
+	binDir := t.TempDir()
+	writeAgentStub(t, binDir, "agent")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "testrig")
+	townSettings := NewTownSettings()
+	townSettings.RoleAgents = map[string]string{constants.RoleWitness: "target-cleaner"}
+	townSettings.Agents["target-cleaner"] = &RuntimeConfig{
+		Command: "agent",
+		Env: map[string]string{
+			"BEADS_DIR":                  "/agent/beads",
+			"BEADS_DOLT_DATA_DIR":        "/agent/data",
+			"BEADS_DOLT_SERVER_DATABASE": "agentdb",
+			"BEADS_DOLT_SERVER_SOCKET":   "/agent/socket",
+			"GT_DOLT_DATA":               "/agent/data",
+			"GT_DOLT_PORT":               "1555",
+			"GT_DOLT_HOST":               "agent-host",
+			"BEADS_DOLT_PORT":            "1555",
+			"BEADS_DOLT_SERVER_PORT":     "1555",
+			"BEADS_DOLT_SERVER_HOST":     "agent-host",
+			"BEADS_DOLT_AUTO_START":      "0",
+		},
+	}
+	if err := SaveTownSettings(TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatalf("SaveTownSettings: %v", err)
+	}
+	if err := SaveRigSettings(RigSettingsPath(rigPath), NewRigSettings()); err != nil {
+		t.Fatalf("SaveRigSettings: %v", err)
+	}
+
+	cmd := BuildStartupCommand(map[string]string{
+		"GT_ROLE":                    constants.RoleWitness,
+		"BEADS_DIR":                  "/caller/beads",
+		"BEADS_DOLT_DATA_DIR":        "/caller/data",
+		"BEADS_DOLT_SERVER_DATABASE": "callerdb",
+		"GT_DOLT_DATA":               "/caller/data",
+		"GT_DOLT_PORT":               "1444",
+		"GT_DOLT_HOST":               "caller-host",
+	}, rigPath, "")
+
+	for _, key := range bdTargetSelectorEnvVars {
+		if !strings.Contains(cmd, key+"=") {
+			t.Fatalf("startup command missing cleared %s assignment: %q", key, cmd)
+		}
+	}
+	for _, stale := range []string{"/caller", "/agent", "callerdb", "agentdb"} {
+		if strings.Contains(cmd, stale) {
+			t.Fatalf("startup command leaked stale bd selector value %q: %q", stale, cmd)
+		}
+	}
+	for _, want := range []string{
+		"GT_DOLT_PORT=1555",
+		"GT_DOLT_HOST=agent-host",
+		"BEADS_DOLT_PORT=1555",
+		"BEADS_DOLT_SERVER_PORT=1555",
+		"BEADS_DOLT_SERVER_HOST=agent-host",
+		"BEADS_DOLT_AUTO_START=0",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Fatalf("startup command missing preserved connection env %q: %q", want, cmd)
+		}
+	}
+}
+
 func TestBuildStartupCommand_UsesRoleAgentsFromTownSettings(t *testing.T) {
 	townRoot := t.TempDir()
 	rigPath := filepath.Join(townRoot, "testrig")

--- a/internal/proxy/exec_test.go
+++ b/internal/proxy/exec_test.go
@@ -356,6 +356,8 @@ func TestHandleExec_BDCreateRepoAliasPinsCanonicalBeadsDir(t *testing.T) {
 	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\nfor arg in \"$@\"; do printf '[%s]' \"$arg\"; done\nprintf '\\nBEADS_DIR=%s\\nBEADS_DOLT_SERVER_DATABASE=%s\\nBEADS_DOLT_DATA_DIR=%s\\nBD_DOLT_AUTO_COMMIT=%s\\nBD_NO_GIT_OPS=%s\\n' \"${BEADS_DIR:-}\" \"${BEADS_DOLT_SERVER_DATABASE:-}\" \"${BEADS_DOLT_DATA_DIR:-}\" \"${BD_DOLT_AUTO_COMMIT:-}\" \"${BD_NO_GIT_OPS:-}\"\n"), 0755))
 	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "stale")
+	t.Setenv("BEADS_DOLT_DATA_DIR", "/stale/data")
+	t.Setenv("GT_DOLT_DATA", "/stale/data")
 	t.Setenv("BEADS_DIR", "/wrong")
 
 	srv, err := New(Config{
@@ -394,6 +396,7 @@ func TestHandleExec_BDCreateRepoAliasPinsCanonicalBeadsDir(t *testing.T) {
 		assert.NotContains(t, resp.Stdout, "[gastown]")
 		assert.Contains(t, resp.Stdout, "BEADS_DIR="+canonicalBeads)
 		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=gastown\n")
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_DATA_DIR=\n")
 		assert.Contains(t, resp.Stdout, "BD_DOLT_AUTO_COMMIT=on")
 		assert.Contains(t, resp.Stdout, "BD_NO_GIT_OPS=true")
 		assert.NotContains(t, resp.Stdout, "BEADS_DIR="+decoyBeads)
@@ -413,6 +416,7 @@ func TestHandleExec_BDCreateRepoAliasPinsCanonicalBeadsDir(t *testing.T) {
 		assert.NotContains(t, resp.Stdout, "[gastown]")
 		assert.Contains(t, resp.Stdout, "BEADS_DIR="+canonicalBeads)
 		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=gastown\n")
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_DATA_DIR=\n")
 		assert.Contains(t, resp.Stdout, "BD_DOLT_AUTO_COMMIT=on")
 	})
 
@@ -423,6 +427,7 @@ func TestHandleExec_BDCreateRepoAliasPinsCanonicalBeadsDir(t *testing.T) {
 		assert.NotContains(t, resp.Stdout, "[hq]")
 		assert.Contains(t, resp.Stdout, "BEADS_DIR="+townBeads)
 		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=hq\n")
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_DATA_DIR=\n")
 	})
 
 	t.Run("town alias", func(t *testing.T) {
@@ -432,6 +437,7 @@ func TestHandleExec_BDCreateRepoAliasPinsCanonicalBeadsDir(t *testing.T) {
 		assert.NotContains(t, resp.Stdout, "[town]")
 		assert.Contains(t, resp.Stdout, "BEADS_DIR="+townBeads)
 		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=hq\n")
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_DATA_DIR=\n")
 	})
 
 	t.Run("path-like repo remains explicit", func(t *testing.T) {


### PR DESCRIPTION
Release-blocking fix for #4394. Keeps bd subprocess env connection-only and strips BEADS_DOLT_DATA_DIR, GT_DOLT_DATA, and bd target selectors from agent/startup/restart envs so metadata-backed routing remains authoritative.

Evidence: bead gt-4394-dolt-data-dir-routing records 15 research legs, 5 pre-implementation reviews, and 5 post-implementation reviews.

Local verification:
- git diff --check origin/main..fork/polecat/guzzle/gt-4394-dolt-data-dir-routing+37d179
- CGO_ENABLED=0 go test ./internal/beads ./internal/config ./internal/cmd ./internal/proxy -run 'Test(BuildBDEnvDoesNotRestoreGTDoltDataDir|BuildPinnedBDEnvStripsCaseVariantTargetEnvWhenKeysAreCaseInsensitive|RunEnv_StripsPollutedDoltEnvAndUsesRigMetadata|SanitizeAgentEnv_ClearsBDTargetSelectors|AgentEnv_ClearsBDTargetSelectors|BuildStartupCommand_ClearsBDTargetSelectors|BuildRestartCommand_ClearsBDTargetSelectors|SlingRoutesRawReviewOnlyHookBeadToTargetRigDatabase|HandleExec_BDCreateRepoAliasPinsCanonicalBeadsDir)$' -count=1
- CGO_ENABLED=0 go test ./... is baseline-red only in internal/doctor, internal/doltserver, and internal/tmux; the same failing packages reproduce on origin/main.

Closes #4394.