### PR TITLE
fix(polecat): refuse a resume branch a LIVE worktree holds, prune a dead one

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2314,11 +2314,85 @@ func (g *Git) WorktreeAddExisting(path, branch string) error {
 
 // WorktreeAddExistingForce creates a new worktree even if the branch is already checked out elsewhere.
 // This is useful for cross-rig worktrees where multiple clones need to be on main.
+//
+// DO NOT use this to attach a worker to a branch another worker may be on. It
+// forces past git's "already used by worktree at ..." check without asking
+// whether the holder is live, which puts two worktrees on one ref; a commit in
+// either then shows up in the other as a delta to re-commit, and an auto-saver
+// will commit that delta with no agent acting. That is si-d6kw, which cost a
+// fleet-wide sweep and three armed worktrees (7767 / 6824 / 434 staged
+// deletions). Use WorktreeAddExistingSafe for anything worker-facing.
 func (g *Git) WorktreeAddExistingForce(path, branch string) error {
 	if _, err := g.run("worktree", "add", "--force", path, branch); err != nil {
 		return err
 	}
 	return InitSubmodules(path, g.submoduleReferencePath())
+}
+
+// BranchHeldError reports that a branch is checked out by a live worktree, so
+// attaching a second one would put two workers on a single ref.
+type BranchHeldError struct {
+	Branch string
+	Path   string
+}
+
+func (e *BranchHeldError) Error() string {
+	return fmt.Sprintf("branch %s is already checked out by a live worktree at %s", e.Branch, e.Path)
+}
+
+// LiveWorktreeForBranch returns the worktree that currently has branch checked
+// out, or nil if none does. Worktrees git reports as prunable — the record
+// survives but the directory does not — are NOT live and are not returned.
+func (g *Git) LiveWorktreeForBranch(branch string) (*Worktree, error) {
+	branch = strings.TrimPrefix(branch, "refs/heads/")
+	worktrees, err := g.WorktreeList()
+	if err != nil {
+		return nil, err
+	}
+	for i := range worktrees {
+		wt := worktrees[i]
+		if wt.Branch != branch || wt.Prunable {
+			continue
+		}
+		// Belt and braces: a record can be current-looking and still point at a
+		// directory that is gone, if the list ran before something removed it.
+		if _, statErr := os.Stat(wt.Path); statErr != nil {
+			continue
+		}
+		return &wt, nil
+	}
+	return nil, nil
+}
+
+// WorktreeAddExistingSafe attaches a worktree to an existing branch, refusing
+// when a LIVE worktree already holds that branch and clearing the way when the
+// only thing holding it is a stale record.
+//
+// This is the distinction plain git does not make for you. "git worktree add"
+// refuses both cases with the same message, which is why callers reached for
+// --force; but --force cannot tell "the previous worker was reaped" (safe, and
+// the case the resume workflow is built on) from "another worker is on this ref
+// right now" (si-d6kw: mutual reversion, and an auto-saver that commits a mass
+// deletion nobody authored).
+//
+// Live holder  -> *BranchHeldError, nothing created.
+// Stale holder -> prune the dead record, then attach normally.
+// No holder    -> attach normally.
+func (g *Git) WorktreeAddExistingSafe(path, branch string) error {
+	holder, err := g.LiveWorktreeForBranch(branch)
+	if err != nil {
+		return fmt.Errorf("checking whether %s is already checked out: %w", branch, err)
+	}
+	if holder != nil {
+		return &BranchHeldError{Branch: branch, Path: holder.Path}
+	}
+	// No live holder. A stale record may still make git refuse, so drop dead
+	// records first. Prune only removes worktrees whose directory is already
+	// gone; it cannot touch a live one.
+	if err := g.WorktreePrune(); err != nil {
+		return fmt.Errorf("pruning stale worktree records before attaching %s: %w", branch, err)
+	}
+	return g.WorktreeAddExisting(path, branch)
 }
 
 // submoduleReferencePath returns the mayor/rig path to use as --reference
@@ -2430,10 +2504,19 @@ func (g *Git) WorktreePrune() error {
 }
 
 // Worktree represents a git worktree.
+//
+// Prunable distinguishes a worktree git still has an administrative record for
+// but whose directory is gone (reaped, moved, deleted) from one that is live on
+// disk. Git refuses "worktree add" for a branch held by EITHER kind with the
+// same "already used by worktree at ..." message, so callers that want to
+// tolerate the first without tolerating the second must read this field —
+// see WorktreeAddExistingSafe.
 type Worktree struct {
-	Path   string
-	Branch string
-	Commit string
+	Path           string
+	Branch         string
+	Commit         string
+	Prunable       bool
+	PrunableReason string
 }
 
 // WorktreeList returns all worktrees for this repository.
@@ -2462,6 +2545,9 @@ func (g *Git) WorktreeList() ([]Worktree, error) {
 			current.Commit = strings.TrimPrefix(line, "HEAD ")
 		case strings.HasPrefix(line, "branch "):
 			current.Branch = strings.TrimPrefix(line, "branch refs/heads/")
+		case line == "prunable" || strings.HasPrefix(line, "prunable "):
+			current.Prunable = true
+			current.PrunableReason = strings.TrimSpace(strings.TrimPrefix(line, "prunable"))
 		}
 	}
 

--- a/internal/git/worktree_holder_test.go
+++ b/internal/git/worktree_holder_test.go
@@ -1,0 +1,362 @@
+package git
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// si-d6kw: gt put two polecat worktrees on one branch. A commit in either then
+// appeared in the other as a delta to re-commit, and the auto-save committed
+// that delta with no agent acting — 7767 / 6824 / 434 staged deletions found
+// armed across the fleet.
+//
+// The subtlety these tests exist to pin down: git refuses BOTH a live holder
+// and a stale record with the same "already used by worktree at ..." message,
+// which is why callers reached for --force in the first place. Dropping --force
+// would fix the collision and break the reap-and-resume workflow it was added
+// for. So the guard is not "refuse when git refuses" — it is "refuse a LIVE
+// holder, clear a dead one" — and the tests have to show both halves, plus that
+// the refusal is the guard's and not git's.
+
+func worktreeHolderRepo(t *testing.T) (*Git, string) {
+	t.Helper()
+	dir := initTestRepo(t)
+	return NewGit(dir), dir
+}
+
+// addWorktreeOnNewBranch creates a real worktree holding a real branch.
+func addWorktreeOnNewBranch(t *testing.T, repo string, path, branch string) {
+	t.Helper()
+	cmd := exec.Command("git", "worktree", "add", "-b", branch, path)
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("seed worktree %s on %s: %v\n%s", path, branch, err, out)
+	}
+}
+
+func TestWorktreeAddExistingSafeRefusesBranchHeldByLiveWorktree(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	holder := filepath.Join(t.TempDir(), "holder")
+	addWorktreeOnNewBranch(t, repo, holder, "polecat/dag/si-aka.9")
+
+	second := filepath.Join(t.TempDir(), "second")
+	err := g.WorktreeAddExistingSafe(second, "polecat/dag/si-aka.9")
+	if err == nil {
+		t.Fatal("WorktreeAddExistingSafe attached a second worktree to a live-held branch; " +
+			"that is the si-d6kw defect")
+	}
+
+	var held *BranchHeldError
+	if !errors.As(err, &held) {
+		t.Fatalf("error = %v (%T), want *BranchHeldError — callers switch on this type to "+
+			"produce the actionable refusal", err, err)
+	}
+	if !sameResolvedPath(t, held.Path, holder) {
+		t.Fatalf("BranchHeldError.Path = %q, want %q — the message must NAME the holder, "+
+			"or the operator cannot act on it", held.Path, holder)
+	}
+
+	// The refusal must be total. A partially-created worktree is the hazard.
+	if _, statErr := os.Stat(second); !os.IsNotExist(statErr) {
+		t.Fatalf("refused, but %s exists anyway — nothing may be created on the refusal path", second)
+	}
+	for _, wt := range mustList(t, g) {
+		if wt.Path == second {
+			t.Fatalf("refused, but git registered a worktree at %s", second)
+		}
+	}
+}
+
+// NEGATIVE CONTROL. Without this, the test above passes even if the guard does
+// nothing, because plain git would refuse too — and the whole point is that the
+// old code got PAST git's refusal. This asserts the setup really is one --force
+// away from the two-worktrees-on-one-ref state, so the refusal above is
+// attributable to the guard rather than to git.
+func TestWorktreeAddExistingForceStillReachesTheStateTheGuardRefuses(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	holder := filepath.Join(t.TempDir(), "holder")
+	addWorktreeOnNewBranch(t, repo, holder, "polecat/dag/si-aka.9")
+
+	second := filepath.Join(t.TempDir(), "second")
+	if err := g.WorktreeAddExistingForce(second, "polecat/dag/si-aka.9"); err != nil {
+		t.Fatalf("WorktreeAddExistingForce: %v — if this now fails, the negative control is "+
+			"stale and the refusal test above may be measuring git rather than the guard", err)
+	}
+
+	var holders int
+	for _, wt := range mustList(t, g) {
+		if wt.Branch == "polecat/dag/si-aka.9" {
+			holders++
+		}
+	}
+	if holders != 2 {
+		t.Fatalf("worktrees on polecat/dag/si-aka.9 = %d, want 2 — the reproduction of si-d6kw "+
+			"did not reproduce, so the guard test proves nothing", holders)
+	}
+}
+
+// The workflow that must NOT break. Alice's recovery slings were 4-of-5 clean
+// precisely because the original worktree had been reaped; a guard that refuses
+// this case removes the only working recovery route and pushes operators to a
+// worse one.
+func TestWorktreeAddExistingSafeResumesBranchAfterHolderWasReaped(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	holder := filepath.Join(t.TempDir(), "holder")
+	addWorktreeOnNewBranch(t, repo, holder, "polecat/keeper/si-aka.37")
+
+	// Reap it the way the fleet does: the directory goes, the record remains.
+	if err := os.RemoveAll(holder); err != nil {
+		t.Fatalf("reap holder: %v", err)
+	}
+
+	// Denominator: the stale record must actually still be there, otherwise this
+	// test proves only that attaching to an unheld branch works.
+	if !recordExistsFor(t, g, "polecat/keeper/si-aka.37") {
+		t.Fatal("no worktree record for the branch after reaping — test setup no longer " +
+			"reproduces the stale-holder case it is named for")
+	}
+
+	resumed := filepath.Join(t.TempDir(), "resumed")
+	if err := g.WorktreeAddExistingSafe(resumed, "polecat/keeper/si-aka.37"); err != nil {
+		t.Fatalf("WorktreeAddExistingSafe refused a reaped holder: %v\n"+
+			"This is the resume workflow --force existed for; refusing it is the regression "+
+			"si-d6kw's own fix order warned about", err)
+	}
+	assertOnBranch(t, resumed, "polecat/keeper/si-aka.37")
+}
+
+// The case a directory-existence check alone gets WRONG, and the reason
+// LiveWorktreeForBranch reads git's prunable flag rather than just stat()ing
+// the path. A worktree whose .git file is broken still has its DIRECTORY on
+// disk, and git still reports the branch as taken — but it is not a live
+// worker, it is the broken worktree that "gt polecat repair" exists for.
+// Treating it as a live holder makes such a polecat permanently unresumable.
+//
+// This test was added because a mutation that deleted the Prunable check went
+// GREEN: the stat() fallback covered the reaped-directory case and hid it.
+func TestWorktreeAddExistingSafeResumesWorktreeWhoseGitFileIsBroken(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	broken := filepath.Join(t.TempDir(), "broken")
+	addWorktreeOnNewBranch(t, repo, broken, "polecat/coma/si-aka.14.2")
+
+	// Break the link without removing the directory.
+	if err := os.Remove(filepath.Join(broken, ".git")); err != nil {
+		t.Fatalf("break worktree .git: %v", err)
+	}
+
+	// Denominator: the state under test must actually hold — directory present,
+	// git reporting prunable. If either drifts, this test silently becomes a
+	// duplicate of the reaped-holder one.
+	if _, err := os.Stat(broken); err != nil {
+		t.Fatalf("broken worktree directory should still exist: %v", err)
+	}
+	var sawBrokenAsPrunable bool
+	for _, wt := range mustList(t, g) {
+		if wt.Branch == "polecat/coma/si-aka.14.2" && wt.Prunable {
+			sawBrokenAsPrunable = true
+		}
+	}
+	if !sawBrokenAsPrunable {
+		t.Fatal("git no longer reports the broken worktree as prunable — this test is not " +
+			"exercising the directory-exists-but-dead case it is named for")
+	}
+
+	resumed := filepath.Join(t.TempDir(), "resumed")
+	if err := g.WorktreeAddExistingSafe(resumed, "polecat/coma/si-aka.14.2"); err != nil {
+		t.Fatalf("WorktreeAddExistingSafe refused a broken (not live) worktree: %v\n"+
+			"A directory-existence check alone gives this wrong answer; the prunable flag "+
+			"is what distinguishes 'someone is working here' from 'this worktree is dead'", err)
+	}
+	assertOnBranch(t, resumed, "polecat/coma/si-aka.14.2")
+}
+
+func TestWorktreeAddExistingSafeAttachesWhenNoWorktreeHoldsBranch(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	cmd := exec.Command("git", "branch", "polecat/toast/si-aka.9+rework")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create branch: %v\n%s", err, out)
+	}
+
+	path := filepath.Join(t.TempDir(), "fresh")
+	if err := g.WorktreeAddExistingSafe(path, "polecat/toast/si-aka.9+rework"); err != nil {
+		t.Fatalf("WorktreeAddExistingSafe on an unheld branch: %v", err)
+	}
+	assertOnBranch(t, path, "polecat/toast/si-aka.9+rework")
+}
+
+// LiveWorktreeForBranch is the predicate the whole guard rests on. Test it
+// directly so a failure points at the discrimination rather than at the caller.
+func TestLiveWorktreeForBranchIgnoresPrunableRecords(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	live := filepath.Join(t.TempDir(), "live")
+	stale := filepath.Join(t.TempDir(), "stale")
+	addWorktreeOnNewBranch(t, repo, live, "branch/live")
+	addWorktreeOnNewBranch(t, repo, stale, "branch/stale")
+	if err := os.RemoveAll(stale); err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+
+	// Denominator on the parse itself: if WorktreeList stopped reporting
+	// prunable at all, every record would look live and the "stale" assertion
+	// below would still pass by accident on a differently-broken parser.
+	list := mustList(t, g)
+	var sawPrunable bool
+	for _, wt := range list {
+		if wt.Branch == "branch/stale" {
+			if !wt.Prunable {
+				t.Fatalf("record for branch/stale parsed with Prunable=false; "+
+					"reason=%q — git reports it as prunable", wt.PrunableReason)
+			}
+			sawPrunable = true
+		}
+	}
+	if !sawPrunable {
+		t.Fatal("no record found for branch/stale — cannot distinguish 'correctly ignored' " +
+			"from 'never examined'")
+	}
+
+	got, err := g.LiveWorktreeForBranch("branch/stale")
+	if err != nil {
+		t.Fatalf("LiveWorktreeForBranch(stale): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("LiveWorktreeForBranch(branch/stale) = %s, want nil — a reaped worktree is "+
+			"not a live holder", got.Path)
+	}
+
+	got, err = g.LiveWorktreeForBranch("branch/live")
+	if err != nil {
+		t.Fatalf("LiveWorktreeForBranch(live): %v", err)
+	}
+	if got == nil || !sameResolvedPath(t, got.Path, live) {
+		t.Fatalf("LiveWorktreeForBranch(branch/live) = %v, want %s", got, live)
+	}
+
+	// refs/heads/ prefix must resolve the same way; callers pass both forms.
+	got, err = g.LiveWorktreeForBranch("refs/heads/branch/live")
+	if err != nil {
+		t.Fatalf("LiveWorktreeForBranch(refs/heads/...): %v", err)
+	}
+	if got == nil || !sameResolvedPath(t, got.Path, live) {
+		t.Fatalf("LiveWorktreeForBranch with refs/heads/ prefix = %v, want %s", got, live)
+	}
+}
+
+// samePath compares paths after resolving symlinks. On macOS t.TempDir() hands
+// back /var/... while git reports the resolved /private/var/..., so a raw
+// string compare fails on a correct result.
+func sameResolvedPath(t *testing.T, a, b string) bool {
+	t.Helper()
+	ra, err := filepath.EvalSymlinks(a)
+	if err != nil {
+		ra = a
+	}
+	rb, err := filepath.EvalSymlinks(b)
+	if err != nil {
+		rb = b
+	}
+	return ra == rb
+}
+
+// PRODUCTION ARCHITECTURE. Rigs use a bare .repo.git as the repo base and hang
+// every polecat worktree off it (si-d6kw measured dag's git-dir as
+// .repo.git/worktrees/silicon7). The manager-level tests run on the LEGACY
+// mayor/rig base because that is what the scaffolding builds, so without this
+// test nothing exercises the guard on the shape it actually ships against.
+//
+// Two properties matter, and the first is the one that would bite: a bare repo
+// appears in "worktree list --porcelain" with a "bare" line and NO "branch"
+// line. If that parsed as a worktree holding something, the base itself could
+// read as a live holder and refuse every resume.
+func TestWorktreeGuardOnBareRepoBase(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	if err := os.MkdirAll(src, 0755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	runGit(t, src, "init", "-b", "main", ".")
+	runGit(t, src, "config", "user.email", "test@test.com")
+	runGit(t, src, "config", "user.name", "Test User")
+	runGit(t, src, "commit", "--allow-empty", "-m", "init")
+
+	bare := filepath.Join(root, "repo.git")
+	runGit(t, root, "clone", "--bare", src, bare)
+	g := NewGitWithDir(bare, "")
+
+	// The bare base holds no branch.
+	for _, wt := range mustList(t, g) {
+		if wt.Branch != "" && wt.Path == bare {
+			t.Fatalf("bare repo base parsed as holding branch %q; it has no working tree "+
+				"and must never read as a live holder", wt.Branch)
+		}
+	}
+	held, err := g.LiveWorktreeForBranch("main")
+	if err != nil {
+		t.Fatalf("LiveWorktreeForBranch(main) on bare base: %v", err)
+	}
+	if held != nil {
+		t.Fatalf("bare base reported as live holder of main at %s — every resume would refuse", held.Path)
+	}
+
+	// A polecat worktree off the bare base IS a live holder.
+	runGit(t, bare, "branch", "polecat/dag/si-aka.9", "main")
+	holder := filepath.Join(root, "dag")
+	runGit(t, bare, "worktree", "add", holder, "polecat/dag/si-aka.9")
+
+	second := filepath.Join(root, "toast")
+	err = g.WorktreeAddExistingSafe(second, "polecat/dag/si-aka.9")
+	var branchHeld *BranchHeldError
+	if !errors.As(err, &branchHeld) {
+		t.Fatalf("WorktreeAddExistingSafe on bare base = %v, want *BranchHeldError — "+
+			"this is the exact dag/toast collision, on the exact architecture it happened on", err)
+	}
+
+	// And the reaped case still resumes on a bare base.
+	if err := os.RemoveAll(holder); err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+	if err := g.WorktreeAddExistingSafe(second, "polecat/dag/si-aka.9"); err != nil {
+		t.Fatalf("resume after reap on bare base: %v", err)
+	}
+	assertOnBranch(t, second, "polecat/dag/si-aka.9")
+}
+
+func mustList(t *testing.T, g *Git) []Worktree {
+	t.Helper()
+	list, err := g.WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatal("WorktreeList returned nothing — an empty list satisfies every loop below")
+	}
+	return list
+}
+
+func recordExistsFor(t *testing.T, g *Git, branch string) bool {
+	t.Helper()
+	for _, wt := range mustList(t, g) {
+		if wt.Branch == branch {
+			return true
+		}
+	}
+	return false
+}
+
+func assertOnBranch(t *testing.T, path, branch string) {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = path
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse in %s: %v", path, err)
+	}
+	if got := strings.TrimSpace(string(out)); got != branch {
+		t.Fatalf("worktree %s is on %q, want %q", path, got, branch)
+	}
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -32,6 +32,29 @@ import (
 	"github.com/steveyegge/gastown/internal/util"
 )
 
+// resumeBranchError wraps a failure to attach a worktree to a resume branch.
+//
+// The refusal case gets an actionable message on purpose. si-d6kw's own
+// post-mortem found that the operator reached for the unsafe option because the
+// safe one failed with a bare "exit status 1" — a defect that manufactures
+// pressure toward the dangerous path. A refusal that does not say what to do
+// instead recreates exactly that.
+func resumeBranchError(resumeBranch string, err error) error {
+	var held *git.BranchHeldError
+	if errors.As(err, &held) {
+		return fmt.Errorf("refusing to resume %s: it is checked out by a live worktree at %s\n\n"+
+			"Two worktrees on one branch is not a warning, it is data loss: a commit in either\n"+
+			"appears in the other as a delta to re-commit, and the auto-save commits that delta\n"+
+			"with no agent acting (si-d6kw).\n\n"+
+			"Instead:\n"+
+			"  - sling to the worker that already holds the branch, or\n"+
+			"  - let a fresh polecat branch be minted (drop --branch) and rebase, or\n"+
+			"  - if that worktree is genuinely finished, retire it first, then retry",
+			resumeBranch, held.Path)
+	}
+	return fmt.Errorf("creating worktree on existing branch %s: %w", resumeBranch, err)
+}
+
 // Retry constants for Dolt operations (matching hook update pattern in sling.go).
 // Configurable via operational.polecat in settings/config.json.
 const (
@@ -766,14 +789,15 @@ func (m *Manager) addWithOptionsLocked(name string, opts AddOptions, polecatDir 
 
 	if opts.ResumeBranch != "" {
 		// Resume an existing branch (gh#3602). Make sure we have the latest tip
-		// for the named branch, then attach the worktree directly. WorktreeAddExistingForce
-		// handles the case where another worktree previously had this branch checked out.
+		// for the named branch, then attach the worktree directly. Safe, not
+		// Force: a worktree PREVIOUSLY on this branch is pruned and resumed, but
+		// one that still holds it is refused (si-d6kw).
 		if err := repoGit.FetchBranch("origin", opts.ResumeBranch); err != nil {
 			style.PrintWarning("could not fetch resume branch %s: %v", opts.ResumeBranch, err)
 		}
-		if err := repoGit.WorktreeAddExistingForce(clonePath, opts.ResumeBranch); err != nil {
+		if err := repoGit.WorktreeAddExistingSafe(clonePath, opts.ResumeBranch); err != nil {
 			cleanupOnError()
-			return nil, fmt.Errorf("creating worktree on existing branch %s: %w", opts.ResumeBranch, err)
+			return nil, resumeBranchError(opts.ResumeBranch, err)
 		}
 		worktreeCreated = true
 	} else {
@@ -964,15 +988,17 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (_ *Polecat, retE
 
 	if opts.ResumeBranch != "" {
 		// Resume an existing branch (gh#3602): attach the worktree directly to the
-		// named branch. WorktreeAddExistingForce tolerates the branch being checked
-		// out elsewhere (stale worktree), and the explicit fetch ensures we have
-		// the latest tip before checkout.
+		// named branch. WorktreeAddExistingSafe tolerates a STALE worktree record
+		// for the branch — which is what "tolerates the branch being checked out
+		// elsewhere" was always meant to cover — and refuses a live holder, which
+		// --force could not tell apart (si-d6kw). The explicit fetch ensures we
+		// have the latest tip before checkout.
 		if err := repoGit.FetchBranch("origin", opts.ResumeBranch); err != nil {
 			style.PrintWarning("could not fetch resume branch %s: %v", opts.ResumeBranch, err)
 		}
-		if err := repoGit.WorktreeAddExistingForce(clonePath, opts.ResumeBranch); err != nil {
+		if err := repoGit.WorktreeAddExistingSafe(clonePath, opts.ResumeBranch); err != nil {
 			cleanupOnError()
-			return nil, fmt.Errorf("creating worktree on existing branch %s: %w", opts.ResumeBranch, err)
+			return nil, resumeBranchError(opts.ResumeBranch, err)
 		}
 		worktreeCreated = true
 	} else {
@@ -1596,6 +1622,15 @@ func (m *Manager) RepairWorktreeWithOptions(name string, force bool, opts AddOpt
 	if opts.ResumeBranch != "" {
 		// Resume an existing branch: fetch and attach the temp worktree directly
 		// to the named branch instead of creating a fresh polecat/<name>/<bead>+<ts>.
+		//
+		// Deliberately still Force, unlike the two sling resume paths (si-d6kw).
+		// Repair rebuilds ONE polecat's own worktree and does not remove the old
+		// registration first, so the record most likely holding this branch is
+		// the very one being replaced — WorktreeAddExistingSafe would refuse and
+		// repair could never run. Note also that no production caller sets
+		// ResumeBranch here: RepairWorktree passes AddOptions{}. A future caller
+		// that does must remove the old worktree registration before this point,
+		// otherwise it inherits the two-worktrees-one-ref hazard.
 		if err := repoGit.FetchBranch("origin", opts.ResumeBranch); err != nil {
 			style.PrintWarning("could not fetch resume branch %s: %v", opts.ResumeBranch, err)
 		}

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1688,6 +1688,25 @@ func TestAddWithOptions_ResumeBranch(t *testing.T) {
 		t.Fatalf("update-ref origin/%s: %v\n%s", prBranch, err, out)
 	}
 
+	// Return the repo base to main. createStalePolecatCommit builds the marker
+	// commit by CHECKING OUT the branch here and never switching back, which
+	// parks the repo base itself on the branch we are about to resume.
+	//
+	// That state does not exist in production: repoBase() prefers the bare
+	// .repo.git, which has no working tree and therefore holds no branch (the
+	// live rig confirms it — si-d6kw measured polecat git-dirs as
+	// .repo.git/worktrees/silicon7). mayor/rig is the legacy fallback this
+	// scaffolding happens to use.
+	//
+	// Leaving it parked would make this test assert that a polecat may attach to
+	// a branch a live working tree already has checked out — which is exactly
+	// the si-d6kw defect, and the si-d6kw guard now correctly refuses it.
+	cmd = exec.Command("git", "checkout", "main")
+	cmd.Dir = mayorRig
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("return repo base to main: %v\n%s", err, out)
+	}
+
 	polecat, err := mgr.AddWithOptions("toast", AddOptions{ResumeBranch: prBranch})
 	if err != nil {
 		t.Fatalf("AddWithOptions with ResumeBranch: %v", err)

--- a/internal/polecat/resume_branch_holder_test.go
+++ b/internal/polecat/resume_branch_holder_test.go
@@ -1,0 +1,180 @@
+package polecat
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+// si-d6kw. "gt sling <bead> <rig> --branch <held-branch>" spawned a SECOND
+// polecat onto a branch another polecat's worktree still had checked out. The
+// two auto-checkpointed over each other; a fleet sweep then found three more
+// worktrees armed with 7767 / 6824 / 434 staged deletions, and one of those
+// deletions was committed at 08:01 during an explicit stop-write with both
+// agents complying — because the auto-save needs no agent to act.
+//
+// The guard lives in internal/git; these tests exist because a guard the sling
+// resume path does not CALL protects nothing. Both spawn entry points are
+// covered: AddWithOptions (named polecat) and addWithOptionsLocked, reached via
+// AllocateAndAdd (pool allocation), which is the one --branch actually used.
+
+// seedLiveWorktreeOnBranch creates a real branch in the repo and a real, live
+// worktree holding it — the "dag still has it checked out" precondition.
+func seedLiveWorktreeOnBranch(t *testing.T, repo, branch string) string {
+	t.Helper()
+	cmd := exec.Command("git", "branch", branch, "HEAD")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create branch %s: %v\n%s", branch, err, out)
+	}
+	holder := filepath.Join(t.TempDir(), "holder")
+	cmd = exec.Command("git", "worktree", "add", holder, branch)
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("seed live worktree on %s: %v\n%s", branch, err, out)
+	}
+	return holder
+}
+
+func assertRefusalIsActionable(t *testing.T, err error, branch, holder string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("resume onto a live-held branch SUCCEEDED — this is si-d6kw: two worktrees " +
+			"on one ref, which the auto-save turns into committed data loss")
+	}
+	msg := err.Error()
+	// Naming the holder is the difference between a refusal an operator can act
+	// on and one they route around. si-d6kw's post-mortem traced the original
+	// incident to a safe path that failed with a bare "exit status 1".
+	if !strings.Contains(msg, holder) {
+		resolved, evalErr := filepath.EvalSymlinks(holder)
+		if evalErr != nil || !strings.Contains(msg, resolved) {
+			t.Fatalf("refusal does not name the holding worktree %s.\nGot: %s", holder, msg)
+		}
+	}
+	if !strings.Contains(msg, branch) {
+		t.Fatalf("refusal does not name the branch %s.\nGot: %s", branch, msg)
+	}
+	// It must tell the operator what to do instead, or it manufactures pressure
+	// toward the dangerous option exactly as the original defect did.
+	if !strings.Contains(msg, "Instead:") {
+		t.Fatalf("refusal offers no alternative; an operator who is blocked will find a "+
+			"worse route.\nGot: %s", msg)
+	}
+}
+
+func TestAddWithOptionsRefusesResumeBranchHeldByLiveWorktree(t *testing.T) {
+	mgr, mayorRig := setupCanonicalBranchManagerTest(t)
+	const branch = "polecat/dag/si-aka.9+ms43eli5"
+	holder := seedLiveWorktreeOnBranch(t, mayorRig, branch)
+
+	_, err := mgr.AddWithOptions("toast", AddOptions{ResumeBranch: branch})
+	assertRefusalIsActionable(t, err, branch, holder)
+
+	// The refusal must leave nothing behind. A half-built polecat directory is
+	// its own failure mode — reconcile treats it as an allocation.
+	polecatDir := filepath.Join(mgr.rig.Path, "polecats", "toast")
+	if _, statErr := os.Stat(polecatDir); !os.IsNotExist(statErr) {
+		t.Fatalf("polecat dir %s survived the refusal; rollback did not run", polecatDir)
+	}
+
+	// And the original holder must be untouched: still the only worktree on the
+	// branch, still on it. Refusing loudly while having already forced would be
+	// the worst of both.
+	holders := worktreesOnBranch(t, mayorRig, branch)
+	if len(holders) != 1 {
+		t.Fatalf("worktrees on %s = %d (%v), want exactly 1 — the original holder", branch, len(holders), holders)
+	}
+}
+
+func TestAllocateAndAddRefusesResumeBranchHeldByLiveWorktree(t *testing.T) {
+	mgr, mayorRig := setupCanonicalBranchManagerTest(t)
+	const branch = "polecat/keeper/si-aka.37+ms43gm2z"
+	holder := seedLiveWorktreeOnBranch(t, mayorRig, branch)
+
+	_, _, err := mgr.AllocateAndAdd(AddOptions{ResumeBranch: branch})
+	assertRefusalIsActionable(t, err, branch, holder)
+
+	holders := worktreesOnBranch(t, mayorRig, branch)
+	if len(holders) != 1 {
+		t.Fatalf("worktrees on %s = %d (%v), want exactly 1", branch, len(holders), holders)
+	}
+}
+
+// The recovery workflow --branch exists for, which the guard must NOT break.
+// Four of Alice's five recovery slings were exactly this case.
+func TestAddWithOptionsResumesBranchWhoseHolderWasReaped(t *testing.T) {
+	mgr, mayorRig := setupCanonicalBranchManagerTest(t)
+	const branch = "polecat/cheedo/si-aka.10+ms43f8l0"
+	holder := seedLiveWorktreeOnBranch(t, mayorRig, branch)
+
+	// Reap the original worker the way the fleet does.
+	if err := os.RemoveAll(holder); err != nil {
+		t.Fatalf("reap holder: %v", err)
+	}
+	// Denominator: the stale record must survive the reap, or this test is just
+	// the unheld-branch case wearing a different name. Note this deliberately
+	// counts records INCLUDING prunable ones — worktreesOnBranch excludes them,
+	// which is the whole point of the reap.
+	if !anyWorktreeRecordFor(t, mayorRig, branch) {
+		t.Fatal("no worktree record for the branch after reaping — setup no longer " +
+			"reproduces the stale-holder case")
+	}
+
+	polecat, err := mgr.AddWithOptions("toast", AddOptions{ResumeBranch: branch})
+	if err != nil {
+		t.Fatalf("resume after reap was refused: %v\n"+
+			"This is the workflow --force was added for. A guard that blocks it removes the "+
+			"only working recovery route, which is what si-d6kw's fix order warned about", err)
+	}
+	if polecat.Branch != branch {
+		t.Fatalf("resumed polecat is on %q, want %q", polecat.Branch, branch)
+	}
+	head, err := git.NewGit(polecat.ClonePath).CurrentBranch()
+	if err != nil {
+		t.Fatalf("read resumed worktree branch: %v", err)
+	}
+	if head != branch {
+		t.Fatalf("resumed worktree HEAD is on %q, want %q", head, branch)
+	}
+}
+
+// anyWorktreeRecordFor reports whether git still has ANY record for the branch,
+// live or prunable. Used for setup denominators, where the point is that a dead
+// record survives.
+func anyWorktreeRecordFor(t *testing.T, repo, branch string) bool {
+	t.Helper()
+	list, err := git.NewGit(repo).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	for _, wt := range list {
+		if wt.Branch == branch {
+			return true
+		}
+	}
+	return false
+}
+
+// worktreesOnBranch returns the LIVE worktrees holding branch.
+func worktreesOnBranch(t *testing.T, repo, branch string) []string {
+	t.Helper()
+	list, err := git.NewGit(repo).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatal("WorktreeList returned nothing — an empty list satisfies any count assertion")
+	}
+	var paths []string
+	for _, wt := range list {
+		if wt.Branch == branch && !wt.Prunable {
+			paths = append(paths, wt.Path)
+		}
+	}
+	return paths
+}


### PR DESCRIPTION
`gt sling --branch` put two polecat worktrees on one ref. A commit in either then appeared in the other as a delta to re-commit, and the auto-save committed that delta **with no agent acting** — proven at 08:01 during an explicit stop-write, with both agents complying. A fleet sweep then found three more worktrees armed with 7767 / 6824 / 434 staged deletions.

```
gt sling si-aka.9 silicon --branch 'polecat/dag/si-aka.9+ms43eli5'
-> "Created polecat: toast"     # a NEW polecat, on a branch dag's worktree still held
```

## The obvious fix is wrong

`git checkout` refuses this, so it reads like "gt is routing around an existing guard — stop passing `--force`". Measured before writing any code:

```
worktree add (no --force), LIVE holder   -> fatal: 'X' is already used by worktree at ...
worktree add (no --force), STALE holder  -> fatal: 'X' is already used by worktree at ...
```

Identical. Git refuses **both**, so `--force` was load-bearing rather than gratuitous — it is what makes reap-and-resume work at all. Dropping it would have closed the recovery route for the slings that were *clean* (4 of 5 in the incident), which is the regression this defect's own fix order warned about.

But git does distinguish them, somewhere nothing was reading:

```
git worktree list --porcelain  ->  prunable gitdir file points to non-existent location
```

So `WorktreeAddExistingSafe` refuses a live holder, prunes a dead record and attaches, and attaches normally when nothing holds the branch. Both sling resume paths use it.

`RepairWorktreeWithOptions` deliberately stays on `Force`: it rebuilds one polecat's *own* worktree without removing the old registration first, so `Safe` would refuse and repair could never run. The reasoning is recorded at the call site, along with a warning for any future caller that sets `ResumeBranch` there (none does today).

## The refusal is actionable on purpose

The post-mortem traced the original incident to the *safe* path failing with a bare `exit status 1` — a defect that manufactures pressure toward the dangerous option. A refusal that doesn't say what to do instead recreates that, so it names the holding worktree and lists alternatives.

## Mutation-proven

Every guard was verified by breaking the protected thing and observing red, then restoring:

| Mutation | Result |
|---|---|
| `Safe` reverts to force | refusal test fails |
| drop `Prunable`, keep `stat()` | broken-`.git` resume test fails |
| stop parsing the `prunable` line | prunable-discrimination test fails |
| both sling sites back to `Force` | both manager tests fail |
| `AddWithOptions` ignores `ResumeBranch` | `TestAddWithOptions_ResumeBranch` fails |

**The second mutation passed on the first attempt, and that was a real hole rather than an equivalent mutant.** A `stat()` fallback covered the reaped-*directory* case and hid the loss of the prunable check. The case it missed: a worktree whose directory **exists** but whose `.git` file is broken — git reports it prunable, and treating it as live makes such a polecat permanently unresumable, which is precisely what `gt polecat repair` exists to fix. Test added; that mutation now fails.

Also included:

- a **negative control** — `--force` must still reach 2 worktrees on 1 ref in the same fixture, otherwise the refusal test is measuring git rather than the guard;
- **bare-repo coverage** — the manager scaffolding uses the legacy `mayor/rig` base while production is `.repo.git`. Verified on a real bare repo that the base emits `bare` with no `branch` line (so it can never read as a holder and refuse every resume), that polecat worktrees list normally, and that `prunable` is still reported.

## One test needed a setup correction, not a guard change

`TestAddWithOptions_ResumeBranch` went red. `createStalePolecatCommit` builds its marker commit by checking the branch out in `mayor/rig` and never switching back, parking the repo base on the branch under test. That state doesn't exist in production, where `repoBase()` prefers the bare `.repo.git` and holds no branch at all. Left parked, the test would assert that a polecat may attach to a branch a live working tree already holds — the defect itself. Mutation E confirms the correction didn't defang it.

## Verified against a clean baseline

Run in a separate worktree off `origin/main`, so a pre-existing failure isn't mistaken for a new one:

```
baseline  ok internal/polecat 218.5s | FAIL internal/git 74.6s — TestNestedWorkDirResolvingToTownRootGitIsBlocked
changed   ok internal/polecat 192.8s | FAIL internal/git 62.5s — TestNestedWorkDirResolvingToTownRootGitIsBlocked
CGO_ENABLED=0 go build ./...  clean
```

Identical pre-existing failure (a macOS `/private/var` symlink assertion), no new ones. The baseline earned its keep: the first run of `internal/polecat` failed, and it was the only way to know that failure was mine.

## Not covered here

Detection of *already*-shared refs, and making `gt sling <rig>/<polecat>` able to resume an idle polecat so `--branch` isn't the only recovery route. Both tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)