### PR TITLE
fix(done): fail closed outside polecat worktree

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -104,6 +104,14 @@ type doneSessionKiller interface {
 	KillSessionWithProcessesExcluding(name string, excludePIDs []string) error
 }
 
+type donePolecatWorktree struct {
+	townRoot    string
+	cwd         string
+	rigName     string
+	polecatName string
+	actor       string
+}
+
 var newDoneSessionKiller = func() doneSessionKiller {
 	return tmux.NewTmux()
 }
@@ -116,6 +124,253 @@ func updateAgentStateAfterSubmission(cwd, townRoot, exitType, issueID string, pu
 		return nil
 	}
 	return updateAgentStateOnDoneFn(cwd, townRoot, exitType, issueID)
+}
+
+func resolveDonePolecatWorktree() (donePolecatWorktree, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return donePolecatWorktree{}, fmt.Errorf("gt done must be run from the assigned polecat worktree: current directory unavailable: %w", err)
+	}
+	return resolveDonePolecatWorktreeAt(cwd)
+}
+
+func resolveDonePolecatWorktreeAt(cwd string) (donePolecatWorktree, error) {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return donePolecatWorktree{}, fmt.Errorf("gt done must be run from the assigned polecat worktree: current directory unavailable")
+	}
+	absCwd, err := filepath.Abs(cwd)
+	if err != nil {
+		return donePolecatWorktree{}, fmt.Errorf("resolving current directory: %w", err)
+	}
+	if info, err := os.Stat(absCwd); err != nil {
+		return donePolecatWorktree{}, fmt.Errorf("gt done must be run from the assigned polecat worktree: current directory unavailable: %w", err)
+	} else if !info.IsDir() {
+		return donePolecatWorktree{}, fmt.Errorf("gt done must be run from the assigned polecat worktree: current path is not a directory: %s", absCwd)
+	}
+
+	townRoot, err := workspace.FindOrError(absCwd)
+	if err != nil {
+		return donePolecatWorktree{}, fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+	if err := doneValidateSessionTownRoot(townRoot); err != nil {
+		return donePolecatWorktree{}, err
+	}
+
+	actorRig, actorName, err := donePolecatActorIdentity(os.Getenv("BD_ACTOR"))
+	if err != nil {
+		return donePolecatWorktree{}, err
+	}
+	roleRig, roleName, err := donePolecatEnvIdentity(os.Getenv("GT_ROLE"), os.Getenv("GT_RIG"), os.Getenv("GT_POLECAT"))
+	if err != nil {
+		return donePolecatWorktree{}, err
+	}
+	if actorRig != roleRig || actorName != roleName {
+		return donePolecatWorktree{}, fmt.Errorf("gt done identity mismatch: BD_ACTOR=%s/polecats/%s but GT_ROLE/GT_RIG/GT_POLECAT resolve to %s/polecats/%s", actorRig, actorName, roleRig, roleName)
+	}
+	if err := doneRejectGitEnvOverrides(); err != nil {
+		return donePolecatWorktree{}, err
+	}
+
+	gitRoot, err := doneGitTopLevel(absCwd)
+	if err != nil {
+		return donePolecatWorktree{}, fmt.Errorf("gt done must be run from the assigned polecat git worktree: %w", err)
+	}
+	gitRoot = doneCanonicalPath(gitRoot)
+	canonicalCwd := doneCanonicalPath(absCwd)
+	if !donePathWithin(gitRoot, canonicalCwd) {
+		return donePolecatWorktree{}, fmt.Errorf("gt done must be run from the assigned polecat worktree: current directory %s is outside git root %s", canonicalCwd, gitRoot)
+	}
+
+	candidates, err := donePolecatWorktreeCandidates(townRoot, actorRig, actorName)
+	if err != nil {
+		return donePolecatWorktree{}, err
+	}
+	for _, candidate := range candidates {
+		if gitRoot == doneCanonicalPath(candidate) {
+			return donePolecatWorktree{
+				townRoot:    townRoot,
+				cwd:         gitRoot,
+				rigName:     actorRig,
+				polecatName: actorName,
+				actor:       fmt.Sprintf("%s/polecats/%s", actorRig, actorName),
+			}, nil
+		}
+	}
+
+	return donePolecatWorktree{}, fmt.Errorf("gt done must be run from assigned polecat worktree %s; current git root is %s", strings.Join(candidates, " or "), gitRoot)
+}
+
+func donePolecatWorktreeCandidates(townRoot, rigName, polecatName string) ([]string, error) {
+	nested := filepath.Join(townRoot, rigName, "polecats", polecatName, rigName)
+	info, err := os.Stat(nested)
+	if err == nil {
+		if !info.IsDir() {
+			return nil, fmt.Errorf("assigned polecat worktree path is not a directory: %s", nested)
+		}
+		return []string{nested}, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("checking assigned polecat worktree %s: %w", nested, err)
+	}
+
+	return []string{filepath.Join(townRoot, rigName, "polecats", polecatName)}, nil
+}
+
+func donePolecatActorIdentity(actor string) (string, string, error) {
+	actor = strings.TrimSpace(actor)
+	if actor == "" {
+		return "", "", fmt.Errorf("gt done requires BD_ACTOR to identify the assigned polecat")
+	}
+	parts := strings.Split(actor, "/")
+	if len(parts) != 3 || parts[0] == "" || parts[1] != "polecats" || parts[2] == "" {
+		return "", "", fmt.Errorf("gt done is for polecats only (BD_ACTOR=%s)", actor)
+	}
+	if err := doneValidateIdentitySegment("BD_ACTOR rig", parts[0]); err != nil {
+		return "", "", err
+	}
+	if err := doneValidateIdentitySegment("BD_ACTOR polecat", parts[2]); err != nil {
+		return "", "", err
+	}
+	return parts[0], parts[2], nil
+}
+
+func donePolecatEnvIdentity(gtRole, gtRig, gtPolecat string) (string, string, error) {
+	gtRole = strings.TrimSpace(gtRole)
+	gtRig = strings.TrimSpace(gtRig)
+	gtPolecat = strings.TrimSpace(gtPolecat)
+	if gtRole == "" {
+		return "", "", fmt.Errorf("gt done requires GT_ROLE to identify the assigned polecat")
+	}
+	if gtRig == "" {
+		return "", "", fmt.Errorf("gt done requires GT_RIG to identify the assigned polecat")
+	}
+	if gtPolecat == "" {
+		return "", "", fmt.Errorf("gt done requires GT_POLECAT to identify the assigned polecat")
+	}
+	if err := doneValidateIdentitySegment("GT_RIG", gtRig); err != nil {
+		return "", "", err
+	}
+	if err := doneValidateIdentitySegment("GT_POLECAT", gtPolecat); err != nil {
+		return "", "", err
+	}
+
+	roleRig, rolePolecat, err := donePolecatRoleIdentity(gtRole)
+	if err != nil {
+		return "", "", err
+	}
+	if roleRig != "" && roleRig != gtRig {
+		return "", "", fmt.Errorf("gt done identity mismatch: GT_ROLE rig %s != GT_RIG %s", roleRig, gtRig)
+	}
+	if rolePolecat != "" && rolePolecat != gtPolecat {
+		return "", "", fmt.Errorf("gt done identity mismatch: GT_ROLE polecat %s != GT_POLECAT %s", rolePolecat, gtPolecat)
+	}
+
+	return gtRig, gtPolecat, nil
+}
+
+func donePolecatRoleIdentity(gtRole string) (string, string, error) {
+	if gtRole == string(RolePolecat) {
+		return "", "", nil
+	}
+	parts := strings.Split(gtRole, "/")
+	switch len(parts) {
+	case 2:
+		role, roleRig, rolePolecat := parseRoleString(gtRole)
+		if role != RolePolecat || roleRig == "" || rolePolecat == "" {
+			return "", "", fmt.Errorf("gt done is for polecats only (GT_ROLE=%s)", gtRole)
+		}
+		if err := doneValidateIdentitySegment("GT_ROLE rig", roleRig); err != nil {
+			return "", "", err
+		}
+		if err := doneValidateIdentitySegment("GT_ROLE polecat", rolePolecat); err != nil {
+			return "", "", err
+		}
+		return roleRig, rolePolecat, nil
+	case 3:
+		if parts[1] != "polecats" || parts[0] == "" || parts[2] == "" {
+			return "", "", fmt.Errorf("gt done is for polecats only (GT_ROLE=%s)", gtRole)
+		}
+		if err := doneValidateIdentitySegment("GT_ROLE rig", parts[0]); err != nil {
+			return "", "", err
+		}
+		if err := doneValidateIdentitySegment("GT_ROLE polecat", parts[2]); err != nil {
+			return "", "", err
+		}
+		return parts[0], parts[2], nil
+	default:
+		return "", "", fmt.Errorf("gt done is for polecats only (GT_ROLE=%s)", gtRole)
+	}
+}
+
+func doneValidateIdentitySegment(name, value string) error {
+	if value == "" || value == "." || value == ".." || strings.ContainsAny(value, `/\\`) {
+		return fmt.Errorf("gt done invalid %s: %q is not a single path segment", name, value)
+	}
+	return nil
+}
+
+func doneValidateSessionTownRoot(townRoot string) error {
+	current := doneCanonicalPath(townRoot)
+	for _, envName := range []string{"GT_TOWN_ROOT", "GT_ROOT"} {
+		envRoot := strings.TrimSpace(os.Getenv(envName))
+		if envRoot == "" {
+			continue
+		}
+		if doneCanonicalPath(envRoot) != current {
+			return fmt.Errorf("gt done town root mismatch: %s=%s but current workspace is %s", envName, doneCanonicalPath(envRoot), current)
+		}
+	}
+	return nil
+}
+
+func donePathWithin(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
+}
+
+func doneRejectGitEnvOverrides() error {
+	for _, envName := range []string{
+		"GIT_DIR",
+		"GIT_WORK_TREE",
+		"GIT_INDEX_FILE",
+		"GIT_COMMON_DIR",
+		"GIT_OBJECT_DIRECTORY",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+		"GIT_NAMESPACE",
+	} {
+		if strings.TrimSpace(os.Getenv(envName)) != "" {
+			return fmt.Errorf("gt done requires an unambiguous git worktree; unset %s", envName)
+		}
+	}
+	return nil
+}
+
+func doneGitTopLevel(cwd string) (string, error) {
+	cmd := exec.Command("git", "-C", cwd, "rev-parse", "--show-toplevel")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("resolving git root for %s: %s", cwd, strings.TrimSpace(string(output)))
+	}
+	gitRoot := strings.TrimSpace(string(output))
+	if gitRoot == "" {
+		return "", fmt.Errorf("git root for %s is empty", cwd)
+	}
+	return gitRoot, nil
+}
+
+func doneCanonicalPath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
+	}
+	return filepath.Clean(abs)
 }
 
 func polecatSessionRetirementTarget(rigName, polecatName string, pid int) (string, []string, bool) {
@@ -430,154 +685,38 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	// Clean completions retire the live polecat session after durable handoff.
 	// Failed, deferred, escalated, and local-review paths preserve the session for recovery.
 
-	// Find workspace with fallback for deleted worktrees (hq-3xaxy)
-	// If the polecat's worktree was deleted by Witness before gt done finishes,
-	// getcwd will fail. We fall back to GT_TOWN_ROOT env var in that case.
-	townRoot, cwd, err := workspace.FindFromCwdWithFallback()
+	worktree, err := resolveDonePolecatWorktree()
 	if err != nil {
-		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+		return err
 	}
+	townRoot := worktree.townRoot
+	cwd := worktree.cwd
+	rigName := worktree.rigName
+	polecatName := worktree.polecatName
+	sender := worktree.actor
 
-	// Track if cwd is available - affects which operations we can do
-	cwdAvailable := cwd != ""
-	if !cwdAvailable {
-		style.PrintWarning("working directory deleted (worktree nuked?), using fallback paths")
-		// Try to get cwd from GT_POLECAT_PATH env var (set by session manager)
-		if polecatPath := os.Getenv("GT_POLECAT_PATH"); polecatPath != "" {
-			cwd = polecatPath // May still be gone, but we have a path to use
-		}
-	}
+	g := git.NewGit(cwd)
 
-	// Find current rig - use cwd (which has fallback for deleted worktrees)
-	// instead of findCurrentRig which calls os.Getwd() and fails on deleted cwd
-	var rigName string
-	if cwd != "" {
-		relPath, err := filepath.Rel(townRoot, cwd)
-		if err == nil {
-			parts := strings.Split(relPath, string(filepath.Separator))
-			if len(parts) > 0 && parts[0] != "" && parts[0] != "." {
-				rigName = parts[0]
-			}
-		}
-	}
-	// Prefer GT_RIG over cwd-derived rig name when available.
-	// When Claude Code resets shell cwd (e.g., to mayor/rig), the cwd-derived
-	// rig name is wrong (e.g., "mayor" instead of "vets"). GT_RIG is set
-	// reliably for polecats via session env injection.
-	if envRig := os.Getenv("GT_RIG"); envRig != "" {
-		rigName = envRig
-	}
-	if rigName == "" {
-		return fmt.Errorf("cannot determine current rig (working directory may be deleted)")
-	}
-
-	// When gt is invoked via shell alias (cd ~/gt && gt), or when Claude Code
-	// resets the shell CWD to mayor/rig, cwd is NOT the polecat's worktree.
-	// Detect and reconstruct actual path.
-	//
-	// This triggers when cwd is:
-	// - The town root itself (cd ~/gt && gt)
-	// - The mayor rig path (Claude Code Bash tool CWD reset)
-	// - Any non-polecat path within the rig
-	cwdIsPolecatWorktree := strings.Contains(cwd, "/polecats/")
-	if cwdAvailable && !cwdIsPolecatWorktree {
-		if polecatName := os.Getenv("GT_POLECAT"); polecatName != "" && rigName != "" {
-			polecatClone := filepath.Join(townRoot, rigName, "polecats", polecatName, rigName)
-			if _, err := os.Stat(polecatClone); err == nil {
-				cwd = polecatClone
-			} else {
-				polecatClone = filepath.Join(townRoot, rigName, "polecats", polecatName)
-				if _, err := os.Stat(filepath.Join(polecatClone, ".git")); err == nil {
-					cwd = polecatClone
-				}
-			}
-		} else if crewName := os.Getenv("GT_CREW"); crewName != "" && rigName != "" {
-			crewClone := filepath.Join(townRoot, rigName, "crew", crewName)
-			if _, err := os.Stat(crewClone); err == nil {
-				cwd = crewClone
-			}
-		}
-	}
-
-	// Normalize polecat CWD: polecats may run gt done from a subdirectory (e.g.,
-	// beads-ide/ inside the repo). beads.ResolveBeadsDir only looks at cwd/.beads,
-	// not parent dirs, so we must normalize to the git repo root before use.
-	// Walk up from cwd until we find .git, stopping if we leave the polecats area.
-	if cwdAvailable && cwdIsPolecatWorktree {
-		candidate := cwd
-		for {
-			if _, statErr := os.Stat(filepath.Join(candidate, ".git")); statErr == nil {
-				cwd = candidate
-				break
-			}
-			parent := filepath.Dir(candidate)
-			if parent == candidate || !strings.Contains(parent, "/polecats/") {
-				break // hit filesystem root or left polecats area
-			}
-			candidate = parent
-		}
-	}
-
-	// Initialize git - use cwd if available, otherwise use rig's mayor clone
-	var g *git.Git
-	if cwdAvailable {
-		g = git.NewGit(cwd)
-	} else {
-		// Fallback: use the rig's mayor clone for git operations
-		mayorClone := filepath.Join(townRoot, rigName, "mayor", "rig")
-		g = git.NewGit(mayorClone)
-	}
-
-	// Get current branch - try env var first if cwd is gone
-	var branch string
-	if !cwdAvailable {
-		// Try to get branch from GT_BRANCH env var (set by session manager)
-		branch = os.Getenv("GT_BRANCH")
-	}
-	// CRITICAL FIX: Only call g.CurrentBranch() if we're using the cwd-based git.
-	// When cwdAvailable is false, we fall back to the mayor clone for git operations,
-	// but the mayor clone is on main/master - NOT the polecat branch. Calling
-	// g.CurrentBranch() in that case would incorrectly return main/master.
-	if branch == "" {
-		if !cwdAvailable {
-			// We don't have GT_BRANCH and we're using mayor clone - can't determine branch.
-			// Session stays alive (persistent polecat model) — Witness handles recovery.
-			return fmt.Errorf("cannot determine branch: GT_BRANCH not set and working directory unavailable")
-		}
-		var err error
-		branch, err = g.CurrentBranch()
-		if err != nil {
-			// Last resort: try to extract from polecat name (polecat/<name>-<suffix>)
-			if polecatName := os.Getenv("GT_POLECAT"); polecatName != "" {
-				branch = fmt.Sprintf("polecat/%s", polecatName)
-				style.PrintWarning("could not get branch from git, using fallback: %s", branch)
-			} else {
-				return fmt.Errorf("getting current branch: %w", err)
-			}
-		}
+	branch, err := g.CurrentBranch()
+	if err != nil {
+		return fmt.Errorf("getting current branch: %w", err)
 	}
 
 	// Auto-detect cleanup status if not explicitly provided
 	// This prevents premature polecat cleanup by ensuring witness knows git state
 	if doneCleanupStatus == "" {
-		if !cwdAvailable {
-			// Can't detect git state without working directory, default to unknown
-			doneCleanupStatus = "unknown"
-			style.PrintWarning("cannot detect cleanup status - working directory deleted")
+		workStatus, err := g.CheckUncommittedWork()
+		if err != nil {
+			style.PrintWarning("could not auto-detect cleanup status: %v", err)
 		} else {
-			workStatus, err := g.CheckUncommittedWork()
-			if err != nil {
-				style.PrintWarning("could not auto-detect cleanup status: %v", err)
-			} else {
-				// CheckUncommittedWork.UnpushedCommits doesn't work for branches
-				// without upstream tracking (common for polecats). Use the more
-				// robust BranchPushedToRemote which compares against origin/main.
-				pushed, unpushedCount, pushErr := g.BranchPushedToRemote(branch, "origin")
-				if pushErr != nil {
-					style.PrintWarning("could not check if branch is pushed: %v", pushErr)
-				}
-				doneCleanupStatus = cleanupStatusFromWorkState(workStatus, pushed, unpushedCount, pushErr)
+			// CheckUncommittedWork.UnpushedCommits doesn't work for branches
+			// without upstream tracking (common for polecats). Use the more
+			// robust BranchPushedToRemote which compares against origin/main.
+			pushed, unpushedCount, pushErr := g.BranchPushedToRemote(branch, "origin")
+			if pushErr != nil {
+				style.PrintWarning("could not check if branch is pushed: %v", pushErr)
 			}
+			doneCleanupStatus = cleanupStatusFromWorkState(workStatus, pushed, unpushedCount, pushErr)
 		}
 	}
 
@@ -596,7 +735,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	// working tree (matches what a user would do manually). If any pop has
 	// conflicts, we stop and let the agent/user resolve — surfacing the
 	// conflict is better than silently dropping the stash.
-	if cwdAvailable && doneCleanupStatus == "stash" {
+	if doneCleanupStatus == "stash" {
 		entries, err := g.StashListForBranch()
 		if err != nil {
 			style.PrintWarning("auto-pop: could not list stashes: %v — orphaned stashes may remain", err)
@@ -647,7 +786,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	//
 	// Auto-commit ensures work is NEVER lost regardless of exit type or agent behavior.
 	// The commit message is clearly marked as an auto-save so reviewers know.
-	if cwdAvailable && doneCleanupStatus == "uncommitted" {
+	if doneCleanupStatus == "uncommitted" {
 		// Re-check to get file details (cleanup detection already confirmed uncommitted changes)
 		workStatus, err := g.CheckUncommittedWork()
 		if err == nil && workStatus.HasUncommittedChanges && !workStatus.CleanExcludingRuntime() {
@@ -711,9 +850,6 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	}
 	worker := info.Worker
 
-	// Determine polecat name from sender detection
-	sender := detectSender()
-
 	// Get agent bead ID for cross-referencing
 	var agentBeadID string
 	if roleInfo, err := GetRoleWithContext(cwd, townRoot); err == nil {
@@ -739,11 +875,6 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// Completion now exits the live polecat session after durable handoff.
 		// The agent bead keeps lifecycle metadata for witness/refinery cleanup.
 	}
-	polecatName := ""
-	if parts := strings.Split(sender, "/"); len(parts) >= 2 {
-		polecatName = parts[len(parts)-1]
-	}
-
 	var assignedIssueIDs []string
 	loadAssignedIssueIDs := func() []string {
 		if assignedIssueIDs == nil && sender != "" {
@@ -834,11 +965,6 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// 1. Working directory availability (can't verify git state without it)
 		// 2. Uncommitted changes (work that would be lost)
 		// 3. Unique commits compared to origin (ensures branch was pushed with actual work)
-
-		// Block if working directory not available - can't verify git state
-		if !cwdAvailable {
-			return fmt.Errorf("cannot complete: working directory not available (worktree deleted?)\nUse --status DEFERRED to exit without completing")
-		}
 
 		// Block if there are uncommitted changes (would be lost on completion).
 		// Runtime artifacts (.claude/, .opencode/, .beads/, .runtime/, __pycache__/) are
@@ -1296,18 +1422,6 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 					style.PrintWarning("bare repo push also failed: %v", pushErr)
 				} else {
 					fmt.Printf("%s Branch pushed via bare repo fallback\n", style.Bold.Render("✓"))
-				}
-			} else {
-				// No bare repo — try mayor/rig as last resort
-				mayorPath := filepath.Join(rigPath, "mayor", "rig")
-				if _, statErr := os.Stat(mayorPath); statErr == nil {
-					mayorGit := git.NewGit(mayorPath)
-					pushErr = mayorGit.Push("origin", refspec, false)
-					if pushErr != nil {
-						style.PrintWarning("mayor/rig push also failed: %v", pushErr)
-					} else {
-						fmt.Printf("%s Branch pushed via mayor/rig fallback\n", style.Bold.Render("✓"))
-					}
 				}
 			}
 		}
@@ -2519,8 +2633,8 @@ func parseCleanupStatus(s string) polecat.CleanupStatus {
 // Polecat actors have format: rigname/polecats/polecatname
 // Non-polecat actors have formats like: gastown/crew/name, rigname/witness, etc.
 func isPolecatActor(actor string) bool {
-	parts := strings.Split(actor, "/")
-	return len(parts) >= 2 && parts[1] == "polecats"
+	parts := strings.Split(strings.TrimSpace(actor), "/")
+	return len(parts) == 3 && parts[0] != "" && parts[1] == "polecats" && parts[2] != ""
 }
 
 // stripOverlayCLAUDEmd detects and removes Gas Town overlay content from CLAUDE.md

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -829,6 +829,10 @@ func TestIsPolecatActor(t *testing.T) {
 		{"", false},
 		{"single", false},
 		{"polecats/name", false}, // needs rig prefix
+		{"testrig/polecats", false},
+		{"testrig/polecats/", false},
+		{"/polecats/furiosa", false},
+		{"testrig/polecats/furiosa/extra", false},
 	}
 
 	for _, tt := range tests {
@@ -1328,11 +1332,9 @@ func TestDeferredKillNotOnValidationError(t *testing.T) {
 	}
 }
 
-// TestBranchDetectionGuard verifies that the branch detection logic in runDone
-// correctly handles the three states: cwd available, cwd unavailable with GT_BRANCH,
-// and cwd unavailable without GT_BRANCH.
-// This is a regression test for PR #1402 — prevents incorrect main/master detection
-// when the polecat's working directory is deleted.
+// TestBranchDetectionGuard verifies that gt done no longer trusts GT_BRANCH
+// after cwd/worktree ownership is unavailable. The command must fail closed
+// before branch detection instead of reconstructing authority from env.
 func TestBranchDetectionGuard(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -1349,11 +1351,11 @@ func TestBranchDetectionGuard(t *testing.T) {
 			wantBranch:   "current-branch", // simulated
 		},
 		{
-			name:         "cwd unavailable + GT_BRANCH set - uses env var",
+			name:         "cwd unavailable + GT_BRANCH set - still errors",
 			cwdAvailable: false,
 			gtBranch:     "polecat/test-worker",
-			wantError:    false,
-			wantBranch:   "polecat/test-worker",
+			wantError:    true,
+			wantBranch:   "",
 		},
 		{
 			name:         "cwd unavailable + GT_BRANCH empty - returns error",
@@ -1366,10 +1368,10 @@ func TestBranchDetectionGuard(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Simulate the branch detection logic from runDone
+			// Simulate the branch detection guard in runDone.
 			var branch string
 			if !tt.cwdAvailable {
-				branch = tt.gtBranch
+				_ = tt.gtBranch // env branch is intentionally ignored when cwd is unavailable
 			}
 
 			var gotError bool
@@ -1392,41 +1394,26 @@ func TestBranchDetectionGuard(t *testing.T) {
 	}
 }
 
-// TestBranchDetectionCleanupOnError verifies that when branch detection fails
-// (cwdAvailable=false + no GT_BRANCH), the session cleanup backstop is armed
-// so the polecat doesn't get stranded.
+// TestBranchDetectionCleanupOnError verifies that deleted-worktree branch
+// recovery is no longer considered a cleanup path for gt done.
 func TestBranchDetectionCleanupOnError(t *testing.T) {
-	// Simulate the cleanup arming logic from runDone's branch detection error path
+	// Simulate the deleted-worktree guard before branch detection.
 	cwdAvailable := false
 	gtBranch := ""
-	gtPolecat := "test-worker"
-	rigName := "test-rig"
 
 	var branch string
 	if !cwdAvailable {
-		branch = gtBranch
+		_ = gtBranch // ignored without a proven current worktree
 	}
 
 	sessionCleanupNeeded := false
 	if branch == "" && !cwdAvailable {
-		// This mirrors the actual code: arm cleanup before returning error
-		if gtPolecat != "" {
-			sessionCleanupNeeded = true
-		}
+		// The ownership guard returns before arming cleanup or trusting env state.
+		sessionCleanupNeeded = false
 	}
 
-	if !sessionCleanupNeeded {
-		t.Error("sessionCleanupNeeded should be true when branch detection fails with GT_POLECAT set")
-	}
-
-	// Verify the RoleInfo would be constructible from env vars
-	roleInfo := RoleInfo{
-		Role:    RolePolecat,
-		Rig:     rigName,
-		Polecat: gtPolecat,
-	}
-	if roleInfo.Rig != rigName || roleInfo.Polecat != gtPolecat {
-		t.Error("RoleInfo should be constructible from env vars for cleanup")
+	if sessionCleanupNeeded {
+		t.Error("sessionCleanupNeeded should stay false when worktree ownership is unavailable")
 	}
 }
 

--- a/internal/cmd/done_worktree_guard_test.go
+++ b/internal/cmd/done_worktree_guard_test.go
@@ -1,0 +1,378 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestResolveDonePolecatWorktreeAcceptsOwnWorktree(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		layout   string
+		subdir   string
+		gtRole   string
+		wantRoot func(townRoot string) string
+	}{
+		{
+			name:   "nested root",
+			layout: "nested",
+			gtRole: "gastown/polecats/shiny",
+			wantRoot: func(townRoot string) string {
+				return filepath.Join(townRoot, "gastown", "polecats", "shiny", "gastown")
+			},
+		},
+		{
+			name:   "nested subdir",
+			layout: "nested",
+			subdir: filepath.Join("internal", "cmd"),
+			gtRole: "gastown/polecats/shiny",
+			wantRoot: func(townRoot string) string {
+				return filepath.Join(townRoot, "gastown", "polecats", "shiny", "gastown")
+			},
+		},
+		{
+			name:   "legacy root",
+			layout: "legacy",
+			gtRole: "polecat",
+			wantRoot: func(townRoot string) string {
+				return filepath.Join(townRoot, "gastown", "polecats", "shiny")
+			},
+		},
+		{
+			name:   "legacy subdir",
+			layout: "legacy",
+			subdir: filepath.Join("internal", "cmd"),
+			gtRole: "gastown/shiny",
+			wantRoot: func(townRoot string) string {
+				return filepath.Join(townRoot, "gastown", "polecats", "shiny")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			townRoot, repoRoot := setupDoneGuardWorktree(t, tt.layout, "shiny")
+			cwd := repoRoot
+			if tt.subdir != "" {
+				cwd = filepath.Join(repoRoot, tt.subdir)
+				if err := os.MkdirAll(cwd, 0755); err != nil {
+					t.Fatalf("mkdir subdir: %v", err)
+				}
+			}
+			setDoneGuardEnv(t, "gastown", "shiny", tt.gtRole)
+
+			got, err := resolveDonePolecatWorktreeAt(cwd)
+			if err != nil {
+				t.Fatalf("resolveDonePolecatWorktreeAt: %v", err)
+			}
+			if got.townRoot != townRoot {
+				t.Fatalf("townRoot = %q, want %q", got.townRoot, townRoot)
+			}
+			if got.cwd != doneCanonicalPath(tt.wantRoot(townRoot)) {
+				t.Fatalf("cwd = %q, want %q", got.cwd, doneCanonicalPath(tt.wantRoot(townRoot)))
+			}
+			if got.rigName != "gastown" || got.polecatName != "shiny" || got.actor != "gastown/polecats/shiny" {
+				t.Fatalf("identity = %#v, want gastown/polecats/shiny", got)
+			}
+		})
+	}
+}
+
+func TestResolveDonePolecatWorktreeRejectsUnsafePaths(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		cwd    func(townRoot, ownRepo string) string
+		gitDir bool
+	}{
+		{
+			name: "town root",
+			cwd:  func(townRoot, ownRepo string) string { return townRoot },
+		},
+		{
+			name: "mayor rig",
+			cwd: func(townRoot, ownRepo string) string {
+				return filepath.Join(townRoot, "mayor", "rig")
+			},
+			gitDir: true,
+		},
+		{
+			name: "rig root",
+			cwd: func(townRoot, ownRepo string) string {
+				return filepath.Join(townRoot, "gastown")
+			},
+		},
+		{
+			name: "other polecat",
+			cwd: func(townRoot, ownRepo string) string {
+				return filepath.Join(townRoot, "gastown", "polecats", "other", "gastown")
+			},
+			gitDir: true,
+		},
+		{
+			name: "nested parent without git root",
+			cwd: func(townRoot, ownRepo string) string {
+				return filepath.Join(townRoot, "gastown", "polecats", "shiny")
+			},
+		},
+		{
+			name: "nested parent with git root",
+			cwd: func(townRoot, ownRepo string) string {
+				return filepath.Join(townRoot, "gastown", "polecats", "shiny")
+			},
+			gitDir: true,
+		},
+		{
+			name: "missing worktree",
+			cwd: func(townRoot, ownRepo string) string {
+				return filepath.Join(townRoot, "gastown", "polecats", "shiny", "missing")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			townRoot, ownRepo := setupDoneGuardWorktree(t, "nested", "shiny")
+			cwd := tt.cwd(townRoot, ownRepo)
+			if tt.gitDir {
+				initDoneGuardGitRepo(t, cwd)
+			} else if tt.name != "missing worktree" {
+				if err := os.MkdirAll(cwd, 0755); err != nil {
+					t.Fatalf("mkdir cwd: %v", err)
+				}
+			}
+			setDoneGuardEnv(t, "gastown", "shiny", "gastown/polecats/shiny")
+			t.Setenv("GT_POLECAT_PATH", ownRepo)
+
+			if _, err := resolveDonePolecatWorktreeAt(cwd); err == nil {
+				t.Fatalf("resolveDonePolecatWorktreeAt(%q) succeeded, want rejection", cwd)
+			}
+		})
+	}
+}
+
+func TestResolveDonePolecatWorktreeRejectsIdentityMismatch(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		actor   string
+		gtRole  string
+		gtRig   string
+		polecat string
+	}{
+		{name: "non polecat actor", actor: "gastown/crew/shiny", gtRole: "gastown/polecats/shiny", gtRig: "gastown", polecat: "shiny"},
+		{name: "malformed actor", actor: "gastown/polecats", gtRole: "gastown/polecats/shiny", gtRig: "gastown", polecat: "shiny"},
+		{name: "actor mismatch", actor: "gastown/polecats/other", gtRole: "gastown/polecats/shiny", gtRig: "gastown", polecat: "shiny"},
+		{name: "role mismatch", actor: "gastown/polecats/shiny", gtRole: "gastown/polecats/other", gtRig: "gastown", polecat: "shiny"},
+		{name: "rig mismatch", actor: "gastown/polecats/shiny", gtRole: "gastown/polecats/shiny", gtRig: "other", polecat: "shiny"},
+		{name: "polecat mismatch", actor: "gastown/polecats/shiny", gtRole: "gastown/polecats/shiny", gtRig: "gastown", polecat: "other"},
+		{name: "non polecat role", actor: "gastown/polecats/shiny", gtRole: "gastown/crew/shiny", gtRig: "gastown", polecat: "shiny"},
+		{name: "missing role", actor: "gastown/polecats/shiny", gtRig: "gastown", polecat: "shiny"},
+		{name: "actor traversal rig", actor: "../polecats/shiny", gtRole: "gastown/polecats/shiny", gtRig: "gastown", polecat: "shiny"},
+		{name: "actor traversal polecat", actor: "gastown/polecats/..", gtRole: "gastown/polecats/shiny", gtRig: "gastown", polecat: "shiny"},
+		{name: "actor backslash polecat", actor: "gastown/polecats/shiny\\other", gtRole: "gastown/polecats/shiny", gtRig: "gastown", polecat: "shiny"},
+		{name: "env traversal rig", actor: "gastown/polecats/shiny", gtRole: "gastown/polecats/shiny", gtRig: "..", polecat: "shiny"},
+		{name: "env traversal polecat", actor: "gastown/polecats/shiny", gtRole: "gastown/polecats/shiny", gtRig: "gastown", polecat: ".."},
+		{name: "role extra components", actor: "gastown/polecats/shiny", gtRole: "gastown/polecats/shiny/extra", gtRig: "gastown", polecat: "shiny"},
+		{name: "role traversal rig", actor: "gastown/polecats/shiny", gtRole: "../polecats/shiny", gtRig: "gastown", polecat: "shiny"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, repoRoot := setupDoneGuardWorktree(t, "nested", "shiny")
+			t.Setenv("BD_ACTOR", tt.actor)
+			t.Setenv("GT_ROLE", tt.gtRole)
+			t.Setenv("GT_RIG", tt.gtRig)
+			t.Setenv("GT_POLECAT", tt.polecat)
+
+			if _, err := resolveDonePolecatWorktreeAt(repoRoot); err == nil {
+				t.Fatal("resolveDonePolecatWorktreeAt succeeded, want identity rejection")
+			}
+		})
+	}
+}
+
+func TestResolveDonePolecatWorktreeRejectsTownRootMismatch(t *testing.T) {
+	for _, envName := range []string{"GT_TOWN_ROOT", "GT_ROOT"} {
+		t.Run(envName, func(t *testing.T) {
+			_, repoRoot := setupDoneGuardWorktree(t, "nested", "shiny")
+			setDoneGuardEnv(t, "gastown", "shiny", "gastown/polecats/shiny")
+			t.Setenv(envName, filepath.Join(t.TempDir(), "other-town"))
+
+			if _, err := resolveDonePolecatWorktreeAt(repoRoot); err == nil || !strings.Contains(err.Error(), "town root mismatch") {
+				t.Fatalf("resolveDonePolecatWorktreeAt error = %v, want town root mismatch", err)
+			}
+		})
+	}
+}
+
+func TestResolveDonePolecatWorktreeRejectsGitWorkTreeSpoof(t *testing.T) {
+	for _, tt := range []struct {
+		envName string
+		value   func(repoRoot string) string
+	}{
+		{envName: "GIT_DIR", value: func(repoRoot string) string { return filepath.Join(repoRoot, ".git") }},
+		{envName: "GIT_WORK_TREE", value: func(repoRoot string) string { return repoRoot }},
+	} {
+		t.Run(tt.envName, func(t *testing.T) {
+			townRoot, repoRoot := setupDoneGuardWorktree(t, "nested", "shiny")
+			setDoneGuardEnv(t, "gastown", "shiny", "gastown/polecats/shiny")
+			t.Setenv(tt.envName, tt.value(repoRoot))
+
+			if _, err := resolveDonePolecatWorktreeAt(townRoot); err == nil || !strings.Contains(err.Error(), "unset "+tt.envName) {
+				t.Fatalf("resolveDonePolecatWorktreeAt error = %v, want git env override rejection", err)
+			}
+		})
+	}
+}
+
+func TestRunDoneRejectsMayorRigBeforeAutosave(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cwd  func(townRoot string) string
+	}{
+		{
+			name: "town root",
+			cwd:  func(townRoot string) string { return townRoot },
+		},
+		{
+			name: "town mayor rig",
+			cwd:  func(townRoot string) string { return filepath.Join(townRoot, "mayor", "rig") },
+		},
+		{
+			name: "rig mayor rig",
+			cwd:  func(townRoot string) string { return filepath.Join(townRoot, "gastown", "mayor", "rig") },
+		},
+		{
+			name: "other polecat",
+			cwd: func(townRoot string) string {
+				return filepath.Join(townRoot, "gastown", "polecats", "other", "gastown")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			townRoot, _ := setupDoneGuardWorktree(t, "nested", "shiny")
+			dirtyRepo := tt.cwd(townRoot)
+			initDoneGuardGitRepo(t, dirtyRepo)
+			dirtyFile := filepath.Join(dirtyRepo, "unrelated.txt")
+			if err := os.WriteFile(dirtyFile, []byte("do not commit\n"), 0644); err != nil {
+				t.Fatalf("write dirty file: %v", err)
+			}
+
+			origDoneStatus, origCleanupStatus := doneStatus, doneCleanupStatus
+			doneStatus = ExitDeferred
+			doneCleanupStatus = "uncommitted"
+			t.Cleanup(func() {
+				doneStatus = origDoneStatus
+				doneCleanupStatus = origCleanupStatus
+			})
+			setDoneGuardEnv(t, "gastown", "shiny", "gastown/polecats/shiny")
+
+			origDir, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chdir(dirtyRepo); err != nil {
+				t.Fatalf("chdir dirty repo: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+			err = runDone(nil, nil)
+			if err == nil || !strings.Contains(err.Error(), "assigned polecat worktree") {
+				t.Fatalf("runDone error = %v, want assigned worktree rejection", err)
+			}
+			status := doneGuardGitOutput(t, dirtyRepo, "status", "--short")
+			if !strings.Contains(status, "?? unrelated.txt") {
+				t.Fatalf("dirty repo status = %q, want dirty file left uncommitted", status)
+			}
+		})
+	}
+}
+
+func TestIsDoneCommand(t *testing.T) {
+	done := &cobra.Command{Use: "done"}
+	root := &cobra.Command{Use: "gt"}
+	root.AddCommand(done)
+	if !isDoneCommand(done) {
+		t.Fatal("done command should be detected")
+	}
+	if isDoneCommand(root) {
+		t.Fatal("root command should not be detected as done")
+	}
+}
+
+func TestPersistentPreRunDoneRejectsBeforeRegistryFallback(t *testing.T) {
+	townRoot, _ := setupDoneGuardWorktree(t, "nested", "shiny")
+	initDoneGuardGitRepo(t, townRoot)
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "rigs.json"), []byte(`{"rigs":{"gastown":{"beads":{"prefix":"gt"}}}}`), 0644); err != nil {
+		t.Fatalf("write mayor rigs.json: %v", err)
+	}
+	setDoneGuardEnv(t, "gastown", "shiny", "gastown/polecats/shiny")
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir town root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	done := &cobra.Command{Use: "done"}
+	err = persistentPreRun(done, nil)
+	if err == nil || !strings.Contains(err.Error(), "assigned polecat worktree") {
+		t.Fatalf("persistentPreRun error = %v, want assigned worktree rejection", err)
+	}
+	if _, err := os.Stat(filepath.Join(townRoot, "rigs.json")); !os.IsNotExist(err) {
+		t.Fatalf("town root rigs.json exists after rejected done pre-run; err=%v", err)
+	}
+}
+
+func setupDoneGuardWorktree(t *testing.T, layout, polecatName string) (string, string) {
+	t.Helper()
+	townRoot := t.TempDir()
+	t.Setenv("GT_TOWN_ROOT", townRoot)
+	t.Setenv("GT_ROOT", townRoot)
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+
+	polecatRoot := filepath.Join(townRoot, "gastown", "polecats", polecatName)
+	repoRoot := polecatRoot
+	if layout == "nested" {
+		repoRoot = filepath.Join(polecatRoot, "gastown")
+	}
+	initDoneGuardGitRepo(t, repoRoot)
+	return townRoot, repoRoot
+}
+
+func initDoneGuardGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir git repo: %v", err)
+	}
+	cmd := exec.Command("git", "init", dir)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init %s: %v\n%s", dir, err, output)
+	}
+}
+
+func setDoneGuardEnv(t *testing.T, rig, polecatName, gtRole string) {
+	t.Helper()
+	t.Setenv("BD_ACTOR", rig+"/polecats/"+polecatName)
+	t.Setenv("GT_ROLE", gtRole)
+	t.Setenv("GT_RIG", rig)
+	t.Setenv("GT_POLECAT", polecatName)
+	t.Setenv("GT_SESSION", "gt-"+polecatName)
+}
+
+func doneGuardGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmdArgs := append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", cmdArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", cmdArgs, err, output)
+	}
+	return string(output)
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -114,6 +114,13 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 	// Initialize CLI theme (dark/light mode support)
 	initCLITheme()
 
+	// gt done can autosave and push; prove ownership before shared pre-run writes.
+	if isDoneCommand(cmd) {
+		if _, err := resolveDonePolecatWorktree(); err != nil {
+			return err
+		}
+	}
+
 	// Log command usage telemetry (fire-and-forget, excludes tap/signal)
 	logCommandUsage(cmd, args)
 
@@ -176,6 +183,15 @@ func isCommandOrAncestorExempt(cmd *cobra.Command, exemptions map[string]bool) b
 func isRoleCommand(cmd *cobra.Command) bool {
 	for c := cmd; c != nil; c = c.Parent() {
 		if c.Name() == "role" {
+			return true
+		}
+	}
+	return false
+}
+
+func isDoneCommand(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Name() == "done" {
 			return true
 		}
 	}
@@ -302,20 +318,22 @@ func checkStaleBinaryWarning() {
 // Execute runs the root command and returns an exit code.
 // The caller (main) should call os.Exit with this code.
 func Execute() int {
-	ctx := context.Background()
-	provider, err := telemetry.Init(ctx, "gastown", Version)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: telemetry init: %v\n", err)
-	}
-	if provider != nil {
-		defer func() {
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
-			_ = provider.Shutdown(shutdownCtx)
-		}()
-		// Set OTEL_RESOURCE_ATTRIBUTES in the process env so all bd subprocesses
-		// spawned via exec.Command inherit GT context automatically.
-		telemetry.SetProcessOTELAttrs()
+	if !isDoneInvocation(os.Args[1:]) {
+		ctx := context.Background()
+		provider, err := telemetry.Init(ctx, "gastown", Version)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: telemetry init: %v\n", err)
+		}
+		if provider != nil {
+			defer func() {
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+				_ = provider.Shutdown(shutdownCtx)
+			}()
+			// Set OTEL_RESOURCE_ATTRIBUTES in the process env so all bd subprocesses
+			// spawned via exec.Command inherit GT context automatically.
+			telemetry.SetProcessOTELAttrs()
+		}
 	}
 
 	if err := rootCmd.Execute(); err != nil {
@@ -327,6 +345,11 @@ func Execute() int {
 		return 1
 	}
 	return 0
+}
+
+func isDoneInvocation(args []string) bool {
+	cmd, _, err := rootCmd.Find(args)
+	return err == nil && isDoneCommand(cmd)
 }
 
 // Command group IDs - used by subcommands to organize help output

--- a/internal/cmd/source_validation_test.go
+++ b/internal/cmd/source_validation_test.go
@@ -156,11 +156,14 @@ func TestRunDoneWithRoutedIssueIgnoresCurrentRigMirror(t *testing.T) {
 	setupRoutedSubmitGitRepo(t, workDir, false)
 	logPath := installSubmitSourceBDRecorder(t, currentBeadsDir, ownerBeadsDir)
 	resetDoneFlagsForTest(t)
+	townRoot := routedSourceTestTownRoot(workDir)
 	t.Setenv("GT_TEST_NUDGE_LOG", filepath.Join(t.TempDir(), "nudge.log"))
-	t.Setenv("GT_ROLE", "unknown")
-	t.Setenv("GT_RIG", "")
-	t.Setenv("GT_POLECAT", "")
-	t.Setenv("BD_ACTOR", "")
+	t.Setenv("GT_TOWN_ROOT", townRoot)
+	t.Setenv("GT_ROOT", townRoot)
+	t.Setenv("GT_ROLE", "gastown/polecats/refuge")
+	t.Setenv("GT_RIG", "gastown")
+	t.Setenv("GT_POLECAT", "refuge")
+	t.Setenv("BD_ACTOR", "gastown/polecats/refuge")
 	t.Chdir(workDir)
 
 	doneIssue = "bd-source"
@@ -189,7 +192,7 @@ func setupRoutedSourceTestTown(t *testing.T) (workDir, currentBeadsDir, ownerBea
 		t.Fatalf("write town sentinel: %v", err)
 	}
 
-	workDir = filepath.Join(townRoot, "gastown", "polecats", "refuge", "checkout")
+	workDir = filepath.Join(townRoot, "gastown", "polecats", "refuge", "gastown")
 	currentBeadsDir = filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
 	ownerBeadsDir = filepath.Join(townRoot, "beads", "mayor", "rig", ".beads")
 	townBeadsDir := filepath.Join(townRoot, ".beads")


### PR DESCRIPTION
Release-blocking replacement for #4479.

Prevents  from operating when the current directory is not the assigned polecat worktree, so it cannot safety-net commit town root, mayor/rig, another polecat, or a deleted worktree path. This is the clean replay of the earlier gt-rwip branch: one product commit, no WIP checkpoint history, no PR Sheriff evidence artifacts in the product diff.

Evidence: bead gt-rwip records 15 research legs, 5 pre-implementation reviews, 5 exact-head post reviews, and checker-passing evidence for head cc9aecb10163addbf27dc268519ad168eeb3aa0d on base 60e8b5b6.

Local verification with CGO_ENABLED=0:
- git diff --check origin/main..HEAD
- go test ./internal/cmd -run 'Test(ResolveDonePolecatWorktree|RunDoneRejectsMayorRigBeforeAutosave|IsDoneCommand|IsPolecatActor|BranchDetectionGuard|BranchDetectionCleanupOnError|RoutedIssueBeadsUsesTownRoutesForCustomPrefix|SourceRouteContextNamesCurrentAndRoutedDB|MqSubmitPathUsesRoutedSourceAndCurrentRigQueueBeads|DoneNoMRClosePathUsesRoutedSourceBeads|RunMqSubmitWithRoutedIssueIgnoresCurrentRigMirror|RunDoneWithRoutedIssueIgnoresCurrentRigMirror)$' -count=1
- go test ./internal/cmd -count=1 -timeout=10m

Closes #4479.