### PR TITLE
fix: bound hook queries and propagate cancellation

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -542,9 +542,10 @@ type UpdateOptions struct {
 // eliminates ~600ms of subprocess overhead per operation.
 type Beads struct {
 	workDir    string
-	beadsDir   string // Optional BEADS_DIR override for cross-database access
-	isolated   bool   // If true, suppress inherited beads env vars (for test isolation)
-	serverPort int    // If set, pass --server-port to bd init and GT_DOLT_PORT to env
+	beadsDir   string          // Optional BEADS_DIR override for cross-database access
+	isolated   bool            // If true, suppress inherited beads env vars (for test isolation)
+	serverPort int             // If set, pass --server-port to bd init and GT_DOLT_PORT to env
+	ctx        context.Context // Optional caller deadline/cancellation for all operations.
 
 	// store is an optional in-process beadsdk.Storage. When set, methods
 	// bypass the bd subprocess and use the store directly. Follows the
@@ -569,6 +570,24 @@ type Beads struct {
 // New creates a new Beads wrapper for the given directory.
 func New(workDir string) *Beads {
 	return &Beads{workDir: workDir}
+}
+
+// WithContext binds caller cancellation and deadlines to subsequent operations.
+// It mutates and returns b so callers can configure a newly-created wrapper
+// fluently. Derived wrappers used for prefix routing preserve this context.
+func (b *Beads) WithContext(ctx context.Context) *Beads {
+	b.ctx = ctx
+	return b
+}
+
+// operationContext applies the normal per-operation ceiling while respecting
+// any earlier caller deadline.
+func (b *Beads) operationContext(timeout time.Duration) (context.Context, context.CancelFunc) {
+	parent := b.ctx
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, timeout)
 }
 
 // NewIsolated creates a Beads wrapper for test isolation.
@@ -621,6 +640,7 @@ func (b *Beads) ForAgentBead() *Beads {
 		beadsDir:   townBeadsDir,
 		isolated:   b.isolated,
 		serverPort: b.serverPort,
+		ctx:        b.ctx,
 		store:      b.store,
 		townRoot:   townRoot,
 		noRoute:    true,
@@ -711,6 +731,7 @@ func (b *Beads) forIssueID(id string) *Beads {
 		beadsDir:   resolved,
 		isolated:   b.isolated,
 		serverPort: b.serverPort,
+		ctx:        b.ctx,
 		townRoot:   b.townRoot,
 		noRoute:    true,
 	}
@@ -785,7 +806,7 @@ func (b *Beads) runWithStdin(stdinData []byte, args ...string) (_ []byte, retErr
 	// Bound the subprocess runtime so a slow Dolt response doesn't leave bd
 	// blocking forever (under memory pressure that invites Jetsam SIGKILL).
 	// The context covers both the initial attempt and the --flat retry.
-	ctx, cancel := context.WithTimeout(context.Background(), resolveBdSubprocessTimeout())
+	ctx, cancel := b.operationContext(resolveBdSubprocessTimeout())
 	defer cancel()
 
 	// Always explicitly set BEADS_DIR to prevent inherited env vars from
@@ -860,7 +881,7 @@ func (b *Beads) runWithRouting(args ...string) (_ []byte, retErr error) { //noli
 	fullArgs := MaybePrependAllowStaleWithEnv(runEnv, args)
 
 	// Bound subprocess runtime — see bdSubprocessTimeout doc comment.
-	ctx, cancel := context.WithTimeout(context.Background(), resolveBdSubprocessTimeout())
+	ctx, cancel := b.operationContext(resolveBdSubprocessTimeout())
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "bd", fullArgs...) //nolint:gosec // G204: bd is a trusted internal tool
@@ -1634,7 +1655,7 @@ func (b *Beads) ShowMultiple(ids []string) (map[string]*Issue, error) {
 			for targetDir, groupIDs := range groups {
 				target := b
 				if targetDir != fallbackDir {
-					target = NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
+					target = NewWithBeadsDir(filepath.Dir(targetDir), targetDir).WithContext(b.ctx)
 				}
 				issues, err := target.showMultipleLocal(groupIDs)
 				if err != nil {
@@ -1721,6 +1742,7 @@ func (b *Beads) Create(opts CreateOptions) (*Issue, error) {
 			beadsDir:   targetDir,
 			serverPort: b.serverPort,
 			isolated:   b.isolated,
+			ctx:        b.ctx,
 		}
 		return bdForCreate.Create(opts)
 	}
@@ -1796,6 +1818,7 @@ func (b *Beads) CreateWithID(id string, opts CreateOptions) (*Issue, error) {
 			beadsDir:   targetDir,
 			serverPort: b.serverPort,
 			isolated:   b.isolated,
+			ctx:        b.ctx,
 		}
 		return bdForCreate.CreateWithID(id, opts)
 	}
@@ -2165,7 +2188,7 @@ func (b *Beads) ReleaseWithReason(id, reason string) error {
 		if reason != "" {
 			updates["notes"] = "Released: " + reason
 		}
-		ctx, cancel := storeCtx()
+		ctx, cancel := b.storeCtx()
 		defer cancel()
 		return b.store.UpdateIssue(ctx, id, updates, b.getActor())
 	}

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -813,7 +813,7 @@ func (b *Beads) runWithStdin(stdinData []byte, args ...string) (_ []byte, retErr
 	// causing prefix mismatches. Use explicit beadsDir if set, otherwise
 	// resolve from working directory.
 	cmd := exec.CommandContext(ctx, "bd", fullArgs...) //nolint:gosec // G204: bd is a trusted internal tool
-	util.SetDetachedProcessGroup(cmd)
+	util.SetProcessGroup(cmd)
 	cmd.Dir = b.workDir
 
 	cmd.Env = runEnv
@@ -840,7 +840,7 @@ func (b *Beads) runWithStdin(stdinData []byte, args ...string) (_ []byte, retErr
 		stdout.Reset()
 		stderr.Reset()
 		cmd = exec.CommandContext(ctx, "bd", retryArgs...) //nolint:gosec // G204: bd is a trusted internal tool
-		util.SetDetachedProcessGroup(cmd)
+		util.SetProcessGroup(cmd)
 		cmd.Dir = b.workDir
 		cmd.Env = runEnv
 		cmd.Env = append(cmd.Env, telemetry.OTELEnvForSubprocess()...)
@@ -885,7 +885,7 @@ func (b *Beads) runWithRouting(args ...string) (_ []byte, retErr error) { //noli
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "bd", fullArgs...) //nolint:gosec // G204: bd is a trusted internal tool
-	util.SetDetachedProcessGroup(cmd)
+	util.SetProcessGroup(cmd)
 	cmd.Dir = b.workDir
 
 	cmd.Env = runEnv

--- a/internal/beads/beads_context_test.go
+++ b/internal/beads/beads_context_test.go
@@ -1,0 +1,62 @@
+package beads
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWithContextCancelsSlowBDQuery(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell bd stub")
+	}
+
+	root := t.TempDir()
+	workDir := filepath.Join(root, "rig")
+	if err := os.MkdirAll(filepath.Join(workDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
+	}
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	stub := `#!/bin/sh
+if [ "${1:-}" = "--allow-stale" ]; then
+  shift
+fi
+if [ "${1:-}" = "version" ]; then
+  echo "bd test"
+  exit 0
+fi
+sleep 30
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(stub), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	ResetBdAllowStaleCacheForTest()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := NewIsolated(workDir).WithContext(ctx).List(ListOptions{
+		Status:   StatusHooked,
+		Assignee: "gastown/polecats/test",
+		Priority: -1,
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("slow bd list unexpectedly succeeded")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("caller deadline was not propagated: query returned after %s", elapsed)
+	}
+	if !strings.Contains(err.Error(), "bd list") {
+		t.Fatalf("error does not identify the canceled query: %v", err)
+	}
+}

--- a/internal/beads/beads_context_test.go
+++ b/internal/beads/beads_context_test.go
@@ -8,7 +8,18 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	beadsdk "github.com/steveyegge/beads"
 )
+
+type contextBlockingStore struct {
+	*mockStorage
+}
+
+func (s *contextBlockingStore) SearchIssues(ctx context.Context, _ string, _ beadsdk.IssueFilter) ([]*beadsdk.Issue, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
 
 func TestWithContextCancelsSlowBDQuery(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -58,5 +69,22 @@ sleep 30
 	}
 	if !strings.Contains(err.Error(), "bd list") {
 		t.Fatalf("error does not identify the canceled query: %v", err)
+	}
+}
+
+func TestWithContextCancelsSlowStoreQuery(t *testing.T) {
+	store := &contextBlockingStore{mockStorage: newMockStorage()}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := NewWithStore("/tmp/test", store).WithContext(ctx).List(ListOptions{})
+	elapsed := time.Since(start)
+
+	if err == nil || !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("slow store query error = %v, want deadline exceeded", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("store query ignored caller deadline: %s", elapsed)
 	}
 }

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -74,9 +74,10 @@ func (b *Beads) OpenStore(ctx context.Context) (beadsdk.Storage, func(), error) 
 	return store, cleanup, nil
 }
 
-// storeCtx returns a context with a standard timeout for store operations.
-func storeCtx() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 30*time.Second)
+// storeCtx returns a context with a standard timeout for store operations while
+// preserving any earlier caller deadline.
+func (b *Beads) storeCtx() (context.Context, context.CancelFunc) {
+	return b.operationContext(30 * time.Second)
 }
 
 // sdkIssueToIssue converts a beadsdk Issue (types.Issue) to the gastown
@@ -274,7 +275,7 @@ func workFilterFromListOpts(opts ListOptions) beadsdk.WorkFilter {
 
 // storeList implements List using the in-process store.
 func (b *Beads) storeList(opts ListOptions) ([]*Issue, error) {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	filter := issueFilterFromListOpts(opts)
@@ -288,7 +289,7 @@ func (b *Beads) storeList(opts ListOptions) ([]*Issue, error) {
 
 // storeShow implements Show using the in-process store.
 func (b *Beads) storeShow(id string) (*Issue, error) {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	si, err := b.store.GetIssue(ctx, id)
@@ -321,7 +322,7 @@ func (b *Beads) storeShowMultiple(ids []string) (map[string]*Issue, error) {
 		return make(map[string]*Issue), nil
 	}
 
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	sdkIssues, err := b.store.GetIssuesByIDs(ctx, ids)
@@ -355,7 +356,7 @@ func (b *Beads) storeHydrateIssueDetails(ctx context.Context, issue *Issue) (*Is
 
 // storeCreate implements Create using the in-process store.
 func (b *Beads) storeCreate(opts CreateOptions) (*Issue, error) {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	sdkIssue := &beadsdk.Issue{
@@ -401,7 +402,7 @@ func (b *Beads) storeCreate(opts CreateOptions) (*Issue, error) {
 
 // storeUpdate implements Update using the in-process store.
 func (b *Beads) storeUpdate(id string, opts UpdateOptions) error {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	updates := make(map[string]interface{})
@@ -466,7 +467,7 @@ func (b *Beads) storeUpdate(id string, opts UpdateOptions) error {
 
 // storeClose implements Close using the in-process store.
 func (b *Beads) storeClose(reason, session string, ids ...string) error {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	actor := b.getActor()
@@ -481,7 +482,7 @@ func (b *Beads) storeClose(reason, session string, ids ...string) error {
 
 // storeReady implements Ready using the in-process store.
 func (b *Beads) storeReady() ([]*Issue, error) {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	sdkIssues, err := b.store.GetReadyWork(ctx, beadsdk.WorkFilter{})
@@ -494,7 +495,7 @@ func (b *Beads) storeReady() ([]*Issue, error) {
 
 // storeReadyWithFilter implements Ready with a WorkFilter using the in-process store.
 func (b *Beads) storeReadyWithFilter(filter beadsdk.WorkFilter) ([]*Issue, error) {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	sdkIssues, err := b.store.GetReadyWork(ctx, filter)
@@ -507,7 +508,7 @@ func (b *Beads) storeReadyWithFilter(filter beadsdk.WorkFilter) ([]*Issue, error
 
 // storeBlocked implements Blocked using the in-process store.
 func (b *Beads) storeBlocked() ([]*Issue, error) {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	blocked, err := b.store.GetBlockedIssues(ctx, beadsdk.WorkFilter{})
@@ -525,7 +526,7 @@ func (b *Beads) storeBlocked() ([]*Issue, error) {
 
 // storeSearch implements Search using the in-process store.
 func (b *Beads) storeSearch(opts SearchOptions) ([]*Issue, error) {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	filter := beadsdk.IssueFilter{
@@ -555,7 +556,7 @@ func (b *Beads) storeSearch(opts SearchOptions) ([]*Issue, error) {
 
 // storeAddDependency implements AddDependency using the in-process store.
 func (b *Beads) storeAddDependency(issue, dependsOn string) error {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	dep := &beadsdk.Dependency{
@@ -569,7 +570,7 @@ func (b *Beads) storeAddDependency(issue, dependsOn string) error {
 
 // storeRemoveDependency implements RemoveDependency using the in-process store.
 func (b *Beads) storeRemoveDependency(issue, dependsOn string) error {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	return b.store.RemoveDependency(ctx, issue, dependsOn, b.getActor())
@@ -577,7 +578,7 @@ func (b *Beads) storeRemoveDependency(issue, dependsOn string) error {
 
 // storeAddLabel implements AddLabel using the in-process store.
 func (b *Beads) storeAddLabel(id, label string) error {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	return b.store.AddLabel(ctx, id, label, b.getActor())
@@ -585,7 +586,7 @@ func (b *Beads) storeAddLabel(id, label string) error {
 
 // storeRemoveLabel implements RemoveLabel using the in-process store.
 func (b *Beads) storeRemoveLabel(id, label string) error {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	return b.store.RemoveLabel(ctx, id, label, b.getActor())
@@ -593,7 +594,7 @@ func (b *Beads) storeRemoveLabel(id, label string) error {
 
 // storeGetLabels implements GetLabels using the in-process store.
 func (b *Beads) storeGetLabels(id string) ([]string, error) {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	return b.store.GetLabels(ctx, id)
@@ -603,7 +604,7 @@ func (b *Beads) storeGetLabels(id string) ([]string, error) {
 // "delegated_from" key. Merges with any existing metadata to avoid clobbering
 // other keys.
 func (b *Beads) storeDelegationSet(childID string, d *Delegation) error {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	actor := b.getActor()
@@ -624,7 +625,7 @@ func (b *Beads) storeDelegationSet(childID string, d *Delegation) error {
 
 // storeDelegationClear removes the "delegated_from" key from the issue's metadata.
 func (b *Beads) storeDelegationClear(childID string) error {
-	ctx, cancel := storeCtx()
+	ctx, cancel := b.storeCtx()
 	defer cancel()
 
 	actor := b.getActor()

--- a/internal/cmd/hook_timeout_test.go
+++ b/internal/cmd/hook_timeout_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestHookStatusTimeoutDiagnosticNamesStageAndQuery(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-ctx.Done()
+
+	stage := &hookStatusStage{}
+	stage.begin("rig active-work query: bd list/query --assignee=gastown/dogs/bravo")
+	err := stage.wrap(ctx, context.DeadlineExceeded)
+	message := err.Error()
+
+	for _, want := range []string{
+		"gt hook timed out",
+		"rig active-work query",
+		"bd list/query",
+		"gastown/dogs/bravo",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("timeout diagnostic %q does not contain %q", message, want)
+		}
+	}
+}
+
+func TestHookStatusStagePreservesNonTimeoutQueryError(t *testing.T) {
+	stage := &hookStatusStage{}
+	stage.begin("town active-work query: bd query ephemeral=true")
+
+	err := stage.wrap(context.Background(), context.Canceled)
+	if got := err.Error(); !strings.Contains(got, "town active-work query") ||
+		!strings.Contains(got, "context canceled") {
+		t.Fatalf("query diagnostic lost stage or cause: %q", got)
+	}
+}
+
+func TestRunMoleculeStatusBoundsSlowDogHookQuery(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell bd stub")
+	}
+
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
+	}
+	dogDir := filepath.Join(townRoot, "deacon", "dogs", "bravo")
+	if err := os.MkdirAll(dogDir, 0755); err != nil {
+		t.Fatalf("mkdir dog dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dogDir, ".git"), 0755); err != nil {
+		t.Fatalf("mkdir dog git metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dogDir, ".git", "HEAD"), []byte("ref: refs/heads/test\n"), 0644); err != nil {
+		t.Fatalf("write dog git HEAD: %v", err)
+	}
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	stub := `#!/bin/sh
+if [ "${1:-}" = "--allow-stale" ]; then
+  shift
+fi
+if [ "${1:-}" = "version" ]; then
+  echo "bd test"
+  exit 0
+fi
+sleep 30
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(stub), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dogDir); err != nil {
+		t.Fatalf("chdir dog: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BEADS_DIR", beadsDir)
+	t.Setenv("GT_ROLE", "")
+	beads.ResetBdAllowStaleCacheForTest()
+
+	oldTimeout := hookStatusTimeout
+	hookStatusTimeout = 150 * time.Millisecond
+	t.Cleanup(func() { hookStatusTimeout = oldTimeout })
+
+	start := time.Now()
+	err = runMoleculeStatus(&cobra.Command{}, nil)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("slow dog hook query unexpectedly succeeded")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("dog hook query exceeded command bound: %s", elapsed)
+	}
+	for _, want := range []string{
+		"gt hook timed out after 150ms",
+		"rig active-work query",
+		"bd list",
+		"--assignee=deacon/dogs/bravo",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("timeout diagnostic %q does not contain %q", err, want)
+		}
+	}
+}

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -16,6 +18,33 @@ import (
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
+
+var hookStatusTimeout = 5 * time.Second
+
+type hookStatusStage struct {
+	name    string
+	started time.Time
+}
+
+func (s *hookStatusStage) begin(name string) {
+	s.name = name
+	s.started = time.Now()
+}
+
+func (s *hookStatusStage) wrap(ctx context.Context, err error) error {
+	if err == nil {
+		err = ctx.Err()
+	}
+	elapsed := time.Since(s.started).Round(time.Millisecond)
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("gt hook timed out after %s during %s (stage elapsed %s): %w",
+			hookStatusTimeout, s.name, elapsed, err)
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return fmt.Errorf("gt hook canceled during %s (stage elapsed %s): %w", s.name, elapsed, err)
+	}
+	return fmt.Errorf("%s: %w", s.name, err)
+}
 
 // Note: Agent field parsing is now in internal/beads/fields.go (AgentFields, ParseAgentFields)
 
@@ -316,6 +345,14 @@ func extractMoleculeID(description string) string {
 }
 
 func runMoleculeStatus(cmd *cobra.Command, args []string) error {
+	parentCtx := context.Background()
+	if cmd != nil && cmd.Context() != nil {
+		parentCtx = cmd.Context()
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, hookStatusTimeout)
+	defer cancel()
+	stage := &hookStatusStage{}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("getting current directory: %w", err)
@@ -377,7 +414,7 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 		workDir = resolveHookLookupWorkDir(workDir, target, townRoot)
 	}
 
-	b := beads.New(workDir)
+	b := beads.New(workDir).WithContext(ctx)
 
 	// Build status info
 	status := MoleculeStatusInfo{
@@ -387,32 +424,30 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 
 	// lookupHookedWork performs the full multi-step hook lookup for target.
 	// Called in a retry loop for polecats to handle Dolt propagation lag.
-	lookupHookedWork := func() *beads.Issue {
+	lookupHookedWork := func() (*beads.Issue, error) {
 		// Resolve agent bead ID for display purposes only.
 		// Agent bead's hook_bead field is no longer maintained (updateAgentHookBead is
-		// a no-op since hq-l6mm5), so reading it returns stale data. See GH#2371.
+		// a no-op since hq-l6mm5), so reading the bead adds a database round-trip
+		// without contributing to hook resolution. See GH#2371.
 		agentBeadID := buildAgentBeadID(target, roleCtx.Role, townRoot)
 		if agentBeadID != "" {
-			agentBeadPath := beads.ResolveHookDir(townRoot, agentBeadID, workDir)
-			agentB := b
-			if agentBeadPath != workDir {
-				agentB = beads.New(agentBeadPath)
-			}
-			agentBead, err := agentB.Show(agentBeadID)
-			if err == nil && beads.IsAgentBead(agentBead) {
-				status.AgentBeadID = agentBeadID
-			}
+			status.AgentBeadID = agentBeadID
 		}
 
 		// Query for active work using the authoritative source: bead status + assignee.
+		stage.begin(fmt.Sprintf("rig active-work query: bd list/query --assignee=%s", target))
 		hookedBeads, err := listAssignedActiveWork(b, target)
 		if err != nil {
-			return nil
+			return nil, stage.wrap(ctx, err)
 		}
 
 		// For town-level roles (mayor, deacon), scan all rigs if nothing found locally
 		if len(hookedBeads) == 0 && isTownLevelRole(target) {
-			hookedBeads = scanAllRigsForHookedBeads(townRoot, target)
+			stage.begin(fmt.Sprintf("cross-rig active-work query: bd list/query --assignee=%s", target))
+			hookedBeads, err = scanAllRigsForHookedBeadsContext(ctx, townRoot, target)
+			if err != nil {
+				return nil, stage.wrap(ctx, err)
+			}
 		}
 
 		// For rig-level agents (polecats, crew), also search town-level beads.
@@ -420,16 +455,21 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 		// townRoot/.beads, not the rig's .beads database.
 		// See: https://github.com/steveyegge/gastown/issues/1438
 		if len(hookedBeads) == 0 && !isTownLevelRole(target) && townRoot != "" {
-			townB := beads.New(filepath.Join(townRoot, ".beads"))
-			if townWork, err := listAssignedActiveWork(townB, target); err == nil && len(townWork) > 0 {
+			stage.begin(fmt.Sprintf("town active-work query: bd list/query --assignee=%s", target))
+			townB := beads.New(filepath.Join(townRoot, ".beads")).WithContext(ctx)
+			townWork, townErr := listAssignedActiveWork(townB, target)
+			if townErr != nil {
+				return nil, stage.wrap(ctx, townErr)
+			}
+			if len(townWork) > 0 {
 				hookedBeads = townWork
 			}
 		}
 
 		if len(hookedBeads) > 0 {
-			return hookedBeads[0]
+			return hookedBeads[0], nil
 		}
-		return nil
+		return nil, nil
 	}
 
 	// Run the lookup. In polecat context, retry with backoff to handle Dolt
@@ -442,15 +482,28 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 			return r == RolePolecat
 		}())
 
-	hookBead = lookupHookedWork()
+	hookBead, err = lookupHookedWork()
+	if err != nil {
+		return err
+	}
 	if hookBead == nil && isPolecat {
 		const maxRetries = 5
 		const baseBackoff = 500 * time.Millisecond
 		const maxBackoff = 8 * time.Second
 		for attempt := 1; attempt <= maxRetries; attempt++ {
 			backoff := slingBackoff(attempt, baseBackoff, maxBackoff)
-			time.Sleep(backoff)
-			hookBead = lookupHookedWork()
+			stage.begin(fmt.Sprintf("propagation retry backoff %d/%d", attempt, maxRetries))
+			timer := time.NewTimer(backoff)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return stage.wrap(ctx, ctx.Err())
+			}
+			hookBead, err = lookupHookedWork()
+			if err != nil {
+				return err
+			}
 			if hookBead != nil {
 				break
 			}
@@ -474,11 +527,19 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 				strings.Contains(hookBead.Description, "is_wisp: true")
 
 			if attachment.AttachedMolecule != "" {
+				stage.begin("molecule progress query: bd show/list " + attachment.AttachedMolecule)
 				progress, _ := getMoleculeProgressInfo(b, attachment.AttachedMolecule)
+				if ctx.Err() != nil {
+					return stage.wrap(ctx, ctx.Err())
+				}
 				status.Progress = progress
 				status.NextAction = determineNextAction(status)
 			} else if attachment.AttachedFormula != "" {
+				stage.begin("formula progress query: bd show/list " + hookBead.ID)
 				progress, _ := getMoleculeProgressInfo(b, hookBead.ID)
+				if ctx.Err() != nil {
+					return stage.wrap(ctx, ctx.Err())
+				}
 				status.Progress = progress
 				status.NextAction = determineNextAction(status)
 			}
@@ -1165,11 +1226,19 @@ func extractMailSender(labels []string) string {
 // assigned to the target agent. Used for town-level roles that may have
 // work hooked in any rig.
 func scanAllRigsForHookedBeads(townRoot, target string) []*beads.Issue {
+	hooked, _ := scanAllRigsForHookedBeadsContext(context.Background(), townRoot, target)
+	return hooked
+}
+
+// scanAllRigsForHookedBeadsContext is the bounded variant used by gt hook.
+// It stops scanning as soon as the command deadline expires instead of allowing
+// each rig query to consume a fresh subprocess timeout.
+func scanAllRigsForHookedBeadsContext(ctx context.Context, townRoot, target string) ([]*beads.Issue, error) {
 	// Load routes from town beads
 	townBeadsDir := filepath.Join(townRoot, ".beads")
 	routes, err := beads.LoadRoutes(townBeadsDir)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	// Scan each rig's beads directory
@@ -1186,16 +1255,19 @@ func scanAllRigsForHookedBeads(townRoot, target string) []*beads.Issue {
 			continue
 		}
 
-		b := beads.New(rigBeadsDir)
+		b := beads.New(rigBeadsDir).WithContext(ctx)
 		hookedBeads, err := listAssignedActiveWork(b, target)
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil, err
+			}
 			continue
 		}
 
 		if len(hookedBeads) > 0 {
-			return hookedBeads
+			return hookedBeads, nil
 		}
 	}
 
-	return nil
+	return nil, ctx.Err()
 }


### PR DESCRIPTION
## Summary
- propagate cancellation/deadlines through Beads store queries
- terminate timed-out query process groups rather than leaving children behind
- bound dog molecule hook/status startup with actionable stage diagnostics
- add deterministic timeout and healthy-path regression coverage

## Validation
- focused subprocess/store cancellation tests
- dog hook timeout, hook diagnostics, active-work, lookup, and output tests
- `go vet ./internal/beads ./internal/cmd`
- `CGO_ENABLED=0 make build`
- live healthy `./gt hook`: 4.10s
- `git diff --check`

Full `go test ./...` was attempted and remains red on unrelated baseline/host fixtures documented on gt-12o. No local MQ entry, force push, or Dolt history rewrite was used.

Tracks gt-12o.