### PR TITLE
fix(tmux): snapshot process traversal

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -623,14 +623,14 @@ const processKillGracePeriod = 2 * time.Second
 // Process:
 // 1. Get the pane's main process PID and its process group ID (PGID)
 // 2. Kill the entire process group (catches reparented processes that stayed in the group)
-// 3. Find all descendant processes recursively (catches any stragglers)
+// 3. Find all descendant processes from one process snapshot (catches any stragglers)
 // 4. Send SIGTERM/SIGKILL to descendants
 // 5. Kill the pane process itself
 // 6. Kill the tmux session
 //
 // The process group kill is critical because:
-// - pgrep -P only finds direct children (PPID matching)
-// - Processes that reparent to init (PID 1) are missed by pgrep
+// - Descendant snapshots only find processes still connected by PPID
+// - Processes that reparent to init (PID 1) are missed by PPID traversal
 // - But they typically stay in the same process group unless they call setsid()
 //
 // This ensures Claude processes and all their children are properly terminated.
@@ -844,24 +844,83 @@ func collectReparentedGroupMembers(pgid string, knownPIDs map[string]bool) []str
 	return reparented
 }
 
-// getAllDescendants recursively finds all descendant PIDs of a process.
+type processSnapshot struct {
+	children map[string][]string
+	names    map[string]string
+}
+
+// getAllDescendants finds all descendant PIDs of a process from one process snapshot.
 // Returns PIDs in deepest-first order so killing them doesn't orphan grandchildren.
 func getAllDescendants(pid string) []string {
+	out, err := exec.Command("ps", "-axo", "pid=,ppid=,comm=").Output()
+	if err != nil {
+		return nil
+	}
+	return descendantsFromPS(pid, out)
+}
+
+func descendantsFromPS(pid string, out []byte) []string {
+	root, ok := normalizeProcessID(pid)
+	if !ok {
+		return nil
+	}
+	return descendantsFromSnapshot(root, parseProcessSnapshot(out))
+}
+
+func parseProcessSnapshot(out []byte) processSnapshot {
+	snapshot := processSnapshot{
+		children: make(map[string][]string),
+		names:    make(map[string]string),
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 2 {
+			continue
+		}
+
+		pid, ok := normalizeProcessID(fields[0])
+		if !ok {
+			continue
+		}
+		ppid, ok := normalizeProcessID(fields[1])
+		if !ok {
+			continue
+		}
+
+		if len(fields) > 2 {
+			snapshot.names[pid] = strings.Join(fields[2:], " ")
+		}
+		snapshot.children[ppid] = append(snapshot.children[ppid], pid)
+	}
+
+	return snapshot
+}
+
+func normalizeProcessID(pid string) (string, bool) {
+	n, err := strconv.Atoi(strings.TrimSpace(pid))
+	if err != nil || n < 0 {
+		return "", false
+	}
+	return strconv.Itoa(n), true
+}
+
+func descendantsFromSnapshot(root string, snapshot processSnapshot) []string {
+	seen := map[string]bool{root: true}
 	var result []string
 
-	// Get direct children using pgrep
-	out, err := exec.Command("pgrep", "-P", pid).Output()
-	if err != nil {
-		return result
+	var walk func(string)
+	walk = func(pid string) {
+		for _, child := range snapshot.children[pid] {
+			if seen[child] {
+				continue
+			}
+			seen[child] = true
+			walk(child)
+			result = append(result, child)
+		}
 	}
-
-	children := strings.Fields(strings.TrimSpace(string(out)))
-	for _, child := range children {
-		// First add grandchildren (recursively) - deepest first
-		result = append(result, getAllDescendants(child)...)
-		// Then add this child
-		result = append(result, child)
-	}
+	walk(root)
 
 	return result
 }
@@ -2438,7 +2497,7 @@ func hasDescendantWithNamesChecked(pid string, names []string, depth int) (bool,
 	return hasDescendantWithNamesPosixChecked(pid, names, depth)
 }
 
-// hasDescendantWithNamesPosix uses pgrep to find child processes on Unix systems.
+// hasDescendantWithNamesPosix walks one ps snapshot on Unix systems.
 func hasDescendantWithNamesPosix(pid string, names []string, depth int) bool {
 	found, _ := hasDescendantWithNamesPosixChecked(pid, names, depth)
 	return found
@@ -2446,50 +2505,69 @@ func hasDescendantWithNamesPosix(pid string, names []string, depth int) bool {
 
 func hasDescendantWithNamesPosixChecked(pid string, names []string, depth int) (bool, error) {
 	const maxDepth = 10
-	if depth > maxDepth {
+	if len(names) == 0 || depth > maxDepth {
 		return false, nil
 	}
-	// Use pgrep to find child processes
-	cmd := exec.Command("pgrep", "-P", pid, "-l")
-	out, err := cmd.Output()
+	root, ok := normalizeProcessID(pid)
+	if !ok {
+		return false, fmt.Errorf("invalid process ID %q", pid)
+	}
+
+	out, err := exec.Command("ps", "-axo", "pid=,ppid=,comm=").Output()
 	if err != nil {
-		if isNoMatchExit(err) {
-			return false, nil
-		}
 		return false, err
 	}
+	return hasDescendantWithNamesFromSnapshot(root, names, depth, parseProcessSnapshot(out)), nil
+}
+
+func hasDescendantWithNamesFromPS(pid string, names []string, depth int, out []byte) bool {
+	root, ok := normalizeProcessID(pid)
+	if !ok {
+		return false
+	}
+	return hasDescendantWithNamesFromSnapshot(root, names, depth, parseProcessSnapshot(out))
+}
+
+func hasDescendantWithNamesFromSnapshot(root string, names []string, depth int, snapshot processSnapshot) bool {
+	const maxDepth = 10
+	if len(names) == 0 || depth > maxDepth {
+		return false
+	}
+
 	// Build a set of names for fast lookup
 	nameSet := make(map[string]bool, len(names))
 	for _, n := range names {
-		nameSet[n] = true
-	}
-	// Check if any child matches, or recursively check grandchildren
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		// Format: "PID name" e.g., "29677 node"
-		parts := strings.Fields(line)
-		if len(parts) >= 2 {
-			childPid := parts[0]
-			childName := parts[1]
-			// Direct match
-			if nameSet[childName] {
-				return true, nil
-			}
-			// Recursive check of descendants
-			found, err := hasDescendantWithNamesChecked(childPid, names, depth+1)
-			if err != nil {
-				return false, err
-			}
-			if found {
-				return true, nil
-			}
+		n = strings.TrimSpace(n)
+		if n != "" {
+			nameSet[n] = true
 		}
 	}
-	return false, nil
+	if len(nameSet) == 0 {
+		return false
+	}
+
+	seen := map[string]bool{root: true}
+	var walk func(string, int) bool
+	walk = func(pid string, currentDepth int) bool {
+		if currentDepth > maxDepth {
+			return false
+		}
+		for _, child := range snapshot.children[pid] {
+			if seen[child] {
+				continue
+			}
+			seen[child] = true
+			if nameSet[filepath.Base(strings.TrimSpace(snapshot.names[child]))] {
+				return true
+			}
+			if walk(child, currentDepth+1) {
+				return true
+			}
+		}
+		return false
+	}
+
+	return walk(root, depth)
 }
 
 func isNoMatchExit(err error) bool {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -714,6 +715,118 @@ func TestGetAllDescendants(t *testing.T) {
 				t.Errorf("getAllDescendants returned non-numeric PID: %q", pid)
 			}
 		}
+	}
+}
+
+func TestDescendantsFromPS(t *testing.T) {
+	t.Parallel()
+
+	snapshot := []byte(`
+1 0 root
+2 1 bash
+3 1 zsh
+4 2 node
+5 4 claude
+2 1 bash-duplicate
+bad header row
+8 bad nope
+1 5 root-cycle
+7 99 node
+`)
+
+	got := descendantsFromPS("1", snapshot)
+	want := []string{"5", "4", "2", "3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("descendantsFromPS deepest-first = %v, want %v", got, want)
+	}
+
+	if got := descendantsFromPS("42", snapshot); len(got) != 0 {
+		t.Fatalf("descendantsFromPS missing root = %v, want empty", got)
+	}
+
+	if got := descendantsFromPS("not-a-pid", snapshot); len(got) != 0 {
+		t.Fatalf("descendantsFromPS invalid root = %v, want empty", got)
+	}
+}
+
+func TestHasDescendantWithNamesFromPS(t *testing.T) {
+	t.Parallel()
+
+	snapshot := []byte(`
+1 0 bash
+2 1 /usr/local/bin/node
+3 2 /Users/peter/bin/claude
+4 1 tmux: client
+5 1 claude-helper
+6 5 nodejs
+7 99 node
+8 0 opencode
+9 8 /opt/homebrew/bin/bun
+10 9 opencode
+1 10 root-cycle
+bad header row
+11 bad nope
+`)
+
+	tests := []struct {
+		name  string
+		pid   string
+		names []string
+		depth int
+		want  bool
+	}{
+		{name: "direct child basename", pid: "1", names: []string{"node"}, want: true},
+		{name: "grandchild basename path", pid: "1", names: []string{"claude"}, want: true},
+		{name: "multi word comm", pid: "1", names: []string{"tmux: client"}, want: true},
+		{name: "exact match only", pid: "1", names: []string{"nodejs"}, want: true},
+		{name: "no substring match", pid: "1", names: []string{"claude-helper"}, want: true},
+		{name: "unrelated ambient ignored", pid: "42", names: []string{"node", "opencode", "bun"}, want: false},
+		{name: "empty names", pid: "1", names: []string{"", "  "}, want: false},
+		{name: "depth limit preserves current semantics", pid: "8", names: []string{"opencode"}, depth: 10, want: false},
+		{name: "invalid root", pid: "nope", names: []string{"node"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := hasDescendantWithNamesFromPS(tt.pid, tt.names, tt.depth, snapshot)
+			if got != tt.want {
+				t.Fatalf("hasDescendantWithNamesFromPS(%q, %v, %d) = %v, want %v", tt.pid, tt.names, tt.depth, got, tt.want)
+			}
+		})
+	}
+
+	substringSnapshot := []byte(`
+1 0 bash
+2 1 claude-helper
+3 1 nodejs
+`)
+	if hasDescendantWithNamesFromPS("1", []string{"claude", "node"}, 0, substringSnapshot) {
+		t.Fatal("hasDescendantWithNamesFromPS matched a process name substring")
+	}
+}
+
+func TestHasDescendantWithNamesFromPSDoesNotMatchRoot(t *testing.T) {
+	t.Parallel()
+
+	snapshot := []byte(`1 0 node`)
+	if hasDescendantWithNamesFromPS("1", []string{"node"}, 0, snapshot) {
+		t.Fatal("hasDescendantWithNamesFromPS matched the root as its own descendant")
+	}
+}
+
+func TestHasDescendantWithNamesPosixCheckedReportsSnapshotError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX helper test")
+	}
+
+	t.Setenv("PATH", "")
+	found, err := hasDescendantWithNamesPosixChecked("1", []string{"node"}, 0)
+	if err == nil {
+		t.Fatal("hasDescendantWithNamesPosixChecked with missing ps error = nil, want error")
+	}
+	if found {
+		t.Fatal("hasDescendantWithNamesPosixChecked with missing ps found match, want false")
 	}
 }
 


### PR DESCRIPTION
Clean current-main replacement for review-failed PRs #4380 and #4398.

Ports Peter Banka's dead-PID process traversal fix onto current main `f81d2fd3d7ab34176305dde7768268aa17a03f73`, with replacement head `e01f892dd2eb1dd65c0dc940e4d59c79d2befcf5`.

This replaces recursive POSIX `pgrep -P` traversal with a single `ps -axo pid=,ppid=,comm=` snapshot plus in-memory descendant/name matching. It preserves deepest-first traversal behavior and avoids PID prechecks, timeouts, macOS shims, and workaround layers.

Attribution is preserved in the commit with `Original-commit` and `Co-authored-by` trailers for Peter Banka.

Evidence: bead `gt-4398fx` records 15 research legs, 5 pre-implementation reviews, 5 exact-final-head post reviews, and refreshed checker-passing evidence for head `e01f892dd2eb1dd65c0dc940e4d59c79d2befcf5`. Direct macOS verification remains technically unavailable in this environment and is recorded as a precise blocker.

PR Sheriff checker: `gt-pr-sheriff-check --evidence /tmp/opencode/gt-4398fx-evidence/evidence.json --merge-gate` passed with `merge_path_allowed=true`, `verdict=merge_replacement`, `12 pass`, `2 not_applicable`, `0 fail`.

Local verification on exact head `e01f892dd2eb1dd65c0dc940e4d59c79d2befcf5`:

- `git diff --check upstream/main...HEAD`
- `go test ./internal/tmux -run '^(TestDescendantsFromPS|TestHasDescendantWithNamesFromPS|TestHasDescendantWithNamesFromPSDoesNotMatchRoot|TestHasDescendantWithNamesPosixCheckedReportsSnapshotError|TestGetAllDescendants|TestHasDescendantWithNames)$' -count=1 -timeout=2m`
- `go test -race ./internal/tmux -run '^(TestDescendantsFromPS|TestHasDescendantWithNamesFromPS|TestHasDescendantWithNamesFromPSDoesNotMatchRoot|TestGetAllDescendants|TestHasDescendantWithNames)$' -count=1 -timeout=5m`
- `PATH=/tmp/opencode/gt-4398fx-bin:$PATH go test ./internal/tmux -count=1 -timeout=10m`
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=0 make build`

GitHub CI for PR #4555 is green on head `e01f892dd2eb1dd65c0dc940e4d59c79d2befcf5`. Supersedes #4380 and #4398 after replacement merge proof.
