### PR TITLE
fix: fail closed on orphan-wisp burn-set mismatch

### DIFF
--- a/internal/cmd/molecule.go
+++ b/internal/cmd/molecule.go
@@ -243,6 +243,7 @@ func init() {
 
 	// Burn flags
 	moleculeBurnCmd.Flags().BoolVar(&moleculeJSON, "json", false, "Output as JSON")
+	registerOrphanBurnFlags()
 
 	// Squash flags
 	moleculeSquashCmd.Flags().BoolVar(&moleculeJSON, "json", false, "Output as JSON")
@@ -258,6 +259,7 @@ func init() {
 	moleculeCmd.AddCommand(moleculeStatusCmd)
 	moleculeCmd.AddCommand(moleculeCurrentCmd)
 	moleculeCmd.AddCommand(moleculeBurnCmd)
+	moleculeCmd.AddCommand(moleculeBurnOrphansCmd)
 	moleculeCmd.AddCommand(moleculeSquashCmd)
 	moleculeCmd.AddCommand(moleculeProgressCmd)
 	moleculeCmd.AddCommand(moleculeDagCmd)

--- a/internal/cmd/molecule_orphan_burn.go
+++ b/internal/cmd/molecule_orphan_burn.go
@@ -1,0 +1,282 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+var (
+	orphanBurnPreview         bool
+	orphanBurnExecute         bool
+	orphanBurnValidatedDigest string
+	orphanBurnAuditBead       string
+)
+
+type orphanBurnExclusion struct {
+	ID     string `json:"id"`
+	Reason string `json:"reason"`
+}
+
+type orphanBurnPlan struct {
+	Requested []string              `json:"requested"`
+	Safe      []string              `json:"safe"`
+	Excluded  []orphanBurnExclusion `json:"excluded,omitempty"`
+	SetDigest string                `json:"set_digest"`
+}
+
+type orphanBurnAudit struct {
+	Operation       string                `json:"operation"`
+	Result          string                `json:"result"`
+	Requested       []string              `json:"requested"`
+	Safe            []string              `json:"safe"`
+	Excluded        []orphanBurnExclusion `json:"excluded,omitempty"`
+	SetDigest       string                `json:"set_digest"`
+	ValidatedDigest string                `json:"validated_digest,omitempty"`
+	Error           string                `json:"error,omitempty"`
+}
+
+var moleculeBurnOrphansCmd = &cobra.Command{
+	Use:   "burn-orphans [wisp-id...]",
+	Short: "Preview or execute an audited, fail-closed orphan-wisp burn batch",
+	Long: `Safely burn a reviewed batch of orphan wisps.
+
+Preview canonicalizes the IDs, excludes preserved records, computes a digest,
+and writes the plan to the audit bead. Execution independently repeats those
+checks and refuses to mutate anything unless the requested IDs exactly equal
+the safe set and its digest equals --validated-digest.
+
+Examples:
+  gt mol burn-orphans --preview --audit-bead hq-audit hq-wisp-a hq-wisp-b
+  gt mol burn-orphans --execute --audit-bead hq-audit \
+    --validated-digest <preview-digest> hq-wisp-a hq-wisp-b`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: runMoleculeBurnOrphans,
+}
+
+func registerOrphanBurnFlags() {
+	moleculeBurnOrphansCmd.Flags().BoolVar(&orphanBurnPreview, "preview", false, "Validate and persist the reviewed safe set without mutation")
+	moleculeBurnOrphansCmd.Flags().BoolVar(&orphanBurnExecute, "execute", false, "Execute a previously reviewed set")
+	moleculeBurnOrphansCmd.Flags().StringVar(&orphanBurnValidatedDigest, "validated-digest", "", "Digest printed by the matching preview")
+	moleculeBurnOrphansCmd.Flags().StringVar(&orphanBurnAuditBead, "audit-bead", "", "Durable bead that receives preview and result comments")
+}
+
+func runMoleculeBurnOrphans(_ *cobra.Command, args []string) error {
+	if orphanBurnPreview == orphanBurnExecute {
+		return fmt.Errorf("exactly one of --preview or --execute is required")
+	}
+	if strings.TrimSpace(orphanBurnAuditBead) == "" {
+		return fmt.Errorf("--audit-bead is required")
+	}
+	if orphanBurnPreview && orphanBurnValidatedDigest != "" {
+		return fmt.Errorf("--validated-digest is only valid with --execute")
+	}
+	if orphanBurnExecute && strings.TrimSpace(orphanBurnValidatedDigest) == "" {
+		return fmt.Errorf("--validated-digest is required with --execute")
+	}
+
+	workDir, err := findLocalBeadsDir()
+	if err != nil {
+		return fmt.Errorf("not in a beads workspace: %w", err)
+	}
+	bd := beads.New(workDir)
+	plan, err := buildOrphanBurnPlan(bd, args)
+	if err != nil {
+		return persistOrphanBurnFailure(bd, "validation", args, orphanBurnValidatedDigest, err)
+	}
+
+	if orphanBurnPreview {
+		audit := orphanBurnAudit{
+			Operation: "orphan-wisp-burn-preview", Result: "review-required",
+			Requested: plan.Requested, Safe: plan.Safe, Excluded: plan.Excluded, SetDigest: plan.SetDigest,
+		}
+		if err := addOrphanBurnAudit(bd, audit); err != nil {
+			return err
+		}
+		return writeOrphanBurnJSON(plan)
+	}
+
+	if err := validateOrphanBurnExecution(plan, orphanBurnValidatedDigest); err != nil {
+		return persistOrphanBurnPlanFailure(bd, plan, err)
+	}
+
+	preflight := orphanBurnAudit{
+		Operation: "orphan-wisp-burn-execute", Result: "validated-before-mutation",
+		Requested: plan.Requested, Safe: plan.Safe, SetDigest: plan.SetDigest,
+		ValidatedDigest: strings.TrimSpace(orphanBurnValidatedDigest),
+	}
+	if err := addOrphanBurnAudit(bd, preflight); err != nil {
+		return err
+	}
+	if err := bd.ForceCloseWithReason("burned: audited orphan recovery", plan.Safe...); err != nil {
+		return persistOrphanBurnPlanFailure(bd, plan, fmt.Errorf("closing orphan wisps: %w", err))
+	}
+
+	result := orphanBurnAudit{
+		Operation: "orphan-wisp-burn-execute", Result: "burned",
+		Requested: plan.Requested, Safe: plan.Safe, SetDigest: plan.SetDigest,
+		ValidatedDigest: strings.TrimSpace(orphanBurnValidatedDigest),
+	}
+	if err := addOrphanBurnAudit(bd, result); err != nil {
+		return fmt.Errorf("burn completed but result audit failed: %w", err)
+	}
+	return writeOrphanBurnJSON(result)
+}
+
+type orphanBurnIssueReader interface {
+	ShowMultiple(ids []string) (map[string]*beads.Issue, error)
+}
+
+func buildOrphanBurnPlan(reader orphanBurnIssueReader, requested []string) (orphanBurnPlan, error) {
+	canonical, err := canonicalBurnIDs(requested)
+	if err != nil {
+		return orphanBurnPlan{}, err
+	}
+	issues, err := reader.ShowMultiple(canonical)
+	if err != nil {
+		return orphanBurnPlan{}, fmt.Errorf("loading requested wisps: %w", err)
+	}
+
+	plan := orphanBurnPlan{Requested: canonical}
+	for _, id := range canonical {
+		issue, ok := issues[id]
+		if !ok || issue == nil {
+			return orphanBurnPlan{}, fmt.Errorf("requested wisp %s was not found", id)
+		}
+		if reason := orphanBurnPreserveReason(issue); reason != "" {
+			plan.Excluded = append(plan.Excluded, orphanBurnExclusion{ID: id, Reason: reason})
+			continue
+		}
+		plan.Safe = append(plan.Safe, id)
+	}
+	plan.SetDigest = burnSetDigest(plan.Safe)
+	return plan, nil
+}
+
+func canonicalBurnIDs(ids []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(ids))
+	canonical := make([]string, 0, len(ids))
+	for _, raw := range ids {
+		id := strings.ToLower(strings.TrimSpace(raw))
+		if id == "" {
+			return nil, fmt.Errorf("burn set contains an empty ID")
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		canonical = append(canonical, id)
+	}
+	if len(canonical) == 0 {
+		return nil, fmt.Errorf("burn set is empty")
+	}
+	sort.Strings(canonical)
+	return canonical, nil
+}
+
+func burnSetDigest(ids []string) string {
+	sum := sha256.Sum256([]byte(strings.Join(ids, "\n")))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func orphanBurnPreserveReason(issue *beads.Issue) string {
+	if issue == nil {
+		return "missing"
+	}
+	id := strings.ToLower(strings.TrimSpace(issue.ID))
+	if !issue.Ephemeral && !strings.Contains(id, "-wisp-") {
+		return "not-an-ephemeral-wisp"
+	}
+	preservedTypes := map[string]bool{
+		"message": true, "escalation": true, "audit": true, "event": true,
+		"handoff": true, "agent": true, "queue": true, "convoy": true,
+		"formula": true, "merge-request": true, "role": true, "rig": true,
+	}
+	if typ := strings.ToLower(strings.TrimSpace(issue.Type)); preservedTypes[typ] {
+		return "preserved-type:" + typ
+	}
+	for _, raw := range issue.Labels {
+		label := strings.ToLower(strings.TrimSpace(raw))
+		if beads.ProtectedIssueLabel(label) {
+			return "preserved-label:" + label
+		}
+		switch label {
+		case "gt:message", "gt:escalation", "gt:audit", "gt:event", "gt:handoff",
+			"gt:agent", "gt:queue", "gt:convoy", "gt:formula", "gt:merge-request":
+			return "preserved-label:" + label
+		}
+	}
+	return ""
+}
+
+func equalStringSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func validateOrphanBurnExecution(plan orphanBurnPlan, validatedDigest string) error {
+	// Both comparisons are intentional. The set comparison catches explicitly
+	// supplied preserved IDs, while the digest comparison catches any extra or
+	// missing otherwise-safe ID relative to the reviewed preview.
+	if !equalStringSets(plan.Requested, plan.Safe) {
+		return fmt.Errorf("requested burn set differs from validated safe set (requested=%d safe=%d)", len(plan.Requested), len(plan.Safe))
+	}
+	if !strings.EqualFold(plan.SetDigest, strings.TrimSpace(validatedDigest)) {
+		return fmt.Errorf("requested burn digest %s differs from validated digest %s", plan.SetDigest, strings.TrimSpace(validatedDigest))
+	}
+	return nil
+}
+
+func addOrphanBurnAudit(bd *beads.Beads, audit orphanBurnAudit) error {
+	payload, err := json.Marshal(audit)
+	if err != nil {
+		return fmt.Errorf("encoding orphan burn audit: %w", err)
+	}
+	if err := bd.AddComment(orphanBurnAuditBead, "ORPHAN-WISP-BURN-AUDIT "+string(payload)); err != nil {
+		return fmt.Errorf("persisting orphan burn audit on %s: %w", orphanBurnAuditBead, err)
+	}
+	return nil
+}
+
+func persistOrphanBurnPlanFailure(bd *beads.Beads, plan orphanBurnPlan, cause error) error {
+	audit := orphanBurnAudit{
+		Operation: "orphan-wisp-burn-execute", Result: "rejected",
+		Requested: plan.Requested, Safe: plan.Safe, Excluded: plan.Excluded,
+		SetDigest: plan.SetDigest, ValidatedDigest: strings.TrimSpace(orphanBurnValidatedDigest), Error: cause.Error(),
+	}
+	if err := addOrphanBurnAudit(bd, audit); err != nil {
+		return fmt.Errorf("%v; additionally failed to persist rejection audit: %w", cause, err)
+	}
+	return cause
+}
+
+func persistOrphanBurnFailure(bd *beads.Beads, result string, requested []string, digest string, cause error) error {
+	audit := orphanBurnAudit{
+		Operation: "orphan-wisp-burn-execute", Result: result,
+		Requested: requested, ValidatedDigest: strings.TrimSpace(digest), Error: cause.Error(),
+	}
+	if err := addOrphanBurnAudit(bd, audit); err != nil {
+		return fmt.Errorf("%v; additionally failed to persist rejection audit: %w", cause, err)
+	}
+	return cause
+}
+
+func writeOrphanBurnJSON(value any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(value)
+}

--- a/internal/cmd/molecule_orphan_burn_test.go
+++ b/internal/cmd/molecule_orphan_burn_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+type orphanBurnReader map[string]*beads.Issue
+
+func (r orphanBurnReader) ShowMultiple(_ []string) (map[string]*beads.Issue, error) {
+	return r, nil
+}
+
+func TestBuildOrphanBurnPlanCanonicalSetAndDigest(t *testing.T) {
+	reader := orphanBurnReader{
+		"hq-wisp-a": {ID: "hq-wisp-a", Ephemeral: true, Type: "task", Labels: []string{"gt:wisp"}},
+		"hq-wisp-b": {ID: "hq-wisp-b", Ephemeral: true, Type: "molecule"},
+	}
+	one, err := buildOrphanBurnPlan(reader, []string{" HQ-WISP-B ", "hq-wisp-a", "hq-wisp-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	two, err := buildOrphanBurnPlan(reader, []string{"hq-wisp-a", "hq-wisp-b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(one.Safe, ","); got != "hq-wisp-a,hq-wisp-b" {
+		t.Fatalf("safe set = %q", got)
+	}
+	if one.SetDigest != two.SetDigest {
+		t.Fatalf("canonical digests differ: %s != %s", one.SetDigest, two.SetDigest)
+	}
+}
+
+func TestBuildOrphanBurnPlanReproduces59vs60Incident(t *testing.T) {
+	reader := make(orphanBurnReader)
+	requested := make([]string, 0, 60)
+	for i := 0; i < 59; i++ {
+		id := fmtWispID(i)
+		requested = append(requested, id)
+		reader[id] = &beads.Issue{ID: id, Ephemeral: true, Type: "task", Labels: []string{"gt:wisp"}}
+	}
+	requested = append(requested, "hq-wisp-d5y")
+	reader["hq-wisp-d5y"] = &beads.Issue{
+		ID: "hq-wisp-d5y", Ephemeral: true, Type: "message", Labels: []string{"gt:wisp", "gt:message"},
+	}
+
+	plan, err := buildOrphanBurnPlan(reader, requested)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Requested) != 60 || len(plan.Safe) != 59 {
+		t.Fatalf("requested=%d safe=%d, want 60 and 59", len(plan.Requested), len(plan.Safe))
+	}
+	if equalStringSets(plan.Requested, plan.Safe) {
+		t.Fatal("59-vs-60 batch must be rejected before mutation")
+	}
+	if len(plan.Excluded) != 1 || plan.Excluded[0].ID != "hq-wisp-d5y" {
+		t.Fatalf("exclusions = %#v", plan.Excluded)
+	}
+}
+
+func TestOrphanBurnPreservesAuditEventAndProtectedLabels(t *testing.T) {
+	tests := []struct {
+		name  string
+		issue *beads.Issue
+	}{
+		{"message type", &beads.Issue{ID: "hq-wisp-a", Ephemeral: true, Type: "message"}},
+		{"escalation label", &beads.Issue{ID: "hq-wisp-b", Ephemeral: true, Type: "task", Labels: []string{"gt:escalation"}}},
+		{"audit type", &beads.Issue{ID: "hq-wisp-c", Ephemeral: true, Type: "audit"}},
+		{"event label", &beads.Issue{ID: "hq-wisp-d", Ephemeral: true, Type: "task", Labels: []string{"gt:event"}}},
+		{"keep label", &beads.Issue{ID: "hq-wisp-e", Ephemeral: true, Type: "task", Labels: []string{"gt:keep"}}},
+		{"durable bead", &beads.Issue{ID: "hq-task", Type: "task"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if reason := orphanBurnPreserveReason(tt.issue); reason == "" {
+				t.Fatal("expected preservation reason")
+			}
+		})
+	}
+}
+
+func TestOrphanBurnDigestRejectsExtraOrMissingSafeID(t *testing.T) {
+	validatedIDs := []string{"hq-wisp-a", "hq-wisp-b"}
+	validated := burnSetDigest(validatedIDs)
+	for _, ids := range [][]string{{"hq-wisp-a"}, {"hq-wisp-a", "hq-wisp-b", "hq-wisp-c"}} {
+		plan := orphanBurnPlan{Requested: ids, Safe: ids, SetDigest: burnSetDigest(ids)}
+		if err := validateOrphanBurnExecution(plan, validated); err == nil {
+			t.Fatalf("validation unexpectedly accepted %v", ids)
+		}
+	}
+	exact := orphanBurnPlan{Requested: validatedIDs, Safe: validatedIDs, SetDigest: validated}
+	if err := validateOrphanBurnExecution(exact, validated); err != nil {
+		t.Fatalf("exact reviewed set rejected: %v", err)
+	}
+	preservedExtra := orphanBurnPlan{
+		Requested: []string{"hq-wisp-a", "hq-wisp-b", "hq-wisp-message"},
+		Safe:      validatedIDs,
+		SetDigest: validated,
+	}
+	if err := validateOrphanBurnExecution(preservedExtra, validated); err == nil {
+		t.Fatal("explicitly supplied preserved ID was accepted")
+	}
+}
+
+func fmtWispID(i int) string {
+	const digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+	return "hq-wisp-test" + string(digits[i/36]) + string(digits[i%36])
+}

--- a/internal/formula/formulas/mol-orphan-scan.formula.toml
+++ b/internal/formula/formulas/mol-orphan-scan.formula.toml
@@ -243,9 +243,20 @@ Recommended action: ..."
 
 **5. BURN orphans:**
 ```bash
-# For empty wisps, etc.
-rm .beads-wisp/<wisp-file>
+# Preview the complete candidate batch. This canonicalizes IDs, excludes
+# message/escalation/audit/event and other preserved records, and persists the
+# reviewed safe set plus digest on the recovery bead.
+gt mol burn-orphans --preview --audit-bead <recovery-bead> <wisp-id>...
+
+# Execute exactly the safe IDs printed by preview. Copy the preview digest;
+# execution independently revalidates labels/types and fails before mutation
+# if any ID is extra, missing, newly preserved, or otherwise changed.
+gt mol burn-orphans --execute --audit-bead <recovery-bead> \
+  --validated-digest <preview-digest> <safe-wisp-id>...
 ```
+
+Never manipulate `.beads-wisp` or other Dolt-internal files directly. Preview
+and execution audit comments are the durable recovery record.
 
 **Exit criteria:** All orphans handled."""
 


### PR DESCRIPTION
## Summary
- canonicalize and bind orphan-wisp burn execution to the reviewed safe set
- reject extra or missing IDs before mutation
- independently protect message, escalation, audit, and event records
- persist preview/set digest and regression coverage for the 59-vs-60 incident

## Validation
- focused orphan-burn tests
- `go test ./internal/formula`
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=0 make build`
- `git diff --check`

Full `go test ./...` remains blocked by unrelated host/environment failures recorded on gt-juu. No Dolt force-push or history rewrite was attempted.

Tracks gt-juu and incident hq-wisp-ppk.