### PR TITLE
fix(mq): route submit source validation through owning DB

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -821,6 +821,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	var mrFailed bool
 	var doneErrors []string
 	var convoyInfo *ConvoyInfo // Populated if issue is tracked by a convoy
+	var sourceIssueForNoMerge *beads.Issue
+	var sourceBD *beads.Beads
 	if exitType == ExitCompleted {
 		if branch == defaultBranch || branch == "master" {
 			return fmt.Errorf("cannot submit %s/master branch to merge queue", defaultBranch)
@@ -871,12 +873,13 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		isNoMergeTask := false
 		reviewOnlySource := false
 		if issueID != "" {
-			noMergeBd := beads.New(cwd)
-			noMergeIssue, showErr := noMergeBd.Show(issueID)
-			if showErr != nil {
-				return fmt.Errorf("cannot inspect source issue %s before completion: %w", issueID, showErr)
+			sourceInfo, sourceErr := resolveSubmitSourceIssue(cwd, issueID)
+			if sourceErr != nil {
+				return fmt.Errorf("source issue validation failed: %w", sourceErr)
 			}
-			if af := beads.ParseAttachmentFields(noMergeIssue); af != nil {
+			sourceIssueForNoMerge = sourceInfo.Issue
+			sourceBD = sourceInfo.BD
+			if af := beads.ParseAttachmentFields(sourceIssueForNoMerge); af != nil {
 				if af.NoMerge || af.ReviewOnly {
 					isNoMergeTask = true
 				}
@@ -928,10 +931,13 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			// Normally the Refinery closes after merge, but with no MR, nothing
 			// would ever close the issue.
 			if issueID != "" {
-				bd := beads.New(cwd)
+				bd := sourceBD
+				if bd == nil {
+					bd = beads.New(cwd)
+				}
 
 				skipClose := false
-				if skipReason, fatal := doneSourceCloseSkipReason(bd, issueID, nil); skipReason != "" {
+				if skipReason, fatal := doneSourceCloseSkipReason(bd, issueID, sourceIssueForNoMerge); skipReason != "" {
 					style.PrintWarning("%s", skipReason)
 					fmt.Printf("  The bead will remain open for witness/mayor review.\n")
 					notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
@@ -945,7 +951,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 					closeReason := "Completed with no code changes (already fixed or already merged)"
 					noMRCommitSHA, _ := g.Rev("HEAD")
 					if doneSkipVerify {
-						noteVerifiedPushSkipped(cwd, issueID, defaultBranch, noMRCommitSHA, "--skip-verify on no-MR close")
+						noteVerifiedPushSkipped(bd, cwd, issueID, defaultBranch, noMRCommitSHA, "--skip-verify on no-MR close")
 						if noMRCommitSHA != "" {
 							closeReason = fmt.Sprintf("%s\nskip_verify: true\ntarget_branch: %s\ncommit_sha: %s", closeReason, defaultBranch, noMRCommitSHA)
 						}
@@ -954,7 +960,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 							return fmt.Errorf("cannot close no-MR code bead in fork/upstream mode: %s has no commits ahead of %s; use the fork PR flow instead", branch, baseRef)
 						}
 						if verifyErr := g.VerifyPushedCommitReachableFromPushTarget("origin", defaultBranch, noMRCommitSHA); verifyErr != nil {
-							noteVerifiedPushFailure(cwd, issueID, defaultBranch, noMRCommitSHA, verifyErr)
+							noteVerifiedPushFailure(bd, cwd, issueID, defaultBranch, noMRCommitSHA, verifyErr)
 							return fmt.Errorf("cannot close no-MR code bead: %w", verifyErr)
 						}
 						if noMRCommitSHA != "" {
@@ -1056,7 +1062,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// which avoids unreliable cross-rig dep resolution at gt done time.
 		// Fallback: dep-based lookup via getConvoyInfoForIssue (for issues dispatched
 		// before this fix, or where attachment fields weren't set).
-		convoyInfo = getConvoyInfoFromIssue(issueID, cwd)
+		convoyInfo = getConvoyInfoFromSourceIssue(sourceIssueForNoMerge)
 		if convoyInfo == nil {
 			convoyInfo = getConvoyInfoForIssue(issueID)
 		}
@@ -1076,8 +1082,11 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// Handle "direct" strategy: push to target branch, skip MR
 		if convoyInfo != nil && convoyInfo.MergeStrategy == "direct" {
 			fmt.Printf("%s Direct merge strategy: pushing to %s\n", style.Bold.Render("→"), defaultBranch)
-			directBd := beads.New(cwd)
-			if skipReason := doneDirectMergeSkipReason(directBd, issueID, nil, defaultBranch); skipReason != "" {
+			directBd := sourceBD
+			if directBd == nil {
+				directBd = beads.New(cwd)
+			}
+			if skipReason := doneDirectMergeSkipReason(directBd, issueID, sourceIssueForNoMerge, defaultBranch); skipReason != "" {
 				style.PrintWarning("%s", skipReason)
 				notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
 				return fmt.Errorf("cannot complete direct-merge work: %s", skipReason)
@@ -1095,12 +1104,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			}
 			directCommitSHA, _ := g.Rev("HEAD")
 			if doneSkipVerify {
-				noteVerifiedPushSkipped(cwd, issueID, defaultBranch, directCommitSHA, "--skip-verify on direct merge")
+				noteVerifiedPushSkipped(directBd, cwd, issueID, defaultBranch, directCommitSHA, "--skip-verify on direct merge")
 			} else if verifyErr := g.VerifyPushedCommitReachableFromPushTarget("origin", defaultBranch, directCommitSHA); verifyErr != nil {
 				pushFailed = true
 				errMsg := verifyErr.Error()
 				doneErrors = append(doneErrors, errMsg)
-				noteVerifiedPushFailure(cwd, issueID, defaultBranch, directCommitSHA, verifyErr)
+				noteVerifiedPushFailure(directBd, cwd, issueID, defaultBranch, directCommitSHA, verifyErr)
 				style.PrintWarning("%s\nDirect merge pushed but remote verification failed. Source bead will remain in progress.", errMsg)
 				goto notifyWitness
 			}
@@ -1109,7 +1118,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 			// Close the base issue — no MR/refinery will close it
 			if issueID != "" {
-				if skipReason, fatal := doneSourceCloseSkipReason(directBd, issueID, nil); skipReason != "" {
+				if skipReason, fatal := doneSourceCloseSkipReason(directBd, issueID, sourceIssueForNoMerge); skipReason != "" {
 					style.PrintWarning("%s", skipReason)
 					notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
 					if fatal {
@@ -1152,22 +1161,6 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			fmt.Fprintf(os.Stderr, "  MR beads written here will be invisible to the Refinery — run 'gt polecat repair' to fix\n")
 		}
 		bd := beads.NewWithBeadsDir(cwd, resolvedBeads)
-
-		sourceIssueForNoMerge, err := bd.Show(issueID)
-		if err != nil {
-			mrFailed = true
-			errMsg := fmt.Sprintf("source issue validation failed: source_issue %s could not be resolved: %v", issueID, err)
-			doneErrors = append(doneErrors, errMsg)
-			style.PrintWarning("%s\nBranch is not pushed and MR bead not created. Witness will be notified.", errMsg)
-			goto notifyWitness
-		}
-		if err := validateConcreteSourceIssue(issueID, sourceIssueForNoMerge); err != nil {
-			mrFailed = true
-			errMsg := fmt.Sprintf("source issue validation failed: %v", err)
-			doneErrors = append(doneErrors, errMsg)
-			style.PrintWarning("%s\nBranch is not pushed and MR bead not created. Witness will be notified.", errMsg)
-			goto notifyWitness
-		}
 		if attachmentFields := beads.ParseAttachmentFields(sourceIssueForNoMerge); attachmentFields != nil && strings.EqualFold(strings.TrimSpace(attachmentFields.MergeStrategy), "local") {
 			fmt.Printf("%s Local merge strategy: skipping push and merge queue\n", style.Bold.Render("→"))
 			fmt.Printf("  Branch: %s\n", branch)
@@ -1182,14 +1175,18 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// fix, or where dep-based lookup failed at that point. This must happen
 		// before the generic branch/submodule push because direct mode has no MR or
 		// refinery recheck.
-		convoyInfo = getConvoyInfoFromIssue(issueID, cwd)
+		convoyInfo = getConvoyInfoFromSourceIssue(sourceIssueForNoMerge)
 		if convoyInfo == nil {
 			convoyInfo = getConvoyInfoForIssue(issueID)
 		}
 		if convoyInfo != nil && convoyInfo.MergeStrategy == "direct" {
 			fmt.Printf("%s Late-detected direct merge strategy: pushing to %s\n", style.Bold.Render("→"), defaultBranch)
 			fmt.Printf("  Convoy: %s\n", convoyInfo.ID)
-			if skipReason := doneDirectMergeSkipReason(bd, issueID, sourceIssueForNoMerge, defaultBranch); skipReason != "" {
+			directBd := sourceBD
+			if directBd == nil {
+				directBd = bd
+			}
+			if skipReason := doneDirectMergeSkipReason(directBd, issueID, sourceIssueForNoMerge, defaultBranch); skipReason != "" {
 				style.PrintWarning("%s", skipReason)
 				notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
 				return fmt.Errorf("cannot complete direct-merge work: %s", skipReason)
@@ -1207,19 +1204,19 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			}
 			directCommitSHA, _ := g.Rev("HEAD")
 			if doneSkipVerify {
-				noteVerifiedPushSkipped(cwd, issueID, defaultBranch, directCommitSHA, "--skip-verify on late direct merge")
+				noteVerifiedPushSkipped(directBd, cwd, issueID, defaultBranch, directCommitSHA, "--skip-verify on late direct merge")
 			} else if verifyErr := g.VerifyPushedCommitReachableFromPushTarget("origin", defaultBranch, directCommitSHA); verifyErr != nil {
 				pushFailed = true
 				errMsg := verifyErr.Error()
 				doneErrors = append(doneErrors, errMsg)
-				noteVerifiedPushFailure(cwd, issueID, defaultBranch, directCommitSHA, verifyErr)
+				noteVerifiedPushFailure(directBd, cwd, issueID, defaultBranch, directCommitSHA, verifyErr)
 				style.PrintWarning("%s\nLate direct merge pushed but remote verification failed. Source bead will remain in progress.", errMsg)
 				goto notifyWitness
 			}
 			fmt.Printf("%s Branch pushed directly to %s\n", style.Bold.Render("✓"), defaultBranch)
 			doneCleanupStatus = cleanupStatusAfterSuccessfulPush(doneCleanupStatus)
 
-			if skipReason, fatal := doneSourceCloseSkipReason(bd, issueID, sourceIssueForNoMerge); skipReason != "" {
+			if skipReason, fatal := doneSourceCloseSkipReason(directBd, issueID, sourceIssueForNoMerge); skipReason != "" {
 				style.PrintWarning("%s", skipReason)
 				notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
 				if fatal {
@@ -1228,7 +1225,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			} else {
 				var closeErr error
 				for attempt := 1; attempt <= 3; attempt++ {
-					closeErr = bd.ForceCloseWithReason(
+					closeErr = directBd.ForceCloseWithReason(
 						fmt.Sprintf("Direct merge to %s (convoy strategy, late detection)", defaultBranch), issueID)
 					if closeErr == nil {
 						fmt.Printf("%s Issue %s closed (direct merge)\n", style.Bold.Render("✓"), issueID)
@@ -1331,12 +1328,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			pushedCommitSHA, _ = g.Rev("HEAD")
 		}
 		if doneSkipVerify {
-			noteVerifiedPushSkipped(cwd, issueID, branch, pushedCommitSHA, "--skip-verify on branch push")
+			noteVerifiedPushSkipped(sourceBD, cwd, issueID, branch, pushedCommitSHA, "--skip-verify on branch push")
 		} else if verifyErr := verifyPushedCommitWithBareFallback(g, townRoot, rigName, branch, pushedCommitSHA); verifyErr != nil {
 			pushFailed = true
 			errMsg := verifyErr.Error()
 			doneErrors = append(doneErrors, errMsg)
-			noteVerifiedPushFailure(cwd, issueID, branch, pushedCommitSHA, verifyErr)
+			noteVerifiedPushFailure(sourceBD, cwd, issueID, branch, pushedCommitSHA, verifyErr)
 			style.PrintWarning("%s\nCommits exist locally but verified push failed. Witness will be notified.", errMsg)
 			goto notifyWitness
 		}
@@ -1446,8 +1443,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				// No-merge work never goes through the refinery, so close the source bead
 				// here after notifying the dispatcher. Otherwise hooked work remains open.
 				if issueID != "" {
+					noMergeBd := sourceBD
+					if noMergeBd == nil {
+						noMergeBd = bd
+					}
 					canCloseIssue := true
-					if skipReason, fatal := doneSourceCloseSkipReason(bd, issueID, sourceIssueForNoMerge); skipReason != "" {
+					if skipReason, fatal := doneSourceCloseSkipReason(noMergeBd, issueID, sourceIssueForNoMerge); skipReason != "" {
 						style.PrintWarning("%s", skipReason)
 						notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, skipReason)
 						if fatal {
@@ -1456,11 +1457,11 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 						canCloseIssue = false
 					}
 					if canCloseIssue && attachmentFields.AttachedMolecule != "" {
-						if n := closeDescendants(bd, attachmentFields.AttachedMolecule); n > 0 {
+						if n := closeDescendants(noMergeBd, attachmentFields.AttachedMolecule); n > 0 {
 							fmt.Fprintf(os.Stderr, "Closed %d molecule step(s) for %s\n", n, attachmentFields.AttachedMolecule)
 						}
 						if closeErr := forceCloseIssueWithRetry(
-							bd.ForceCloseWithReason,
+							noMergeBd.ForceCloseWithReason,
 							attachmentFields.AttachedMolecule,
 							"done",
 							"Attached molecule %s closed",
@@ -1476,7 +1477,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 					}
 					if canCloseIssue {
 						if closeErr := forceCloseIssueWithRetry(
-							bd.ForceCloseWithReason,
+							noMergeBd.ForceCloseWithReason,
 							issueID,
 							closeReason,
 							"Issue %s closed (no-merge)",
@@ -1526,7 +1527,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				refineryEnabled = settings.MergeQueue.IsRefineryIntegrationEnabled()
 			}
 			if refineryEnabled {
-				autoTarget, err := beads.DetectIntegrationBranch(bd, g, issueID)
+				autoTarget, err := beads.DetectIntegrationBranch(sourceBD, g, issueID)
 				if err == nil && autoTarget != "" {
 					target = autoTarget
 				}
@@ -1561,7 +1562,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			if cpMR, cpErr := bd.Show(cpMRID); cpErr == nil && cpMR != nil {
 				branchPrefix := "branch: " + branch + "\n"
 				if strings.HasPrefix(cpMR.Description, branchPrefix) {
-					if err := validateMergeRequestSource(bd, cpMR, issueID); err != nil {
+					if err := validateMergeRequestSource(cpMR, issueID, sourceIssueForNoMerge); err != nil {
 						mrFailed = true
 						errMsg := fmt.Sprintf("checkpoint MR validation failed: %v", err)
 						doneErrors = append(doneErrors, errMsg)
@@ -1591,7 +1592,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 		if existingMR != nil {
 			// MR already exists with same branch AND commit — true idempotent retry
-			if err := validateMergeRequestSource(bd, existingMR, issueID); err != nil {
+			if err := validateMergeRequestSource(existingMR, issueID, sourceIssueForNoMerge); err != nil {
 				mrFailed = true
 				errMsg := fmt.Sprintf("existing MR validation failed: %v", err)
 				doneErrors = append(doneErrors, errMsg)
@@ -1722,7 +1723,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			// GH#2599: Back-link source issue to MR bead for discoverability.
 			if issueID != "" {
 				comment := fmt.Sprintf("MR created: %s", mrID)
-				if err := bd.AddComment(issueID, comment); err != nil {
+				if err := sourceBD.AddComment(issueID, comment); err != nil {
 					style.PrintWarning("could not back-link source issue %s to MR %s: %v", issueID, mrID, err)
 				}
 			}
@@ -1829,7 +1830,7 @@ notifyWitness:
 			fmt.Printf("%s Work needs recovery (push or MR failed) — session preserved\n", style.Bold.Render("⚠"))
 		}
 		if exitType == ExitCompleted && issueID != "" && convoyInfo == nil {
-			convoyInfo = getConvoyInfoFromIssue(issueID, cwd)
+			convoyInfo = getConvoyInfoFromSourceIssue(sourceIssueForNoMerge)
 			if convoyInfo == nil {
 				convoyInfo = getConvoyInfoForIssue(issueID)
 			}
@@ -1937,23 +1938,30 @@ func notifyDoneCloseSkipped(townRoot, rigName, sender, issueID, reason string) {
 	}
 }
 
-func noteVerifiedPushFailure(cwd, issueID, branch, commit string, verifyErr error) {
+func noteVerifiedPushFailure(sourceBD *beads.Beads, cwd, issueID, branch, commit string, verifyErr error) {
 	if issueID == "" || cwd == "" {
 		return
 	}
-	bd := beads.New(cwd)
+	bd := sourceBD
+	if bd == nil {
+		bd, _, _ = routedIssueBeads(cwd, issueID)
+	}
 	inProgress := "in_progress"
 	_ = bd.Update(issueID, beads.UpdateOptions{Status: &inProgress})
 	msg := fmt.Sprintf("verified_push_failed: commit %s not verified on origin/%s: %v", commit, branch, verifyErr)
 	_ = bd.AddComment(issueID, msg)
 }
 
-func noteVerifiedPushSkipped(cwd, issueID, branch, commit, reason string) {
+func noteVerifiedPushSkipped(sourceBD *beads.Beads, cwd, issueID, branch, commit, reason string) {
 	if issueID == "" || cwd == "" {
 		return
 	}
 	msg := fmt.Sprintf("verified_push_skipped: commit %s branch origin/%s reason=%s", commit, branch, reason)
-	_ = beads.New(cwd).AddComment(issueID, msg)
+	bd := sourceBD
+	if bd == nil {
+		bd, _, _ = routedIssueBeads(cwd, issueID)
+	}
+	_ = bd.AddComment(issueID, msg)
 }
 
 func verifyPushedCommitWithBareFallback(g *git.Git, townRoot, rigName, branch, commit string) error {
@@ -2209,7 +2217,11 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 		// DEFERRED exits preserve the bead: work is paused, not done. The bead
 		// stays open/in_progress so it can be resumed on the next session.
 		// Exception: workflow step beads (*-wfs-*) are always closed — see above.
-		if hookedBead, err := bd.Show(hookedBeadID); err == nil && !beads.IssueStatus(hookedBead.Status).IsTerminal() {
+		hookBd, _, _ := routedIssueBeads(beadsPath, hookedBeadID)
+		if hookBd == nil {
+			hookBd = bd
+		}
+		if hookedBead, err := hookBd.Show(hookedBeadID); err == nil && !beads.IssueStatus(hookedBead.Status).IsTerminal() {
 			// Guard: never close a rig identity bead. Polecats dispatched with the
 			// rig bead as their hook (via mol-polecat-work) must not close permanent
 			// infrastructure. Skip close and fall through to idle state update.
@@ -2218,7 +2230,7 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 				goto doneStateUpdate
 			}
 
-			if skipReason, fatal := doneSourceCloseSkipReason(bd, hookedBeadID, hookedBead); skipReason != "" {
+			if skipReason, fatal := doneSourceCloseSkipReason(hookBd, hookedBeadID, hookedBead); skipReason != "" {
 				style.PrintWarning("%s", skipReason)
 				fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
 				notifyDoneCloseSkipped(townRoot, ctx.Rig, detectSender(), hookedBeadID, skipReason)
@@ -2239,7 +2251,7 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 				// bd close doesn't cascade — without this, open/in_progress steps
 				// from the molecule stay stuck forever after gt done completes.
 				// Order: step children -> wisp root -> base bead.
-				if n := closeDescendants(bd, attachment.AttachedMolecule); n > 0 {
+				if n := closeDescendants(hookBd, attachment.AttachedMolecule); n > 0 {
 					fmt.Fprintf(os.Stderr, "Closed %d molecule step(s) for %s\n", n, attachment.AttachedMolecule)
 				}
 
@@ -2247,7 +2259,7 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 				// ForceCloseWithReason handles any status (hooked, open, in_progress)
 				// and records the reason + session for attribution.
 				// Same pattern as gt mol burn/squash (#1879).
-				if closeErr := bd.ForceCloseWithReason("done", attachment.AttachedMolecule); closeErr != nil {
+				if closeErr := hookBd.ForceCloseWithReason("done", attachment.AttachedMolecule); closeErr != nil {
 					if !errors.Is(closeErr, beads.ErrNotFound) {
 						fmt.Fprintf(os.Stderr, "Warning: couldn't close attached molecule %s: %v\n", attachment.AttachedMolecule, closeErr)
 						// Don't try to close hookedBeadID - it may still be blocked.
@@ -2263,7 +2275,7 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) error {
 			if unchecked := beads.HasUncheckedCriteria(hookedBead); unchecked > 0 {
 				style.PrintWarning("hooked bead %s has %d unchecked acceptance criteria — skipping close", hookedBeadID, unchecked)
 				fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
-			} else if err := bd.Close(hookedBeadID); err != nil {
+			} else if err := hookBd.Close(hookedBeadID); err != nil {
 				// Non-fatal: warn but continue
 				fmt.Fprintf(os.Stderr, "Warning: couldn't close hooked bead %s: %v\n", hookedBeadID, err)
 			}

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -434,12 +434,12 @@ func TestSourceValidationRejectsInternalIssues(t *testing.T) {
 
 func TestValidateMergeRequestSourceRejectsMissingAndMismatchedSource(t *testing.T) {
 	missing := &beads.Issue{ID: "gt-mr", Description: "branch: polecat/test/gt-work\n"}
-	if err := validateMergeRequestSource(nil, missing, "gt-work"); err == nil || !strings.Contains(err.Error(), "missing source_issue") {
+	if err := validateMergeRequestSource(missing, "gt-work", &beads.Issue{ID: "gt-work", Type: "task"}); err == nil || !strings.Contains(err.Error(), "missing source_issue") {
 		t.Fatalf("missing source validation error = %v, want missing source_issue", err)
 	}
 
 	mismatched := &beads.Issue{ID: "gt-mr", Description: "source_issue: gt-other\n"}
-	if err := validateMergeRequestSource(nil, mismatched, "gt-work"); err == nil || !strings.Contains(err.Error(), "does not match expected") {
+	if err := validateMergeRequestSource(mismatched, "gt-work", &beads.Issue{ID: "gt-work", Type: "task"}); err == nil || !strings.Contains(err.Error(), "does not match expected") {
 		t.Fatalf("mismatched source validation error = %v, want mismatch", err)
 	}
 }

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -139,15 +139,15 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cannot determine source issue from branch '%s'; use --issue to specify", branch)
 	}
 
-	// Initialize beads for looking up source issue
+	// Initialize current-rig beads for merge-request queue operations, then
+	// resolve the source through town-level routing for source-owned operations.
 	bd := beads.New(cwd)
-	sourceIssue, err := bd.Show(issueID)
+	sourceInfo, err := resolveSubmitSourceIssue(cwd, issueID)
 	if err != nil {
-		return fmt.Errorf("source issue validation failed: source_issue %s could not be resolved: %w", issueID, err)
-	}
-	if err := validateConcreteSourceIssue(issueID, sourceIssue); err != nil {
 		return fmt.Errorf("source issue validation failed: %w", err)
 	}
+	sourceBD := sourceInfo.BD
+	sourceIssue := sourceInfo.Issue
 
 	// Determine target branch
 	// Priority: explicit --epic > formula_vars base_branch > integration branch auto-detect > rig default.
@@ -155,7 +155,7 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 	if mqSubmitEpic != "" {
 		// Explicit --epic flag: read stored branch name, fall back to template
 		rigPath := filepath.Join(townRoot, rigName)
-		target = resolveIntegrationBranchName(bd, rigPath, mqSubmitEpic)
+		target = resolveIntegrationBranchName(sourceBD, rigPath, mqSubmitEpic)
 	} else {
 		// Check for explicit --base-branch override in formula vars on the source issue.
 		// When gt sling dispatches with --base-branch, the value is persisted in
@@ -179,7 +179,7 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 				refineryEnabled = settings.MergeQueue.IsRefineryIntegrationEnabled()
 			}
 			if refineryEnabled {
-				autoTarget, err := beads.DetectIntegrationBranch(bd, g, issueID)
+				autoTarget, err := beads.DetectIntegrationBranch(sourceBD, g, issueID)
 				if err != nil {
 					// Non-fatal: log and continue with default branch as target
 					fmt.Printf("  %s\n", style.Dim.Render(fmt.Sprintf("(note: %v)", err)))
@@ -203,7 +203,7 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 	// steps are complete. This prevents polecats from skipping steps like
 	// self-review, build-check, or state-update.
 	if !mqSubmitSkipDeps && !mqSubmitResubmit && sourceIssue != nil {
-		if err := checkMoleculeStepDeps(bd, sourceIssue); err != nil {
+		if err := checkMoleculeStepDeps(sourceBD, sourceIssue); err != nil {
 			return err
 		}
 	}
@@ -247,7 +247,7 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 	}
 
 	if existingMR != nil {
-		if err := validateMergeRequestSource(bd, existingMR, issueID); err != nil {
+		if err := validateMergeRequestSource(existingMR, issueID, sourceIssue); err != nil {
 			return fmt.Errorf("existing merge request validation failed: %w", err)
 		}
 		mrIssue = existingMR
@@ -277,7 +277,7 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		// GH#2599: Back-link source issue to MR bead for discoverability.
 		if issueID != "" {
 			comment := fmt.Sprintf("MR created: %s", mrIssue.ID)
-			if err := bd.AddComment(issueID, comment); err != nil {
+			if err := sourceBD.AddComment(issueID, comment); err != nil {
 				style.PrintWarning("could not back-link source issue %s to MR %s: %v", issueID, mrIssue.ID, err)
 			}
 		}

--- a/internal/cmd/sling_convoy.go
+++ b/internal/cmd/sling_convoy.go
@@ -198,6 +198,10 @@ func getConvoyInfoFromIssue(issueID, cwd string) *ConvoyInfo {
 		return nil
 	}
 
+	return getConvoyInfoFromSourceIssue(issue)
+}
+
+func getConvoyInfoFromSourceIssue(issue *beads.Issue) *ConvoyInfo {
 	attachment := beads.ParseAttachmentFields(issue)
 	if attachment == nil || attachment.ConvoyID == "" {
 		return nil

--- a/internal/cmd/source_validation.go
+++ b/internal/cmd/source_validation.go
@@ -7,6 +7,47 @@ import (
 	"github.com/steveyegge/gastown/internal/beads"
 )
 
+type submitSourceIssue struct {
+	ID              string
+	Issue           *beads.Issue
+	BD              *beads.Beads
+	CurrentBeadsDir string
+	RoutedBeadsDir  string
+}
+
+func routedIssueBeads(cwd, issueID string) (*beads.Beads, string, string) {
+	currentBeadsDir := beads.ResolveBeadsDir(cwd)
+	routedBeadsDir := beads.ResolveBeadsDirForID(currentBeadsDir, issueID)
+	return beads.NewWithBeadsDir(cwd, routedBeadsDir), currentBeadsDir, routedBeadsDir
+}
+
+func sourceRouteContext(currentBeadsDir, routedBeadsDir string) string {
+	return fmt.Sprintf("current_db=%s routed_db=%s", currentBeadsDir, routedBeadsDir)
+}
+
+func resolveSubmitSourceIssue(cwd, issueID string) (*submitSourceIssue, error) {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return nil, fmt.Errorf("source_issue is required")
+	}
+
+	sourceBD, currentBeadsDir, routedBeadsDir := routedIssueBeads(cwd, issueID)
+	issue, err := sourceBD.Show(issueID)
+	if err != nil {
+		return nil, fmt.Errorf("source_issue %s could not be resolved (%s): %w", issueID, sourceRouteContext(currentBeadsDir, routedBeadsDir), err)
+	}
+	if err := validateConcreteSourceIssue(issueID, issue); err != nil {
+		return nil, err
+	}
+	return &submitSourceIssue{
+		ID:              issueID,
+		Issue:           issue,
+		BD:              sourceBD,
+		CurrentBeadsDir: currentBeadsDir,
+		RoutedBeadsDir:  routedBeadsDir,
+	}, nil
+}
+
 func validateConcreteSourceIssue(issueID string, issue *beads.Issue) error {
 	if reason := beads.ConcreteWorkIssueRejectReason(issue); reason != "" {
 		return fmt.Errorf("source_issue %s is not concrete (%s)", issueID, reason)
@@ -14,7 +55,7 @@ func validateConcreteSourceIssue(issueID string, issue *beads.Issue) error {
 	return nil
 }
 
-func validateMergeRequestSource(bd *beads.Beads, mr *beads.Issue, expectedIssueID string) error {
+func validateMergeRequestSource(mr *beads.Issue, expectedIssueID string, expectedIssue *beads.Issue) error {
 	if mr == nil {
 		return fmt.Errorf("merge request is missing")
 	}
@@ -26,9 +67,11 @@ func validateMergeRequestSource(bd *beads.Beads, mr *beads.Issue, expectedIssueI
 	if sourceIssueID != strings.TrimSpace(expectedIssueID) {
 		return fmt.Errorf("merge request %s source_issue %s does not match expected %s", mr.ID, sourceIssueID, expectedIssueID)
 	}
-	sourceIssue, err := bd.Show(sourceIssueID)
-	if err != nil {
-		return fmt.Errorf("source_issue %s could not be resolved: %w", sourceIssueID, err)
+	if expectedIssue == nil {
+		return fmt.Errorf("source_issue %s was not pre-resolved for merge request validation", sourceIssueID)
 	}
-	return validateConcreteSourceIssue(sourceIssueID, sourceIssue)
+	if resolvedID := strings.TrimSpace(expectedIssue.ID); resolvedID != "" && resolvedID != sourceIssueID {
+		return fmt.Errorf("pre-resolved source_issue %s does not match merge request source_issue %s", resolvedID, sourceIssueID)
+	}
+	return validateConcreteSourceIssue(sourceIssueID, expectedIssue)
 }

--- a/internal/cmd/source_validation_test.go
+++ b/internal/cmd/source_validation_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,6 +27,38 @@ func TestSourceRouteContextNamesCurrentAndRoutedDB(t *testing.T) {
 	for _, want := range []string{"current_db=/town/gastown/.beads", "routed_db=/town/beads/.beads"} {
 		if !strings.Contains(context, want) {
 			t.Fatalf("source route context %q missing %q", context, want)
+		}
+	}
+}
+
+func TestResolveSubmitSourceIssueIgnoresCurrentRigMirror(t *testing.T) {
+	workDir, currentBeadsDir, ownerBeadsDir := setupRoutedSourceTestTown(t)
+	installSubmitSourceBDStub(t, currentBeadsDir, ownerBeadsDir, false)
+
+	source, err := resolveSubmitSourceIssue(workDir, "bd-source")
+	if err != nil {
+		t.Fatalf("resolveSubmitSourceIssue: %v", err)
+	}
+	if source.Issue.Title != "owner source" {
+		t.Fatalf("source title = %q, want routed owner source (current-rig mirror must be ignored)", source.Issue.Title)
+	}
+	if source.CurrentBeadsDir != currentBeadsDir || source.RoutedBeadsDir != ownerBeadsDir {
+		t.Fatalf("route = current %q routed %q, want current %q routed %q", source.CurrentBeadsDir, source.RoutedBeadsDir, currentBeadsDir, ownerBeadsDir)
+	}
+}
+
+func TestResolveSubmitSourceIssueFailureNamesRoutingContext(t *testing.T) {
+	workDir, currentBeadsDir, ownerBeadsDir := setupRoutedSourceTestTown(t)
+	installSubmitSourceBDStub(t, currentBeadsDir, ownerBeadsDir, true)
+
+	_, err := resolveSubmitSourceIssue(workDir, "bd-source")
+	if err == nil {
+		t.Fatal("resolveSubmitSourceIssue succeeded, want routed owner lookup failure")
+	}
+	errText := err.Error()
+	for _, want := range []string{"source_issue bd-source could not be resolved", "current_db=" + currentBeadsDir, "routed_db=" + ownerBeadsDir} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("error %q missing %q", errText, want)
 		}
 	}
 }
@@ -69,4 +102,47 @@ func setupRoutedSourceTestTown(t *testing.T) (workDir, currentBeadsDir, ownerBea
 		t.Fatalf("write routes: %v", err)
 	}
 	return workDir, currentBeadsDir, ownerBeadsDir
+}
+
+func installSubmitSourceBDStub(t *testing.T, currentBeadsDir, ownerBeadsDir string, ownerMissing bool) {
+	t.Helper()
+	binDir := t.TempDir()
+	ownerCase := fmt.Sprintf(`
+if [ "$BEADS_DIR" = %q ]; then
+  echo '[{"id":"bd-source","title":"owner source","status":"open","priority":1,"issue_type":"task"}]'
+  exit 0
+fi`, ownerBeadsDir)
+	if ownerMissing {
+		ownerCase = fmt.Sprintf(`
+if [ "$BEADS_DIR" = %q ]; then
+  echo "Issue not found in owner" >&2
+  exit 1
+fi`, ownerBeadsDir)
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--allow-stale" ]; then
+  shift
+fi
+if [ "$1" = "version" ]; then
+  echo "bd stub"
+  exit 0
+fi
+if [ "$1" = "show" ] && [ "$2" = "bd-source" ]; then
+  if [ "$BEADS_DIR" = %q ]; then
+    echo '[{"id":"bd-source","title":"current mirror","status":"open","priority":1,"issue_type":"task"}]'
+    exit 0
+  fi
+%s
+  echo "Issue not found in $BEADS_DIR" >&2
+  exit 1
+fi
+echo "unexpected bd command: $*" >&2
+exit 1
+`, currentBeadsDir, ownerCase)
+	path := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	beads.ResetBdAllowStaleCacheForTest()
 }

--- a/internal/cmd/source_validation_test.go
+++ b/internal/cmd/source_validation_test.go
@@ -73,6 +73,58 @@ func TestValidateMergeRequestSourceUsesPreResolvedSource(t *testing.T) {
 	}
 }
 
+func TestMqSubmitPathUsesRoutedSourceAndCurrentRigQueueBeads(t *testing.T) {
+	workDir, currentBeadsDir, ownerBeadsDir := setupRoutedSourceTestTown(t)
+	logPath := installSubmitSourceBDRecorder(t, currentBeadsDir, ownerBeadsDir)
+
+	currentBD := beads.New(workDir)
+	source, err := resolveSubmitSourceIssue(workDir, "bd-source")
+	if err != nil {
+		t.Fatalf("resolveSubmitSourceIssue: %v", err)
+	}
+
+	if _, err := currentBD.Create(beads.CreateOptions{
+		Title:       "Merge: bd-source",
+		Labels:      []string{"gt:merge-request"},
+		Priority:    source.Issue.Priority,
+		Description: "branch: polecat/refuge/bd-source\ntarget: main\nsource_issue: bd-source\nrig: gastown",
+		Ephemeral:   true,
+		Rig:         "gastown",
+	}); err != nil {
+		t.Fatalf("current-rig MR create: %v", err)
+	}
+	if err := source.BD.AddComment("bd-source", "MR created: gt-mr"); err != nil {
+		t.Fatalf("source back-link comment: %v", err)
+	}
+
+	log := readSubmitSourceBDLog(t, logPath)
+	assertBDLogContains(t, log, ownerBeadsDir, "show bd-source --json")
+	assertBDLogContains(t, log, currentBeadsDir, "create --json")
+	assertBDLogContains(t, log, ownerBeadsDir, "comments add bd-source")
+	assertBDLogNotContains(t, log, currentBeadsDir, "show bd-source --json")
+}
+
+func TestDoneNoMRClosePathUsesRoutedSourceBeads(t *testing.T) {
+	workDir, currentBeadsDir, ownerBeadsDir := setupRoutedSourceTestTown(t)
+	logPath := installSubmitSourceBDRecorder(t, currentBeadsDir, ownerBeadsDir)
+
+	source, err := resolveSubmitSourceIssue(workDir, "bd-source")
+	if err != nil {
+		t.Fatalf("resolveSubmitSourceIssue: %v", err)
+	}
+	if skipReason, fatal := doneSourceCloseSkipReason(source.BD, "bd-source", source.Issue); skipReason != "" || fatal {
+		t.Fatalf("doneSourceCloseSkipReason = %q, %v; want close allowed", skipReason, fatal)
+	}
+	if err := source.BD.ForceCloseWithReason("done", "bd-source"); err != nil {
+		t.Fatalf("routed source close: %v", err)
+	}
+
+	log := readSubmitSourceBDLog(t, logPath)
+	assertBDLogContains(t, log, ownerBeadsDir, "show bd-source --json")
+	assertBDLogContains(t, log, ownerBeadsDir, "close bd-source")
+	assertBDLogNotContains(t, log, currentBeadsDir, "close bd-source")
+}
+
 func setupRoutedSourceTestTown(t *testing.T) (workDir, currentBeadsDir, ownerBeadsDir string) {
 	t.Helper()
 	townRoot := t.TempDir()
@@ -145,4 +197,77 @@ exit 1
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	beads.ResetBdAllowStaleCacheForTest()
+}
+
+func installSubmitSourceBDRecorder(t *testing.T, currentBeadsDir, ownerBeadsDir string) string {
+	t.Helper()
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--allow-stale" ]; then
+  shift
+fi
+if [ "$1" = "version" ]; then
+  echo "bd stub"
+  exit 0
+fi
+printf '%%s\t%%s\n' "$BEADS_DIR" "$*" >> %q
+if [ "$1" = "show" ] && [ "$2" = "bd-source" ]; then
+  if [ "$BEADS_DIR" = %q ]; then
+    echo '[{"id":"bd-source","title":"current mirror","status":"open","priority":1,"issue_type":"task"}]'
+    exit 0
+  fi
+  if [ "$BEADS_DIR" = %q ]; then
+    echo '[{"id":"bd-source","title":"owner source","status":"open","priority":1,"issue_type":"task"}]'
+    exit 0
+  fi
+  echo "Issue not found in $BEADS_DIR" >&2
+  exit 1
+fi
+if [ "$1" = "create" ]; then
+  echo '{"id":"gt-mr","title":"Merge: bd-source","status":"open","priority":1,"issue_type":"task","labels":["gt:merge-request"]}'
+  exit 0
+fi
+if [ "$1" = "comments" ] && [ "$2" = "add" ]; then
+  exit 0
+fi
+if [ "$1" = "close" ]; then
+  exit 0
+fi
+echo "unexpected bd command: $*" >&2
+exit 1
+`, logPath, currentBeadsDir, ownerBeadsDir)
+	path := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write bd recorder: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	beads.ResetBdAllowStaleCacheForTest()
+	t.Cleanup(beads.ResetBdAllowStaleCacheForTest)
+	return logPath
+}
+
+func readSubmitSourceBDLog(t *testing.T, logPath string) string {
+	t.Helper()
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd recorder log: %v", err)
+	}
+	return string(log)
+}
+
+func assertBDLogContains(t *testing.T, log, beadsDir, args string) {
+	t.Helper()
+	needle := beadsDir + "\t" + args
+	if !strings.Contains(log, needle) {
+		t.Fatalf("bd log missing %q:\n%s", needle, log)
+	}
+}
+
+func assertBDLogNotContains(t *testing.T, log, beadsDir, args string) {
+	t.Helper()
+	needle := beadsDir + "\t" + args
+	if strings.Contains(log, needle) {
+		t.Fatalf("bd log unexpectedly contains %q:\n%s", needle, log)
+	}
 }

--- a/internal/cmd/source_validation_test.go
+++ b/internal/cmd/source_validation_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
 )
 
 func TestRoutedIssueBeadsUsesTownRoutesForCustomPrefix(t *testing.T) {
@@ -125,6 +126,59 @@ func TestDoneNoMRClosePathUsesRoutedSourceBeads(t *testing.T) {
 	assertBDLogNotContains(t, log, currentBeadsDir, "close bd-source")
 }
 
+func TestRunMqSubmitWithRoutedIssueIgnoresCurrentRigMirror(t *testing.T) {
+	workDir, currentBeadsDir, ownerBeadsDir := setupRoutedSourceTestTown(t)
+	setupRoutedSubmitCommandTown(t, workDir)
+	branch := setupRoutedSubmitGitRepo(t, workDir, true)
+	logPath := installSubmitSourceBDRecorder(t, currentBeadsDir, ownerBeadsDir)
+	resetMqSubmitFlagsForTest(t)
+	t.Setenv("GT_TEST_NUDGE_LOG", filepath.Join(t.TempDir(), "nudge.log"))
+	t.Setenv("GT_RIG", "")
+	t.Chdir(workDir)
+
+	mqSubmitBranch = branch
+	mqSubmitIssue = "bd-source"
+	mqSubmitNoCleanup = true
+	if err := runMqSubmit(nil, nil); err != nil {
+		t.Fatalf("runMqSubmit: %v", err)
+	}
+
+	log := readSubmitSourceBDLog(t, logPath)
+	assertBDLogContains(t, log, ownerBeadsDir, "show bd-source --json")
+	assertBDLogContains(t, log, currentBeadsDir, "create --json")
+	assertBDLogContains(t, log, ownerBeadsDir, "comments add bd-source")
+	assertBDLogNotContains(t, log, currentBeadsDir, "show bd-source --json")
+}
+
+func TestRunDoneWithRoutedIssueIgnoresCurrentRigMirror(t *testing.T) {
+	workDir, currentBeadsDir, ownerBeadsDir := setupRoutedSourceTestTown(t)
+	setupRoutedSubmitCommandTown(t, workDir)
+	setupRoutedSubmitGitRepo(t, workDir, false)
+	logPath := installSubmitSourceBDRecorder(t, currentBeadsDir, ownerBeadsDir)
+	resetDoneFlagsForTest(t)
+	t.Setenv("GT_TEST_NUDGE_LOG", filepath.Join(t.TempDir(), "nudge.log"))
+	t.Setenv("GT_ROLE", "unknown")
+	t.Setenv("GT_RIG", "")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("BD_ACTOR", "")
+	t.Chdir(workDir)
+
+	doneIssue = "bd-source"
+	doneCleanupStatus = "unpushed"
+	doneSkipVerify = true
+	updateAgentStateOnDoneFn = func(cwd, townRoot, exitType, issueID string) error { return nil }
+	if err := runDone(nil, nil); err != nil {
+		t.Fatalf("runDone: %v", err)
+	}
+
+	log := readSubmitSourceBDLog(t, logPath)
+	assertBDLogContains(t, log, ownerBeadsDir, "show bd-source --json")
+	assertBDLogContains(t, log, currentBeadsDir, "create --json")
+	assertBDLogContains(t, log, ownerBeadsDir, "comments add bd-source")
+	assertBDLogContains(t, log, currentBeadsDir, "show gt-mr --json")
+	assertBDLogNotContains(t, log, currentBeadsDir, "show bd-source --json")
+}
+
 func setupRoutedSourceTestTown(t *testing.T) (workDir, currentBeadsDir, ownerBeadsDir string) {
 	t.Helper()
 	townRoot := t.TempDir()
@@ -154,6 +208,48 @@ func setupRoutedSourceTestTown(t *testing.T) (workDir, currentBeadsDir, ownerBea
 		t.Fatalf("write routes: %v", err)
 	}
 	return workDir, currentBeadsDir, ownerBeadsDir
+}
+
+func routedSourceTestTownRoot(workDir string) string {
+	return filepath.Clean(filepath.Join(workDir, "..", "..", "..", ".."))
+}
+
+func setupRoutedSubmitCommandTown(t *testing.T, workDir string) {
+	t.Helper()
+	townRoot := routedSourceTestTownRoot(workDir)
+	rigsPath := filepath.Join(townRoot, "mayor", "rigs.json")
+	if err := config.SaveRigsConfig(rigsPath, &config.RigsConfig{
+		Version: config.CurrentRigsVersion,
+		Rigs: map[string]config.RigEntry{
+			"gastown": {GitURL: "file://test-gastown"},
+		},
+	}); err != nil {
+		t.Fatalf("save rigs config: %v", err)
+	}
+}
+
+func setupRoutedSubmitGitRepo(t *testing.T, workDir string, pushBranch bool) string {
+	t.Helper()
+	remote := t.TempDir()
+	runGitForMQSubmitTest(t, remote, "init", "--bare")
+	runGitForMQSubmitTest(t, workDir, "init")
+	runGitForMQSubmitTest(t, workDir, "config", "user.email", "test@example.com")
+	runGitForMQSubmitTest(t, workDir, "config", "user.name", "Test User")
+	runGitForMQSubmitTest(t, workDir, "remote", "add", "origin", remote)
+	writeMQSubmitTestFile(t, workDir, ".gitignore", ".beads/\n.runtime/\n")
+	writeMQSubmitTestFile(t, workDir, "file.txt", "main\n")
+	runGitForMQSubmitTest(t, workDir, "add", ".gitignore", "file.txt")
+	runGitForMQSubmitTest(t, workDir, "commit", "-m", "main")
+	runGitForMQSubmitTest(t, workDir, "branch", "-M", "main")
+	runGitForMQSubmitTest(t, workDir, "push", "-u", "origin", "main")
+	branch := "feature/routed-submit"
+	runGitForMQSubmitTest(t, workDir, "checkout", "-b", branch)
+	writeMQSubmitTestFile(t, workDir, "file.txt", "feature\n")
+	runGitForMQSubmitTest(t, workDir, "commit", "-am", "feature")
+	if pushBranch {
+		runGitForMQSubmitTest(t, workDir, "push", "origin", branch)
+	}
+	return branch
 }
 
 func installSubmitSourceBDStub(t *testing.T, currentBeadsDir, ownerBeadsDir string, ownerMissing bool) {
@@ -214,15 +310,27 @@ fi
 printf '%%s\t%%s\n' "$BEADS_DIR" "$*" >> %q
 if [ "$1" = "show" ] && [ "$2" = "bd-source" ]; then
   if [ "$BEADS_DIR" = %q ]; then
-    echo '[{"id":"bd-source","title":"current mirror","status":"open","priority":1,"issue_type":"task"}]'
+    echo '[{"id":"bd-source","title":"current mirror","status":"open","priority":1,"issue_type":"task","description":"convoy_id: hq-cv-test\\nmerge_strategy: mr"}]'
     exit 0
   fi
   if [ "$BEADS_DIR" = %q ]; then
-    echo '[{"id":"bd-source","title":"owner source","status":"open","priority":1,"issue_type":"task"}]'
+    echo '[{"id":"bd-source","title":"owner source","status":"open","priority":1,"issue_type":"task","description":"convoy_id: hq-cv-test\\nmerge_strategy: mr"}]'
     exit 0
   fi
   echo "Issue not found in $BEADS_DIR" >&2
   exit 1
+fi
+if [ "$1" = "show" ] && [ "$2" = "gt-mr" ]; then
+  echo '[{"id":"gt-mr","title":"Merge: bd-source","status":"open","priority":1,"issue_type":"task","labels":["gt:merge-request"],"description":"branch: feature/routed-submit\\ntarget: main\\nsource_issue: bd-source\\nrig: gastown"}]'
+  exit 0
+fi
+if [ "$1" = "list" ]; then
+  echo '[]'
+  exit 0
+fi
+if [ "$1" = "sql" ]; then
+  echo '[]'
+  exit 0
 fi
 if [ "$1" = "create" ]; then
   echo '{"id":"gt-mr","title":"Merge: bd-source","status":"open","priority":1,"issue_type":"task","labels":["gt:merge-request"]}'
@@ -270,4 +378,41 @@ func assertBDLogNotContains(t *testing.T, log, beadsDir, args string) {
 	if strings.Contains(log, needle) {
 		t.Fatalf("bd log unexpectedly contains %q:\n%s", needle, log)
 	}
+}
+
+func resetMqSubmitFlagsForTest(t *testing.T) {
+	t.Helper()
+	oldBranch, oldIssue, oldEpic := mqSubmitBranch, mqSubmitIssue, mqSubmitEpic
+	oldPriority := mqSubmitPriority
+	oldNoCleanup, oldSkipDeps, oldResubmit := mqSubmitNoCleanup, mqSubmitSkipDeps, mqSubmitResubmit
+	mqSubmitBranch, mqSubmitIssue, mqSubmitEpic = "", "", ""
+	mqSubmitPriority = -1
+	mqSubmitNoCleanup, mqSubmitSkipDeps, mqSubmitResubmit = false, false, false
+	t.Cleanup(func() {
+		mqSubmitBranch, mqSubmitIssue, mqSubmitEpic = oldBranch, oldIssue, oldEpic
+		mqSubmitPriority = oldPriority
+		mqSubmitNoCleanup, mqSubmitSkipDeps, mqSubmitResubmit = oldNoCleanup, oldSkipDeps, oldResubmit
+	})
+}
+
+func resetDoneFlagsForTest(t *testing.T) {
+	t.Helper()
+	oldIssue, oldStatus, oldCleanupStatus, oldTarget := doneIssue, doneStatus, doneCleanupStatus, doneTarget
+	oldPriority := donePriority
+	oldResume, oldPreVerified, oldSkipVerify := doneResume, donePreVerified, doneSkipVerify
+	oldUpdateAgentStateOnDoneFn := updateAgentStateOnDoneFn
+	doneIssue = ""
+	donePriority = -1
+	doneStatus = ExitCompleted
+	doneCleanupStatus = ""
+	doneResume = false
+	donePreVerified = false
+	doneTarget = ""
+	doneSkipVerify = false
+	t.Cleanup(func() {
+		doneIssue, doneStatus, doneCleanupStatus, doneTarget = oldIssue, oldStatus, oldCleanupStatus, oldTarget
+		donePriority = oldPriority
+		doneResume, donePreVerified, doneSkipVerify = oldResume, oldPreVerified, oldSkipVerify
+		updateAgentStateOnDoneFn = oldUpdateAgentStateOnDoneFn
+	})
 }

--- a/internal/cmd/source_validation_test.go
+++ b/internal/cmd/source_validation_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestRoutedIssueBeadsUsesTownRoutesForCustomPrefix(t *testing.T) {
+	workDir, currentBeadsDir, ownerBeadsDir := setupRoutedSourceTestTown(t)
+
+	_, gotCurrent, gotRouted := routedIssueBeads(workDir, "bd-source")
+	if gotCurrent != currentBeadsDir {
+		t.Fatalf("current beads dir = %q, want %q", gotCurrent, currentBeadsDir)
+	}
+	if gotRouted != ownerBeadsDir {
+		t.Fatalf("routed beads dir = %q, want %q", gotRouted, ownerBeadsDir)
+	}
+}
+
+func TestSourceRouteContextNamesCurrentAndRoutedDB(t *testing.T) {
+	context := sourceRouteContext("/town/gastown/.beads", "/town/beads/.beads")
+	for _, want := range []string{"current_db=/town/gastown/.beads", "routed_db=/town/beads/.beads"} {
+		if !strings.Contains(context, want) {
+			t.Fatalf("source route context %q missing %q", context, want)
+		}
+	}
+}
+
+func TestValidateMergeRequestSourceUsesPreResolvedSource(t *testing.T) {
+	mr := &beads.Issue{ID: "gt-mr", Description: "source_issue: bd-source\n"}
+	if err := validateMergeRequestSource(mr, "bd-source", nil); err == nil || !strings.Contains(err.Error(), "pre-resolved") {
+		t.Fatalf("validateMergeRequestSource without source = %v, want pre-resolved error", err)
+	}
+	if err := validateMergeRequestSource(mr, "bd-source", &beads.Issue{ID: "bd-source", Type: "task"}); err != nil {
+		t.Fatalf("validateMergeRequestSource with routed source: %v", err)
+	}
+}
+
+func setupRoutedSourceTestTown(t *testing.T) (workDir, currentBeadsDir, ownerBeadsDir string) {
+	t.Helper()
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0o755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write town sentinel: %v", err)
+	}
+
+	workDir = filepath.Join(townRoot, "gastown", "polecats", "refuge", "checkout")
+	currentBeadsDir = filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
+	ownerBeadsDir = filepath.Join(townRoot, "beads", "mayor", "rig", ".beads")
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	for _, dir := range []string{filepath.Join(workDir, ".beads"), currentBeadsDir, ownerBeadsDir, townBeadsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(workDir, ".beads", "redirect"), []byte("../../../mayor/rig/.beads\n"), 0o644); err != nil {
+		t.Fatalf("write redirect: %v", err)
+	}
+	if err := beads.WriteRoutes(townBeadsDir, []beads.Route{
+		{Prefix: "gt-", Path: "gastown/mayor/rig"},
+		{Prefix: "bd-", Path: "beads/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+	return workDir, currentBeadsDir, ownerBeadsDir
+}


### PR DESCRIPTION
Replacement for stale #4538, refreshed onto current main a9ada467 after #4552.

Release gate for #4532. Routes source-owned validation/comments/closes through the owning Beads DB while keeping merge-queue operations in the current rig DB.

Evidence: bead gt-4532-routed-submit-validation records 15 research legs, 5 pre-implementation reviews, 5 exact-final-head post reviews, and checker-passing evidence at head 395aa9e3737404ddef64723138ac79cd08d28137.

Local verification with CGO_ENABLED=0:
- git diff --check origin/main..HEAD
- go test ./internal/cmd -run 'Test(RoutedIssueBeadsUsesTownRoutesForCustomPrefix|SourceRouteContextNamesCurrentAndRoutedDB|ResolveSubmitSourceIssueIgnoresCurrentRigMirror|ResolveSubmitSourceIssueFailureNamesRoutingContext|ValidateMergeRequestSourceUsesPreResolvedSource|MqSubmitPathUsesRoutedSourceAndCurrentRigQueueBeads|DoneNoMRClosePathUsesRoutedSourceBeads|RunMqSubmitWithRoutedIssueIgnoresCurrentRigMirror|RunDoneWithRoutedIssueIgnoresCurrentRigMirror)$' -count=1
- go test ./internal/cmd -run '^$' -count=1
- go test ./internal/beads -run 'Test.*Routed|Test.*ResolveBeadsDirForID|Test.*MutationsRouteIDsByResolvedBeadsDir' -count=1

Supersedes #4538.
Closes #4532.