### PR TITLE
fix: make orphan-scan scope declaration consistent

### DIFF
--- a/internal/formula/convoy_feed_integration_test.go
+++ b/internal/formula/convoy_feed_integration_test.go
@@ -97,7 +97,8 @@ func TestConvoyFeedWorkflow_Integration(t *testing.T) {
 // Deacon's dogs) can pass variable validation for wisp creation.
 //
 // Dog formulas are special because they're invoked via:
-//   gt sling mol-<name> deacon/dogs/<dog> --var convoy=<id>
+//
+//	gt sling mol-<name> deacon/dogs/<dog> --var convoy=<id>
 //
 // The wisp creation validates that all template variables are either:
 // - Provided via --var flags, OR
@@ -143,6 +144,29 @@ func TestAllDogFormulas_CanBeWisped(t *testing.T) {
 				t.Log("Warning: formula has no required input variables")
 			}
 		})
+	}
+}
+
+func TestOrphanScanScopeDefaultsToTown(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("formulas", "mol-orphan-scan.formula.toml"))
+	if err != nil {
+		t.Fatalf("Read mol-orphan-scan formula: %v", err)
+	}
+
+	f, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse mol-orphan-scan formula: %v", err)
+	}
+
+	scope, ok := f.Vars["scope"]
+	if !ok {
+		t.Fatal("Missing scope variable")
+	}
+	if scope.Required {
+		t.Error("scope must be optional when it has a default")
+	}
+	if scope.Default != "town" {
+		t.Errorf("scope default = %q, want town", scope.Default)
 	}
 }
 

--- a/internal/formula/formulas/mol-digest-generate.formula.toml
+++ b/internal/formula/formulas/mol-digest-generate.formula.toml
@@ -223,7 +223,6 @@ Dog returns to available state in the pool.
 [vars]
 [vars.period]
 description = "The digest period type (daily, weekly, custom)"
-required = true
 default = "daily"
 
 [vars.date]

--- a/internal/formula/formulas/mol-orphan-scan.formula.toml
+++ b/internal/formula/formulas/mol-orphan-scan.formula.toml
@@ -322,7 +322,7 @@ Dog returns to available state in the pool.
 [vars]
 [vars.scope]
 description = "Scan scope: 'town' or specific rig name"
-required = true
+default = "town"
 
 [vars.action]
 description = "Recovery action taken for an orphan (computed during execution)"

--- a/internal/formula/formulas/mol-shutdown-dance.formula.toml
+++ b/internal/formula/formulas/mol-shutdown-dance.formula.toml
@@ -515,5 +515,4 @@ required = true
 
 [vars.requester]
 description = "Who filed the warrant (deacon, witness, mayor)"
-required = true
 default = "deacon"

--- a/internal/formula/variable_validation_test.go
+++ b/internal/formula/variable_validation_test.go
@@ -1,6 +1,7 @@
 package formula
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -217,12 +218,21 @@ func TestAllEmbeddedFormulas_VariableValidation(t *testing.T) {
 
 		f, err := Parse(data)
 		if err != nil {
-			// Skip formulas that don't parse (may have other issues)
+			failures = append(failures, entry.Name()+": "+err.Error())
 			continue
 		}
 
 		if err := f.ValidateTemplateVariables(); err != nil {
 			failures = append(failures, entry.Name()+": "+err.Error())
+		}
+
+		for name, variable := range f.Vars {
+			if variable.Required && variable.Default != "" {
+				failures = append(failures, fmt.Sprintf(
+					"%s: variable %q cannot be required and have a default",
+					entry.Name(), name,
+				))
+			}
 		}
 	}
 

--- a/internal/formula/variable_validation_test.go
+++ b/internal/formula/variable_validation_test.go
@@ -218,7 +218,7 @@ func TestAllEmbeddedFormulas_VariableValidation(t *testing.T) {
 
 		f, err := Parse(data)
 		if err != nil {
-			failures = append(failures, entry.Name()+": "+err.Error())
+			// Skip formulas that don't parse (may have other issues)
 			continue
 		}
 

--- a/internal/formula/variable_validation_test.go
+++ b/internal/formula/variable_validation_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/steveyegge/gastown/internal/constants"
 )
 
@@ -221,13 +222,19 @@ func TestAllEmbeddedFormulas_VariableValidation(t *testing.T) {
 			// Skip formulas that don't parse (may have other issues)
 			continue
 		}
+		var decoded Formula
+		metadata, err := toml.Decode(string(data), &decoded)
+		if err != nil {
+			failures = append(failures, entry.Name()+": "+err.Error())
+			continue
+		}
 
 		if err := f.ValidateTemplateVariables(); err != nil {
 			failures = append(failures, entry.Name()+": "+err.Error())
 		}
 
 		for name, variable := range f.Vars {
-			if variable.Required && variable.Default != "" {
+			if variable.Required && metadata.IsDefined("vars", name, "default") {
 				failures = append(failures, fmt.Sprintf(
 					"%s: variable %q cannot be required and have a default",
 					entry.Name(), name,


### PR DESCRIPTION
## Summary
- make `mol-orphan-scan` scope optional with default `town`
- validate shipped formulas against required-plus-default contradictions, including explicit empty defaults
- repair equivalent contradictions exposed in digest-generation and shutdown-dance formulas
- cover omitted, town, and explicit rig scope dry runs

## Validation
- `go test ./internal/formula`
- `go vet ./internal/formula`
- focused shipped-formula validation tests
- `bd mol pour mol-orphan-scan --dry-run` with omitted scope, `scope=town`, and `scope=gastown`
- `git diff --check`

Full `go test ./...` is host-blocked by the existing `go-icu-regex` dependency requiring `unicode/regex.h`; no system packages were changed. No local MQ entry or force push was used.

Tracks gt-8bl.