### PR TITLE
fix(mail): the group-address vocabulary the directory prints and the router accepts had drifted apart, both ways

### DIFF
--- a/internal/cmd/mail_directory.go
+++ b/internal/cmd/mail_directory.go
@@ -112,12 +112,17 @@ func runMailDirectory(cmd *cobra.Command, args []string) error {
 		{Address: "mayor/", Type: "well-known"},
 		{Address: "--human", Type: "well-known"},
 		{Address: "--self", Type: "well-known"},
-		{Address: "@town", Type: "special"},
-		{Address: "@crew", Type: "special"},
-		{Address: "@witnesses", Type: "special"},
-		{Address: "@overseer", Type: "special"},
 	}
 	entries = append(entries, wellKnown...)
+
+	// 6. Group addresses — DERIVED from mail.GroupVocabulary, never re-listed here ([si-zgo]).
+	// This block used to be four hardcoded literals: @town, @crew, @witnesses, @overseer. It
+	// advertised `@crew` bare, which the send path rejects because crew is arity-1 (crew of WHICH
+	// rig?), and it omitted @dogs/@refineries/@deacons entirely — three sendable audiences no
+	// reader could discover. Deriving fixes both directions at once and keeps them fixed.
+	for _, addr := range mail.GroupAddresses() {
+		entries = append(entries, DirectoryEntry{Address: addr, Type: "special"})
+	}
 
 	// Deduplicate (e.g., mayor/ may appear as both agent and well-known)
 	seen := make(map[string]bool)

--- a/internal/cmd/mail_directory_parity_test.go
+++ b/internal/cmd/mail_directory_parity_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/mail"
+)
+
+// [si-zgo] THE PARITY GATE, READING WHAT THE COMMAND ACTUALLY EMITS.
+//
+// The defect: `gt mail directory` advertised `@crew`; `gt mail send @crew` answered "invalid group
+// address". A vocabulary one side exports and the other never accepts.
+//
+// WHY THIS TEST LIVES HERE AND NOT NEXT TO THE VOCABULARY. My first version of this gate sat in
+// internal/mail and took its "advertised" set from mail.GroupAddresses(). That is the vocabulary
+// itself, not the directory's output — so both sides of the "round trip" derived from one source
+// and the gate could not see the directory emitting anything extra. It was a tautology wearing a
+// round trip's clothes, which is the exact failure this bead is about.
+//
+// It was caught by RUNNING THE ACCEPTANCE CRITERION rather than reasoning about it: appending a
+// rogue `@ghosts` entry to the directory left the suite green. That mutation now reds here.
+//
+// So: the left side is DATA — the JSON the command really prints. The right side is BEHAVIOUR —
+// what mail.ParseGroupAddress really accepts. Derivation cannot make those trivially equal.
+
+// directoryEntries runs the real directory command and returns what it printed.
+func directoryEntries(t *testing.T) []DirectoryEntry {
+	t.Helper()
+	townRoot := setupTestTownForCrewList(t, map[string][]string{"rig-a": {"alice"}})
+	withCwd(t, townRoot)
+
+	mailDirJSON = true
+	defer func() { mailDirJSON = false }()
+
+	output := captureStdout(t, func() {
+		if err := runMailDirectory(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("runMailDirectory error: %v", err)
+		}
+	})
+
+	var entries []DirectoryEntry
+	if err := json.Unmarshal([]byte(output), &entries); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\nraw output:\n%s", err, output)
+	}
+	return entries
+}
+
+func TestEveryGroupAddressTheDirectoryPrintsIsRoutable(t *testing.T) {
+	entries := directoryEntries(t)
+
+	var advertised []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Address, "@") {
+			advertised = append(advertised, e.Address)
+		}
+	}
+
+	// DENOMINATOR ASSERT. "Every advertised address routes" is trivially satisfied by advertising
+	// nothing, and an empty result here would otherwise render exactly like a clean pass.
+	if len(advertised) == 0 {
+		t.Fatal("the directory printed ZERO group addresses — every assertion below would " +
+			"pass vacuously, so this is a failure, not a clean run")
+	}
+	t.Logf("directory printed %d group address(es)", len(advertised))
+
+	for _, addr := range advertised {
+		// Arity-1 groups are advertised as a pattern, "@crew/<rig>". Substitute a concrete
+		// qualifier: the parser's contract is about SHAPE; a real send resolves the rig.
+		probe := strings.Replace(addr, "/<rig>", "/somerig", 1)
+		probe = strings.Replace(probe, "/<name>", "/somename", 1)
+
+		if mail.ParseGroupAddress(probe) == nil {
+			t.Errorf("`gt mail directory` advertises %q but the send path refuses %q.\n"+
+				"That is si-zgo: a vocabulary one side exports and the other never accepts. "+
+				"Add it to mail.GroupVocabulary rather than printing it here.", addr, probe)
+		}
+	}
+}
+
+func TestEveryRoutableGroupIsPrintedByTheDirectory(t *testing.T) {
+	if len(mail.GroupVocabulary) == 0 {
+		t.Fatal("mail.GroupVocabulary is EMPTY — the assertions below would pass vacuously")
+	}
+
+	printed := make(map[string]bool)
+	for _, e := range directoryEntries(t) {
+		printed[e.Address] = true
+	}
+
+	for _, spec := range mail.GroupVocabulary {
+		// spec.Address() renders the correctly-arity'd form; spelling it here would be the
+		// third copy of the vocabulary this bead exists to remove.
+		if !printed[spec.Address()] {
+			t.Errorf("the send path accepts group %q (arity %d) but `gt mail directory` never "+
+				"prints %q — a sendable audience no reader can discover. That direction is how "+
+				"@dogs/@refineries/@deacons stayed invisible.",
+				spec.Name, spec.Arity(), spec.Address())
+		}
+	}
+}

--- a/internal/cmd/mail_directory_test.go
+++ b/internal/cmd/mail_directory_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/mail"
 )
 
 func TestRunMailDirectory_WellKnownAddresses(t *testing.T) {
@@ -36,8 +37,11 @@ func TestRunMailDirectory_WellKnownAddresses(t *testing.T) {
 		}
 	}
 
-	// Should contain special addresses
-	for _, addr := range []string{"@town", "@crew", "@witnesses", "@overseer"} {
+	// Should contain every group address — DERIVED from the vocabulary ([si-zgo]), not listed
+	// here. This block used to name @town/@crew/@witnesses/@overseer, which was a second copy of
+	// the set: it asserted the bare `@crew` the send path rejects, and it never noticed that
+	// @dogs/@refineries/@deacons were advertised nowhere.
+	for _, addr := range mail.GroupAddresses() {
 		if !strings.Contains(output, addr) {
 			t.Errorf("output should contain %q, got:\n%s", addr, output)
 		}
@@ -80,7 +84,15 @@ func TestRunMailDirectory_JSONOutput(t *testing.T) {
 		addrSet[e.Address] = e.Type
 	}
 
-	for _, addr := range []string{"--human", "--self", "@town", "@crew"} {
+	for _, addr := range []string{"--human", "--self"} {
+		if _, ok := addrSet[addr]; !ok {
+			t.Errorf("JSON output missing address %q", addr)
+		}
+	}
+	// Group addresses derived, same reason as above ([si-zgo]). Note this is an EXACT-key check,
+	// which is why it caught the change the substring check above missed: "@crew/<rig>" contains
+	// "@crew", so a Contains assertion passes on both the correct and the defective rendering.
+	for _, addr := range mail.GroupAddresses() {
 		if _, ok := addrSet[addr]; !ok {
 			t.Errorf("JSON output missing address %q", addr)
 		}

--- a/internal/mail/groups.go
+++ b/internal/mail/groups.go
@@ -1,0 +1,107 @@
+package mail
+
+import (
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/constants"
+)
+
+// [si-zgo] THE GROUP-ADDRESS VOCABULARY — one owner, for both the send path and the directory.
+//
+// WHY THIS FILE EXISTS. `gt mail directory` advertised `@crew` and `gt mail send @crew` answered
+// "invalid group address: @crew". A vocabulary one side exports and the other never accepts.
+// silicon/refinery hit it trying to reach two crew members and had to route through the Mayor.
+//
+// THE ELEMENT IS (GROUP, ARITY), NOT A BARE TOKEN — and that is what resolves the defect rather
+// than papering over it. Modelled as bare strings, the two obvious repairs are both wrong:
+// teaching send to accept bare `@crew` invents an audience that does not exist (crew of WHICH
+// rig?), and dropping `@crew` from the directory hides a real, reachable one. With arity in the
+// element, `@crew` is a genuine member of the vocabulary AND the directory's bare rendering of it
+// was malformed. The directory's bug was rendering an arity-1 group in arity-0 form.
+//
+// EVERY CONSUMER COMPOSES THIS. Do not re-spell the set anywhere — a hand-written copy is a gate
+// that silently stops tracking the real one, and this defect is what that looks like in
+// production. tests/TestNoConsumerHardcodesTheGroupVocabulary enforces it by AST.
+
+// GroupSpec is one entry in the group-address vocabulary: the bare group token, whether it
+// requires a qualifier, and what the router resolves it to.
+type GroupSpec struct {
+	// Name is the token after '@', e.g. "town" or "crew".
+	Name string
+	// Qualifier names the required argument ("rig", "name"), or "" for an arity-0 group.
+	Qualifier string
+	// Type and RoleType are what parseGroupAddress yields for this entry.
+	Type     GroupType
+	RoleType string
+}
+
+// Arity reports how many qualifiers the group requires: 0 or 1.
+func (g GroupSpec) Arity() int {
+	if g.Qualifier == "" {
+		return 0
+	}
+	return 1
+}
+
+// Address renders the canonical form a human can act on: "@town" for arity 0, "@crew/<rig>" for
+// arity 1. An arity-1 group rendered without its qualifier is exactly the si-zgo defect, so the
+// rendering is derived from Arity rather than written per entry.
+func (g GroupSpec) Address() string {
+	if g.Arity() == 0 {
+		return "@" + g.Name
+	}
+	return "@" + g.Name + "/<" + g.Qualifier + ">"
+}
+
+// GroupVocabulary is the single source of truth for group addresses. The send path (see
+// parseGroupAddress) and `gt mail directory` both derive from it.
+var GroupVocabulary = []GroupSpec{
+	{Name: "overseer", Type: GroupTypeOverseer},
+	{Name: "town", Type: GroupTypeTown},
+	{Name: "witnesses", Type: GroupTypeRole, RoleType: constants.RoleWitness},
+	{Name: "dogs", Type: GroupTypeRole, RoleType: "dog"},
+	{Name: "refineries", Type: GroupTypeRole, RoleType: constants.RoleRefinery},
+	{Name: "deacons", Type: GroupTypeRole, RoleType: constants.RoleDeacon},
+
+	{Name: "rig", Qualifier: "rig", Type: GroupTypeRig},
+	{Name: constants.RoleCrew, Qualifier: "rig", Type: GroupTypeRigRole, RoleType: constants.RoleCrew},
+	{Name: "polecats", Qualifier: "rig", Type: GroupTypeRigRole, RoleType: constants.RolePolecat},
+}
+
+// lookupGroup returns the vocabulary entry for a bare group name.
+func lookupGroup(name string) (GroupSpec, bool) {
+	for _, g := range GroupVocabulary {
+		if g.Name == name {
+			return g, true
+		}
+	}
+	return GroupSpec{}, false
+}
+
+// GroupAddresses renders every address in the vocabulary, canonically. This is what the directory
+// advertises — derived, so a group added here reaches readers without a second edit.
+func GroupAddresses() []string {
+	out := make([]string, 0, len(GroupVocabulary))
+	for _, g := range GroupVocabulary {
+		out = append(out, g.Address())
+	}
+	return out
+}
+
+// ParseGroupAddress is the exported entry point for parsing a group address, so tests and
+// consumers can ask the ROUTER whether an address routes rather than re-deriving the rule.
+// Returns nil for anything the vocabulary does not admit, including an arity-1 group written
+// without its qualifier (bare "@crew") and an arity-0 group written with one ("@town/x").
+func ParseGroupAddress(address string) *ParsedGroup {
+	return parseGroupAddress(address)
+}
+
+// splitGroupAddress splits "@name/qualifier" into its parts. The qualifier is "" when absent.
+func splitGroupAddress(address string) (name, qualifier string) {
+	trimmed := strings.TrimPrefix(address, "@")
+	parts := strings.SplitN(trimmed, "/", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return parts[0], ""
+}

--- a/internal/mail/groups_ast_test.go
+++ b/internal/mail/groups_ast_test.go
@@ -1,0 +1,165 @@
+package mail
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// [si-zgo] HALF 2 — NO CONSUMER CARRIES ITS OWN COPY OF THE GROUP VOCABULARY.
+//
+// The parity round trip in groups_test.go passes even if a consumer re-hardcodes the set locally,
+// because it only compares the router's behaviour to the derived directory. That is exactly how
+// si-75d hid: a gate that runs, passes, and was never testing the thing.
+//
+// This is the more important half, for the enumerated-vs-derived reason. A hand-placed guard only
+// covers what someone anticipated; this walks every consumer and finds the copy nobody declared.
+//
+// WHAT IT LOOKS FOR: a composite literal or slice of string literals, outside this file's owning
+// package, containing two or more group addresses ("@town", "@crew", ...). One mention is a doc
+// example or a single-address call; two or more collected together is a second spelling of the set.
+
+// groupTokens is DERIVED from the vocabulary, not typed here — a hand-kept list of what to look
+// for would itself be the third copy, and would silently stop covering a group added later.
+func groupTokens() []string {
+	out := make([]string, 0, len(GroupVocabulary))
+	for _, g := range GroupVocabulary {
+		out = append(out, "@"+g.Name)
+	}
+	return out
+}
+
+func TestNoConsumerHardcodesTheGroupVocabulary(t *testing.T) {
+	tokens := groupTokens()
+	if len(tokens) < 2 {
+		t.Fatal("fewer than 2 group tokens derived — this scan would pass vacuously")
+	}
+
+	root := repoRoot(t)
+	var scanned int
+	var offenders []string
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			base := info.Name()
+			if base == ".git" || base == "vendor" || base == "node_modules" || base == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// The owning package is where the vocabulary is ALLOWED to be spelled.
+		if filepath.Dir(path) == filepath.Join(root, "internal", "mail") {
+			return nil
+		}
+		// PRODUCTION CONSUMERS ONLY, and this exclusion is a judgement worth stating rather than
+		// hiding. Run against _test.go files this scan flags four sites, and only two are the
+		// defect: the other two are validator TEST TABLES (TestIsValidMemberPattern,
+		// TestIsValidMailAddress) that must enumerate concrete addresses — including invalid ones
+		// — because enumerating examples IS their job. Deriving those from the vocabulary would
+		// destroy the test.
+		//
+		// A guard that reds correct code is one somebody deletes, after which there is no guard.
+		// The rule this encodes: production code must COMPOSE the vocabulary; a test may spell an
+		// address it is specifically about. The two genuine test-side copies were assertions on
+		// the shipped directory list, and those are caught by the parity round trip and by their
+		// own failure — they do not need this scan as well.
+		if strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		scanned++
+
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return nil
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			found := map[string]bool{}
+			collectGroupStrings(lit, tokens, found)
+			if len(found) >= 2 {
+				names := make([]string, 0, len(found))
+				for k := range found {
+					names = append(names, k)
+				}
+				rel, _ := filepath.Rel(root, path)
+				offenders = append(offenders, rel+":"+
+					strconv.Itoa(fset.Position(lit.Pos()).Line)+" carries "+strings.Join(names, " "))
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk failed: %v", err)
+	}
+
+	// DENOMINATOR ASSERT — a walk that examined no files reports "no offenders" and reads exactly
+	// like a clean scan. The count is asserted so an empty scan fails loudly instead of passing.
+	if scanned == 0 {
+		t.Fatal("scanned ZERO .go files — this check examined nothing and its pass is meaningless")
+	}
+	t.Logf("scanned %d .go file(s) outside internal/mail", scanned)
+
+	if len(offenders) > 0 {
+		t.Errorf("consumer(s) carry their own copy of the group vocabulary; compose "+
+			"mail.GroupAddresses() / mail.GroupVocabulary instead:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+// collectGroupStrings records which group tokens appear as string literals inside a composite
+// literal — including nested ones, so a []DirectoryEntry{{Address: "@town"}, ...} is caught.
+func collectGroupStrings(n ast.Node, tokens []string, found map[string]bool) {
+	ast.Inspect(n, func(x ast.Node) bool {
+		bl, ok := x.(*ast.BasicLit)
+		if !ok || bl.Kind != token.STRING {
+			return true
+		}
+		v, err := strconv.Unquote(bl.Value)
+		if err != nil {
+			return true
+		}
+		for _, tok := range tokens {
+			if v == tok || strings.HasPrefix(v, tok+"/") {
+				found[tok] = true
+			}
+		}
+		return true
+	})
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("could not locate repo root (no go.mod found walking up)")
+	return ""
+}

--- a/internal/mail/groups_test.go
+++ b/internal/mail/groups_test.go
@@ -1,0 +1,118 @@
+package mail
+
+import (
+	"strings"
+	"testing"
+)
+
+// [si-zgo] THE PARITY GATE — advertised must route, routable must be advertised.
+//
+// The defect: `gt mail directory` listed `@crew`; `gt mail send @crew` answered "invalid group
+// address". A vocabulary one side exports and the other never accepts.
+//
+// WHY THIS IS A ROUND TRIP AND NOT A SET COMPARISON, which is the whole design of this file:
+// the original spec asked for set equality between the directory's list and the router's
+// vocabulary. Now that the directory is DERIVED from GroupVocabulary, that comparison compares a
+// thing to its own source and passes by construction — a tautology with a green tick. So the left
+// side here is DATA (what the directory advertises) and the right side is BEHAVIOUR (what
+// ParseGroupAddress actually accepts). Derivation cannot make those trivially equal.
+//
+// Both directions are required. "Advertised => routable" alone is satisfied by advertising
+// nothing; "routable => advertised" alone is satisfied by advertising everything plus junk.
+
+// advertisedAddresses is the group vocabulary as the directory renders it. The directory command
+// composes exactly this (see internal/cmd/mail_directory.go), so this test reads what ships.
+func advertisedAddresses() []string { return GroupAddresses() }
+
+func TestEveryAdvertisedGroupAddressRoutes(t *testing.T) {
+	advertised := advertisedAddresses()
+
+	// DENOMINATOR ASSERT. Without it the loop below passes vacuously on an empty vocabulary —
+	// "every advertised address routes" is trivially true when nothing is advertised. That is
+	// the failure this repo keeps finding in its own guards, so it is asserted, not assumed.
+	if len(advertised) == 0 {
+		t.Fatal("advertised group set is EMPTY — every assertion below would pass vacuously")
+	}
+
+	for _, addr := range advertised {
+		// The directory renders arity-1 groups as a pattern, "@crew/<rig>". Substitute a
+		// concrete qualifier: the parser's contract is about SHAPE, and a real send resolves
+		// the rig separately.
+		probe := strings.Replace(addr, "/<rig>", "/somerig", 1)
+		probe = strings.Replace(probe, "/<name>", "/somename", 1)
+
+		if got := ParseGroupAddress(probe); got == nil {
+			t.Errorf("directory advertises %q but the router refuses %q — "+
+				"this is the si-zgo defect: a vocabulary one side exports and the other "+
+				"never accepts", addr, probe)
+		}
+	}
+}
+
+func TestEveryRoutableGroupIsAdvertised(t *testing.T) {
+	if len(GroupVocabulary) == 0 {
+		t.Fatal("GroupVocabulary is EMPTY — the assertions below would pass vacuously")
+	}
+
+	advertised := make(map[string]bool, len(GroupVocabulary))
+	for _, a := range advertisedAddresses() {
+		advertised[a] = true
+	}
+
+	for _, spec := range GroupVocabulary {
+		// The correctly-arity'd rendering, derived from the spec rather than spelled here —
+		// spelling it would be the third copy of the vocabulary this bead exists to remove.
+		if !advertised[spec.Address()] {
+			t.Errorf("router accepts group %q (arity %d) but the directory does not advertise "+
+				"%q — a sendable audience no reader can discover",
+				spec.Name, spec.Arity(), spec.Address())
+		}
+	}
+}
+
+// NEGATIVE CONTROL. Both loops above are "everything in X satisfies P" and are satisfiable by an
+// over-permissive parser: if ParseGroupAddress returned non-nil for anything, both would pass.
+// This is what makes the absence of failures above evidence rather than decoration.
+func TestTheParserRefusesAddressesOutsideTheVocabulary(t *testing.T) {
+	refused := []struct {
+		addr string
+		why  string
+	}{
+		{"@crew", "arity-1 group written bare — THE original si-zgo defect; " +
+			"crew of which rig?"},
+		{"@polecats", "arity-1 group written bare"},
+		{"@rig", "arity-1 group written bare"},
+		{"@town/somerig", "arity-0 group given a qualifier"},
+		{"@nonsense", "not in the vocabulary at all"},
+		{"@crew/", "arity-1 group with an empty qualifier"},
+	}
+
+	for _, tc := range refused {
+		if got := ParseGroupAddress(tc.addr); got != nil {
+			t.Errorf("ParseGroupAddress(%q) returned %+v, want nil — %s", tc.addr, got, tc.why)
+		}
+	}
+}
+
+// The arity-1 groups must still route WITH a qualifier. Without this, the negative control above
+// could be satisfied by a parser that refuses @crew in every form, which would "fix" si-zgo by
+// deleting the audience.
+func TestArityOneGroupsRouteWhenQualified(t *testing.T) {
+	for _, spec := range GroupVocabulary {
+		if spec.Arity() != 1 {
+			continue
+		}
+		addr := "@" + spec.Name + "/somerig"
+		got := ParseGroupAddress(addr)
+		if got == nil {
+			t.Fatalf("ParseGroupAddress(%q) = nil, want a parse — the qualified form is the "+
+				"one that must work", addr)
+		}
+		if got.Rig != "somerig" {
+			t.Errorf("ParseGroupAddress(%q).Rig = %q, want %q", addr, got.Rig, "somerig")
+		}
+		if got.Type != spec.Type {
+			t.Errorf("ParseGroupAddress(%q).Type = %q, want %q", addr, got.Type, spec.Type)
+		}
+	}
+}

--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -301,42 +301,28 @@ func parseGroupAddress(address string) *ParsedGroup {
 		return nil
 	}
 
-	// Remove @ prefix
-	group := strings.TrimPrefix(address, "@")
+	// [si-zgo] Derived from GroupVocabulary (groups.go) — the single owner of this set. This
+	// function used to carry its own switch, which is how `@crew` came to be advertised by the
+	// directory and rejected here: two hand-written copies of one vocabulary, drifted.
+	name, qualifier := splitGroupAddress(address)
 
-	// Special cases that don't require parsing
-	switch group {
-	case "overseer":
-		return &ParsedGroup{Type: GroupTypeOverseer, Original: address}
-	case "town":
-		return &ParsedGroup{Type: GroupTypeTown, Original: address}
-	case "witnesses":
-		return &ParsedGroup{Type: GroupTypeRole, RoleType: constants.RoleWitness, Original: address}
-	case "dogs":
-		return &ParsedGroup{Type: GroupTypeRole, RoleType: "dog", Original: address}
-	case "refineries":
-		return &ParsedGroup{Type: GroupTypeRole, RoleType: constants.RoleRefinery, Original: address}
-	case "deacons":
-		return &ParsedGroup{Type: GroupTypeRole, RoleType: constants.RoleDeacon, Original: address}
+	spec, ok := lookupGroup(name)
+	if !ok {
+		return nil // not in the vocabulary
 	}
 
-	// Parse patterns with slashes: @rig/<name>, @crew/<rig>, @polecats/<rig>
-	parts := strings.SplitN(group, "/", 2)
-	if len(parts) != 2 || parts[1] == "" {
-		return nil // Invalid format
+	// Arity is enforced in BOTH directions. A missing qualifier on an arity-1 group is the
+	// original bare-`@crew` defect; a supplied qualifier on an arity-0 group ("@town/x") was
+	// silently accepted-then-dropped before, which is the same class pointing the other way.
+	if (spec.Arity() == 1) != (qualifier != "") {
+		return nil
 	}
 
-	prefix, qualifier := parts[0], parts[1]
-
-	switch prefix {
-	case "rig":
-		return &ParsedGroup{Type: GroupTypeRig, Rig: qualifier, Original: address}
-	case constants.RoleCrew:
-		return &ParsedGroup{Type: GroupTypeRigRole, RoleType: constants.RoleCrew, Rig: qualifier, Original: address}
-	case "polecats":
-		return &ParsedGroup{Type: GroupTypeRigRole, RoleType: constants.RolePolecat, Rig: qualifier, Original: address}
-	default:
-		return nil // Unknown group type
+	return &ParsedGroup{
+		Type:     spec.Type,
+		RoleType: spec.RoleType,
+		Rig:      qualifier,
+		Original: address,
 	}
 }
 


### PR DESCRIPTION
`gt mail directory` advertised addresses `gt mail send` rejects, and `gt mail send` accepted addresses the directory never advertised. silicon/refinery hit this trying to reach two crew members at once and had to route through the Mayor.

```
gt mail directory   lists:  '@crew       special'
gt mail send @crew   Error: all sends failed: @crew: invalid group address: @crew
```

## The mismatch was bidirectional, and the reported half was the smaller one

Measured by building the binary and running the command, not by reading tests:

```
before  @crew @overseer @town @witnesses                                              (4)
after   @crew/ @deacons @dogs @overseer @polecats/ @refineries @rig/ @town @witnesses (9)
```

`@dogs`, `@refineries` and `@deacons` were sendable audiences no reader could discover. That direction was entirely unreported.

## (group, arity) is what made it tractable

Modelled as bare tokens, the defect forces one of two wrong repairs: make `send` accept bare `@crew` (which invents an audience — crew of *which* rig?), or drop `@crew` from the directory (which hides a real one). With arity in the set element both readings hold at once: `@crew` is genuinely in the vocabulary, and its bare rendering was malformed.

```
@town @dogs @refineries @deacons @witnesses @overseer   arity 0
@crew @polecats @rig                                     arity 1
```

Arity is now enforced in both directions — `@town/x` is refused too, where before it was silently accepted and dropped.

## The parity gate, and why the first one was a tautology

A set-equality test between the directory and the vocabulary passes by construction once the directory *derives* from the vocabulary: it compares a thing to its own source. The first version of this gate did exactly that, and appending a rogue `@ghosts` entry to the directory left the suite green.

The gate now reads the JSON the command really prints (**data**) against what `ParseGroupAddress` really accepts (**behaviour**) — the one pairing derivation cannot make trivially self-equal.

Three guards, each mutation-proven by breaking the protected thing and observing red:

| Mutation | Result |
|---|---|
| advertise an address `send` rejects | `TestEveryGroupAddressTheDirectoryPrintsIsRoutable` fails |
| re-hardcode the vocabulary in a consumer | `TestNoConsumerHardcodesTheGroupVocabulary` fails |
| drop a group from the directory | `TestEveryRoutableGroupIsPrintedByTheDirectory` fails |

Plus a negative control (`@crew`, `@polecats`, `@rig`, `@town/x`, `@nonsense` must all be refused) and denominator asserts on every loop — an empty advertised set, an empty vocabulary, or zero files scanned each **fail** rather than reporting a clean zero.

The AST guard scans production consumers only. Against `_test.go` it flags 4 sites of which only 2 are the defect; the rest are validator tables whose job is to enumerate concrete addresses. A guard that reds correct code gets deleted. The 2 genuine test-side copies now derive.

## Tests

```
ok  github.com/steveyegge/gastown/internal/mail   (-count=1)
    groups_ast_test.go:117: scanned 655 .go file(s) outside internal/mail
ok  github.com/steveyegge/gastown/internal/cmd
```

`internal/cmd` carries two pre-existing failures (agent-tracking beads dir) that are identical on a clean stashed tree — verified, not assumed.

## Note for reviewers

The directory prints the *pattern* `@crew/` rather than expanding to concrete live rigs. Expansion is better information, but it would make the advertised set a function of live cluster state, and the parity gate asserts every advertised address routes — so the gate's denominator would start moving with the rig count. Tracked separately rather than decided silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)