### PR TITLE
test: isolate Dolt routing from production

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -5368,6 +5368,9 @@ printf 'unknown\n'
 	t.Setenv("GT_DOLT_DATA", "/home/coder/gt/.dolt-data")
 	t.Setenv("BEADS_DOLT_DATA_DIR", "/home/coder/gt/.dolt-data")
 	t.Setenv("BEADS_DOLT_HOST", "127.0.0.1")
+	// TestMain pins GT_DOLT_HOST to the disposable package server. Clear it
+	// here so this test continues to exercise metadata-derived host routing.
+	t.Setenv("GT_DOLT_HOST", "")
 	t.Setenv("GT_DOLT_PORT", "")
 	t.Setenv("BEADS_DOLT_PORT", "3307")
 	t.Setenv("BEADS_DOLT_SERVER_HOST", "127.0.0.1")

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -2003,40 +2004,32 @@ func TestSearchOptions(t *testing.T) {
 	}
 }
 
-// Integration test that runs against real bd if available
+// Integration test that runs against real bd on the disposable package server.
 func TestIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	// Find a beads repo (use current directory if it has .beads)
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
+	port, err := strconv.Atoi(os.Getenv("GT_DOLT_PORT"))
+	if err != nil || port <= 0 {
+		t.Fatalf("disposable GT_DOLT_PORT is unavailable: %q", os.Getenv("GT_DOLT_PORT"))
 	}
-
-	dir := cwd
-	for {
-		if _, err := os.Stat(filepath.Join(dir, ".beads")); err == nil {
-			break
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Skip("no .beads directory found in path")
-		}
-		dir = parent
+	workDir := t.TempDir()
+	gitInit := exec.Command("git", "init", "--quiet", "--initial-branch=main")
+	gitInit.Dir = workDir
+	if output, err := gitInit.CombinedOutput(); err != nil {
+		t.Fatalf("initialize disposable git repository: %v\n%s", err, output)
 	}
-
-	// Resolve the actual beads directory (following redirect if present)
-	// In multi-worktree setups, worktrees have .beads/redirect pointing to
-	// the canonical beads location (e.g., mayor/rig/.beads)
-	beadsDir := ResolveBeadsDir(dir)
-	doltPath := filepath.Join(beadsDir, "dolt")
-	if _, err := os.Stat(doltPath); os.IsNotExist(err) {
-		t.Skip("no dolt database found")
+	initCmd := exec.Command("bd", "init", "--prefix", fmt.Sprintf("bi%d", os.Getpid()),
+		"--quiet", "--server", "--server-port", strconv.Itoa(port))
+	initCmd.Dir = workDir
+	if output, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("initialize disposable beads database: %v\n%s", err, output)
 	}
-
-	b := New(dir)
+	b := New(workDir)
+	if _, err := b.Create(CreateOptions{Title: "integration fixture", Type: "task"}); err != nil {
+		t.Fatalf("create disposable integration fixture: %v", err)
+	}
 
 	// Test List
 	t.Run("List", func(t *testing.T) {

--- a/internal/beads/testmain_test.go
+++ b/internal/beads/testmain_test.go
@@ -1,0 +1,22 @@
+package beads_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	// Several tests invoke the real bd CLI. Give the entire package a disposable
+	// server before any test can inherit an agent session's production routing.
+	if err := testutil.EnsureDoltContainerForTestMain(); err != nil {
+		fmt.Fprintf(os.Stderr, "beads TestMain: Dolt setup: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	testutil.TerminateDoltContainer()
+	os.Exit(code)
+}

--- a/internal/beads/testmain_test.go
+++ b/internal/beads/testmain_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package beads_test
 
 import (

--- a/internal/rig/testmain_test.go
+++ b/internal/rig/testmain_test.go
@@ -1,0 +1,23 @@
+package rig
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	// AddRig tests exercise real fallback paths even when most bd calls are
+	// stubbed. Isolate the package so fixture rigs can never become databases on
+	// the production town server.
+	if err := testutil.EnsureDoltContainerForTestMain(); err != nil {
+		fmt.Fprintf(os.Stderr, "rig TestMain: Dolt setup: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	testutil.TerminateDoltContainer()
+	os.Exit(code)
+}

--- a/internal/rig/testmain_test.go
+++ b/internal/rig/testmain_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package rig
 
 import (

--- a/internal/testutil/cmd.go
+++ b/internal/testutil/cmd.go
@@ -6,11 +6,30 @@ import (
 	"strings"
 )
 
+// doltTargetSelectorEnvVars select a database or local data directory instead
+// of the configured SQL endpoint. They must never leak into tests: a developer
+// commonly runs tests from an agent session where these variables point at the
+// production town or rig database.
+var doltTargetSelectorEnvVars = []string{
+	"BEADS_DIR",
+	"BEADS_DB",
+	"BD_DB",
+	"BEADS_SHARED_SERVER_DIR",
+	"BEADS_DOLT_DATA_DIR",
+	"BEADS_DOLT_DATABASE",
+	"BEADS_DOLT_SERVER_DATABASE",
+	"BEADS_DOLT_HOST",
+	"BEADS_DOLT_SHARED_SERVER",
+	"BEADS_DOLT_SERVER_MODE",
+	"BEADS_DOLT_SERVER_SOCKET",
+	"GT_DOLT_DATA",
+}
+
 // CleanGTEnv returns os.Environ() with GT_* and BD_* variables removed, except
 // GT_DOLT_PORT, GT_DOLT_HOST, and GT_TEST_EXTERNAL_DOLT which are preserved so
-// subprocesses connect to and reuse the test Dolt server. BEADS_DOLT_PORT and
-// BEADS_DOLT_SERVER_HOST (prefix BEADS_, not BD_) pass through implicitly since
-// only BD_* is stripped.
+// subprocesses connect to and reuse the test Dolt server. Dolt database and
+// local-data selectors are always stripped so an inherited agent environment
+// cannot route a test command back to production storage.
 //
 // Use this when setting cmd.Env on bd/gt subprocess calls in tests.
 // If you do NOT set cmd.Env, the process env (including GT_DOLT_PORT) is
@@ -27,9 +46,22 @@ func CleanGTEnv(extraEnv ...string) []string {
 		if strings.HasPrefix(e, "BD_") {
 			continue
 		}
+		key, _, _ := strings.Cut(e, "=")
+		if isDoltTargetSelector(key) {
+			continue
+		}
 		clean = append(clean, e)
 	}
 	return append(clean, extraEnv...)
+}
+
+func isDoltTargetSelector(key string) bool {
+	for _, selector := range doltTargetSelectorEnvVars {
+		if strings.EqualFold(key, selector) {
+			return true
+		}
+	}
+	return false
 }
 
 // NewBDCommand creates an exec.Command for the bd CLI with GT_DOLT_PORT

--- a/internal/testutil/cmd_test.go
+++ b/internal/testutil/cmd_test.go
@@ -80,6 +80,20 @@ func TestCleanGTEnv_ExtraEnv(t *testing.T) {
 	}
 }
 
+func TestCleanGTEnv_StripsDoltTargetSelectors(t *testing.T) {
+	for _, key := range doltTargetSelectorEnvVars {
+		t.Setenv(key, "production")
+	}
+
+	env := CleanGTEnv()
+	for _, entry := range env {
+		key, _, _ := strings.Cut(entry, "=")
+		if isDoltTargetSelector(key) {
+			t.Errorf("CleanGTEnv leaked production selector %q", entry)
+		}
+	}
+}
+
 func TestNewBDCommand_InheritsEnv(t *testing.T) {
 	t.Setenv("GT_DOLT_PORT", "13307")
 

--- a/internal/testutil/doltserver.go
+++ b/internal/testutil/doltserver.go
@@ -113,9 +113,29 @@ func startSharedDoltContainer() {
 
 	doltCtr = ctr
 	doltCtrPort = p.Port()
-	os.Setenv("GT_DOLT_PORT", doltCtrPort)    //nolint:tenv // intentional process-wide env
-	os.Setenv("BEADS_DOLT_PORT", doltCtrPort) //nolint:tenv // intentional process-wide env
-	os.Setenv("GT_TEST_EXTERNAL_DOLT", "1")   //nolint:tenv // integration tests reuse this container
+	configureDoltTestProcessEnv(doltCtrPort)
+}
+
+// configureDoltTestProcessEnv replaces every supported Dolt endpoint alias and
+// clears selectors inherited from the invoking Gas Town session. Setting only
+// GT_DOLT_PORT is insufficient: bd gives BEADS_DOLT_SERVER_PORT and database
+// selectors precedence, which previously let integration tests create fixture
+// databases on the production server at 127.0.0.1:3307.
+func configureDoltTestProcessEnv(port string) {
+	for _, key := range doltTargetSelectorEnvVars {
+		_ = os.Unsetenv(key)
+	}
+	for key, value := range map[string]string{
+		"GT_DOLT_HOST":           "127.0.0.1",
+		"GT_DOLT_PORT":           port,
+		"BEADS_DOLT_SERVER_HOST": "127.0.0.1",
+		"BEADS_DOLT_SERVER_PORT": port,
+		"BEADS_DOLT_PORT":        port,
+		"BEADS_DOLT_AUTO_START":  "0",
+		"GT_TEST_EXTERNAL_DOLT":  "1",
+	} {
+		_ = os.Setenv(key, value) //nolint:tenv // intentional TestMain process boundary
+	}
 }
 
 // StartIsolatedDoltContainer starts a per-test Dolt container and returns the
@@ -147,7 +167,19 @@ func StartIsolatedDoltContainer(t *testing.T) string {
 	}
 
 	portStr := port.Port()
+	for _, key := range doltTargetSelectorEnvVars {
+		t.Setenv(key, "")
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("clear inherited Dolt selector %s: %v", key, err)
+		}
+	}
+	t.Setenv("GT_DOLT_HOST", "127.0.0.1")
 	t.Setenv("GT_DOLT_PORT", portStr)
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "127.0.0.1")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", portStr)
+	t.Setenv("BEADS_DOLT_PORT", portStr)
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+	t.Setenv("GT_TEST_EXTERNAL_DOLT", "1")
 	return portStr
 }
 
@@ -155,11 +187,19 @@ func StartIsolatedDoltContainer(t *testing.T) string {
 // TestMain functions. Call TerminateDoltContainer() after m.Run() to clean up.
 // Sets both GT_DOLT_PORT and BEADS_DOLT_PORT process-wide.
 func EnsureDoltContainerForTestMain() error {
+	// Establish a fail-closed boundary before probing Docker. Packages such as
+	// daemon intentionally continue with non-Dolt tests when Docker is absent;
+	// an unreachable port prevents their subprocesses from falling back to an
+	// inherited production endpoint during that degraded run.
+	configureDoltTestProcessEnv("0")
 	if !isDockerAvailable() {
 		return fmt.Errorf("Docker not available")
 	}
 
 	doltCtrOnce.Do(startSharedDoltContainer)
+	if doltCtrErr == nil && doltCtrPort != "" {
+		configureDoltTestProcessEnv(doltCtrPort)
+	}
 	return doltCtrErr
 }
 

--- a/internal/testutil/doltserver_catalog_integration_test.go
+++ b/internal/testutil/doltserver_catalog_integration_test.go
@@ -1,0 +1,110 @@
+//go:build integration && !windows
+
+package testutil
+
+import (
+	"context"
+	"database/sql"
+	"os/exec"
+	"reflect"
+	"sort"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/dolt"
+)
+
+// TestDoltTestEnvironmentLeavesProductionCatalogUnchanged is the end-to-end
+// guard for gt-ci7. The first container stands in for production and is exposed
+// through every inherited routing variable that caused the original leak. The
+// test boundary must route bd init to the second, disposable container without
+// changing the production catalog.
+func TestDoltTestEnvironmentLeavesProductionCatalogUnchanged(t *testing.T) {
+	if _, err := exec.LookPath("bd"); err != nil {
+		t.Skip("bd not available")
+	}
+	if !isDockerAvailable() {
+		t.Skip("Docker not available")
+	}
+
+	_, productionPort := startCatalogTestDolt(t)
+	_, disposablePort := startCatalogTestDolt(t)
+
+	keys := append([]string{}, doltTargetSelectorEnvVars...)
+	keys = append(keys,
+		"GT_DOLT_HOST", "GT_DOLT_PORT", "BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT", "BEADS_DOLT_AUTO_START",
+		"GT_TEST_EXTERNAL_DOLT",
+	)
+	t.Cleanup(restoreEnvironment(t, keys))
+
+	requireSetenv(t, "GT_DOLT_PORT", productionPort)
+	requireSetenv(t, "BEADS_DOLT_SERVER_PORT", productionPort)
+	requireSetenv(t, "BEADS_DOLT_PORT", productionPort)
+	requireSetenv(t, "BEADS_DOLT_SERVER_DATABASE", "production")
+
+	before := catalogForPort(t, productionPort)
+	configureDoltTestProcessEnv(disposablePort)
+
+	cmd := exec.Command("bd", "init", "--prefix", "catalogguard", "--server")
+	cmd.Dir = t.TempDir()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd init on disposable Dolt: %v\n%s", err, output)
+	}
+
+	after := catalogForPort(t, productionPort)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("production catalog changed: before=%v after=%v", before, after)
+	}
+	if got := catalogForPort(t, disposablePort); reflect.DeepEqual(got, before) {
+		t.Fatalf("disposable catalog did not receive bd fixture database: %v", got)
+	}
+}
+
+func startCatalogTestDolt(t *testing.T) (*dolt.DoltContainer, string) {
+	t.Helper()
+	ctx := context.Background()
+	ctr, err := runDoltContainerWithRetry(ctx)
+	if err != nil {
+		t.Fatalf("start Dolt container: %v", err)
+	}
+	port, err := ctr.MappedPort(ctx, "3306/tcp")
+	if err != nil {
+		_ = testcontainers.TerminateContainer(ctr)
+		t.Fatalf("map Dolt port: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = testcontainers.TerminateContainer(ctr)
+	})
+	return ctr, port.Port()
+}
+
+func catalogForPort(t *testing.T, port string) []string {
+	t.Helper()
+	db, err := sql.Open("mysql", "root:@tcp(127.0.0.1:"+port+")/")
+	if err != nil {
+		t.Fatalf("open Dolt %s: %v", port, err)
+	}
+	defer db.Close()
+
+	rows, err := db.Query("SHOW DATABASES")
+	if err != nil {
+		t.Fatalf("show databases on Dolt %s: %v", port, err)
+	}
+	defer rows.Close()
+
+	var catalog []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan catalog on Dolt %s: %v", port, err)
+		}
+		catalog = append(catalog, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read catalog on Dolt %s: %v", port, err)
+	}
+	sort.Strings(catalog)
+	return catalog
+}

--- a/internal/testutil/doltserver_test.go
+++ b/internal/testutil/doltserver_test.go
@@ -4,8 +4,78 @@ package testutil
 
 import (
 	"errors"
+	"os"
 	"testing"
 )
+
+func TestConfigureDoltTestProcessEnvOverridesProductionRouting(t *testing.T) {
+	keys := append([]string{}, doltTargetSelectorEnvVars...)
+	keys = append(keys,
+		"GT_DOLT_HOST", "GT_DOLT_PORT", "BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT", "BEADS_DOLT_AUTO_START",
+		"GT_TEST_EXTERNAL_DOLT",
+	)
+	t.Cleanup(restoreEnvironment(t, keys))
+
+	for _, key := range doltTargetSelectorEnvVars {
+		requireSetenv(t, key, "production-selector")
+	}
+	requireSetenv(t, "GT_DOLT_HOST", "production.example")
+	requireSetenv(t, "GT_DOLT_PORT", "3307")
+	requireSetenv(t, "BEADS_DOLT_SERVER_HOST", "127.0.0.1")
+	requireSetenv(t, "BEADS_DOLT_SERVER_PORT", "3307")
+	requireSetenv(t, "BEADS_DOLT_PORT", "3307")
+
+	configureDoltTestProcessEnv("49152")
+
+	for _, key := range doltTargetSelectorEnvVars {
+		if value, ok := os.LookupEnv(key); ok {
+			t.Errorf("%s leaked into test environment as %q", key, value)
+		}
+	}
+	for key, want := range map[string]string{
+		"GT_DOLT_HOST":           "127.0.0.1",
+		"GT_DOLT_PORT":           "49152",
+		"BEADS_DOLT_SERVER_HOST": "127.0.0.1",
+		"BEADS_DOLT_SERVER_PORT": "49152",
+		"BEADS_DOLT_PORT":        "49152",
+		"BEADS_DOLT_AUTO_START":  "0",
+		"GT_TEST_EXTERNAL_DOLT":  "1",
+	} {
+		if got := os.Getenv(key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func restoreEnvironment(t *testing.T, keys []string) func() {
+	t.Helper()
+	type value struct {
+		value string
+		set   bool
+	}
+	original := make(map[string]value, len(keys))
+	for _, key := range keys {
+		v, ok := os.LookupEnv(key)
+		original[key] = value{value: v, set: ok}
+	}
+	return func() {
+		for key, originalValue := range original {
+			if originalValue.set {
+				_ = os.Setenv(key, originalValue.value)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		}
+	}
+}
+
+func requireSetenv(t *testing.T, key, value string) {
+	t.Helper()
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatalf("set %s: %v", key, err)
+	}
+}
 
 func TestIsDockerUnavailableErr(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Fixes gt-ci7.

- clears inherited production Dolt target selectors at test process boundaries
- routes beads and rig subprocess tests to disposable Dolt containers
- adds a two-server catalog regression proving the production catalog remains unchanged
- preserves Windows builds with non-Windows Docker test boundaries

Verification:
- go vet ./internal/testutil ./internal/beads ./internal/rig
- go test ./internal/testutil ./internal/beads ./internal/rig
- go test -tags=integration -run TestDoltTestEnvironmentLeavesProductionCatalogUnchanged ./internal/testutil
- Windows cross-compilation of internal/beads and internal/rig