### PR TITLE
fix: make Dolt diagnostics non-destructive

### DIFF
--- a/docs/dolt-health-guide.md
+++ b/docs/dolt-health-guide.md
@@ -25,6 +25,11 @@ gt dolt dump 2>&1 | tee /tmp/dolt-hang-$(date +%s).log
 gt dolt status 2>&1 | tee /tmp/dolt-status-$(date +%s).log
 ```
 
+The managed PID file is `<town-root>/daemon/dolt.pid` (normally
+`~/gt/daemon/dolt.pid`). It is metadata, not a diagnostic control: do not send
+signals to the PID it contains. `gt dolt dump` resolves the live PID and captures
+available metadata and logs without interrupting the server.
+
 Then escalate with the evidence path:
 
 ```bash

--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -849,6 +849,7 @@ func runDoltDump(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Dolt diagnostic snapshot (non-fatal)\n")
 	fmt.Printf("  Live PID:   %d\n", pid)
+	fmt.Printf("  PID file:   %s\n", config.PidFile)
 	fmt.Printf("  Port:       %d\n", config.Port)
 	fmt.Printf("  Data dir:   %s\n", config.DataDir)
 	fmt.Printf("  Log file:   %s\n", config.LogFile)

--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -889,7 +889,7 @@ func runDoltDump(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  (unable to read recent logs: %v)\n", err)
 	}
 
-	fmt.Printf("\nNo signal was sent. Do not use kill -QUIT for routine diagnostics unless the Dolt version has been verified not to terminate on SIGQUIT.\n")
+	fmt.Printf("\nNo signal was sent. Never send SIGQUIT to the live Dolt server; use gt dolt dump for non-signaling diagnostics.\n")
 
 	return nil
 }

--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -249,10 +249,15 @@ func TestOpenCodeTemplateFailureDiagnostics(t *testing.T) {
 		"timeout 10s ${gtCommand()} dolt status 2>&1",
 		"dolt_status_tail:",
 		"suggested_recovery:",
+		"`gt dolt dump`",
+		"Never send SIGQUIT",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("opencode template missing diagnostic field %q", want)
 		}
+	}
+	if strings.Contains(content, "capture SIGQUIT") {
+		t.Fatal("opencode template must not recommend destructive SIGQUIT diagnostics")
 	}
 }
 

--- a/internal/hooks/templates/opencode/gastown.js
+++ b/internal/hooks/templates/opencode/gastown.js
@@ -76,7 +76,7 @@ export const GasTown = async ({ $, directory }) => {
     if (isDoltBackedCommand(cmd)) {
       lines.push(`dolt_status_tail:\n${outputTail(await captureDoltStatus())}`);
       lines.push(
-        "suggested_recovery: If Dolt is unhealthy or another gt/bd command is hanging, capture SIGQUIT and `gt dolt status` diagnostics before escalating; otherwise retry after the timeout clears."
+        "suggested_recovery: If Dolt is unhealthy or another gt/bd command is hanging, run `gt dolt dump` and `gt dolt status` before escalating; otherwise retry after the timeout clears. Never send SIGQUIT to the live Dolt server."
       );
     } else {
       lines.push("suggested_recovery: Inspect the command, stdout/stderr tails, and retry once the timeout or process failure is resolved.");

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -20,6 +20,26 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestTownRootDoltHangDiagnosticsAreNonFatal(t *testing.T) {
+	content := TownRootCLAUDEmd()
+	for _, want := range []string{
+		"gt dolt dump",
+		"gt dolt status",
+		"~/gt/daemon/dolt.pid",
+		"does not signal the process",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("town-root Dolt diagnostics missing %q", want)
+		}
+	}
+	if strings.Contains(content, "~/gt/.dolt-data/dolt.pid") {
+		t.Error("town-root Dolt diagnostics reference the obsolete PID path")
+	}
+	if strings.Contains(content, "kill -QUIT $(") {
+		t.Error("town-root Dolt diagnostics contain an executable SIGQUIT workflow")
+	}
+}
+
 func TestRenderRole_Mayor(t *testing.T) {
 	tmpl, err := New()
 	if err != nil {

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -27,6 +27,7 @@ func TestTownRootDoltHangDiagnosticsAreNonFatal(t *testing.T) {
 		"gt dolt status",
 		"~/gt/daemon/dolt.pid",
 		"does not signal the process",
+		"Never send SIGQUIT to the live Dolt server",
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("town-root Dolt diagnostics missing %q", want)
@@ -35,8 +36,14 @@ func TestTownRootDoltHangDiagnosticsAreNonFatal(t *testing.T) {
 	if strings.Contains(content, "~/gt/.dolt-data/dolt.pid") {
 		t.Error("town-root Dolt diagnostics reference the obsolete PID path")
 	}
-	if strings.Contains(content, "kill -QUIT $(") {
-		t.Error("town-root Dolt diagnostics contain an executable SIGQUIT workflow")
+	for _, forbidden := range []string{
+		"kill -QUIT",
+		"capture SIGQUIT",
+		"only use it if",
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Errorf("town-root Dolt diagnostics contain unsafe SIGQUIT guidance %q", forbidden)
+		}
 	}
 }
 

--- a/internal/templates/townroot.go
+++ b/internal/templates/townroot.go
@@ -12,7 +12,7 @@ var townRootCLAUDEmdRaw string
 
 // TownRootCLAUDEmdVersion is the version of the embedded town-root CLAUDE.md.
 // Increment this when updating the template content with new sections.
-const TownRootCLAUDEmdVersion = 2
+const TownRootCLAUDEmdVersion = 3
 
 // TownRootCLAUDEmd returns the canonical town-root CLAUDE.md content
 // with the CLI command name substituted.

--- a/internal/templates/townroot/claude.md
+++ b/internal/templates/townroot/claude.md
@@ -32,6 +32,10 @@ diagnostics:
 {{cmd}} escalate -s HIGH "Dolt: <describe symptom>"
 ```
 
+The GT-managed PID file is `~/gt/daemon/dolt.pid` for the default town root.
+It does not live under the Dolt data directory. Treat it as metadata only:
+`{{cmd}} dolt dump` resolves the live server PID safely and does not signal the process.
+
 For Dolt outages and non-Dolt GT behavior mismatches, include the RCA capture checklist
 from `docs/dolt-health-guide.md` in the escalation or follow-up bead.
 

--- a/internal/templates/townroot/claude.md
+++ b/internal/templates/townroot/claude.md
@@ -40,9 +40,8 @@ For Dolt outages and non-Dolt GT behavior mismatches, include the RCA capture ch
 from `docs/dolt-health-guide.md` in the escalation or follow-up bead.
 
 **Do NOT just `{{cmd}} dolt stop && {{cmd}} dolt start` without steps 1-2.**
-**Do NOT use `kill -QUIT` for routine diagnostics.** Dolt 1.86.5 terminates
-`sql-server` after SIGQUIT; only use it if the current Dolt version has been
-verified not to exit on that signal.
+**Never send SIGQUIT to the live Dolt server.** Use `{{cmd}} dolt dump` for
+non-signaling diagnostics.
 
 **Escalation path** (any agent can do this):
 ```bash


### PR DESCRIPTION
## Summary

- replace SIGQUIT recovery guidance in generated town instructions and the OpenCode hook with `gt dolt dump` and `gt dolt status`
- document and report the live `<town-root>/daemon/dolt.pid` path
- enforce an unconditional rule against signaling the live Dolt server
- add regression coverage for generated templates and hook diagnostics

## Root cause

Routine hang diagnostics recommended SIGQUIT against the shared Dolt SQL server. Dolt terminates after that signal, so collecting evidence caused the outage it was meant to diagnose. The reviewed fix existed only on an unpushed local branch and was recovered onto current upstream main.

## Validation

- `go test ./internal/templates ./internal/hooks`
- `CGO_ENABLED=0 go test ./internal/doctor -run ^TestTownCLAUDEmdCheck -count=1`
- `CGO_ENABLED=0 go test ./internal/cmd -run ^(TestGenerateCLAUDEMD|TestUpgradeCLAUDEMD_) -count=1`
- `CGO_ENABLED=0 go build ... ./cmd/gt`
- built `gt dolt dump` against the live server: reported `/Users/fkautz/gt/daemon/dolt.pid`, completed without signaling, and `gt dolt status` remained healthy

Native CGO compilation is unavailable on this host because the configured Homebrew ICU prefix has no installed headers. Broad command and doctor suites additionally expose pre-existing macOS path-normalization, signing-guard, and fork-URL fixture failures unrelated to this change.

Bead: gt-rgv