### PR TITLE
fix: preserve HQ agent-bead routing from rig checkouts

### DIFF
--- a/internal/cmd/agent_state.go
+++ b/internal/cmd/agent_state.go
@@ -94,7 +94,7 @@ type agentStateResult struct {
 func runAgentState(cmd *cobra.Command, args []string) error {
 	agentBead := args[0]
 
-	beadsDir, err := resolveAgentTrackingBeadsDir()
+	beadsDir, err := resolveAgentBeadTrackingDir(agentBead)
 	if err != nil {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}

--- a/internal/cmd/agent_tracking_beads.go
+++ b/internal/cmd/agent_tracking_beads.go
@@ -52,3 +52,37 @@ func resolveAgentTrackingBeadsDir() (string, error) {
 	}
 	return beadsDir, nil
 }
+
+// resolveAgentBeadTrackingDir resolves the database that actually contains an
+// agent bead. Patrol commands normally start in a rig checkout, but canonical
+// agent beads may still live in the town database. In that case the ID alone
+// does not carry enough routing information (it commonly has the rig prefix),
+// so probe the cwd-local database first and then the town database.
+func resolveAgentBeadTrackingDir(agentBead string) (string, error) {
+	currentBeadsDir, err := resolveAgentTrackingBeadsDir()
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := getAllAgentLabels(agentBead, currentBeadsDir); err == nil {
+		return currentBeadsDir, nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return currentBeadsDir, nil
+	}
+	townRoot := beads.FindTownRoot(cwd)
+	if townRoot == "" {
+		return currentBeadsDir, nil
+	}
+	townBeadsDir := beads.ResolveBeadsDir(beads.GetTownBeadsPath(townRoot))
+	if townBeadsDir == "" || filepath.Clean(townBeadsDir) == filepath.Clean(currentBeadsDir) {
+		return currentBeadsDir, nil
+	}
+
+	if _, err := getAllAgentLabels(agentBead, townBeadsDir); err == nil {
+		return townBeadsDir, nil
+	}
+	return currentBeadsDir, nil
+}

--- a/internal/cmd/agent_tracking_beads_test.go
+++ b/internal/cmd/agent_tracking_beads_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -171,6 +172,182 @@ esac
 			if !strings.Contains(line, "READONLY= ") || !strings.Contains(line, "AUTO=on") {
 				t.Fatalf("bd mutation was not mutation pinned: %s\nfull log:\n%s", line, log)
 			}
+		}
+	}
+}
+
+func TestAgentStateAndAwaitCommandsRouteHQAgentBeadFromRigCwd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell fake bd")
+	}
+
+	tmp := t.TempDir()
+	townRoot := filepath.Join(tmp, "gt")
+	townBeads := filepath.Join(townRoot, ".beads")
+	rigWorkDir := filepath.Join(townRoot, "gastown", "refinery", "rig")
+	rigRedirect := filepath.Join(rigWorkDir, ".beads")
+	rigBeads := filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
+	mayorDir := filepath.Join(townRoot, "mayor")
+
+	for _, dir := range []string{townBeads, rigRedirect, rigBeads, mayorDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "town.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigRedirect, "redirect"), []byte("../../mayor/rig/.beads"), 0o644); err != nil {
+		t.Fatalf("write rig redirect: %v", err)
+	}
+	for path, database := range map[string]string{townBeads: "towndb", rigBeads: "rigdb"} {
+		metadata := []byte(`{"dolt_database":"` + database + `","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`)
+		if err := os.WriteFile(filepath.Join(path, "metadata.json"), metadata, 0o644); err != nil {
+			t.Fatalf("write metadata: %v", err)
+		}
+	}
+
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	logPath := filepath.Join(tmp, "bd.log")
+	bdScript := `#!/bin/sh
+printf 'cmd=%s BEADS_DIR=%s DB=%s\n' "$1" "${BEADS_DIR-}" "${BEADS_DOLT_SERVER_DATABASE-}" >> "$BD_LOG"
+case "$1" in
+  list)
+    case "$*" in
+      *--ephemeral*) printf '[]\n' ;;
+      *)
+        if [ "${BEADS_DOLT_SERVER_DATABASE-}" = "towndb" ]; then
+          printf '[{"id":"gt-gastown-refinery","status":"open","description":"role_type: refinery\\nrig: gastown","labels":["gt:agent"]}]\n'
+        else
+          printf '[]\n'
+        fi
+        ;;
+    esac
+    ;;
+  show)
+    if [ "${BEADS_DOLT_SERVER_DATABASE-}" = "towndb" ]; then
+      printf '[{"id":"gt-gastown-refinery","labels":["gt:agent","idle:0"]}]\n'
+    else
+      printf 'no issue found\n' >&2
+      exit 1
+    fi
+    ;;
+  update)
+    ;;
+  *)
+    printf 'unexpected bd command: %s\n' "$1" >&2
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("BEADS_DIR", rigBeads)
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(rigWorkDir); err != nil {
+		t.Fatalf("chdir rig work dir: %v", err)
+	}
+
+	oldSet, oldIncr, oldDel, oldStateJSON := agentStateSet, agentStateIncr, agentStateDel, agentStateJSON
+	oldResolveRole, oldResolveRig := agentsResolveRole, agentsResolveRig
+	oldResolveJSON, oldResolveQuiet := agentsResolveJSON, agentsResolveQuiet
+	oldResolveOut := agentsResolveCmd.OutOrStdout()
+	oldChannel, oldTimeout := awaitEventChannel, awaitEventTimeout
+	oldBackoffBase, oldBackoffMax := awaitEventBackoffBase, awaitEventBackoffMax
+	oldBackoffMult, oldQuiet := awaitEventBackoffMult, awaitEventQuiet
+	oldAgentBead, oldCleanup := awaitEventAgentBead, awaitEventCleanup
+	oldContextInterval, oldMoleculeJSON := awaitEventContextCheckInterval, moleculeJSON
+	oldSignalTimeout := awaitSignalTimeout
+	oldSignalBackoffBase, oldSignalBackoffMax := awaitSignalBackoffBase, awaitSignalBackoffMax
+	oldSignalBackoffMult, oldSignalQuiet := awaitSignalBackoffMult, awaitSignalQuiet
+	oldSignalAgentBead := awaitSignalAgentBead
+	t.Cleanup(func() {
+		agentStateSet, agentStateIncr, agentStateDel, agentStateJSON = oldSet, oldIncr, oldDel, oldStateJSON
+		agentsResolveRole, agentsResolveRig = oldResolveRole, oldResolveRig
+		agentsResolveJSON, agentsResolveQuiet = oldResolveJSON, oldResolveQuiet
+		agentsResolveCmd.SetOut(oldResolveOut)
+		awaitEventChannel, awaitEventTimeout = oldChannel, oldTimeout
+		awaitEventBackoffBase, awaitEventBackoffMax = oldBackoffBase, oldBackoffMax
+		awaitEventBackoffMult, awaitEventQuiet = oldBackoffMult, oldQuiet
+		awaitEventAgentBead, awaitEventCleanup = oldAgentBead, oldCleanup
+		awaitEventContextCheckInterval, moleculeJSON = oldContextInterval, oldMoleculeJSON
+		awaitSignalTimeout = oldSignalTimeout
+		awaitSignalBackoffBase, awaitSignalBackoffMax = oldSignalBackoffBase, oldSignalBackoffMax
+		awaitSignalBackoffMult, awaitSignalQuiet = oldSignalBackoffMult, oldSignalQuiet
+		awaitSignalAgentBead = oldSignalAgentBead
+	})
+
+	agentsResolveRole = "refinery"
+	agentsResolveRig = "gastown"
+	agentsResolveJSON = false
+	agentsResolveQuiet = false
+	var resolveOut bytes.Buffer
+	agentsResolveCmd.SetOut(&resolveOut)
+	if err := runAgentsResolve(agentsResolveCmd, nil); err != nil {
+		t.Fatalf("runAgentsResolve() error = %v", err)
+	}
+	if got := strings.TrimSpace(resolveOut.String()); got != "gt-gastown-refinery" {
+		t.Fatalf("runAgentsResolve() output = %q, want HQ agent bead ID", got)
+	}
+
+	agentStateSet = []string{"idle=0"}
+	agentStateIncr = ""
+	agentStateDel = nil
+	agentStateJSON = false
+	if err := runAgentState(nil, []string{"gt-gastown-refinery"}); err != nil {
+		t.Fatalf("runAgentState() error = %v", err)
+	}
+
+	awaitEventChannel = "routing-test"
+	awaitEventTimeout = "1ms"
+	awaitEventBackoffBase = ""
+	awaitEventBackoffMax = ""
+	awaitEventBackoffMult = 2
+	awaitEventQuiet = true
+	awaitEventAgentBead = "gt-gastown-refinery"
+	awaitEventCleanup = true
+	awaitEventContextCheckInterval = ""
+	moleculeJSON = false
+	if err := runMoleculeAwaitEvent(nil, nil); err != nil {
+		t.Fatalf("runMoleculeAwaitEvent() error = %v", err)
+	}
+
+	awaitSignalTimeout = "1ms"
+	awaitSignalBackoffBase = ""
+	awaitSignalBackoffMax = ""
+	awaitSignalBackoffMult = 2
+	awaitSignalQuiet = true
+	awaitSignalAgentBead = "gt-gastown-witness"
+	if err := runMoleculeAwaitSignal(nil, nil); err != nil {
+		t.Fatalf("runMoleculeAwaitSignal() error = %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "cmd=show ") || !strings.Contains(log, "DB=rigdb") {
+		t.Fatalf("expected a rig-local probe before HQ fallback; log:\n%s", log)
+	}
+	if !strings.Contains(log, "DB=towndb") {
+		t.Fatalf("expected HQ agent bead reads; log:\n%s", log)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(log), "\n") {
+		if strings.HasPrefix(line, "cmd=update ") && !strings.Contains(line, "DB=towndb") {
+			t.Fatalf("agent bead update escaped HQ routing: %s\nfull log:\n%s", line, log)
 		}
 	}
 }

--- a/internal/cmd/agents_resolve.go
+++ b/internal/cmd/agents_resolve.go
@@ -108,10 +108,6 @@ func runAgentsResolve(cmd *cobra.Command, _ []string) error {
 		}
 		return fmt.Errorf("%s", message)
 	}
-	if rig != "" && agentBeadSourceIsTown(match.Source) && !agentsResolveJSON {
-		return fmt.Errorf("agent bead %s was found only in %s; patrol await/state commands require a rig-local agent bead", match.ID, match.Source)
-	}
-
 	if agentsResolveJSON {
 		return json.NewEncoder(cmd.OutOrStdout()).Encode(agentsResolveResult{
 			ID:       match.ID,
@@ -271,8 +267,4 @@ func agentBeadSourceRank(source agentBeadSource) int {
 	default:
 		return 99
 	}
-}
-
-func agentBeadSourceIsTown(source agentBeadSource) bool {
-	return source == agentSourceTownWisps || source == agentSourceTownIssues
 }

--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -160,7 +160,7 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 	var beadsDir string
 	if awaitEventAgentBead != "" {
 		var wdErr error
-		beadsDir, wdErr = resolveAgentTrackingBeadsDir()
+		beadsDir, wdErr = resolveAgentBeadTrackingDir(awaitEventAgentBead)
 		if wdErr == nil {
 			labels, labErr := getAgentLabels(awaitEventAgentBead, beadsDir)
 			if labErr != nil {

--- a/internal/cmd/molecule_await_signal.go
+++ b/internal/cmd/molecule_await_signal.go
@@ -132,8 +132,15 @@ func init() {
 }
 
 func runMoleculeAwaitSignal(cmd *cobra.Command, args []string) error {
-	// Find beads directory (rig-local for bead operations)
-	beadsDir, err := resolveAgentTrackingBeadsDir()
+	// Find the database that owns the agent bead. Canonical witness/refinery
+	// beads may live at HQ even when this command runs from a rig checkout.
+	var beadsDir string
+	var err error
+	if awaitSignalAgentBead != "" {
+		beadsDir, err = resolveAgentBeadTrackingDir(awaitSignalAgentBead)
+	} else {
+		beadsDir, err = resolveAgentTrackingBeadsDir()
+	}
 	if err != nil {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}


### PR DESCRIPTION
## Summary
- preserve the resolved HQ Beads directory across agent-state operations
- route await-event and await-signal updates to HQ-backed agent beads from rig working directories
- add rig-CWD regression coverage for resolution, state, and both wait paths

## Validation
- `git diff --check`
- focused routing regression with `CGO_ENABLED=0`
- `CGO_ENABLED=0 go build ./cmd/gt`
- `CGO_ENABLED=0 go vet ./...`
- post-rebase focused regression/build

Native CGO remains host-blocked by the missing ICU header; the full non-CGO suite only showed unrelated environment-sensitive baseline failures documented on gt-bdw. No local MQ entry, force push, or Dolt-history rewrite was used.

Tracks gt-bdw.