### PR TITLE
fix(mq): verify post-merge before cleanup

### DIFF
--- a/internal/bitbucket/pr.go
+++ b/internal/bitbucket/pr.go
@@ -113,7 +113,7 @@ func (c *Client) GetPRApprovalStatus(ctx context.Context, workspace, repoSlug st
 func (c *Client) GetPRComments(ctx context.Context, workspace, repoSlug string, prID int) ([]PRComment, error) {
 	var resp struct {
 		Values []struct {
-			ID      int64  `json:"id"`
+			ID      int64 `json:"id"`
 			Content struct {
 				Raw string `json:"raw"`
 			} `json:"content"`
@@ -172,8 +172,8 @@ func (c *Client) ReplyToPRComment(ctx context.Context, workspace, repoSlug strin
 // Valid strategies: "merge_commit", "squash", "fast_forward".
 func (c *Client) MergePR(ctx context.Context, workspace, repoSlug string, prID int, strategy string) error {
 	reqBody := map[string]any{
-		"merge_strategy":       strategy,
-		"close_source_branch": true,
+		"merge_strategy":      strategy,
+		"close_source_branch": false,
 	}
 	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d/merge", workspace, repoSlug, prID)
 	if err := c.restRequest(ctx, "POST", path, reqBody, nil); err != nil {

--- a/internal/bitbucket/pr_test.go
+++ b/internal/bitbucket/pr_test.go
@@ -214,7 +214,7 @@ func TestMergePR(t *testing.T) {
 		var body map[string]any
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		assert.Equal(t, "squash", body["merge_strategy"])
-		assert.Equal(t, true, body["close_source_branch"])
+		assert.Equal(t, false, body["close_source_branch"])
 		json.NewEncoder(w).Encode(map[string]any{"state": "MERGED"})
 	})
 

--- a/internal/cmd/mq.go
+++ b/internal/cmd/mq.go
@@ -174,9 +174,10 @@ var mqPostMergeCmd = &cobra.Command{
 	Long: `Perform post-merge cleanup after a successful merge.
 
 This command consolidates post-merge steps into a single atomic operation:
-  1. Close the MR bead (status: merged)
-  2. Close the source issue
-  3. Delete the remote polecat branch (unless --skip-branch-delete)
+	 1. Verify the target branch contains the submitted source head
+	 2. Close the MR bead (status: merged)
+	 3. Close the source issue
+	 4. Delete the remote polecat branch at the submitted head (unless --skip-branch-delete)
 
 Designed for use by the refinery formula after a successful merge to main.
 The branch name is read from the MR bead, so no manual branch argument is needed.
@@ -186,6 +187,31 @@ Examples:
   gt mq post-merge gastown gt-mr-abc123 --skip-branch-delete`,
 	Args: cobra.ExactArgs(2),
 	RunE: runMQPostMerge,
+}
+
+type mqPostMergeManager interface {
+	FindMRForPostMerge(idOrBranch string) (*refinery.MergeRequest, error)
+	PostMergeMR(mr *refinery.MergeRequest) (*refinery.PostMergeResult, error)
+}
+
+type mqPostMergeGit interface {
+	VerifyPushedCommitReachableFromPushTarget(remote, branch, commit string) error
+	PushRemoteBranchTip(remote, branch string) (string, error)
+	HasOpenPullRequest(ref git.PullRequestRef) bool
+	Rev(ref string) (string, error)
+	DeleteRemoteBranchIfAt(remote, branch, expectedHash string) error
+	DeleteBranch(branch string, force bool) error
+}
+
+type mqPostMergeBranchCleanup struct {
+	Branch        string
+	NoBranch      bool
+	Skipped       bool
+	Disabled      bool
+	OpenPR        bool
+	AlreadyGone   bool
+	RemoteDeleted bool
+	LocalDeleted  bool
 }
 
 var mqStatusCmd = &cobra.Command{
@@ -509,9 +535,12 @@ func runMQPostMerge(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	rigGit, err := getRigGit(r.Path)
+	if err != nil {
+		return fmt.Errorf("post-merge proof: %w", err)
+	}
 
-	// Run beads-level cleanup (close MR bead + source issue)
-	result, err := mgr.PostMerge(mrID)
+	result, branchCleanup, err := runVerifiedMQPostMerge(mgr, r.Path, rigGit, mrID, mqPostMergeSkipBranchDelete)
 	if err != nil {
 		return fmt.Errorf("post-merge cleanup: %w", err)
 	}
@@ -530,55 +559,128 @@ func runMQPostMerge(_ *cobra.Command, args []string) error {
 		fmt.Printf("  %s Source issue: %s %s\n", style.Dim.Render("○"), result.SourceIssueID, style.Dim.Render("(already closed or not found)"))
 	}
 
-	// Delete remote branch unless skipped
-	if mr.Branch == "" {
+	if branchCleanup.NoBranch {
 		fmt.Printf("  %s No branch name in MR (skipping branch delete)\n", style.Dim.Render("○"))
-		return nil
-	}
-
-	if mqPostMergeSkipBranchDelete {
+	} else if branchCleanup.Skipped {
 		fmt.Printf("  %s Branch delete skipped (--skip-branch-delete)\n", style.Dim.Render("○"))
-		return nil
-	}
-
-	// Check rig config for delete_merged_branches setting
-	settingsPath := filepath.Join(r.Path, "settings", "config.json")
-	deleteEnabled := true // default: delete merged branches
-	if settings, err := config.LoadRigSettings(settingsPath); err == nil {
-		if settings.MergeQueue != nil {
-			deleteEnabled = settings.MergeQueue.IsDeleteMergedBranchesEnabled()
-		}
-	}
-
-	if !deleteEnabled {
+	} else if branchCleanup.Disabled {
 		fmt.Printf("  %s Branch delete disabled by config\n", style.Dim.Render("○"))
-		return nil
-	}
-
-	// Get git client for the rig
-	rigGit, err := getRigGit(r.Path)
-	if err != nil {
-		return fmt.Errorf("remote branch delete: %w", err)
-	}
-
-	// Delete remote branch — but skip if there's an open PR on it.
-	// Deleting a branch with an open PR causes GitHub to auto-close the PR
-	// as "closed" (not "merged"), destroying the PR audit trail. (gas-fk4)
-	if rigGit.HasOpenPullRequest(git.PullRequestRef{URL: mr.PRURL, Number: mr.PRNumber, Branch: mr.Branch, HeadSHA: mr.CommitSHA}) {
+	} else if branchCleanup.OpenPR {
 		fmt.Printf("  %s Skipping remote branch delete for %s: open PR exists (gas-fk4)\n", style.Dim.Render("○"), mr.Branch)
-	} else if err := rigGit.DeleteRemoteBranch("origin", mr.Branch); err != nil {
-		return fmt.Errorf("remote branch delete %s: %w", mr.Branch, err)
-	} else {
+	} else if branchCleanup.AlreadyGone {
+		fmt.Printf("  %s Remote branch already absent: %s\n", style.Dim.Render("○"), mr.Branch)
+	} else if branchCleanup.RemoteDeleted {
 		fmt.Printf("  %s Deleted remote branch: %s\n", style.Success.Render("✓"), mr.Branch)
 	}
 
-	// Also clean up the local tracking ref if it exists
-	if err := rigGit.DeleteBranch(mr.Branch, true); err != nil {
-		// Not a warning — local branch often doesn't exist
-		_ = err
-	} else {
+	if branchCleanup.LocalDeleted {
 		fmt.Printf("  %s Deleted local branch: %s\n", style.Success.Render("✓"), mr.Branch)
 	}
 
 	return nil
+}
+
+func runVerifiedMQPostMerge(mgr mqPostMergeManager, rigPath string, rigGit mqPostMergeGit, mrID string, skipBranchDelete bool) (*refinery.PostMergeResult, mqPostMergeBranchCleanup, error) {
+	mr, err := mgr.FindMRForPostMerge(mrID)
+	if err != nil {
+		return nil, mqPostMergeBranchCleanup{}, err
+	}
+	if err := verifyMQPostMergeProof(rigGit, mr); err != nil {
+		return nil, mqPostMergeBranchCleanup{}, err
+	}
+
+	result, err := mgr.PostMergeMR(mr)
+	if err != nil {
+		return result, mqPostMergeBranchCleanup{}, err
+	}
+
+	branchCleanup, err := cleanupMQPostMergeBranch(rigPath, rigGit, result.MR, skipBranchDelete)
+	return result, branchCleanup, err
+}
+
+func verifyMQPostMergeProof(rigGit mqPostMergeGit, mr *refinery.MergeRequest) error {
+	if mr == nil {
+		return fmt.Errorf("merge proof failed: merge request is missing")
+	}
+	target := strings.TrimSpace(mr.TargetBranch)
+	if target == "" {
+		return fmt.Errorf("merge proof failed for MR %s: missing target branch", mr.ID)
+	}
+	if source := strings.TrimSpace(mr.Branch); source != "" && source == target {
+		return fmt.Errorf("merge proof failed for MR %s: source branch %s matches target branch", mr.ID, source)
+	}
+	commit := strings.TrimSpace(mr.CommitSHA)
+	if commit == "" {
+		return fmt.Errorf("merge proof failed for MR %s: missing submitted commit_sha", mr.ID)
+	}
+	if err := rigGit.VerifyPushedCommitReachableFromPushTarget("origin", target, commit); err != nil {
+		return fmt.Errorf("merge proof failed for MR %s: target %s does not contain submitted head %s: %w", mr.ID, target, commit, err)
+	}
+	return nil
+}
+
+func cleanupMQPostMergeBranch(rigPath string, rigGit mqPostMergeGit, mr *refinery.MergeRequest, skipBranchDelete bool) (mqPostMergeBranchCleanup, error) {
+	cleanup := mqPostMergeBranchCleanup{}
+	if mr == nil {
+		return cleanup, fmt.Errorf("remote branch delete: merge request is missing")
+	}
+
+	cleanup.Branch = strings.TrimSpace(mr.Branch)
+	if cleanup.Branch == "" {
+		cleanup.NoBranch = true
+		return cleanup, nil
+	}
+	if skipBranchDelete {
+		cleanup.Skipped = true
+		return cleanup, nil
+	}
+	if !mqDeleteMergedBranchesEnabled(rigPath) {
+		cleanup.Disabled = true
+		return cleanup, nil
+	}
+
+	expectedHead := strings.TrimSpace(mr.CommitSHA)
+	if expectedHead == "" {
+		return cleanup, fmt.Errorf("remote branch delete %s: missing submitted commit_sha", cleanup.Branch)
+	}
+
+	// Deleting a branch with an open PR causes GitHub to auto-close the PR as
+	// "closed" (not "merged"), destroying the PR audit trail. (gas-fk4)
+	if rigGit.HasOpenPullRequest(git.PullRequestRef{URL: mr.PRURL, Number: mr.PRNumber, Branch: cleanup.Branch, HeadSHA: expectedHead}) {
+		cleanup.OpenPR = true
+	} else {
+		remoteTip, err := rigGit.PushRemoteBranchTip("origin", cleanup.Branch)
+		if err != nil {
+			return cleanup, fmt.Errorf("remote branch delete %s: read remote branch tip: %w", cleanup.Branch, err)
+		}
+		if strings.TrimSpace(remoteTip) == "" {
+			cleanup.AlreadyGone = true
+		} else if err := rigGit.DeleteRemoteBranchIfAt("origin", cleanup.Branch, expectedHead); err != nil {
+			return cleanup, fmt.Errorf("remote branch delete %s at %s: %w", cleanup.Branch, expectedHead, err)
+		} else {
+			cleanup.RemoteDeleted = true
+		}
+	}
+
+	if deleteMQPostMergeLocalBranchIfAt(rigGit, cleanup.Branch, expectedHead) {
+		cleanup.LocalDeleted = true
+	}
+	return cleanup, nil
+}
+
+func deleteMQPostMergeLocalBranchIfAt(rigGit mqPostMergeGit, branch, expectedHead string) bool {
+	localHead, err := rigGit.Rev("refs/heads/" + branch + "^{commit}")
+	if err != nil || strings.TrimSpace(localHead) != strings.TrimSpace(expectedHead) {
+		return false
+	}
+	return rigGit.DeleteBranch(branch, false) == nil
+}
+
+func mqDeleteMergedBranchesEnabled(rigPath string) bool {
+	settingsPath := filepath.Join(rigPath, "settings", "config.json")
+	settings, err := config.LoadRigSettings(settingsPath)
+	if err != nil || settings.MergeQueue == nil {
+		return true
+	}
+	return settings.MergeQueue.IsDeleteMergedBranchesEnabled()
 }

--- a/internal/cmd/mq_integration.go
+++ b/internal/cmd/mq_integration.go
@@ -739,6 +739,16 @@ func runMqIntegrationLand(cmd *cobra.Command, args []string) error {
 // idempotent re-run, but the epic is already marked done).
 func cleanupIntegrationBranch(g *git.Git, bd *beads.Beads, epicID, branchName, targetBranch string, epicAlreadyClosed bool) []string {
 	var warnings []string
+	branchHead, err := g.PushRemoteBranchTip("origin", branchName)
+	if err != nil {
+		return append(warnings, fmt.Sprintf("could not read remote integration branch: %v", err))
+	}
+	if strings.TrimSpace(branchHead) == "" {
+		return append(warnings, "remote integration branch missing before cleanup")
+	}
+	if err := g.VerifyPushedCommitReachableFromPushTarget("origin", targetBranch, branchHead); err != nil {
+		return append(warnings, fmt.Sprintf("integration branch is not proven on %s: %v", targetBranch, err))
+	}
 
 	// Close epic first — ensures retriable state if branch deletion fails
 	fmt.Printf("Updating epic status...\n")
@@ -755,7 +765,7 @@ func cleanupIntegrationBranch(g *git.Git, bd *beads.Beads, epicID, branchName, t
 	// Delete integration branch (use bare repo git — ref-only operations)
 	fmt.Printf("Deleting integration branch...\n")
 	// Delete remote first
-	if err := g.DeleteRemoteBranch("origin", branchName); err != nil {
+	if err := g.DeleteRemoteBranchIfAt("origin", branchName, branchHead); err != nil {
 		warning := fmt.Sprintf("could not delete remote branch: %v", err)
 		warnings = append(warnings, warning)
 		fmt.Printf("  %s\n", style.Dim.Render(fmt.Sprintf("(%s)", warning)))

--- a/internal/cmd/mq_post_merge_test.go
+++ b/internal/cmd/mq_post_merge_test.go
@@ -1,0 +1,259 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/refinery"
+)
+
+type fakeMQPostMergeManager struct {
+	mr              *refinery.MergeRequest
+	findErr         error
+	postMergeErr    error
+	postMergeCalled bool
+	postMergeMR     *refinery.MergeRequest
+}
+
+func (m *fakeMQPostMergeManager) FindMRForPostMerge(string) (*refinery.MergeRequest, error) {
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	return m.mr, nil
+}
+
+func (m *fakeMQPostMergeManager) PostMergeMR(mr *refinery.MergeRequest) (*refinery.PostMergeResult, error) {
+	m.postMergeCalled = true
+	m.postMergeMR = mr
+	if m.postMergeErr != nil {
+		return nil, m.postMergeErr
+	}
+	return &refinery.PostMergeResult{MR: m.mr, MRClosed: true, SourceIssueClosed: true, SourceIssueID: m.mr.IssueID}, nil
+}
+
+type fakeMQPostMergeGit struct {
+	verifyErr error
+	openPR    bool
+	deleteErr error
+	remoteTip string
+	localHead string
+	tipErr    error
+
+	verifiedCommits []string
+	deletedBranches []string
+	deletedHeads    []string
+	localDeleted    []string
+}
+
+func (g *fakeMQPostMergeGit) VerifyPushedCommitReachableFromPushTarget(_, _, commit string) error {
+	g.verifiedCommits = append(g.verifiedCommits, commit)
+	return g.verifyErr
+}
+
+func (g *fakeMQPostMergeGit) HasOpenPullRequest(git.PullRequestRef) bool {
+	return g.openPR
+}
+
+func (g *fakeMQPostMergeGit) PushRemoteBranchTip(_, _ string) (string, error) {
+	return g.remoteTip, g.tipErr
+}
+
+func (g *fakeMQPostMergeGit) Rev(string) (string, error) {
+	return g.localHead, nil
+}
+
+func (g *fakeMQPostMergeGit) DeleteRemoteBranchIfAt(_, branch, expectedHash string) error {
+	g.deletedBranches = append(g.deletedBranches, branch)
+	g.deletedHeads = append(g.deletedHeads, expectedHash)
+	return g.deleteErr
+}
+
+func (g *fakeMQPostMergeGit) DeleteBranch(branch string, _ bool) error {
+	g.localDeleted = append(g.localDeleted, branch)
+	return nil
+}
+
+func testMQPostMergeMR() *refinery.MergeRequest {
+	return &refinery.MergeRequest{
+		ID:           "gt-mr-proof",
+		Branch:       "polecat/test/gt-proof",
+		Worker:       "polecats/test",
+		IssueID:      "gt-proof",
+		TargetBranch: "main",
+		CommitSHA:    "abc123def456",
+	}
+}
+
+func TestRunVerifiedMQPostMerge_ProofFailurePreservesRecordsAndBranch(t *testing.T) {
+	mgr := &fakeMQPostMergeManager{mr: testMQPostMergeMR()}
+	rigGit := &fakeMQPostMergeGit{verifyErr: errors.New("not reachable")}
+
+	_, _, err := runVerifiedMQPostMerge(mgr, t.TempDir(), rigGit, mgr.mr.ID, false)
+	if err == nil || !strings.Contains(err.Error(), "merge proof failed") {
+		t.Fatalf("runVerifiedMQPostMerge error = %v, want merge proof failure", err)
+	}
+	if !strings.Contains(err.Error(), mgr.mr.CommitSHA) {
+		t.Fatalf("proof error %q does not mention submitted head %s", err, mgr.mr.CommitSHA)
+	}
+	if mgr.postMergeCalled {
+		t.Fatal("PostMerge called after failed proof")
+	}
+	if len(rigGit.deletedBranches) != 0 {
+		t.Fatalf("remote branch deleted after failed proof: %v", rigGit.deletedBranches)
+	}
+	if len(rigGit.localDeleted) != 0 {
+		t.Fatalf("local branch deleted after failed proof: %v", rigGit.localDeleted)
+	}
+}
+
+func TestRunVerifiedMQPostMerge_VerifiedHeadClosesAndLeaseDeletes(t *testing.T) {
+	mgr := &fakeMQPostMergeManager{mr: testMQPostMergeMR()}
+	rigGit := &fakeMQPostMergeGit{remoteTip: mgr.mr.CommitSHA, localHead: mgr.mr.CommitSHA}
+
+	_, cleanup, err := runVerifiedMQPostMerge(mgr, t.TempDir(), rigGit, mgr.mr.ID, false)
+	if err != nil {
+		t.Fatalf("runVerifiedMQPostMerge: %v", err)
+	}
+	if !mgr.postMergeCalled {
+		t.Fatal("PostMerge was not called after successful proof")
+	}
+	if mgr.postMergeMR != mgr.mr {
+		t.Fatal("PostMerge did not use the verified MR snapshot")
+	}
+	if len(rigGit.verifiedCommits) != 1 || rigGit.verifiedCommits[0] != mgr.mr.CommitSHA {
+		t.Fatalf("verified commits = %v, want [%s]", rigGit.verifiedCommits, mgr.mr.CommitSHA)
+	}
+	if !cleanup.RemoteDeleted || len(rigGit.deletedBranches) != 1 || rigGit.deletedBranches[0] != mgr.mr.Branch {
+		t.Fatalf("remote delete = cleanup=%+v branches=%v", cleanup, rigGit.deletedBranches)
+	}
+	if len(rigGit.deletedHeads) != 1 || rigGit.deletedHeads[0] != mgr.mr.CommitSHA {
+		t.Fatalf("deleted heads = %v, want [%s]", rigGit.deletedHeads, mgr.mr.CommitSHA)
+	}
+	if !cleanup.LocalDeleted || len(rigGit.localDeleted) != 1 || rigGit.localDeleted[0] != mgr.mr.Branch {
+		t.Fatalf("local delete = cleanup=%+v local=%v", cleanup, rigGit.localDeleted)
+	}
+}
+
+func TestRunVerifiedMQPostMerge_SkipBranchDeleteStillRequiresProof(t *testing.T) {
+	mgr := &fakeMQPostMergeManager{mr: testMQPostMergeMR()}
+	rigGit := &fakeMQPostMergeGit{}
+
+	_, cleanup, err := runVerifiedMQPostMerge(mgr, t.TempDir(), rigGit, mgr.mr.ID, true)
+	if err != nil {
+		t.Fatalf("runVerifiedMQPostMerge: %v", err)
+	}
+	if !mgr.postMergeCalled {
+		t.Fatal("PostMerge was not called after successful proof")
+	}
+	if len(rigGit.verifiedCommits) != 1 || rigGit.verifiedCommits[0] != mgr.mr.CommitSHA {
+		t.Fatalf("verified commits = %v, want [%s]", rigGit.verifiedCommits, mgr.mr.CommitSHA)
+	}
+	if !cleanup.Skipped {
+		t.Fatalf("cleanup.Skipped = false, cleanup=%+v", cleanup)
+	}
+	if len(rigGit.deletedBranches) != 0 || len(rigGit.localDeleted) != 0 {
+		t.Fatalf("branch deleted despite skip: remote=%v local=%v", rigGit.deletedBranches, rigGit.localDeleted)
+	}
+}
+
+func TestRunVerifiedMQPostMerge_OpenPRSkipsRemoteDeleteAfterProof(t *testing.T) {
+	mgr := &fakeMQPostMergeManager{mr: testMQPostMergeMR()}
+	rigGit := &fakeMQPostMergeGit{openPR: true, localHead: mgr.mr.CommitSHA}
+
+	_, cleanup, err := runVerifiedMQPostMerge(mgr, t.TempDir(), rigGit, mgr.mr.ID, false)
+	if err != nil {
+		t.Fatalf("runVerifiedMQPostMerge: %v", err)
+	}
+	if !mgr.postMergeCalled {
+		t.Fatal("PostMerge was not called after successful proof")
+	}
+	if !cleanup.OpenPR {
+		t.Fatalf("cleanup.OpenPR = false, cleanup=%+v", cleanup)
+	}
+	if len(rigGit.deletedBranches) != 0 {
+		t.Fatalf("remote branch deleted despite open PR: %v", rigGit.deletedBranches)
+	}
+	if len(rigGit.localDeleted) != 1 || rigGit.localDeleted[0] != mgr.mr.Branch {
+		t.Fatalf("local branch cleanup = %v, want [%s]", rigGit.localDeleted, mgr.mr.Branch)
+	}
+}
+
+func TestRunVerifiedMQPostMerge_LeaseDeleteFailureReturnsAfterPostMerge(t *testing.T) {
+	mgr := &fakeMQPostMergeManager{mr: testMQPostMergeMR()}
+	rigGit := &fakeMQPostMergeGit{remoteTip: mgr.mr.CommitSHA, deleteErr: errors.New("stale info")}
+
+	_, _, err := runVerifiedMQPostMerge(mgr, t.TempDir(), rigGit, mgr.mr.ID, false)
+	if err == nil || !strings.Contains(err.Error(), "remote branch delete") {
+		t.Fatalf("runVerifiedMQPostMerge error = %v, want remote branch delete failure", err)
+	}
+	if !mgr.postMergeCalled {
+		t.Fatal("PostMerge was not called after successful proof")
+	}
+	if len(rigGit.deletedBranches) != 1 || rigGit.deletedBranches[0] != mgr.mr.Branch {
+		t.Fatalf("remote delete attempts = %v, want [%s]", rigGit.deletedBranches, mgr.mr.Branch)
+	}
+	if len(rigGit.deletedHeads) != 1 || rigGit.deletedHeads[0] != mgr.mr.CommitSHA {
+		t.Fatalf("delete lease heads = %v, want [%s]", rigGit.deletedHeads, mgr.mr.CommitSHA)
+	}
+	if len(rigGit.localDeleted) != 0 {
+		t.Fatalf("local branch deleted after remote lease failure: %v", rigGit.localDeleted)
+	}
+}
+
+func TestRunVerifiedMQPostMerge_MissingRemoteBranchIsIdempotentAfterProof(t *testing.T) {
+	mgr := &fakeMQPostMergeManager{mr: testMQPostMergeMR()}
+	rigGit := &fakeMQPostMergeGit{localHead: mgr.mr.CommitSHA}
+
+	_, cleanup, err := runVerifiedMQPostMerge(mgr, t.TempDir(), rigGit, mgr.mr.ID, false)
+	if err != nil {
+		t.Fatalf("runVerifiedMQPostMerge: %v", err)
+	}
+	if !mgr.postMergeCalled {
+		t.Fatal("PostMerge was not called after successful proof")
+	}
+	if !cleanup.AlreadyGone {
+		t.Fatalf("cleanup.AlreadyGone = false, cleanup=%+v", cleanup)
+	}
+	if len(rigGit.deletedBranches) != 0 {
+		t.Fatalf("remote branch delete attempted for missing branch: %v", rigGit.deletedBranches)
+	}
+}
+
+func TestRunVerifiedMQPostMerge_MissingSubmittedHeadFailsClosed(t *testing.T) {
+	mr := testMQPostMergeMR()
+	mr.CommitSHA = ""
+	mgr := &fakeMQPostMergeManager{mr: mr}
+	rigGit := &fakeMQPostMergeGit{}
+
+	_, _, err := runVerifiedMQPostMerge(mgr, t.TempDir(), rigGit, mgr.mr.ID, false)
+	if err == nil || !strings.Contains(err.Error(), "missing submitted commit_sha") {
+		t.Fatalf("runVerifiedMQPostMerge error = %v, want missing submitted head", err)
+	}
+	if mgr.postMergeCalled {
+		t.Fatal("PostMerge called with missing submitted head")
+	}
+	if len(rigGit.deletedBranches) != 0 {
+		t.Fatalf("branch deleted with missing submitted head: %v", rigGit.deletedBranches)
+	}
+}
+
+func TestRunVerifiedMQPostMerge_SourceTargetBranchFailsClosed(t *testing.T) {
+	mr := testMQPostMergeMR()
+	mr.Branch = "main"
+	mr.TargetBranch = "main"
+	mgr := &fakeMQPostMergeManager{mr: mr}
+	rigGit := &fakeMQPostMergeGit{}
+
+	_, _, err := runVerifiedMQPostMerge(mgr, t.TempDir(), rigGit, mgr.mr.ID, false)
+	if err == nil || !strings.Contains(err.Error(), "matches target branch") {
+		t.Fatalf("runVerifiedMQPostMerge error = %v, want source/target failure", err)
+	}
+	if mgr.postMergeCalled {
+		t.Fatal("PostMerge called when source branch matched target")
+	}
+	if len(rigGit.deletedBranches) != 0 {
+		t.Fatalf("branch deleted when source matched target: %v", rigGit.deletedBranches)
+	}
+}

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -298,18 +298,8 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 					}
 					fmt.Printf("  %s Superseded old MR: %s\n", style.Dim.Render("○"), old.ID)
 
-					// Delete the old remote branch to auto-close the GitHub PR.
-					// Only polecat branches — non-polecat branches may belong to
-					// contributor forks; deleting them closes upstream PRs. (GH#2669)
-					oldFields := beads.ParseMRFields(old)
-					if oldFields != nil && strings.HasPrefix(oldFields.Branch, "polecat/") {
-						g := git.NewGit(cwd)
-						if err := g.DeleteRemoteBranch("origin", oldFields.Branch); err != nil {
-							style.PrintWarning("could not delete superseded branch %s: %v", oldFields.Branch, err)
-						} else {
-							fmt.Printf("  %s Deleted remote branch: %s\n", style.Dim.Render("○"), oldFields.Branch)
-						}
-					}
+					// Leave superseded remote branches intact. Branch deletion belongs to
+					// verified post-merge cleanup, not submit-time queue maintenance.
 				}
 			}
 		}

--- a/internal/formula/formulas/mol-polecat-conflict-resolve.formula.toml
+++ b/internal/formula/formulas/mol-polecat-conflict-resolve.formula.toml
@@ -2,12 +2,12 @@ description = """
 Conflict resolution workflow for polecats handling merge conflicts.
 
 This molecule guides a polecat through resolving merge conflicts for a previously
-submitted MR that failed to rebase. The workflow uses the merge-slot gate to
+submitted MR that failed to merge. The workflow uses the merge-slot gate to
 serialize conflict resolution and prevent racing.
 
 ## Task Recognition
 
-Conflict resolution tasks are created by the Refinery when a mechanical rebase
+Conflict resolution tasks are created by the Refinery when a mechanical merge
 fails. They are identified by:
 - Title prefix: "Resolve merge conflicts:"
 - Metadata fields in description: Original MR, Branch, Conflict SHA
@@ -17,8 +17,8 @@ fails. They are identified by:
 | Aspect | Regular Work | Conflict Resolution |
 |--------|--------------|---------------------|
 | Branch source | Create new branch | Checkout existing MR branch |
-| Merge path | Submit to queue via `gt done` | Push directly to {{base_branch}} |
-| Issue closure | Refinery closes after merge | Close MR bead yourself |
+| Merge path | Submit to queue via `gt done` | Push resolved MR branch for refinery retry |
+| Issue closure | Refinery closes after verified post-merge | Refinery closes after verified post-merge |
 | Serialization | None | Merge-slot gate required |
 
 ## Variables
@@ -27,9 +27,9 @@ fails. They are identified by:
 |----------|--------|-------------|
 | task | hook_bead | The conflict-resolution task ID |
 | original_mr | task metadata | The MR bead that had conflicts |
-| branch | task metadata | The branch to rebase |
+| branch | task metadata | The branch to merge target into |
 | conflict_sha | task metadata | Base branch SHA when conflict occurred |
-| base_branch | sling vars | The base branch to rebase on (default: main) |
+| base_branch | sling vars | The base branch to merge from (default: main) |
 
 ## Failure Modes
 
@@ -77,8 +77,8 @@ The task description contains structured metadata:
 ```
 
 Parse and note:
-- **original_mr**: The MR bead ID (you'll close this after merge)
-- **branch**: The branch to checkout and rebase
+- **original_mr**: The MR bead ID the Refinery will retry and close after verified post-merge cleanup
+- **branch**: The branch to checkout and resolve
 - **source_issue**: The original work issue (read for context if needed)
 - **retry_count**: How many times this has been attempted
 
@@ -165,18 +165,18 @@ git log --oneline -5        # Recent commits
 git log origin/{{base_branch}}..HEAD   # Commits not on {{base_branch}}
 ```
 
-**Exit criteria:** On temp-resolve branch, ready to rebase."""
+**Exit criteria:** On temp-resolve branch, ready to merge target and resolve conflicts."""
 
 [[steps]]
-id = "rebase-resolve"
-title = "Rebase onto base branch and resolve conflicts"
+id = "merge-resolve"
+title = "Merge base branch and resolve conflicts"
 needs = ["checkout-branch"]
 description = """
-Perform the rebase and resolve any conflicts.
+Merge the target into the branch without rewriting branch history and resolve any conflicts.
 
-**1. Start the rebase:**
+**1. Start the merge:**
 ```bash
-git rebase origin/{{base_branch}}
+git merge --no-ff origin/{{base_branch}}
 ```
 
 **2. If conflicts occur:**
@@ -196,7 +196,7 @@ git diff                    # See conflict markers
 **After resolving each file:**
 ```bash
 git add <resolved-file>
-git rebase --continue
+git commit
 ```
 
 **3. If stuck on a conflict:**
@@ -208,18 +208,18 @@ git rebase --continue
   Issue: Cannot determine correct resolution"
   ```
 
-**4. Verify rebase success:**
+**4. Verify merge success:**
 ```bash
-git log --oneline origin/{{base_branch}}..HEAD   # Your commits rebased
+git log --oneline origin/{{base_branch}}..HEAD   # Your commits plus merge resolution
 git status                            # Clean working tree
 ```
 
-**Exit criteria:** Branch successfully rebased onto origin/{{base_branch}}."""
+**Exit criteria:** Branch successfully merged origin/{{base_branch}} without rewriting submitted history."""
 
 [[steps]]
 id = "run-tests"
 title = "Run tests to verify resolution"
-needs = ["rebase-resolve"]
+needs = ["merge-resolve"]
 description = """
 Verify the resolution doesn't break anything.
 
@@ -253,66 +253,53 @@ go build ./...
 
 [[steps]]
 id = "push-to-main"
-title = "Push resolved changes directly to base branch"
+title = "Push resolved MR branch"
 needs = ["run-tests"]
 description = """
-Push the resolved branch directly to {{base_branch}}.
+Push the resolved branch back to {{branch}} for the Refinery to retry.
 
-**Important:** Unlike normal polecat work, conflict resolution pushes directly
-to {{base_branch}}. This is because:
-1. The original MR was already reviewed/approved by being in the queue
-2. We're just resolving conflicts, not adding new functionality
-3. Going back through the queue would create an infinite loop
+**Important:** Do not push directly to {{base_branch}} and do not close the MR
+or source issue yourself. The Refinery must run its verified post-merge cleanup.
 
-**1. Rebase one more time (in case main moved):**
+**1. Merge target one more time (in case it moved):**
 ```bash
 git fetch origin
-git rebase origin/{{base_branch}}
+git merge --no-ff origin/{{base_branch}}
 ```
 
-If new conflicts: resolve them (return to rebase-resolve step).
+If new conflicts: resolve them (return to merge-resolve step).
 
-**2. Push to main:**
+**2. Push resolved branch:**
 ```bash
-git push origin temp-resolve:{{base_branch}}
+git push origin temp-resolve:{{branch}}
 ```
 
 **3. Verify the push:**
 ```bash
-git log origin/{{base_branch}} --oneline -3    # Your commits should be there
+git ls-remote --heads origin {{branch}}        # Branch should exist on origin
 ```
 
-**Exit criteria:** Changes are on origin/{{base_branch}}."""
+**Exit criteria:** Resolved branch is on origin/{{branch}} for refinery retry."""
 
 [[steps]]
 id = "close-beads"
-title = "Close the original MR bead and this task"
+title = "Close this conflict-resolution task"
 needs = ["push-to-main"]
 description = """
-Close the beads to complete the work chain.
+Close only the conflict-resolution task. Leave the original MR and source issue
+open; the Refinery closes them only after verified post-merge proof.
 
-**1. Close the original MR bead:**
+**1. Close this task:**
 ```bash
-bd close {{original_mr}} --reason="merged after conflict resolution"
+bd close {{task}} --reason="resolved conflicts on {{branch}}"
 ```
 
-This completes the MR that was blocked on conflicts.
-
-**2. Close the source issue (if not already closed):**
-```bash
-bd show <source-issue>      # Check status
-bd close <source-issue> --reason="merged via conflict resolution"
-```
-
-The Refinery normally closes issues after merge, but since we pushed
-directly to {{base_branch}}, we handle it here.
-
-**3. Sync beads:**
+**2. Sync beads:**
 ```bash
 bd sync
 ```
 
-**Exit criteria:** Original MR and source issue are closed."""
+**Exit criteria:** Conflict-resolution task is closed; original MR remains queued."""
 
 [[steps]]
 id = "release-slot"
@@ -360,7 +347,7 @@ git stash list              # Empty
 
 **3. Close this task:**
 ```bash
-bd close {{task}} --reason="Conflicts resolved and merged to {{base_branch}}"
+bd close {{task}} --reason="Conflicts resolved on {{branch}}"
 ```
 
 **4. Signal completion:**
@@ -382,9 +369,9 @@ description = "The original MR bead ID (extracted from task metadata)"
 required = true
 
 [vars.branch]
-description = "The branch to rebase (extracted from task metadata)"
+description = "The branch to merge target into (extracted from task metadata)"
 required = true
 
 [vars.base_branch]
-description = "The base branch to rebase on and push to (e.g., main, integration/epic-id)"
+description = "The base branch to merge from (e.g., main, integration/epic-id)"
 default = "main"

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -1,7 +1,7 @@
 description = """
 Merge queue processor patrol loop.
 
-The Refinery is the Engineer in the engine room. You process polecat branches, merging them to their effective target branches one at a time with sequential rebasing.
+The Refinery is the Engineer in the engine room. You process polecat branches, merging them to their effective target branches one at a time without rewriting submitted heads.
 
 **The Scotty Test**: Before proceeding past any failure, ask yourself: "Would Scotty walk past a warp core leak because it existed before his shift?"
 
@@ -16,7 +16,7 @@ Witness                    Refinery                      Git        Polecat
    │─────────────────────────>│                           │            │
    │                          │                           │            │
    │                    (verify branch)                   │            │
-   │                          │ fetch & rebase            │            │
+   │                          │ fetch & merge rehearsal    │            │
    │                          │──────────────────────────>│            │
    │                          │                           │            │
    │                    (run tests)                       │            │
@@ -66,12 +66,12 @@ source of truth.
 | delete_merged_branches | true | Whether to delete source branches after merge |
 | judgment_enabled | false | Enable quality review for merges (true/false) |
 | review_depth | standard | Review depth: quick, standard, or deep |
-| merge_strategy | direct | Merge strategy: 'direct' (ff-only merge+push) or 'pr' (GitHub PR) |
+| merge_strategy | direct | Merge strategy: 'direct' (merge+push) or 'pr' (GitHub PR) |
 | require_review | false | Require at least one approving GitHub review before merging (pr mode only) |
 
 ## Target Resolution Rule
 
-When instructions reference `<rebase-target>`, `<merge-target>`, or `<verification-target>`,
+When instructions reference `<merge-target>` or `<verification-target>`,
 resolve that placeholder with this rule:
 
 - If integration_branch_refinery_enabled = "true": use MR target when present, otherwise {{target_branch}}.
@@ -308,13 +308,13 @@ branch-only `gh pr list --limit 1`, retries, or broad fallback searches.
 
 For each queued MR:
 - If lookup errors or reports ambiguity: leave the MR open and continue to the next MR.
-- If `PR_STATE=MERGED`: send MERGED to Witness, then run post-merge cleanup with branch deletion skipped:
+- If `PR_STATE=MERGED`: run post-merge cleanup with branch deletion skipped, then send MERGED to Witness:
   ```bash
+  gt mq post-merge <rig> <mr-id> --skip-branch-delete
   gt mail send <rig>/witness -s "MERGED <polecat-name>" -m "Branch: <branch>
   Issue: <issue-id>
   PR: ${PR_URL}
   MR: <mr-id>"
-  gt mq post-merge <rig> <mr-id> --skip-branch-delete
   gt mail archive <merge-ready-message-id>
   ```
 - If `PR_STATE=OPEN`: leave it for the normal process-branch/merge-push path.
@@ -325,17 +325,17 @@ After sweeping merged PRs, process only MRs still actionable in process-branch."
 
 [[steps]]
 id = "process-branch"
-title = "Mechanical rebase"
+title = "Merge rehearsal"
 needs = ["merged-pr-sweep"]
 description = """
-Pick next branch from queue. Attempt mechanical rebase on the MR's effective target branch.
+Pick next branch from queue. Rehearse an ancestry-preserving merge against the MR's effective target branch.
 
 **Config: integration_branch_refinery_enabled = {{integration_branch_refinery_enabled}}**
 **Config: target_branch = {{target_branch}}**
 
-**Step 0: Determine rebase target (must match merge target)**
+**Step 0: Determine merge target**
 
-Resolve `<rebase-target>` using the **Target Resolution Rule** above.
+Resolve `<merge-target>` using the **Target Resolution Rule** above.
 Do NOT hardcode `main` unless `main` is actually the resolved MR target.
 
 **Step 0.5: Verify branch still exists (race-condition guard)**
@@ -351,40 +351,40 @@ If the branch no longer exists (exit code non-zero):
 - If `PR_STATE=MERGED`: return to merged-pr-sweep behavior for this MR.
 - If lookup errors, ambiguity, `OPEN`, `CLOSED`, or `NOT_FOUND`: leave the MR open and skip to loop-check; do NOT close it as missing, do NOT nudge the polecat.
 
-**Step 1: Checkout and attempt rebase**
+**Step 1: Checkout and rehearse merge without rewriting the submitted head**
 ```bash
 git checkout -b temp origin/<polecat-branch>
-git rebase origin/<rebase-target>
+git merge --no-ff --no-edit origin/<merge-target>
 ```
 
-**Step 2: Check rebase result**
+**Step 2: Check merge rehearsal result**
 
-The rebase exits with:
+The merge exits with:
 - Exit code 0: Success - proceed to run-tests
 - Exit code 1 (conflicts): Conflict detected - proceed to Step 3
 
-To detect conflict state after rebase fails:
+To detect conflict state after merge fails:
 ```bash
-# Check if we're in a conflicted rebase state
-ls .git/rebase-merge 2>/dev/null && echo "CONFLICT_STATE"
+# Check if we're in a conflicted merge state
+test -f .git/MERGE_HEAD && echo "CONFLICT_STATE"
 ```
 
 **Step 3: Handle conflicts (if any)**
 
-If rebase SUCCEEDED (exit code 0):
+If merge rehearsal SUCCEEDED (exit code 0):
 - Skip to run-tests step (continue normal merge flow)
 
-If rebase FAILED with conflicts:
+If merge rehearsal FAILED with conflicts:
 
-1. **Abort the rebase** (DO NOT leave repo in conflicted state):
+1. **Abort the merge** (DO NOT leave repo in conflicted state):
 ```bash
-git rebase --abort
+git merge --abort
 ```
 
 2. **Record conflict metadata**:
 ```bash
 # Capture target SHA for reference
-TARGET_SHA=$(git rev-parse origin/<rebase-target>)
+TARGET_SHA=$(git rev-parse origin/<merge-target>)
 BRANCH_SHA=$(git rev-parse origin/<polecat-branch>)
 ```
 
@@ -397,14 +397,14 @@ bd create --type=task --priority=1 \
 Original MR: <mr-bead-id>
 Branch: <polecat-branch>
 Original Issue: <issue-id>
-Conflict with target <rebase-target> at: ${TARGET_SHA}
+Conflict with target <merge-target> at: ${TARGET_SHA}
 Branch SHA: ${BRANCH_SHA}
 
 ## Instructions
 1. Clone/checkout the branch
-2. Rebase on target: git rebase origin/<rebase-target>
+2. Merge target without rewriting branch history: git merge --no-ff origin/<merge-target>
 3. Resolve conflicts
-4. Force push: git push -f origin <branch>
+4. Push: git push origin <branch>
 5. Close this task when done
 
 The MR will be re-queued for processing after conflicts are resolved."
@@ -418,7 +418,7 @@ The MR will be re-queued for processing after conflicts are resolved."
 **CRITICAL**: Never delete a branch that has conflicts. The branch contains
 the original work and must be preserved for conflict resolution.
 
-Track: rebase result (success/conflict), conflict task ID if created."""
+Track: merge rehearsal result (success/conflict), conflict task ID if created."""
 
 [[steps]]
 id = "run-tests"
@@ -611,7 +611,8 @@ id = "merge-push"
 title = "Merge and push"
 needs = ["handle-failures"]
 description = """
-Merge and push. CRITICAL: Notifications come IMMEDIATELY after push.
+Merge and push. CRITICAL: verified post-merge cleanup comes immediately after push;
+send MERGED only after `gt mq post-merge` succeeds.
 
 **Config: integration_branch_refinery_enabled = {{integration_branch_refinery_enabled}}**
 **Config: target_branch = {{target_branch}}**
@@ -627,7 +628,7 @@ Determine `<merge-target>` using the **Target Resolution Rule** above.
 
 ```bash
 git checkout <merge-target>
-git merge --ff-only temp
+git merge --no-ff -m "Merge <polecat-branch> into <merge-target>" origin/<polecat-branch>
 git push origin <merge-target>
 ```
 
@@ -678,13 +679,11 @@ Continue to Step 2.
 
 **If merge_strategy = "pr":**
 
-Push the rebased branch and create a GitHub PR instead of direct merge.
+Create a GitHub PR for the submitted branch instead of direct merge. Do not
+force-push or rebase the polecat branch; post-merge proof depends on the
+submitted head remaining stable.
 
 ```bash
-# Push the rebased polecat branch (force-push since we rebased)
-git checkout temp
-git push origin temp:refs/heads/<polecat-branch> --force-with-lease
-
 # Create the PR using bead metadata for title/description
 PR_URL=$(gh pr create \
   --base <merge-target> \
@@ -787,16 +786,41 @@ Clean up temp branch and skip to loop-check.
 **If APPROVED:**
 Merge the PR:
 ```bash
-gh pr merge "$PR_URL" --repo "$REPO_URL" --merge --delete-branch
+gh pr merge "$PR_URL" --repo "$REPO_URL" --merge
 ```
 
 If merge fails (conflict, branch protection), debug and retry.
 
 ⚠️ **STOP HERE - DO NOT PROCEED UNTIL THE PR IS ACTUALLY MERGED ON GITHUB**
 
-**Step 2: Send MERGED Notification (REQUIRED - DO THIS IMMEDIATELY)**
+**Step 2: Post-merge cleanup (REQUIRED — single command)**
 
-RIGHT NOW, before any cleanup, send MERGED mail to Witness.
+This single command handles closing the MR bead, closing the source issue, and
+deleting the remote polecat branch (respects delete_merged_branches config):
+
+```bash
+# If an open PR was detected in Step 1.6 (direct), pass --skip-branch-delete
+# to avoid auto-closing the PR via head_ref_delete.
+# Otherwise, omit the flag.
+gt mq post-merge <rig> <mr-bead-id>            # normal (no open PR)
+gt mq post-merge <rig> <mr-bead-id> --skip-branch-delete  # open PR exists
+```
+
+The MR bead ID was in the MERGE_READY message or find via:
+```bash
+bd list --type=merge-request --status=open | grep <polecat-name>
+```
+
+Verify the command output shows all steps succeeded (✓ for each).
+
+**Note**: In PR mode, run post-merge cleanup only after `gh pr merge` succeeds.
+The branch is deleted by `gt mq post-merge` after merge proof passes, not by
+`gh pr merge`. The `--skip-branch-delete` flag (gas-fk4) prevents branch deletion
+when an open PR is detected in direct merge mode.
+
+**Step 3: Send MERGED Notification (REQUIRED - ONLY AFTER CLEANUP SUCCEEDS)**
+
+After `gt mq post-merge` succeeds, send MERGED mail to Witness.
 
 **If merge_strategy = "direct":**
 ```bash
@@ -813,36 +837,11 @@ PR: ${PR_URL}
 Merged-At: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 ```
 
-Note: In PR mode, MERGED is only sent AFTER `gh pr merge` succeeds — the PR
-is actually merged on GitHub before the witness is notified.
+Note: In PR mode, MERGED is only sent AFTER `gh pr merge` succeeds and
+`gt mq post-merge` verifies the target contains the submitted head.
 
 This signals the Witness to nuke the polecat worktree. WITHOUT THIS NOTIFICATION,
 POLECAT WORKTREES ACCUMULATE INDEFINITELY AND THE LIFECYCLE BREAKS.
-
-**Step 3: Post-merge cleanup (REQUIRED — single command)**
-
-This single command handles closing the MR bead, closing the source issue, and
-deleting the remote polecat branch (respects delete_merged_branches config):
-
-```bash
-# If an open PR was detected in Step 1.6 (direct) or merge_strategy=pr,
-# pass --skip-branch-delete to avoid auto-closing the PR via head_ref_delete.
-# Otherwise, omit the flag.
-gt mq post-merge <rig> <mr-bead-id>            # normal (no open PR)
-gt mq post-merge <rig> <mr-bead-id> --skip-branch-delete  # open PR exists
-```
-
-The MR bead ID was in the MERGE_READY message or find via:
-```bash
-bd list --type=merge-request --status=open | grep <polecat-name>
-```
-
-Verify the command output shows all steps succeeded (✓ for each).
-
-**Note**: In PR mode, the source branch is NOT deleted (it's the PR head branch).
-`delete_merged_branches` is ignored when merge_strategy=pr — the branch is cleaned
-up when the PR is merged on GitHub. The `--skip-branch-delete` flag (gas-fk4) also
-prevents branch deletion when an open PR is detected in direct merge mode.
 
 **Step 4: Archive the MERGE_READY mail (REQUIRED)**
 ```bash
@@ -856,8 +855,8 @@ git branch -d temp
 ```
 
 **VERIFICATION GATE**: You CANNOT proceed to loop-check without:
-- [x] MERGED mail sent to witness (with PR URL if merge_strategy=pr)
 - [x] Post-merge cleanup completed (MR closed, source issue closed, branch deleted)
+- [x] MERGED mail sent to witness (with PR URL if merge_strategy=pr)
 - [x] MERGE_READY mail archived
 
 If you skipped notifications or archiving, GO BACK AND DO THEM NOW.
@@ -893,12 +892,13 @@ description = """
 Summarize this patrol cycle.
 
 **VERIFICATION**: Before generating summary, confirm for each merged branch:
+- [ ] `gt mq post-merge` completed verified cleanup
 - [ ] MERGED mail was sent to witness
-- [ ] MR bead was closed
-- [ ] Source issue was closed
 - [ ] MERGE_READY mail archived
 
-If any notifications, closures, or archiving were missed, do them now!
+If verified cleanup was missed, run `gt mq post-merge`; never manually close
+MR/source issues outside verified cleanup. If notifications or archiving were
+missed, do them now.
 
 Include in summary:
 - Branches merged (count, names)
@@ -1013,7 +1013,7 @@ git fetch origin
 git checkout origin/<branch>
 git merge origin/<target>
 ```
-Resolve the conflicts on the integration branch (force-push), then re-run
+Resolve the conflicts on the integration branch and push it, then re-run
 `gt mq integration land <epic-id>` to retry the consolidation.
 
 ## Why this exists

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1602,7 +1602,10 @@ func (g *Git) GhPrMergePullRequest(pr *PullRequestInfo, method string) (string, 
 	if pr == nil || (pr.Number == 0 && pr.URL == "") {
 		return "", fmt.Errorf("pull request identity is missing")
 	}
-	args := []string{"pr", "merge", pullRequestSelector(pr), "--" + method, "--delete-branch"}
+	args := []string{"pr", "merge", pullRequestSelector(pr), "--" + method}
+	if head := strings.TrimSpace(pr.HeadSHA); head != "" {
+		args = append(args, "--match-head-commit", head)
+	}
 	if pr.BaseRepo != "" {
 		args = append(args, "--repo", pr.BaseRepo)
 	}
@@ -1636,14 +1639,14 @@ func pullRequestSelector(pr *PullRequestInfo) string {
 	return ""
 }
 
-// FindBitbucketPRNumber returns the Bitbucket PR ID for the given branch, or 0 if none exists.
-// It queries the Bitbucket REST API for open PRs with the branch as source.
-func (g *Git) FindBitbucketPRNumber(workspace, repoSlug, branch string) (int, error) {
+// FindBitbucketPullRequest returns the open Bitbucket PR for branch.
+// It includes the source commit hash so refinery can merge only the submitted head.
+func (g *Git) FindBitbucketPullRequest(workspace, repoSlug, branch, headSHA string) (*PullRequestInfo, error) {
 	// Use curl since there is no official Bitbucket CLI equivalent to gh.
 	// The BITBUCKET_TOKEN env var provides authentication.
 	token := os.Getenv("BITBUCKET_TOKEN")
 	if token == "" {
-		return 0, fmt.Errorf("BITBUCKET_TOKEN is required for Bitbucket PR operations")
+		return nil, fmt.Errorf("BITBUCKET_TOKEN is required for Bitbucket PR operations")
 	}
 	url := fmt.Sprintf("https://api.bitbucket.org/2.0/repositories/%s/%s/pullrequests?q=source.branch.name%%3D%%22%s%%22+AND+state%%3D%%22OPEN%%22&pagelen=1",
 		workspace, repoSlug, branch)
@@ -1651,20 +1654,49 @@ func (g *Git) FindBitbucketPRNumber(workspace, repoSlug, branch string) (int, er
 	cmd.Dir = g.workDir
 	out, err := cmd.Output()
 	if err != nil {
-		return 0, fmt.Errorf("bitbucket API request failed: %w", err)
+		return nil, fmt.Errorf("bitbucket API request failed: %w", err)
 	}
 	var resp struct {
 		Values []struct {
-			ID int `json:"id"`
+			ID    int    `json:"id"`
+			State string `json:"state"`
+			Links struct {
+				HTML struct {
+					Href string `json:"href"`
+				} `json:"html"`
+			} `json:"links"`
+			Source struct {
+				Branch struct {
+					Name string `json:"name"`
+				} `json:"branch"`
+				Commit struct {
+					Hash string `json:"hash"`
+				} `json:"commit"`
+			} `json:"source"`
 		} `json:"values"`
 	}
 	if err := json.Unmarshal(bytes.TrimSpace(out), &resp); err != nil {
-		return 0, fmt.Errorf("failed to parse Bitbucket response: %w", err)
+		return nil, fmt.Errorf("failed to parse Bitbucket response: %w", err)
 	}
 	if len(resp.Values) == 0 {
-		return 0, nil
+		return nil, nil
 	}
-	return resp.Values[0].ID, nil
+	pr := resp.Values[0]
+	info := &PullRequestInfo{
+		Number:       pr.ID,
+		URL:          pr.Links.HTML.Href,
+		State:        strings.ToUpper(pr.State),
+		HeadRefName:  pr.Source.Branch.Name,
+		HeadSHA:      strings.TrimSpace(pr.Source.Commit.Hash),
+		LookupSource: "bitbucket-head",
+	}
+	if info.State == "" {
+		info.State = "OPEN"
+	}
+	if err := validatePullRequestHead(info, headSHA); err != nil {
+		return nil, err
+	}
+	return info, nil
 }
 
 // IsBitbucketPRApproved checks whether a Bitbucket PR has at least one approving reviewer.
@@ -1708,7 +1740,7 @@ func (g *Git) BitbucketPRMerge(workspace, repoSlug string, prID int, strategy st
 	}
 	url := fmt.Sprintf("https://api.bitbucket.org/2.0/repositories/%s/%s/pullrequests/%d/merge",
 		workspace, repoSlug, prID)
-	body := fmt.Sprintf(`{"merge_strategy":"%s","close_source_branch":true}`, strategy)
+	body := fmt.Sprintf(`{"merge_strategy":"%s","close_source_branch":false}`, strategy)
 	cmd := exec.Command("curl", "-s", "-X", "POST",
 		"-H", "Authorization: Bearer "+token,
 		"-H", "Content-Type: application/json",

--- a/internal/git/pr_lookup.go
+++ b/internal/git/pr_lookup.go
@@ -66,6 +66,9 @@ func (g *Git) LookupPullRequest(ref PullRequestRef) (*PullRequestInfo, error) {
 			return nil, err
 		}
 		pr.LookupSource = "recorded-url"
+		if err := validatePullRequestHead(pr, strings.TrimSpace(ref.HeadSHA)); err != nil {
+			return nil, err
+		}
 		return pr, nil
 	}
 	if ref.Number > 0 {
@@ -74,6 +77,9 @@ func (g *Git) LookupPullRequest(ref PullRequestRef) (*PullRequestInfo, error) {
 			return nil, err
 		}
 		pr.LookupSource = "recorded-number"
+		if err := validatePullRequestHead(pr, strings.TrimSpace(ref.HeadSHA)); err != nil {
+			return nil, err
+		}
 		return pr, nil
 	}
 
@@ -208,8 +214,10 @@ func selectPullRequest(raw []ghPullRequest, targetRepo, branch, headSHA, source 
 		if pr.BaseRepo != "" && !strings.EqualFold(pr.BaseRepo, targetRepo) {
 			continue
 		}
-		if headSHA != "" && pr.HeadSHA != "" && pr.HeadSHA != headSHA {
-			continue
+		if headSHA != "" {
+			if pr.HeadSHA == "" || pr.HeadSHA != headSHA {
+				continue
+			}
 		}
 		pr.LookupSource = source
 		matches = append(matches, pr)
@@ -221,6 +229,20 @@ func selectPullRequest(raw []ghPullRequest, targetRepo, branch, headSHA, source 
 		return nil, fmt.Errorf("%w: head %s in %s matched %d PRs: %s", ErrPullRequestAmbiguous, branch, targetRepo, len(matches), describePullRequestMatches(matches))
 	}
 	return matches[0], nil
+}
+
+func validatePullRequestHead(pr *PullRequestInfo, headSHA string) error {
+	headSHA = strings.TrimSpace(headSHA)
+	if headSHA == "" || pr == nil {
+		return nil
+	}
+	if pr.HeadSHA == "" {
+		return fmt.Errorf("PR #%d head SHA is missing", pr.Number)
+	}
+	if pr.HeadSHA != headSHA {
+		return fmt.Errorf("PR #%d head changed from submitted %s to %s", pr.Number, shortSHA(headSHA), shortSHA(pr.HeadSHA))
+	}
+	return nil
 }
 
 func githubRepoFromPullURL(raw string) (string, bool) {

--- a/internal/git/pr_lookup_test.go
+++ b/internal/git/pr_lookup_test.go
@@ -36,6 +36,25 @@ exit 1
 	}
 }
 
+func TestLookupPullRequestRecordedURLRejectsHeadDrift(t *testing.T) {
+	installFakeGH(t, `#!/bin/sh
+if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = "https://github.com/upstream/repo/pull/42" ]; then
+  printf '%s\n' '{"number":42,"url":"https://github.com/upstream/repo/pull/42","state":"OPEN","mergedAt":"","headRefName":"fix/drift","headRefOid":"new-head","headRepository":{"nameWithOwner":"fork/repo"},"headRepositoryOwner":{"login":"fork"},"baseRepository":{"nameWithOwner":"upstream/repo"}}'
+  exit 0
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+`)
+	dir := initTestRepo(t)
+	g := NewGit(dir)
+	addGitHubRemotes(t, g)
+
+	_, err := g.LookupPullRequest(PullRequestRef{URL: "https://github.com/upstream/repo/pull/42", Branch: "fix/drift", HeadSHA: "submitted"})
+	if err == nil || !strings.Contains(err.Error(), "head changed") {
+		t.Fatalf("LookupPullRequest err = %v, want head changed", err)
+	}
+}
+
 func TestLookupPullRequestQualifiedForkHead(t *testing.T) {
 	installFakeGH(t, `#!/bin/sh
 if [ "$1" = "api" ] && [ "$2" = "-X" ] && [ "$3" = "GET" ] && [ "$4" = "repos/upstream/repo/pulls" ]; then
@@ -144,7 +163,7 @@ exit 1
 `)
 	dir := initTestRepo(t)
 	g := NewGit(dir)
-	pr := &PullRequestInfo{Number: 42, URL: "https://github.com/upstream/repo/pull/42", BaseRepo: "upstream/repo"}
+	pr := &PullRequestInfo{Number: 42, URL: "https://github.com/upstream/repo/pull/42", BaseRepo: "upstream/repo", HeadSHA: "abc123"}
 
 	approved, err := g.IsPullRequestApproved(pr)
 	if err != nil {
@@ -164,7 +183,7 @@ exit 1
 	log := string(logBytes)
 	for _, want := range []string{
 		"pr view https://github.com/upstream/repo/pull/42 --json reviewDecision --repo upstream/repo",
-		"pr merge https://github.com/upstream/repo/pull/42 --squash --delete-branch --repo upstream/repo",
+		"pr merge https://github.com/upstream/repo/pull/42 --squash --match-head-commit abc123 --repo upstream/repo",
 	} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("gh log missing %q\nlog:\n%s", want, log)

--- a/internal/refinery/batch.go
+++ b/internal/refinery/batch.go
@@ -87,13 +87,13 @@ func (e *Engineer) AssembleBatch(readyMRs []*MRInfo, config *BatchConfig) []*MRI
 	return batch
 }
 
-// BuildRebaseStack constructs a squash-merge stack on the target branch.
-// Each MR is squash-merged sequentially: target ← MR1 ← MR2 ← MR3.
+// BuildRebaseStack constructs an ancestry-preserving merge stack on the target branch.
+// Each MR is merged sequentially: target ← MR1 ← MR2 ← MR3.
 // Returns the list of MRs that were successfully stacked, and any that
 // conflicted (which are removed from the stack and the stack is rebuilt).
 //
 // On return, the git working directory is on the target branch with all
-// successful MR squash-merges applied (but not pushed).
+// successful MR merges applied (but not pushed).
 func (e *Engineer) BuildRebaseStack(ctx context.Context, batch []*MRInfo, target string) (stacked []*MRInfo, conflicts []*MRInfo, err error) {
 	if len(batch) == 0 {
 		return nil, nil, nil
@@ -113,7 +113,7 @@ func (e *Engineer) BuildRebaseStack(ctx context.Context, batch []*MRInfo, target
 		return nil, nil, fmt.Errorf("get base SHA: %w", err)
 	}
 
-	// Try to stack each MR via squash-merge
+	// Try to stack each MR via merge commit.
 	for _, mr := range batch {
 		_, _ = fmt.Fprintf(e.output, "[Batch] Stacking MR %s (branch %s)...\n", mr.ID, mr.Branch)
 
@@ -126,9 +126,13 @@ func (e *Engineer) BuildRebaseStack(ctx context.Context, batch []*MRInfo, target
 			conflicts = append(conflicts, mr)
 			continue
 		}
+		mergeRef, shaErr := e.submittedBranchHead(mr)
+		if shaErr != nil {
+			return nil, nil, shaErr
+		}
 
 		// Check for conflicts before merging
-		conflictFiles, conflictErr := e.git.CheckConflicts(mr.Branch, target)
+		conflictFiles, conflictErr := e.git.CheckConflicts(mergeRef, target)
 		if conflictErr != nil || len(conflictFiles) > 0 {
 			_, _ = fmt.Fprintf(e.output, "[Batch] MR %s: conflicts detected, removing from batch\n", mr.ID)
 			conflicts = append(conflicts, mr)
@@ -139,17 +143,21 @@ func (e *Engineer) BuildRebaseStack(ctx context.Context, batch []*MRInfo, target
 			}
 			// Rebuild the stack with MRs stacked so far (minus the conflicting one)
 			for _, prev := range stacked {
+				prevRef, refErr := e.submittedBranchHead(prev)
+				if refErr != nil {
+					return nil, nil, refErr
+				}
 				msg := e.getMergeMessage(prev)
-				if mergeErr := e.git.MergeSquash(prev.Branch, msg); mergeErr != nil {
+				if mergeErr := e.git.MergeNoFF(prevRef, msg); mergeErr != nil {
 					return nil, nil, fmt.Errorf("rebuild stack for %s: %w", prev.ID, mergeErr)
 				}
 			}
 			continue
 		}
 
-		// Squash-merge this MR onto the stack
+		// Merge this MR onto the stack, preserving the submitted head in ancestry.
 		msg := e.getMergeMessage(mr)
-		if mergeErr := e.git.MergeSquash(mr.Branch, msg); mergeErr != nil {
+		if mergeErr := e.git.MergeNoFF(mergeRef, msg); mergeErr != nil {
 			_, _ = fmt.Fprintf(e.output, "[Batch] MR %s: merge failed: %v, removing from batch\n", mr.ID, mergeErr)
 			conflicts = append(conflicts, mr)
 
@@ -158,8 +166,12 @@ func (e *Engineer) BuildRebaseStack(ctx context.Context, batch []*MRInfo, target
 				return nil, nil, fmt.Errorf("reset after merge failure: %w", resetErr)
 			}
 			for _, prev := range stacked {
+				prevRef, refErr := e.submittedBranchHead(prev)
+				if refErr != nil {
+					return nil, nil, refErr
+				}
 				prevMsg := e.getMergeMessage(prev)
-				if rebuildErr := e.git.MergeSquash(prev.Branch, prevMsg); rebuildErr != nil {
+				if rebuildErr := e.git.MergeNoFF(prevRef, prevMsg); rebuildErr != nil {
 					return nil, nil, fmt.Errorf("rebuild stack for %s: %w", prev.ID, rebuildErr)
 				}
 			}
@@ -173,15 +185,15 @@ func (e *Engineer) BuildRebaseStack(ctx context.Context, batch []*MRInfo, target
 	return stacked, conflicts, nil
 }
 
-// getMergeMessage returns the commit message for a squash-merged MR.
+// getMergeMessage returns the commit message for a merged MR.
 func (e *Engineer) getMergeMessage(mr *MRInfo) string {
 	// Try to get the original commit message from the branch
 	msg, err := e.git.GetBranchCommitMessage(mr.Branch)
 	if err != nil || strings.TrimSpace(msg) == "" {
 		// Fallback to a descriptive message
-		msg = fmt.Sprintf("Squash merge %s into %s", mr.Branch, mr.Target)
+		msg = fmt.Sprintf("Merge %s into %s", mr.Branch, mr.Target)
 		if mr.SourceIssue != "" {
-			msg = fmt.Sprintf("Squash merge %s into %s (%s)", mr.Branch, mr.Target, mr.SourceIssue)
+			msg = fmt.Sprintf("Merge %s into %s (%s)", mr.Branch, mr.Target, mr.SourceIssue)
 		}
 	}
 	return msg
@@ -233,7 +245,7 @@ func (e *Engineer) ProcessBatch(ctx context.Context, batch []*MRInfo, target str
 	// If only one MR survived after conflict removal, just process it directly
 	if len(stacked) == 1 {
 		_, _ = fmt.Fprintln(e.output, "[Batch] Only 1 MR survived stack construction, processing directly")
-		// We already have the squash merge on the target branch, run gates and push
+		// We already have the merged stack on the target branch, run gates and push.
 		return e.verifyAndPush(ctx, stacked, target)
 	}
 
@@ -311,11 +323,17 @@ func (e *Engineer) processSingleMR(ctx context.Context, mr *MRInfo, target strin
 	mergeMR := *mr
 	mergeMR.Target = target
 	processResult := e.doMerge(ctx, &mergeMR)
+	if strings.TrimSpace(mr.CommitSHA) == "" {
+		mr.CommitSHA = mergeMR.CommitSHA
+	}
 	if processResult.Success {
-		result.Merged = []*MRInfo{mr}
 		result.MergeCommit = processResult.MergeCommit
 		// GH#2321: Run post-merge cleanup (close beads, delete branch, nudge mayor)
-		e.HandleMRInfoSuccess(mr, processResult)
+		if e.HandleMRInfoSuccess(mr, processResult) {
+			result.Merged = []*MRInfo{mr}
+		} else {
+			result.Error = fmt.Errorf("post-merge cleanup proof failed for %s", mr.ID)
+		}
 	} else if processResult.Conflict {
 		result.Conflicts = []*MRInfo{mr}
 	} else if processResult.TestsFailed {
@@ -376,7 +394,7 @@ func (e *Engineer) verifyAndPush(ctx context.Context, stacked []*MRInfo, target 
 }
 
 // fastForwardBatch pushes the current state to the target branch.
-// The working tree must already be on the target branch with all squash-merges applied.
+// The working tree must already be on the target branch with all MR merges applied.
 func (e *Engineer) fastForwardBatch(ctx context.Context, stacked []*MRInfo, target string, result *BatchResult) *BatchResult {
 	// Get the tip SHA
 	tipSHA, err := e.git.Rev("HEAD")
@@ -444,17 +462,22 @@ func (e *Engineer) fastForwardBatch(ctx context.Context, stacked []*MRInfo, targ
 	}
 	_, _ = fmt.Fprintf(e.output, "[Batch] Successfully merged batch: %s (commit %s)\n", strings.Join(ids, ", "), shortSHA(tipSHA))
 
-	result.Merged = stacked
 	result.MergeCommit = tipSHA
 
 	// GH#2321: Run post-merge cleanup for each merged MR — close source beads,
 	// delete branches, nudge mayor, and check convoy completion.
 	// HandleMRInfoSuccess was previously dead code (never called), causing task
 	// beads to remain open after successful merges.
+	cleaned := make([]*MRInfo, 0, len(stacked))
 	for _, mr := range stacked {
 		mergeResult := ProcessResult{Success: true, MergeCommit: tipSHA}
-		e.HandleMRInfoSuccess(mr, mergeResult)
+		if e.HandleMRInfoSuccess(mr, mergeResult) {
+			cleaned = append(cleaned, mr)
+		} else if result.Error == nil {
+			result.Error = fmt.Errorf("post-merge cleanup proof failed for %s", mr.ID)
+		}
 	}
+	result.Merged = cleaned
 
 	return result
 }
@@ -582,7 +605,7 @@ func mrIDs(mrs []*MRInfo) []string {
 	return ids
 }
 
-// resetAndRebuildStack resets the target branch and rebuilds the squash-merge stack.
+// resetAndRebuildStack resets the target branch and rebuilds the merge stack.
 func (e *Engineer) resetAndRebuildStack(mrs []*MRInfo, target string) error {
 	// Reset target to origin
 	if err := e.git.Checkout(target); err != nil {
@@ -594,9 +617,13 @@ func (e *Engineer) resetAndRebuildStack(mrs []*MRInfo, target string) error {
 
 	// Rebuild the stack
 	for _, mr := range mrs {
+		mergeRef, refErr := e.submittedBranchHead(mr)
+		if refErr != nil {
+			return refErr
+		}
 		msg := e.getMergeMessage(mr)
-		if err := e.git.MergeSquash(mr.Branch, msg); err != nil {
-			return fmt.Errorf("squash merge %s: %w", mr.ID, err)
+		if err := e.git.MergeNoFF(mergeRef, msg); err != nil {
+			return fmt.Errorf("merge %s: %w", mr.ID, err)
 		}
 	}
 	return nil

--- a/internal/refinery/batch_test.go
+++ b/internal/refinery/batch_test.go
@@ -379,6 +379,36 @@ func TestBuildRebaseStack_MissingBranch(t *testing.T) {
 	}
 }
 
+func TestBuildRebaseStack_RejectsAdvancedSourceBranch(t *testing.T) {
+	workDir, g, cleanup := testGitRepo(t)
+	defer cleanup()
+
+	branch := "feature-advanced"
+	createFeatureBranch(t, workDir, branch, "a.txt", "submitted\n")
+	commit := run(t, workDir, "git", "rev-parse", branch)
+	run(t, workDir, "git", "checkout", branch)
+	writeFile(t, workDir, "later.txt", "not submitted\n")
+	run(t, workDir, "git", "add", ".")
+	run(t, workDir, "git", "commit", "-m", "feat: later")
+	run(t, workDir, "git", "checkout", "main")
+
+	e := newTestEngineer(t, workDir, g)
+	batch := []*MRInfo{{
+		ID:        "mr-advanced",
+		Branch:    branch,
+		Target:    "main",
+		CommitSHA: commit,
+	}}
+
+	_, _, err := e.BuildRebaseStack(context.Background(), batch, "main")
+	if err == nil {
+		t.Fatal("BuildRebaseStack succeeded for advanced source branch")
+	}
+	if !strings.Contains(err.Error(), "changed from submitted head") {
+		t.Fatalf("BuildRebaseStack error = %q, want submitted-head drift", err.Error())
+	}
+}
+
 // --- ProcessBatch tests ---
 
 func TestProcessBatch_EmptyBatch(t *testing.T) {
@@ -842,7 +872,7 @@ func TestGetMergeMessage_Fallback(t *testing.T) {
 	}
 
 	msg := e.getMergeMessage(mr)
-	if !strings.Contains(msg, "Squash merge") {
+	if !strings.Contains(msg, "Merge") {
 		t.Errorf("expected fallback message, got %q", msg)
 	}
 	if !strings.Contains(msg, "gt-abc") {

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -161,7 +161,7 @@ type MergeQueueConfig struct {
 	AutoPush bool `json:"auto_push"`
 
 	// MergeStrategy controls how the refinery lands work: "direct" (default)
-	// does local squash merge + git push; "pr" uses the VCS provider's merge API
+	// does local merge + git push; "pr" uses the VCS provider's merge API
 	// which respects branch protection/restriction rules.
 	MergeStrategy string `json:"merge_strategy,omitempty"`
 
@@ -530,6 +530,10 @@ func (e *Engineer) doMerge(ctx context.Context, mr *MRInfo, skipGates ...bool) P
 			Error:          fmt.Sprintf("branch %s not found locally", branch),
 		}
 	}
+	mergeRef, err := e.submittedBranchHead(mr)
+	if err != nil {
+		return ProcessResult{Success: false, Error: err.Error()}
+	}
 
 	// Step 2: Checkout the target branch
 	_, _ = fmt.Fprintf(e.output, "[Engineer] Checking out target branch %s...\n", target)
@@ -548,7 +552,7 @@ func (e *Engineer) doMerge(ctx context.Context, mr *MRInfo, skipGates ...bool) P
 
 	// Step 3: Check for merge conflicts (using local branch)
 	_, _ = fmt.Fprintf(e.output, "[Engineer] Checking for conflicts...\n")
-	conflicts, err := e.git.CheckConflicts(branch, target)
+	conflicts, err := e.git.CheckConflicts(mergeRef, target)
 	if err != nil {
 		return ProcessResult{
 			Success:  false,
@@ -567,7 +571,7 @@ func (e *Engineer) doMerge(ctx context.Context, mr *MRInfo, skipGates ...bool) P
 	// Step 3.5: Push submodule commits if the branch changes submodule pointers.
 	// The refinery owns all remote pushes — submodule commits must land before the
 	// parent pointer is merged, otherwise main gets dangling submodule references.
-	subChanges, err := e.git.SubmoduleChanges(target, branch)
+	subChanges, err := e.git.SubmoduleChanges(target, mergeRef)
 	if err != nil {
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: could not check submodule changes: %v\n", err)
 	}
@@ -626,27 +630,27 @@ func (e *Engineer) doMerge(ctx context.Context, mr *MRInfo, skipGates ...bool) P
 	}
 
 	// PR merge path: when merge_strategy=pr, use the VCS provider's merge API
-	// instead of local squash merge + direct push. This respects branch
+	// instead of local merge + direct push. This respects branch
 	// protection/restriction rules and preserves the PR audit trail.
 	// The VCS provider (GitHub, Bitbucket) is selected via vcs_provider config.
 	if e.config.MergeStrategy == "pr" {
 		return e.doMergePR(ctx, mr)
 	}
 
-	// Step 5: Perform the actual merge using squash merge
+	// Step 5: Perform the actual merge, preserving the submitted head in target ancestry.
 	// Get the original commit message from the polecat branch to preserve the
-	// conventional commit format (feat:/fix:) instead of creating redundant merge commits
-	originalMsg, err := e.git.GetBranchCommitMessage(branch)
+	// conventional commit format (feat:/fix:) in the merge commit message.
+	mergeMsg, err := e.git.GetBranchCommitMessage(branch)
 	if err != nil {
 		// Fallback to a descriptive message if we can't get the original
-		originalMsg = fmt.Sprintf("Squash merge %s into %s", branch, target)
+		mergeMsg = fmt.Sprintf("Merge %s into %s", branch, target)
 		if mr.SourceIssue != "" {
-			originalMsg = fmt.Sprintf("Squash merge %s into %s (%s)", branch, target, mr.SourceIssue)
+			mergeMsg = fmt.Sprintf("Merge %s into %s (%s)", branch, target, mr.SourceIssue)
 		}
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: could not get original commit message: %v\n", err)
 	}
-	_, _ = fmt.Fprintf(e.output, "[Engineer] Squash merging with message: %s\n", strings.TrimSpace(originalMsg))
-	if err := e.git.MergeSquash(branch, originalMsg); err != nil {
+	_, _ = fmt.Fprintf(e.output, "[Engineer] Merging with message: %s\n", strings.TrimSpace(mergeMsg))
+	if err := e.git.MergeNoFF(mergeRef, mergeMsg); err != nil {
 		// ZFC: Use git's porcelain output to detect conflicts instead of parsing stderr.
 		// GetConflictingFiles() uses `git diff --diff-filter=U` which is proper.
 		conflicts, conflictErr := e.git.GetConflictingFiles()
@@ -668,7 +672,7 @@ func (e *Engineer) doMerge(ctx context.Context, mr *MRInfo, skipGates ...bool) P
 
 	// Step 5.5: Run post-squash gates on the merged result.
 	// These validate the actual combined code before it goes anywhere.
-	// On failure, reset the merge to undo the local squash commit.
+	// On failure, reset the merge to undo the local merge commit.
 	if !shouldSkipGates {
 		postResult := e.runGatesForPhase(ctx, GatePhasePostSquash)
 		if !postResult.Success {
@@ -698,7 +702,7 @@ func (e *Engineer) doMerge(ctx context.Context, mr *MRInfo, skipGates ...bool) P
 			var slotErr error
 			pushHolder, slotErr = e.acquireMainPushSlot(ctx)
 			if slotErr != nil {
-				// Reset the checked-out target branch to origin to undo the local squash commit.
+				// Reset the checked-out target branch to origin to undo the local merge commit.
 				// ResetHard is required because target is the current branch (checked out in Step 2).
 				if resetErr := e.git.ResetHard("origin/" + target); resetErr != nil {
 					_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to reset %s after slot failure: %v\n", target, resetErr)
@@ -732,7 +736,7 @@ func (e *Engineer) doMerge(ctx context.Context, mr *MRInfo, skipGates ...bool) P
 
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Pushing to origin/%s...\n", target)
 		if err := e.git.Push("origin", target, false); err != nil {
-			// Reset the checked-out target branch to undo the local squash commit.
+			// Reset the checked-out target branch to undo the local merge commit.
 			// Without this, the next retry could see stale local state from the failed push.
 			if resetErr := e.git.ResetHard("origin/" + target); resetErr != nil {
 				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to reset %s after push failure: %v\n", target, resetErr)
@@ -786,7 +790,6 @@ func (e *Engineer) doMergePR(ctx context.Context, mr *MRInfo) ProcessResult {
 			Error:   fmt.Sprintf("no PR provider configured for vcs_provider=%s", provider),
 		}
 	}
-
 	// Step PR.1: Find the PR for this branch
 	pr, err := e.prProvider.FindPullRequest(branch, mr.PRURL, mr.PRNumber, mr.CommitSHA)
 	if err != nil {
@@ -802,6 +805,11 @@ func (e *Engineer) doMergePR(ctx context.Context, mr *MRInfo) ProcessResult {
 		}
 	}
 	_, _ = fmt.Fprintf(e.output, "[Engineer] Found PR #%d for branch %s\n", pr.Number, branch)
+	if strings.TrimSpace(mr.CommitSHA) != "" {
+		if err := requirePullRequestHead(pr, mr.CommitSHA); err != nil {
+			return ProcessResult{Success: false, Error: err.Error()}
+		}
+	}
 
 	// Step PR.2: Check approval status if require_review is enabled
 	requireReview := e.config.RequireReview != nil && *e.config.RequireReview
@@ -827,10 +835,26 @@ func (e *Engineer) doMergePR(ctx context.Context, mr *MRInfo) ProcessResult {
 	if eligibility := e.recheckMRStillMergeable(mr, target); !eligibility.Success {
 		return eligibility
 	}
+	if err := e.ensureMRInfoCommitSHA(mr); err != nil {
+		return ProcessResult{Success: false, Error: err.Error()}
+	}
+	// Re-read immediately before merge so a PR head advance cannot sneak between
+	// approval/recheck and the provider merge call.
+	pr, err = e.prProvider.FindPullRequest(branch, mr.PRURL, mr.PRNumber, mr.CommitSHA)
+	if err != nil {
+		return ProcessResult{Success: false, Error: fmt.Sprintf("failed to refresh PR for branch %s: %v", branch, err)}
+	}
+	if pr == nil {
+		return ProcessResult{Success: false, Error: fmt.Sprintf("no open PR found for branch %s — merge_strategy=pr requires a PR", branch)}
+	}
+	if err := requirePullRequestHead(pr, mr.CommitSHA); err != nil {
+		return ProcessResult{Success: false, Error: err.Error()}
+	}
 
-	// Step PR.3: Merge via VCS provider API using squash merge
-	_, _ = fmt.Fprintf(e.output, "[Engineer] Merging PR #%d via %s API (squash)...\n", pr.Number, provider)
-	mergeCommit, err := e.prProvider.MergePR(pr, "squash")
+	// Step PR.3: Merge via VCS provider API with a merge commit so the submitted
+	// head remains in target ancestry for post-merge proof.
+	_, _ = fmt.Fprintf(e.output, "[Engineer] Merging PR #%d via %s API (merge)...\n", pr.Number, provider)
+	mergeCommit, err := e.prProvider.MergePR(pr, "merge")
 	if err != nil {
 		return ProcessResult{
 			Success: false,
@@ -885,6 +909,7 @@ func (e *Engineer) recheckMRStillMergeable(mr *MRInfo, target string) ProcessRes
 		return e.rejectMRBeforeMerge(mr, "MR has missing source_issue")
 	}
 
+	fieldCommit := ""
 	if mrID := strings.TrimSpace(mr.ID); mrID != "" && !e.isSyntheticMergeMechanicsMR(mr) {
 		mrIssue, err := e.beads.Show(mrID)
 		if err != nil {
@@ -934,10 +959,24 @@ func (e *Engineer) recheckMRStillMergeable(mr *MRInfo, target string) ProcessRes
 		if fields.SourceIssue != sourceIssue {
 			return e.rejectMRBeforeMerge(mr, fmt.Sprintf("MR source_issue changed from %s to %s", sourceIssue, fields.SourceIssue))
 		}
+		fieldCommit = strings.TrimSpace(fields.CommitSHA)
 		sourceIssue = fields.SourceIssue
 	}
 
-	return e.recheckMRSourceStillMergeable(mr, sourceIssue)
+	if eligibility := e.recheckMRSourceStillMergeable(mr, sourceIssue); !eligibility.Success {
+		return eligibility
+	}
+	if strings.TrimSpace(mr.ID) != "" && !e.isSyntheticMergeMechanicsMR(mr) {
+		if fieldCommit == "" {
+			return e.rejectMRBeforeMerge(mr, "MR has missing commit_sha")
+		}
+		if mr.CommitSHA == "" {
+			mr.CommitSHA = fieldCommit
+		} else if fieldCommit != strings.TrimSpace(mr.CommitSHA) {
+			return e.rejectMRBeforeMerge(mr, fmt.Sprintf("MR commit_sha changed from %s to %s", shortSHA(mr.CommitSHA), shortSHA(fieldCommit)))
+		}
+	}
+	return ProcessResult{Success: true}
 }
 
 func (e *Engineer) isSyntheticMergeMechanicsMR(mr *MRInfo) bool {
@@ -1311,7 +1350,7 @@ func (e *Engineer) ProcessMRInfo(ctx context.Context, mr *MRInfo) ProcessResult 
 }
 
 // HandleMRInfoSuccess handles a successful merge from MRInfo.
-func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
+func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) bool {
 	workBeadID := resolveMergedWorkBead(e.beads.ForAgentBead(), mergedWorkBeadCloseRequest{
 		MRID:        mr.ID,
 		Branch:      mr.Branch,
@@ -1329,11 +1368,16 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 	} else {
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Released merge slot\n")
 	}
+	if err := e.verifyMRInfoPostMergeProof(mr); err != nil {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] Post-merge proof failed for %s: %v\n", mr.ID, err)
+		return false
+	}
 
 	// Update and close the MR bead
-	if mr.ID != "" {
+	if mr.ID != "" && !e.isSyntheticMergeMechanicsMR(mr) {
 		if err := e.closeMRWithReason(mr, string(CloseReasonMerged), result.MergeCommit); err != nil {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to close MR %s: %v\n", mr.ID, err)
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Post-merge cleanup failed for %s: %v\n", mr.ID, err)
+			return false
 		}
 	}
 
@@ -1351,17 +1395,12 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 	// and rot as open issues (re-dlcs/re-4i3b/re-gcii pattern).
 	e.closeSupersededConflictArtifacts(mr)
 
-	// 2. Delete source branch (local and remote).
+	// 2. Delete source branch (remote first, then local only if still exact).
 	// Polecat branches (polecat/*) are always cleaned up — they are ephemeral
 	// work branches that should never persist after merge. Other branches
 	// respect the DeleteMergedBranches config.
 	isPolecat := strings.HasPrefix(mr.Branch, "polecat/")
 	if mr.Branch != "" && (e.config.DeleteMergedBranches || isPolecat) {
-		if err := e.git.DeleteBranch(mr.Branch, true); err != nil {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to delete local branch %s: %v\n", mr.Branch, err)
-		} else {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Deleted local branch: %s\n", mr.Branch)
-		}
 		// Remote delete — only polecat branches. Non-polecat branches may belong
 		// to contributor forks with open upstream PRs; deleting them from origin
 		// causes GitHub to auto-close those PRs via head_ref_delete. (GH#2669)
@@ -1369,13 +1408,23 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 		// When merge_strategy=pr, polecat branches have GitHub PRs that should
 		// be closed via gh pr merge (showing "merged"), not via branch deletion
 		// (which shows "closed" and destroys the PR audit trail).
+		expectedHead := strings.TrimSpace(mr.CommitSHA)
+		remoteDeleteSafe := true
 		if isPolecat {
-			if e.git.HasOpenPullRequest(git.PullRequestRef{URL: mr.PRURL, Number: mr.PRNumber, Branch: mr.Branch, HeadSHA: mr.CommitSHA}) {
+			if e.git.HasOpenPullRequest(git.PullRequestRef{URL: mr.PRURL, Number: mr.PRNumber, Branch: mr.Branch, HeadSHA: expectedHead}) {
 				_, _ = fmt.Fprintf(e.output, "[Engineer] Skipping remote branch delete for %s: open PR exists (gas-fk4)\n", mr.Branch)
-			} else if err := e.git.DeleteRemoteBranch("origin", mr.Branch); err != nil {
+			} else if err := e.git.DeleteRemoteBranchIfAt("origin", mr.Branch, expectedHead); err != nil {
 				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to delete remote branch %s: %v\n", mr.Branch, err)
+				remoteDeleteSafe = false
 			} else {
 				_, _ = fmt.Fprintf(e.output, "[Engineer] Deleted remote branch: %s\n", mr.Branch)
+			}
+		}
+		if remoteDeleteSafe {
+			if err := e.deleteLocalBranchIfAt(mr.Branch, expectedHead); err != nil {
+				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to delete local branch %s: %v\n", mr.Branch, err)
+			} else {
+				_, _ = fmt.Fprintf(e.output, "[Engineer] Deleted local branch: %s\n", mr.Branch)
 			}
 		}
 	}
@@ -1398,6 +1447,116 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 
 	// 5. Log success
 	_, _ = fmt.Fprintf(e.output, "[Engineer] ✓ Merged: %s (commit: %s)\n", mr.ID, result.MergeCommit)
+	return true
+}
+
+func (e *Engineer) ensureMRInfoCommitSHA(mr *MRInfo) error {
+	if mr == nil {
+		return fmt.Errorf("merge request is missing")
+	}
+	if strings.TrimSpace(mr.CommitSHA) != "" {
+		return nil
+	}
+	if !e.isSyntheticMergeMechanicsMR(mr) {
+		return fmt.Errorf("missing submitted commit_sha")
+	}
+	if e.git == nil {
+		return fmt.Errorf("missing submitted commit_sha and git client is missing")
+	}
+	branch := strings.TrimSpace(mr.Branch)
+	if branch == "" {
+		return fmt.Errorf("missing submitted commit_sha and source branch")
+	}
+	sha, err := e.git.Rev(branch)
+	if err != nil {
+		return fmt.Errorf("resolve submitted head for %s: %w", branch, err)
+	}
+	mr.CommitSHA = strings.TrimSpace(sha)
+	return nil
+}
+
+func (e *Engineer) submittedBranchHead(mr *MRInfo) (string, error) {
+	if err := e.ensureMRInfoCommitSHA(mr); err != nil {
+		return "", err
+	}
+	if e.git == nil {
+		return "", fmt.Errorf("git client is missing")
+	}
+	branch := strings.TrimSpace(mr.Branch)
+	if branch == "" {
+		return "", fmt.Errorf("missing source branch")
+	}
+	commit := strings.TrimSpace(mr.CommitSHA)
+	localHead, err := e.git.Rev("refs/heads/" + branch + "^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("resolve source branch %s: %w", branch, err)
+	}
+	localHead = strings.TrimSpace(localHead)
+	if localHead != commit {
+		return "", fmt.Errorf("source branch %s changed from submitted head %s to %s", branch, shortSHA(commit), shortSHA(localHead))
+	}
+	return commit, nil
+}
+
+func (e *Engineer) deleteLocalBranchIfAt(branch, expectedHead string) error {
+	branch = strings.TrimSpace(branch)
+	expectedHead = strings.TrimSpace(expectedHead)
+	if branch == "" {
+		return fmt.Errorf("missing source branch")
+	}
+	if expectedHead == "" {
+		return fmt.Errorf("missing submitted commit_sha")
+	}
+	localHead, err := e.git.Rev("refs/heads/" + branch + "^{commit}")
+	if err != nil {
+		return fmt.Errorf("resolve local branch head: %w", err)
+	}
+	if strings.TrimSpace(localHead) != expectedHead {
+		return fmt.Errorf("local branch head changed from submitted %s to %s", shortSHA(expectedHead), shortSHA(localHead))
+	}
+	return e.git.DeleteBranch(branch, false)
+}
+
+func requirePullRequestHead(pr *git.PullRequestInfo, expectedHead string) error {
+	expectedHead = strings.TrimSpace(expectedHead)
+	if expectedHead == "" {
+		return fmt.Errorf("missing submitted commit_sha")
+	}
+	if pr == nil {
+		return fmt.Errorf("pull request is missing")
+	}
+	actualHead := strings.TrimSpace(pr.HeadSHA)
+	if actualHead == "" {
+		return fmt.Errorf("PR #%d head SHA is missing", pr.Number)
+	}
+	if actualHead != expectedHead {
+		return fmt.Errorf("PR #%d head changed from submitted %s to %s", pr.Number, shortSHA(expectedHead), shortSHA(actualHead))
+	}
+	return nil
+}
+
+func (e *Engineer) verifyMRInfoPostMergeProof(mr *MRInfo) error {
+	if mr == nil {
+		return fmt.Errorf("merge request is missing")
+	}
+	if e.git == nil {
+		return fmt.Errorf("git client is missing")
+	}
+	target := strings.TrimSpace(mr.Target)
+	if target == "" {
+		return fmt.Errorf("missing target branch")
+	}
+	if source := strings.TrimSpace(mr.Branch); source != "" && source == target {
+		return fmt.Errorf("source branch %s matches target branch", source)
+	}
+	commit := strings.TrimSpace(mr.CommitSHA)
+	if commit == "" {
+		return fmt.Errorf("missing submitted commit_sha")
+	}
+	if err := e.git.VerifyPushedCommitReachableFromPushTarget("origin", target, commit); err != nil {
+		return fmt.Errorf("target %s does not contain submitted head %s: %w", target, commit, err)
+	}
+	return nil
 }
 
 // HandleMRInfoFailure handles a failed merge from MRInfo.
@@ -1535,11 +1694,16 @@ func (e *Engineer) closeMRWithReason(mr *MRInfo, closeReason string, mergeCommit
 	if len(mergeCommit) > 0 {
 		commit = mergeCommit[0]
 	}
+	var expected *MergeRequest
+	if normalizedMRCloseReason(closeReason) == string(CloseReasonMerged) {
+		expected = mergeRequestFromMRInfo(mr)
+	}
 	result, err := closeTerminalMR(e.beads, mr.ID, terminalMRCloseOptions{
 		Reason:        closeReason,
 		MergeCommit:   commit,
 		AgentBeadHint: mr.AgentBead,
 		MissingOK:     true,
+		ExpectedMR:    expected,
 	})
 	if err != nil {
 		return err
@@ -1551,6 +1715,23 @@ func (e *Engineer) closeMRWithReason(mr *MRInfo, closeReason string, mergeCommit
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to clear agent bead %s active_mr: %v\n", result.AgentBead, result.AgentActiveMRClearErr)
 	}
 	return nil
+}
+
+func mergeRequestFromMRInfo(mr *MRInfo) *MergeRequest {
+	if mr == nil {
+		return nil
+	}
+	return &MergeRequest{
+		ID:           mr.ID,
+		Branch:       mr.Branch,
+		Worker:       mr.Worker,
+		AgentBead:    mr.AgentBead,
+		IssueID:      mr.SourceIssue,
+		TargetBranch: mr.Target,
+		CommitSHA:    mr.CommitSHA,
+		PRURL:        mr.PRURL,
+		PRNumber:     mr.PRNumber,
+	}
 }
 
 func normalizedMRCloseReason(closeReason string) string {
@@ -1652,13 +1833,13 @@ func (e *Engineer) createConflictResolutionTaskForMR(mr *MRInfo, _ ProcessResult
 
 ## Instructions
 1. Check out the branch: git checkout %s
-2. Rebase onto target: git rebase origin/%s
+2. Merge target without rewriting branch history: git merge --no-ff origin/%s
 3. Resolve conflicts in your editor
-4. Complete the rebase: git add . && git rebase --continue
-5. Force-push the resolved branch: git push -f
+4. Complete the merge: git add . && git commit
+5. Push the resolved branch: git push origin %s
 6. Close this task: bd close <this-task-id>
 
-The Refinery will automatically retry the merge after you force-push.`,
+The Refinery will automatically retry the merge after you push.`,
 		mr.Branch,
 		mr.ID,
 		mr.Branch,
@@ -1667,6 +1848,7 @@ The Refinery will automatically retry the merge after you force-push.`,
 		retryCount,
 		mr.Branch,
 		mr.Target,
+		mr.Branch,
 	)
 
 	// Create the conflict resolution task

--- a/internal/refinery/engineer_pr_merge_test.go
+++ b/internal/refinery/engineer_pr_merge_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,31 @@ import (
 	gitpkg "github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/rig"
 )
+
+type recordingPRProvider struct {
+	mergeMethod string
+	mergeFunc   func(method string) (string, error)
+	headSHA     string
+}
+
+func (p *recordingPRProvider) FindPullRequest(_ string, _ string, _ int, headSHA string) (*gitpkg.PullRequestInfo, error) {
+	if p.headSHA != "" {
+		headSHA = p.headSHA
+	}
+	return &gitpkg.PullRequestInfo{Number: 42, State: "OPEN", HeadSHA: headSHA}, nil
+}
+
+func (p *recordingPRProvider) IsPRApproved(*gitpkg.PullRequestInfo) (bool, error) {
+	return true, nil
+}
+
+func (p *recordingPRProvider) MergePR(_ *gitpkg.PullRequestInfo, method string) (string, error) {
+	p.mergeMethod = method
+	if p.mergeFunc != nil {
+		return p.mergeFunc(method)
+	}
+	return "", nil
+}
 
 func TestEngineer_LoadConfig_MergeStrategyPR(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -163,6 +189,67 @@ func TestDoMergePR_NoPR_ReturnsError(t *testing.T) {
 	// The error should mention finding a PR
 	if !strings.Contains(result.Error, "PR") && !strings.Contains(result.Error, "pr") {
 		t.Errorf("expected PR-related error, got: %s", result.Error)
+	}
+}
+
+func TestDoMergePR_UsesMergeCommitAndPreservesSubmittedHead(t *testing.T) {
+	workDir, g, _ := testGitRepo(t)
+	branch := "feat/pr-merge"
+	createFeatureBranch(t, workDir, branch, "pr.txt", "hello")
+	commit := run(t, workDir, "git", "rev-parse", branch)
+
+	e := newTestEngineer(t, workDir, g)
+	provider := &recordingPRProvider{mergeFunc: func(method string) (string, error) {
+		if method != "merge" {
+			return "", fmt.Errorf("method = %s, want merge", method)
+		}
+		run(t, workDir, "git", "checkout", "main")
+		run(t, workDir, "git", "merge", "--no-ff", "-m", "merge PR", branch)
+		run(t, workDir, "git", "push", "origin", "main")
+		return run(t, workDir, "git", "rev-parse", "main"), nil
+	}}
+	e.prProvider = provider
+
+	result := e.doMergePR(context.Background(), &MRInfo{ID: "mr-pr-merge", Branch: branch, Target: "main", CommitSHA: commit})
+	if !result.Success {
+		t.Fatalf("doMergePR failed: %s", result.Error)
+	}
+	if provider.mergeMethod != "merge" {
+		t.Fatalf("MergePR method = %q, want merge", provider.mergeMethod)
+	}
+	if err := g.VerifyPushedCommitReachableFromPushTarget("origin", "main", commit); err != nil {
+		t.Fatalf("submitted head not reachable after PR merge: %v", err)
+	}
+}
+
+func TestDoMergePR_RejectsAdvancedPRHead(t *testing.T) {
+	workDir, g, _ := testGitRepo(t)
+	branch := "feat/pr-advanced"
+	createFeatureBranch(t, workDir, branch, "pr.txt", "hello")
+	commit := run(t, workDir, "git", "rev-parse", branch)
+	run(t, workDir, "git", "checkout", branch)
+	writeFile(t, workDir, "later.txt", "not submitted\n")
+	run(t, workDir, "git", "add", ".")
+	run(t, workDir, "git", "commit", "-m", "feat: later")
+	advanced := run(t, workDir, "git", "rev-parse", branch)
+	run(t, workDir, "git", "checkout", "main")
+
+	e := newTestEngineer(t, workDir, g)
+	provider := &recordingPRProvider{
+		headSHA: advanced,
+		mergeFunc: func(method string) (string, error) {
+			t.Fatalf("MergePR called for advanced PR head with method %s", method)
+			return "", nil
+		},
+	}
+	e.prProvider = provider
+
+	result := e.doMergePR(context.Background(), &MRInfo{ID: "mr-pr-advanced", Branch: branch, Target: "main", CommitSHA: commit})
+	if result.Success {
+		t.Fatal("doMergePR succeeded for advanced PR head")
+	}
+	if !strings.Contains(result.Error, "head changed") {
+		t.Fatalf("doMergePR error = %q, want head changed", result.Error)
 	}
 }
 

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -1052,6 +1052,180 @@ func TestPostMergeConvoyCheck_NoTownBeads(t *testing.T) {
 	}
 }
 
+func TestHandleMRInfoSuccess_ProofFailurePreservesRemoteBranch(t *testing.T) {
+	workDir, g, cleanup := testGitRepo(t)
+	defer cleanup()
+
+	branch := "polecat/test/proof-fail"
+	createFeatureBranch(t, workDir, branch, "proof.txt", "not landed\n")
+	commit := run(t, workDir, "git", "rev-parse", branch)
+	run(t, workDir, "git", "push", "origin", branch)
+
+	e := newTestEngineer(t, workDir, g)
+	var buf bytes.Buffer
+	e.SetOutput(&buf)
+	e.HandleMRInfoSuccess(&MRInfo{
+		ID:          "gt-mr-proof-fail",
+		Branch:      branch,
+		Target:      "main",
+		SourceIssue: "gt-proof-fail",
+		CommitSHA:   commit,
+	}, ProcessResult{Success: true, MergeCommit: "unused"})
+
+	if !strings.Contains(buf.String(), "Post-merge proof failed") {
+		t.Fatalf("output missing proof failure:\n%s", buf.String())
+	}
+	if out := run(t, workDir, "git", "ls-remote", "--heads", "origin", branch); !strings.Contains(out, commit) {
+		t.Fatalf("remote branch was not preserved; ls-remote=%q want commit %s", out, commit)
+	}
+}
+
+func TestHandleMRInfoSuccess_VerifiedHeadLeaseDeletesRemoteBranch(t *testing.T) {
+	workDir, g, cleanup := testGitRepo(t)
+	defer cleanup()
+	installNoPRGH(t)
+	run(t, workDir, "git", "remote", "add", "upstream", "https://github.com/example/repo.git")
+
+	branch := "polecat/test/proof-pass"
+	createFeatureBranch(t, workDir, branch, "proof.txt", "landed\n")
+	commit := run(t, workDir, "git", "rev-parse", branch)
+	run(t, workDir, "git", "push", "origin", branch)
+	run(t, workDir, "git", "checkout", "main")
+	run(t, workDir, "git", "merge", "--ff-only", branch)
+	run(t, workDir, "git", "push", "origin", "main")
+	mergeCommit := run(t, workDir, "git", "rev-parse", "main")
+
+	e := newTestEngineer(t, workDir, g)
+	e.HandleMRInfoSuccess(&MRInfo{
+		ID:        "mr-proof-pass",
+		Branch:    branch,
+		Target:    "main",
+		CommitSHA: commit,
+	}, ProcessResult{Success: true, MergeCommit: mergeCommit})
+
+	if out := run(t, workDir, "git", "ls-remote", "--heads", "origin", branch); strings.TrimSpace(out) != "" {
+		t.Fatalf("remote branch still exists after verified cleanup: %q", out)
+	}
+}
+
+func TestDoMergeDirectPreservesSubmittedHeadForPostMergeProof(t *testing.T) {
+	workDir, g, cleanup := testGitRepo(t)
+	defer cleanup()
+	installNoPRGH(t)
+
+	branch := "polecat/test/native-merge"
+	createFeatureBranch(t, workDir, branch, "native.txt", "native merge\n")
+	commit := run(t, workDir, "git", "rev-parse", branch)
+	run(t, workDir, "git", "push", "origin", branch)
+
+	e := newTestEngineer(t, workDir, g)
+	mr := &MRInfo{
+		ID:        "mr-native-merge",
+		Branch:    branch,
+		Target:    "main",
+		CommitSHA: commit,
+	}
+	result := e.doMerge(context.Background(), mr)
+	if !result.Success {
+		t.Fatalf("doMerge failed: %s", result.Error)
+	}
+	if err := g.VerifyPushedCommitReachableFromPushTarget("origin", "main", commit); err != nil {
+		t.Fatalf("submitted head not reachable after direct merge: %v", err)
+	}
+	run(t, workDir, "git", "remote", "add", "upstream", "https://github.com/example/repo.git")
+	if !e.HandleMRInfoSuccess(mr, result) {
+		t.Fatal("HandleMRInfoSuccess failed after verified direct merge")
+	}
+	if out := run(t, workDir, "git", "ls-remote", "--heads", "origin", branch); strings.TrimSpace(out) != "" {
+		t.Fatalf("remote branch still exists after native verified cleanup: %q", out)
+	}
+}
+
+func TestDoMergeDirectRejectsAdvancedSourceBranch(t *testing.T) {
+	workDir, g, cleanup := testGitRepo(t)
+	defer cleanup()
+
+	branch := "polecat/test/native-advanced"
+	createFeatureBranch(t, workDir, branch, "native.txt", "submitted\n")
+	commit := run(t, workDir, "git", "rev-parse", branch)
+	run(t, workDir, "git", "checkout", branch)
+	writeFile(t, workDir, "later.txt", "not submitted\n")
+	run(t, workDir, "git", "add", ".")
+	run(t, workDir, "git", "commit", "-m", "feat: later")
+	run(t, workDir, "git", "checkout", "main")
+
+	e := newTestEngineer(t, workDir, g)
+	result := e.doMerge(context.Background(), &MRInfo{
+		ID:        "mr-native-advanced",
+		Branch:    branch,
+		Target:    "main",
+		CommitSHA: commit,
+	})
+	if result.Success {
+		t.Fatal("doMerge succeeded for advanced source branch")
+	}
+	if !strings.Contains(result.Error, "changed from submitted head") {
+		t.Fatalf("doMerge error = %q, want submitted-head drift", result.Error)
+	}
+}
+
+func TestHandleMRInfoSuccess_RemoteLeaseFailurePreservesLocalBranch(t *testing.T) {
+	workDir, g, cleanup := testGitRepo(t)
+	defer cleanup()
+	installNoPRGH(t)
+	run(t, workDir, "git", "remote", "add", "upstream", "https://github.com/example/repo.git")
+
+	branch := "polecat/test/lease-advanced"
+	createFeatureBranch(t, workDir, branch, "proof.txt", "landed\n")
+	commit := run(t, workDir, "git", "rev-parse", branch)
+	run(t, workDir, "git", "push", "origin", branch)
+	run(t, workDir, "git", "checkout", "main")
+	run(t, workDir, "git", "merge", "--ff-only", commit)
+	run(t, workDir, "git", "push", "origin", "main")
+	mergeCommit := run(t, workDir, "git", "rev-parse", "main")
+	run(t, workDir, "git", "checkout", branch)
+	writeFile(t, workDir, "later.txt", "preserve me\n")
+	run(t, workDir, "git", "add", ".")
+	run(t, workDir, "git", "commit", "-m", "feat: preserve branch")
+	advanced := run(t, workDir, "git", "rev-parse", branch)
+	run(t, workDir, "git", "push", "origin", branch)
+	run(t, workDir, "git", "checkout", "main")
+
+	e := newTestEngineer(t, workDir, g)
+	if !e.HandleMRInfoSuccess(&MRInfo{
+		ID:        "mr-lease-advanced",
+		Branch:    branch,
+		Target:    "main",
+		CommitSHA: commit,
+	}, ProcessResult{Success: true, MergeCommit: mergeCommit}) {
+		t.Fatal("HandleMRInfoSuccess returned false")
+	}
+	if out := run(t, workDir, "git", "ls-remote", "--heads", "origin", branch); !strings.Contains(out, advanced) {
+		t.Fatalf("remote advanced branch was not preserved; ls-remote=%q want %s", out, advanced)
+	}
+	if got := run(t, workDir, "git", "rev-parse", branch); got != advanced {
+		t.Fatalf("local branch = %s, want advanced head %s", got, advanced)
+	}
+}
+
+func installNoPRGH(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gh")
+	script := `#!/bin/sh
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  printf '[]\n'
+  exit 0
+fi
+printf 'unexpected gh args: %s\n' "$*" >&2
+exit 1
+`
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 func TestCheckAndCloseCompletedConvoys_UsesHardenedBDEnvs(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows - shell stubs")

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -664,6 +664,13 @@ func (m *Manager) findMRForTerminalCleanup(idOrBranch string, b *beads.Beads) (*
 	return m.issueToMR(issue), nil
 }
 
+// FindMRForPostMerge resolves an MR using the same open/terminal lookup rules
+// as PostMerge, so callers can prove the merge before closing beads.
+func (m *Manager) FindMRForPostMerge(idOrBranch string) (*MergeRequest, error) {
+	b := beads.New(m.rig.BeadsPath())
+	return m.findMRForTerminalCleanup(idOrBranch, b)
+}
+
 // Retry is deprecated - the Refinery agent handles retry logic autonomously.
 // ZFC-compliant: no state file, agent uses beads issue status.
 // The agent will automatically retry failed MRs in its patrol cycle.
@@ -742,6 +749,20 @@ func (m *Manager) PostMerge(idOrBranch string) (*PostMergeResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	return m.postMergeMR(b, mr)
+}
+
+// PostMergeMR performs post-merge cleanup for an MR snapshot that the caller has
+// already verified. This keeps proof and side effects on the same MR metadata.
+func (m *Manager) PostMergeMR(mr *MergeRequest) (*PostMergeResult, error) {
+	if mr == nil {
+		return nil, ErrMRNotFound
+	}
+	b := beads.New(m.rig.BeadsPath())
+	return m.postMergeMR(b, mr)
+}
+
+func (m *Manager) postMergeMR(b *beads.Beads, mr *MergeRequest) (*PostMergeResult, error) {
 	workBeadID := resolveMergedWorkBead(b.ForAgentBead(), mergedWorkBeadCloseRequest{
 		MRID:        mr.ID,
 		Branch:      mr.Branch,
@@ -759,6 +780,7 @@ func (m *Manager) PostMerge(idOrBranch string) (*PostMergeResult, error) {
 		Reason:        string(CloseReasonMerged),
 		MergeCommit:   mr.MergeCommit,
 		AgentBeadHint: mr.AgentBead,
+		ExpectedMR:    mr,
 	})
 	if err != nil {
 		return result, fmt.Errorf("closing MR bead: %w", err)

--- a/internal/refinery/pr_provider_bitbucket.go
+++ b/internal/refinery/pr_provider_bitbucket.go
@@ -30,12 +30,8 @@ func newBitbucketPRProvider(g *git.Git) (PRProvider, error) {
 	}, nil
 }
 
-func (p *bitbucketPRProvider) FindPullRequest(branch, _ string, _ int, _ string) (*git.PullRequestInfo, error) {
-	number, err := p.git.FindBitbucketPRNumber(p.workspace, p.repoSlug, branch)
-	if err != nil || number == 0 {
-		return nil, err
-	}
-	return &git.PullRequestInfo{Number: number, State: "OPEN"}, nil
+func (p *bitbucketPRProvider) FindPullRequest(branch, _ string, _ int, headSHA string) (*git.PullRequestInfo, error) {
+	return p.git.FindBitbucketPullRequest(p.workspace, p.repoSlug, branch, headSHA)
 }
 
 func (p *bitbucketPRProvider) IsPRApproved(pr *git.PullRequestInfo) (bool, error) {
@@ -43,15 +39,9 @@ func (p *bitbucketPRProvider) IsPRApproved(pr *git.PullRequestInfo) (bool, error
 }
 
 func (p *bitbucketPRProvider) MergePR(pr *git.PullRequestInfo, method string) (string, error) {
-	// Map generic merge methods to Bitbucket strategy names.
-	bbStrategy := method
-	switch method {
-	case "squash":
-		bbStrategy = "squash"
-	case "merge":
-		bbStrategy = "merge_commit"
-	case "rebase":
-		bbStrategy = "fast_forward"
+	prNumber := 0
+	if pr != nil {
+		prNumber = pr.Number
 	}
-	return p.git.BitbucketPRMerge(p.workspace, p.repoSlug, pr.Number, bbStrategy)
+	return "", fmt.Errorf("bitbucket PR merge is disabled until the provider supports submitted-head conditional merge for PR #%d", prNumber)
 }

--- a/internal/refinery/prepush_recheck_test.go
+++ b/internal/refinery/prepush_recheck_test.go
@@ -25,8 +25,8 @@ type prepushPRProvider struct {
 	mergeCalled bool
 }
 
-func (p *prepushPRProvider) FindPullRequest(string, string, int, string) (*gitpkg.PullRequestInfo, error) {
-	return &gitpkg.PullRequestInfo{Number: 42, State: "OPEN"}, nil
+func (p *prepushPRProvider) FindPullRequest(_ string, _ string, _ int, headSHA string) (*gitpkg.PullRequestInfo, error) {
+	return &gitpkg.PullRequestInfo{Number: 42, State: "OPEN", HeadSHA: headSHA}, nil
 }
 
 func (p *prepushPRProvider) IsPRApproved(*gitpkg.PullRequestInfo) (bool, error) {
@@ -125,13 +125,24 @@ func prepushIssue(id, description string, labels ...string) *beadsdk.Issue {
 	}
 }
 
-func prepushMRIssue(id, branch, target, sourceIssue string) *beadsdk.Issue {
-	desc := beads.FormatMRFields(&beads.MRFields{
+func prepushMRIssue(id, branch, target, sourceIssue string, commitSHA ...string) *beadsdk.Issue {
+	fields := &beads.MRFields{
 		Branch:      branch,
 		Target:      target,
 		SourceIssue: sourceIssue,
 		Worker:      "polecats/test",
 		Rig:         "test-rig",
+	}
+	if len(commitSHA) > 0 {
+		fields.CommitSHA = commitSHA[0]
+	}
+	desc := beads.FormatMRFields(&beads.MRFields{
+		Branch:      fields.Branch,
+		Target:      fields.Target,
+		SourceIssue: fields.SourceIssue,
+		Worker:      fields.Worker,
+		Rig:         fields.Rig,
+		CommitSHA:   fields.CommitSHA,
 	})
 	return prepushIssue(id, desc, "gt:merge-request")
 }
@@ -280,9 +291,10 @@ func TestDoMerge_RechecksSourceFlagsBeforeDirectPush(t *testing.T) {
 			workDir, _, cleanup := testGitRepo(t)
 			defer cleanup()
 			createFeatureBranch(t, workDir, "feature-"+tc.name, tc.name+".txt", tc.name+"\n")
+			commit := run(t, workDir, "git", "rev-parse", "feature-"+tc.name)
 			store := newPrepushStore(
 				prepushIssue("gt-src", ""),
-				prepushMRIssue("gt-mr", "feature-"+tc.name, "main", "gt-src"),
+				prepushMRIssue("gt-mr", "feature-"+tc.name, "main", "gt-src", commit),
 			)
 			e := newPrepushEngineer(t, workDir, store)
 			before := run(t, workDir, "git", "rev-parse", "origin/main")
@@ -297,7 +309,7 @@ func TestDoMerge_RechecksSourceFlagsBeforeDirectPush(t *testing.T) {
 				return &beads.MergeSlotStatus{Available: true, Holder: holder}, nil
 			}
 
-			mr := &MRInfo{ID: "gt-mr", Branch: "feature-" + tc.name, Target: "main", SourceIssue: "gt-src"}
+			mr := &MRInfo{ID: "gt-mr", Branch: "feature-" + tc.name, Target: "main", SourceIssue: "gt-src", CommitSHA: commit}
 			result := e.doMerge(context.Background(), mr)
 			if result.Success || !result.NoMerge {
 				t.Fatalf("expected clean policy rejection before direct push, got: %+v", result)
@@ -341,9 +353,10 @@ func TestDoMerge_RechecksBeforeSubmodulePush(t *testing.T) {
 	run(t, workDir, "git", "checkout", "-b", "feature-submodule", "main")
 	run(t, workDir, "git", "add", "libs/sub")
 	run(t, workDir, "git", "commit", "-m", "feat: update submodule")
+	commit := run(t, workDir, "git", "rev-parse", "feature-submodule")
 	run(t, workDir, "git", "checkout", "main")
 
-	store := newPrepushStore(prepushIssue("gt-src", ""), prepushMRIssue("gt-mr", "feature-submodule", "main", "gt-src"))
+	store := newPrepushStore(prepushIssue("gt-src", ""), prepushMRIssue("gt-mr", "feature-submodule", "main", "gt-src", commit))
 	sourceReads := 0
 	store.beforeGet = func(id string) {
 		if id != "gt-src" {
@@ -357,7 +370,7 @@ func TestDoMerge_RechecksBeforeSubmodulePush(t *testing.T) {
 	}
 	e := newPrepushEngineer(t, workDir, store)
 
-	mr := &MRInfo{ID: "gt-mr", Branch: "feature-submodule", Target: "main", SourceIssue: "gt-src"}
+	mr := &MRInfo{ID: "gt-mr", Branch: "feature-submodule", Target: "main", SourceIssue: "gt-src", CommitSHA: commit}
 	result := e.doMerge(context.Background(), mr)
 	if result.Success || !result.NoMerge {
 		t.Fatalf("expected clean policy rejection before submodule push, got: %+v", result)
@@ -374,7 +387,8 @@ func TestDoMerge_RechecksBeforeSubmodulePush(t *testing.T) {
 func TestDoMergePR_RechecksSourceBeforeMergeAPI(t *testing.T) {
 	workDir, _, cleanup := testGitRepo(t)
 	defer cleanup()
-	store := newPrepushStore(prepushIssue("gt-src", ""), prepushMRIssue("gt-mr-pr", "feature-pr", "main", "gt-src"))
+	commit := "abc123def456"
+	store := newPrepushStore(prepushIssue("gt-src", ""), prepushMRIssue("gt-mr-pr", "feature-pr", "main", "gt-src", commit))
 	e := newPrepushEngineer(t, workDir, store)
 	requireReview := true
 	e.config.RequireReview = &requireReview
@@ -384,7 +398,7 @@ func TestDoMergePR_RechecksSourceBeforeMergeAPI(t *testing.T) {
 	}}
 	e.prProvider = provider
 
-	mr := &MRInfo{ID: "gt-mr-pr", Branch: "feature-pr", Target: "main", SourceIssue: "gt-src"}
+	mr := &MRInfo{ID: "gt-mr-pr", Branch: "feature-pr", Target: "main", SourceIssue: "gt-src", CommitSHA: commit}
 	result := e.doMergePR(context.Background(), mr)
 	if result.Success || !result.NoMerge {
 		t.Fatalf("expected clean policy rejection before PR merge API, got: %+v", result)
@@ -399,11 +413,13 @@ func TestProcessBatch_RechecksBatchBeforePush(t *testing.T) {
 	defer cleanup()
 	createFeatureBranch(t, workDir, "feature-a", "a.txt", "a\n")
 	createFeatureBranch(t, workDir, "feature-b", "b.txt", "b\n")
+	commitA := run(t, workDir, "git", "rev-parse", "feature-a")
+	commitB := run(t, workDir, "git", "rev-parse", "feature-b")
 	store := newPrepushStore(
 		prepushIssue("gt-src-a", ""),
 		prepushIssue("gt-src-b", ""),
-		prepushMRIssue("gt-mr-a", "feature-a", "main", "gt-src-a"),
-		prepushMRIssue("gt-mr-b", "feature-b", "main", "gt-src-b"),
+		prepushMRIssue("gt-mr-a", "feature-a", "main", "gt-src-a", commitA),
+		prepushMRIssue("gt-mr-b", "feature-b", "main", "gt-src-b", commitB),
 	)
 	e := newPrepushEngineer(t, workDir, store)
 	before := run(t, workDir, "git", "rev-parse", "origin/main")
@@ -419,8 +435,8 @@ func TestProcessBatch_RechecksBatchBeforePush(t *testing.T) {
 	}
 
 	batch := []*MRInfo{
-		{ID: "gt-mr-a", Branch: "feature-a", Target: "main", SourceIssue: "gt-src-a"},
-		{ID: "gt-mr-b", Branch: "feature-b", Target: "main", SourceIssue: "gt-src-b"},
+		{ID: "gt-mr-a", Branch: "feature-a", Target: "main", SourceIssue: "gt-src-a", CommitSHA: commitA},
+		{ID: "gt-mr-b", Branch: "feature-b", Target: "main", SourceIssue: "gt-src-b", CommitSHA: commitB},
 	}
 	result := e.ProcessBatch(context.Background(), batch, "main", DefaultBatchConfig())
 	if len(result.Merged) != 0 {
@@ -446,19 +462,21 @@ func TestProcessBatch_RechecksBatchBeforeGates(t *testing.T) {
 	defer cleanup()
 	createFeatureBranch(t, workDir, "feature-a", "a.txt", "a\n")
 	createFeatureBranch(t, workDir, "feature-b", "b.txt", "b\n")
+	commitA := run(t, workDir, "git", "rev-parse", "feature-a")
+	commitB := run(t, workDir, "git", "rev-parse", "feature-b")
 	store := newPrepushStore(
 		prepushIssue("gt-src-a", ""),
 		prepushIssue("gt-src-b", "no_merge: true"),
-		prepushMRIssue("gt-mr-a", "feature-a", "main", "gt-src-a"),
-		prepushMRIssue("gt-mr-b", "feature-b", "main", "gt-src-b"),
+		prepushMRIssue("gt-mr-a", "feature-a", "main", "gt-src-a", commitA),
+		prepushMRIssue("gt-mr-b", "feature-b", "main", "gt-src-b", commitB),
 	)
 	e := newPrepushEngineer(t, workDir, store)
 	e.config.Gates = map[string]*GateConfig{"fail": {Cmd: "false"}}
 	before := run(t, workDir, "git", "rev-parse", "origin/main")
 
 	batch := []*MRInfo{
-		{ID: "gt-mr-a", Branch: "feature-a", Target: "main", SourceIssue: "gt-src-a"},
-		{ID: "gt-mr-b", Branch: "feature-b", Target: "main", SourceIssue: "gt-src-b"},
+		{ID: "gt-mr-a", Branch: "feature-a", Target: "main", SourceIssue: "gt-src-a", CommitSHA: commitA},
+		{ID: "gt-mr-b", Branch: "feature-b", Target: "main", SourceIssue: "gt-src-b", CommitSHA: commitB},
 	}
 	result := e.ProcessBatch(context.Background(), batch, "main", DefaultBatchConfig())
 	if result.Error != nil {
@@ -481,11 +499,13 @@ func TestProcessBatch_RechecksMRCloseReasonBeforePush(t *testing.T) {
 	defer cleanup()
 	createFeatureBranch(t, workDir, "feature-a", "a.txt", "a\n")
 	createFeatureBranch(t, workDir, "feature-b", "b.txt", "b\n")
+	commitA := run(t, workDir, "git", "rev-parse", "feature-a")
+	commitB := run(t, workDir, "git", "rev-parse", "feature-b")
 	store := newPrepushStore(
 		prepushIssue("gt-src-a", ""),
 		prepushIssue("gt-src-b", ""),
-		prepushMRIssue("gt-mr-a", "feature-a", "main", "gt-src-a"),
-		prepushMRIssue("gt-mr-b", "feature-b", "main", "gt-src-b"),
+		prepushMRIssue("gt-mr-a", "feature-a", "main", "gt-src-a", commitA),
+		prepushMRIssue("gt-mr-b", "feature-b", "main", "gt-src-b", commitB),
 	)
 	e := newPrepushEngineer(t, workDir, store)
 	before := run(t, workDir, "git", "rev-parse", "origin/main")
@@ -501,8 +521,8 @@ func TestProcessBatch_RechecksMRCloseReasonBeforePush(t *testing.T) {
 	}
 
 	batch := []*MRInfo{
-		{ID: "gt-mr-a", Branch: "feature-a", Target: "main", SourceIssue: "gt-src-a"},
-		{ID: "gt-mr-b", Branch: "feature-b", Target: "main", SourceIssue: "gt-src-b"},
+		{ID: "gt-mr-a", Branch: "feature-a", Target: "main", SourceIssue: "gt-src-a", CommitSHA: commitA},
+		{ID: "gt-mr-b", Branch: "feature-b", Target: "main", SourceIssue: "gt-src-b", CommitSHA: commitB},
 	}
 	result := e.ProcessBatch(context.Background(), batch, "main", DefaultBatchConfig())
 	if len(result.Merged) != 0 {

--- a/internal/refinery/terminal_mr.go
+++ b/internal/refinery/terminal_mr.go
@@ -13,6 +13,7 @@ type terminalMRCloseOptions struct {
 	MergeCommit   string
 	AgentBeadHint string
 	MissingOK     bool
+	ExpectedMR    *MergeRequest
 }
 
 type terminalMRCloseResult struct {
@@ -49,6 +50,9 @@ func closeTerminalMR(b *beads.Beads, mrID string, opts terminalMRCloseOptions) (
 	}
 	result.SourceIssue = strings.TrimSpace(fields.SourceIssue)
 	result.AgentBead = firstNonEmpty(opts.AgentBeadHint, fields.AgentBead)
+	if err := validateTerminalMRCloseSnapshot(mrID, fields, opts.ExpectedMR); err != nil {
+		return result, err
+	}
 
 	status := beads.IssueStatus(strings.TrimSpace(issue.Status))
 	switch {
@@ -83,6 +87,36 @@ func closeTerminalMR(b *beads.Beads, mrID string, opts terminalMRCloseOptions) (
 		result.AgentActiveMRClearErr = clearErr
 	}
 	return result, nil
+}
+
+func validateTerminalMRCloseSnapshot(mrID string, fields *beads.MRFields, expected *MergeRequest) error {
+	if expected == nil || fields == nil {
+		return nil
+	}
+	checks := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "branch", got: fields.Branch, want: expected.Branch},
+		{name: "source_issue", got: fields.SourceIssue, want: expected.IssueID},
+		{name: "commit_sha", got: fields.CommitSHA, want: expected.CommitSHA},
+	}
+	if strings.TrimSpace(expected.TargetBranch) != "" {
+		checks = append(checks, struct {
+			name string
+			got  string
+			want string
+		}{name: "target", got: fields.Target, want: expected.TargetBranch})
+	}
+	for _, check := range checks {
+		got := strings.TrimSpace(check.got)
+		want := strings.TrimSpace(check.want)
+		if want != "" && got != want {
+			return fmt.Errorf("MR %s changed after merge proof: %s=%q, verified %q", mrID, check.name, got, want)
+		}
+	}
+	return nil
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/refinery/terminal_mr_test.go
+++ b/internal/refinery/terminal_mr_test.go
@@ -1,0 +1,49 @@
+package refinery
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestValidateTerminalMRCloseSnapshotRejectsDrift(t *testing.T) {
+	expected := &MergeRequest{
+		ID:           "gt-mr-proof",
+		Branch:       "polecat/test/proof",
+		IssueID:      "gt-proof",
+		TargetBranch: "main",
+		CommitSHA:    "abc123",
+	}
+	fields := &beads.MRFields{
+		Branch:      "polecat/test/proof",
+		SourceIssue: "gt-proof",
+		Target:      "main",
+		CommitSHA:   "def456",
+	}
+
+	err := validateTerminalMRCloseSnapshot(expected.ID, fields, expected)
+	if err == nil || !strings.Contains(err.Error(), "changed after merge proof") {
+		t.Fatalf("validateTerminalMRCloseSnapshot error = %v, want drift failure", err)
+	}
+}
+
+func TestValidateTerminalMRCloseSnapshotAllowsMatchingSnapshot(t *testing.T) {
+	expected := &MergeRequest{
+		ID:           "gt-mr-proof",
+		Branch:       "polecat/test/proof",
+		IssueID:      "gt-proof",
+		TargetBranch: "main",
+		CommitSHA:    "abc123",
+	}
+	fields := &beads.MRFields{
+		Branch:      "polecat/test/proof",
+		SourceIssue: "gt-proof",
+		Target:      "main",
+		CommitSHA:   "abc123",
+	}
+
+	if err := validateTerminalMRCloseSnapshot(expected.ID, fields, expected); err != nil {
+		t.Fatalf("validateTerminalMRCloseSnapshot: %v", err)
+	}
+}


### PR DESCRIPTION
Replacement/fix for #4472.\n\nThis gates post-merge cleanup and branch deletion on proof that the submitted commit reached the target, so gt mq post-merge cannot record a false merge or delete a branch before verification.\n\nEvidence recorded on Bead gt-4472-post-merge-proof: 15 research legs, 5 pre-implementation reviews, 5 post-implementation reviews, focused CGO_ENABLED=0 tests, and diff check. Internal MR: gt-wisp-x00.\n\nRelease: v1.2.2 blocker.