### PR TITLE
fix(await-event): preserve backoff across context yields

### DIFF
--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -200,11 +200,13 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 
 	// Resume from backoff-until if interrupted (same pattern as await-signal)
 	timeout := fullTimeout
+	resumed := false
 	now := time.Now()
 	if awaitEventAgentBead != "" && !backoffUntil.IsZero() && backoffUntil.After(now) {
 		remaining := backoffUntil.Sub(now)
 		if remaining <= fullTimeout {
 			timeout = remaining
+			resumed = true
 			if !awaitEventQuiet && !moleculeJSON {
 				fmt.Printf("%s Resuming backoff window (%v remaining)\n",
 					style.Dim.Render("↻"), remaining.Round(time.Second))
@@ -212,8 +214,10 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Persist backoff-until for crash recovery
-	if awaitEventAgentBead != "" && beadsDir != "" {
+	// Persist backoff-until for crash recovery.
+	// When resuming an existing window, keep the original deadline stable across
+	// context-yield re-entry instead of rewriting it on every invocation.
+	if awaitEventAgentBead != "" && beadsDir != "" && !resumed {
 		_ = setAgentBackoffUntil(awaitEventAgentBead, beadsDir, now.Add(timeout))
 	}
 
@@ -260,8 +264,11 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 		// For "context-yield": idle cycles unchanged — we yielded early for context
 		// assessment, not because the full backoff window elapsed.
 
-		// Clear backoff-until — we completed (event, timeout, or context-yield)
-		_ = clearAgentBackoffUntil(awaitEventAgentBead, beadsDir)
+		// Keep the backoff window across context-yield so the next invocation
+		// resumes the remaining wait instead of restarting the same idle tier.
+		if result.Reason == "event" || result.Reason == "timeout" {
+			_ = clearAgentBackoffUntil(awaitEventAgentBead, beadsDir)
+		}
 	}
 
 	// Cleanup event files if requested

--- a/internal/cmd/molecule_await_event_test.go
+++ b/internal/cmd/molecule_await_event_test.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -521,6 +523,139 @@ func TestWaitForEventFilesNoContextYieldWhenZero(t *testing.T) {
 	if elapsed > deadline+2*time.Second {
 		t.Errorf("wait took %v; should have returned at ~%v", elapsed, deadline)
 	}
+}
+
+func TestAwaitEventContextYieldPreservesBackoffWindow(t *testing.T) {
+	until := time.Now().Add(2 * time.Second).Unix()
+	log := runAwaitEventBackoffTest(t, []string{"gt:agent", "idle:1", fmt.Sprintf("backoff-until:%d", until)}, "5s", "50ms")
+
+	updates := updateLines(log)
+	if len(updates) == 0 {
+		t.Fatalf("expected bd update calls, log:\n%s", log)
+	}
+	for _, line := range updates {
+		if !strings.Contains(line, "backoff-until:") {
+			t.Fatalf("context-yield cleared backoff window; update %q in log:\n%s", line, log)
+		}
+	}
+}
+
+func TestAwaitEventTimeoutClearsBackoffWindow(t *testing.T) {
+	until := time.Now().Add(2 * time.Second).Unix()
+	log := runAwaitEventBackoffTest(t, []string{"gt:agent", "idle:1", fmt.Sprintf("backoff-until:%d", until)}, "80ms", "")
+
+	updates := updateLines(log)
+	if len(updates) == 0 {
+		t.Fatalf("expected bd update calls, log:\n%s", log)
+	}
+	last := updates[len(updates)-1]
+	if strings.Contains(last, "backoff-until:") {
+		t.Fatalf("timeout did not clear backoff window; last update %q in log:\n%s", last, log)
+	}
+}
+
+func runAwaitEventBackoffTest(t *testing.T, labels []string, timeout, contextCheck string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+	beadsDir := filepath.Join(root, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+	t.Chdir(root)
+
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	logPath := filepath.Join(root, "bd.log")
+	showJSON, err := json.Marshal([]struct {
+		Labels []string `json:"labels"`
+	}{{Labels: labels}})
+	if err != nil {
+		t.Fatalf("marshal labels: %v", err)
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+case "$1" in
+show)
+cat <<'JSON'
+%s
+JSON
+;;
+update)
+exit 0
+;;
+*)
+exit 0
+;;
+esac
+`, logPath, string(showJSON))
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	oldChannel := awaitEventChannel
+	oldTimeout := awaitEventTimeout
+	oldBackoffBase := awaitEventBackoffBase
+	oldBackoffMult := awaitEventBackoffMult
+	oldBackoffMax := awaitEventBackoffMax
+	oldQuiet := awaitEventQuiet
+	oldAgentBead := awaitEventAgentBead
+	oldCleanup := awaitEventCleanup
+	oldContextCheck := awaitEventContextCheckInterval
+	oldJSON := moleculeJSON
+	t.Cleanup(func() {
+		awaitEventChannel = oldChannel
+		awaitEventTimeout = oldTimeout
+		awaitEventBackoffBase = oldBackoffBase
+		awaitEventBackoffMult = oldBackoffMult
+		awaitEventBackoffMax = oldBackoffMax
+		awaitEventQuiet = oldQuiet
+		awaitEventAgentBead = oldAgentBead
+		awaitEventCleanup = oldCleanup
+		awaitEventContextCheckInterval = oldContextCheck
+		moleculeJSON = oldJSON
+	})
+
+	awaitEventChannel = "test"
+	awaitEventTimeout = timeout
+	awaitEventBackoffBase = ""
+	awaitEventBackoffMult = 2
+	awaitEventBackoffMax = ""
+	awaitEventQuiet = true
+	awaitEventAgentBead = "gt-agent"
+	awaitEventCleanup = false
+	awaitEventContextCheckInterval = contextCheck
+	moleculeJSON = false
+
+	if err := runMoleculeAwaitEvent(nil, nil); err != nil {
+		t.Fatalf("runMoleculeAwaitEvent: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	return string(data)
+}
+
+func updateLines(log string) []string {
+	var updates []string
+	for _, line := range strings.Split(log, "\n") {
+		if strings.HasPrefix(line, "update ") {
+			updates = append(updates, line)
+		}
+	}
+	return updates
 }
 
 func TestEffortLevelContextYield(t *testing.T) {


### PR DESCRIPTION
Replacement for #4547 and stale replacement #4559.\n\nThis carries forward the cleanup-first PR Sheriff replacement on current main 7627c26a. It preserves await-event backoff-until across context-yield re-entry and clears it only on event or timeout; it intentionally does not carry forward the doltStateRetries expansion from #4547.\n\nEvidence on gt-pr-sheriff-4547: 15 research legs, 5 pre-implementation reviews, 5 post-implementation reviews, checker PASS, verdict merge_replacement. Local focused verification on head a6aede3: CGO_ENABLED=0 go test ./internal/cmd -run 'TestAwaitEvent(ContextYieldPreservesBackoffWindow|TimeoutClearsBackoffWindow|Result)$' -count=1.