### PR TITLE
fix(si-n7vl): sling to a named polecat resumes ITS worktree instead of replacing it

### DIFF
--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -268,16 +268,35 @@ func reuseIdlePolecatForSling(env *slingPolecatEnv, polecatName string, opts Sli
 // resumeOptionsForPolecat fills in the branch a resume of a NAMED polecat should
 // land on, given the branch its worktree is currently sitting on.
 //
-// With no --branch and no --base-branch, that branch is the polecat's own. This
-// is the point of si-n7vl: recovering an idle polecat must not require the
-// caller to name a branch, because naming one is what put two worktrees on a
-// single ref (si-d6kw). A worktree parked on the rig default branch, or on a
-// detached HEAD, has nothing to resume and takes the normal fresh-branch path.
+// With no --branch and no --base-branch, that branch is the polecat's own — but
+// only when it holds THIS bead's work. This is the point of si-n7vl: recovering
+// an idle polecat must not require the caller to name a branch, because naming
+// one is what put two worktrees on a single ref (si-d6kw).
+//
+// The test is "does the branch encode the bead being slung", not "does the
+// branch look like work". Those differ, and the difference is a live failure:
+// idle keeper sits on polecat/keeper/si-aka.37+ms43gm2z, so slinging a NEW bead
+// si-aka.99 to keeper under the looser test would land si-aka.99's work on
+// si-aka.37's branch and contaminate its MR — with the sling reporting success
+// and no symptom but two beads on one ref (Mayor's ruling, 2026-07-29).
+//
+// Ambiguity resolves to fresh: an unparseable branch, a detached HEAD, the rig
+// default branch, or a parent/child id that does not match exactly. A fresh
+// branch is recoverable; contamination is not.
 func resumeOptionsForPolecat(currentBranch, defaultBranch string, opts SlingSpawnOptions) SlingSpawnOptions {
 	if opts.ResumeBranch != "" || opts.BaseBranch != "" {
 		return opts
 	}
 	if currentBranch == "" || currentBranch == defaultBranch {
+		return opts
+	}
+	// Decode with the inverse of the producer (FormatGeneratedBranchName), so a
+	// change to the branch convention cannot leave this reading the old one.
+	meta, ok := polecat.ParseBranchName(currentBranch)
+	if !ok {
+		return opts
+	}
+	if opts.HookBead != "" && meta.Issue != opts.HookBead {
 		return opts
 	}
 	opts.ResumeBranch = currentBranch

--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -96,10 +96,20 @@ func reclaimBrokenIdlePolecatForSling(polecatMgr *polecat.Manager) (bool, error)
 	return false, nil
 }
 
-// SpawnPolecatForSling creates a fresh polecat and optionally starts its session.
-// This is used by gt sling when the target is a rig name.
-// The caller (sling) handles hook attachment and nudging.
-func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+// slingPolecatEnv holds the town, rig and manager handles that every sling
+// polecat path needs. Resolved in one place so a preflight added for the spawn
+// path cannot go missing from the resume path.
+type slingPolecatEnv struct {
+	townRoot   string
+	rigName    string
+	rig        *rig.Rig
+	tmux       *tmux.Tmux
+	polecatMgr *polecat.Manager
+}
+
+// resolveSlingPolecatEnv loads the rig and polecat manager for a sling and runs
+// the preflight checks that must pass before any polecat is touched.
+func resolveSlingPolecatEnv(rigName string, opts SlingSpawnOptions) (*slingPolecatEnv, error) {
 	// Find workspace
 	townRoot := opts.TownRoot
 	if townRoot == "" {
@@ -149,6 +159,193 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 		return nil, fmt.Errorf("cannot sling to %s rig %q\n%s %s", reason, rigName, undoCmd, rigName)
 	}
 
+	return &slingPolecatEnv{townRoot: townRoot, rigName: rigName, rig: r, tmux: t, polecatMgr: polecatMgr}, nil
+}
+
+// errReuseUnavailable marks a reuse failure the caller may recover from by
+// allocating a different polecat. Failures that happen AFTER reuse succeeded are
+// returned bare: allocating around those would hide a broken polecat record.
+var errReuseUnavailable = errors.New("cannot reuse idle polecat")
+
+// Seams for tests. Production uses the functions they are initialised with.
+var (
+	resolveSlingPolecatEnvFn   = resolveSlingPolecatEnv
+	polecatResumableBranchFn   = polecatResumableBranch
+	reuseIdlePolecatForSlingFn = reuseIdlePolecatForSling
+)
+
+// resolveSlingBaseBranch computes the base branch a sling should start from,
+// origin-qualified for the polecat manager.
+//
+// ResumeBranch (gh#3602) takes precedence: when resuming an existing branch we
+// must not start from main or auto-detect an integration branch.
+func resolveSlingBaseBranch(r *rig.Rig, opts SlingSpawnOptions) string {
+	baseBranch := opts.BaseBranch
+	if opts.ResumeBranch != "" {
+		return baseBranch
+	}
+	if baseBranch == "" && opts.HookBead != "" {
+		// Auto-detect: check if the hooked bead's parent epic has an integration branch
+		settingsPath := filepath.Join(r.Path, "settings", "config.json")
+		polecatIntegrationEnabled := true
+		if settings, err := config.LoadRigSettings(settingsPath); err == nil && settings.MergeQueue != nil {
+			polecatIntegrationEnabled = settings.MergeQueue.IsPolecatIntegrationEnabled()
+		}
+		if polecatIntegrationEnabled {
+			repoGit, repoErr := getRigGit(r.Path)
+			if repoErr == nil {
+				bd := beads.New(r.Path)
+				detected, detectErr := beads.DetectIntegrationBranch(bd, repoGit, opts.HookBead)
+				if detectErr == nil && detected != "" {
+					baseBranch = "origin/" + detected
+					fmt.Printf("  Auto-detected integration branch: %s\n", detected)
+				}
+			}
+		}
+	}
+	if baseBranch != "" && !strings.HasPrefix(baseBranch, "origin/") {
+		baseBranch = "origin/" + baseBranch
+	}
+	return baseBranch
+}
+
+// reuseIdlePolecatForSling puts work on an existing polecat using branch-only
+// operations — its own worktree, no worktree add/remove. Phase 3 of
+// persistent-polecat-pool: eliminates ~5s worktree creation overhead.
+//
+// A reuse that is unsafe or fails returns an error wrapping errReuseUnavailable,
+// which the pool path treats as "allocate a different polecat instead of
+// repairing this worktree destructively".
+func reuseIdlePolecatForSling(env *slingPolecatEnv, polecatName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+	r := env.rig
+	rigName := env.rigName
+	baseBranch := resolveSlingBaseBranch(r, opts)
+
+	addOpts := polecat.AddOptions{
+		HookBead:     opts.HookBead,
+		BaseBranch:   baseBranch,
+		ResumeBranch: opts.ResumeBranch,
+	}
+	if _, err := env.polecatMgr.ReuseIdlePolecat(polecatName, addOpts); err != nil {
+		return nil, fmt.Errorf("%w %s: %w", errReuseUnavailable, polecatName, err)
+	}
+
+	polecatObj, err := env.polecatMgr.Get(polecatName)
+	if err != nil {
+		return nil, fmt.Errorf("getting idle polecat after reuse: %w", err)
+	}
+	if err := verifyWorktreeExists(polecatObj.ClonePath); err != nil {
+		return nil, fmt.Errorf("worktree verification failed for reused %s: %w", polecatName, err)
+	}
+
+	polecatSessMgr := polecat.NewSessionManager(env.tmux, r)
+	sessionName := polecatSessMgr.SessionName(polecatName)
+
+	fmt.Printf("%s Polecat %s reused (idle → working, session start deferred)\n", style.Bold.Render("✓"), polecatName)
+	_ = events.LogFeed(events.TypeSpawn, "gt", events.SpawnPayload(rigName, polecatName))
+
+	effectiveBranch := strings.TrimPrefix(baseBranch, "origin/")
+	if effectiveBranch == "" {
+		effectiveBranch = r.DefaultBranch()
+	}
+	if opts.ResumeBranch != "" {
+		effectiveBranch = opts.ResumeBranch
+	}
+
+	return &SpawnedPolecatInfo{
+		RigName:     rigName,
+		PolecatName: polecatName,
+		ClonePath:   polecatObj.ClonePath,
+		SessionName: sessionName,
+		Pane:        "",
+		BaseBranch:  effectiveBranch,
+		Branch:      polecatObj.Branch,
+		account:     opts.Account,
+		agent:       opts.Agent,
+	}, nil
+}
+
+// resumeOptionsForPolecat fills in the branch a resume of a NAMED polecat should
+// land on, given the branch its worktree is currently sitting on.
+//
+// With no --branch and no --base-branch, that branch is the polecat's own. This
+// is the point of si-n7vl: recovering an idle polecat must not require the
+// caller to name a branch, because naming one is what put two worktrees on a
+// single ref (si-d6kw). A worktree parked on the rig default branch, or on a
+// detached HEAD, has nothing to resume and takes the normal fresh-branch path.
+func resumeOptionsForPolecat(currentBranch, defaultBranch string, opts SlingSpawnOptions) SlingSpawnOptions {
+	if opts.ResumeBranch != "" || opts.BaseBranch != "" {
+		return opts
+	}
+	if currentBranch == "" || currentBranch == defaultBranch {
+		return opts
+	}
+	opts.ResumeBranch = currentBranch
+	return opts
+}
+
+// ResumePolecatForSling reattaches work to a polecat named explicitly in a sling
+// target, on ITS worktree and ITS branch. Used by gt sling when the target names
+// a polecat whose tmux session is gone but whose sandbox is intact.
+//
+// The idle polecat keeps its worktree and its branch when its session dies;
+// only the session is missing. Spawning a fresh polecat instead — which is what
+// gt did before si-n7vl — silently substitutes a different polecat on a fresh
+// branch off main, so the work being recovered is never reattached.
+func ResumePolecatForSling(rigName, polecatName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+	env, err := resolveSlingPolecatEnvFn(rigName, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	currentBranch, err := polecatResumableBranchFn(env, polecatName)
+	if err != nil {
+		return nil, err
+	}
+
+	requestedBranch := opts.ResumeBranch
+	opts = resumeOptionsForPolecat(currentBranch, env.rig.DefaultBranch(), opts)
+	if opts.ResumeBranch != requestedBranch {
+		fmt.Printf("Resuming polecat %s on its existing branch %s\n", polecatName, opts.ResumeBranch)
+	}
+
+	return reuseIdlePolecatForSlingFn(env, polecatName, opts)
+}
+
+// polecatResumableBranch checks that a named polecat still has a usable worktree
+// and reports the branch that worktree is currently on. An error means there is
+// nothing to resume and the caller should allocate a fresh polecat instead.
+func polecatResumableBranch(env *slingPolecatEnv, polecatName string) (string, error) {
+	polecatObj, err := env.polecatMgr.Get(polecatName)
+	if err != nil {
+		return "", fmt.Errorf("polecat '%s' not found in rig '%s': %w", polecatName, env.rigName, err)
+	}
+	if err := verifyWorktreeExists(polecatObj.ClonePath); err != nil {
+		return "", fmt.Errorf("polecat '%s' has no usable worktree at %s: %w", polecatName, polecatObj.ClonePath, err)
+	}
+
+	// Read the branch off the worktree, not off the polecat record: the worktree
+	// is the thing being resumed, and the record can lag it.
+	branch, err := git.NewGit(polecatObj.ClonePath).CurrentBranch()
+	if err != nil {
+		// Not fatal: an unreadable HEAD just means there is no branch to carry
+		// over, and reuse falls back to minting a fresh one.
+		style.PrintWarning("could not read current branch of %s: %v", polecatName, err)
+		return "", nil
+	}
+	return branch, nil
+}
+
+// SpawnPolecatForSling creates a fresh polecat and optionally starts its session.
+// This is used by gt sling when the target is a rig name.
+// The caller (sling) handles hook attachment and nudging.
+func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+	env, err := resolveSlingPolecatEnv(rigName, opts)
+	if err != nil {
+		return nil, err
+	}
+	townRoot, r, t, polecatMgr := env.townRoot, env.rig, env.tmux, env.polecatMgr
+
 	var admission *polecatAdmissionHandle
 	if !opts.SkipAdmission {
 		admission, _, err = acquirePolecatAdmissionFn(townRoot, rigName, opts.HookBead, "spawn-or-reuse")
@@ -188,89 +385,17 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 		polecatName := idlePolecat.Name
 		fmt.Printf("Reusing idle polecat: %s\n", polecatName)
 
-		// ResumeBranch takes precedence over BaseBranch / integration auto-detection:
-		// when the user (or scheduler) wants to resume an existing PR branch, we
-		// must not start from main or an integration branch.
-		baseBranch := opts.BaseBranch
-		if opts.ResumeBranch == "" {
-			if baseBranch == "" && opts.HookBead != "" {
-				settingsPath := filepath.Join(r.Path, "settings", "config.json")
-				polecatIntegrationEnabled := true
-				if settings, err := config.LoadRigSettings(settingsPath); err == nil && settings.MergeQueue != nil {
-					polecatIntegrationEnabled = settings.MergeQueue.IsPolecatIntegrationEnabled()
-				}
-				if polecatIntegrationEnabled {
-					repoGit, repoErr := getRigGit(r.Path)
-					if repoErr == nil {
-						bd := beads.New(r.Path)
-						detected, detectErr := beads.DetectIntegrationBranch(bd, repoGit, opts.HookBead)
-						if detectErr == nil && detected != "" {
-							baseBranch = "origin/" + detected
-							fmt.Printf("  Auto-detected integration branch: %s\n", detected)
-						}
-					}
-				}
-			}
-			if baseBranch != "" && !strings.HasPrefix(baseBranch, "origin/") {
-				baseBranch = "origin/" + baseBranch
-			}
+		info, reuseErr := reuseIdlePolecatForSling(env, polecatName, opts)
+		if reuseErr == nil {
+			return info, nil
 		}
-
-		// Reuse the idle polecat with branch-only operations (no worktree add/remove).
-		// Phase 3 of persistent-polecat-pool: eliminates ~5s worktree creation overhead.
-		// If reuse is unsafe or fails, allocate a new polecat instead of repairing
-		// this worktree destructively.
-		addOpts := polecat.AddOptions{
-			HookBead:     opts.HookBead,
-			BaseBranch:   baseBranch,
-			ResumeBranch: opts.ResumeBranch,
+		// Only an unsafe-or-failed reuse falls through to a fresh allocation.
+		// A failure AFTER reuse succeeded (missing polecat record, unverifiable
+		// worktree) is a hard error: allocating around it would hide it.
+		if !errors.Is(reuseErr, errReuseUnavailable) {
+			return nil, reuseErr
 		}
-		reuseOK := false
-		if _, err := polecatMgr.ReuseIdlePolecat(polecatName, addOpts); err != nil {
-			if errors.Is(err, polecat.ErrPolecatNeedsRecovery) {
-				fmt.Printf("  Idle polecat %s needs recovery before reuse: %v; allocating new...\n", polecatName, err)
-			} else {
-				fmt.Printf("  Branch-only reuse failed for idle polecat %s: %v; allocating new...\n", polecatName, err)
-			}
-		} else {
-			reuseOK = true
-		}
-
-		if reuseOK {
-			polecatObj, err := polecatMgr.Get(polecatName)
-			if err != nil {
-				return nil, fmt.Errorf("getting idle polecat after reuse: %w", err)
-			}
-			if err := verifyWorktreeExists(polecatObj.ClonePath); err != nil {
-				return nil, fmt.Errorf("worktree verification failed for reused %s: %w", polecatName, err)
-			}
-
-			polecatSessMgr := polecat.NewSessionManager(t, r)
-			sessionName := polecatSessMgr.SessionName(polecatName)
-
-			fmt.Printf("%s Polecat %s reused (idle → working, session start deferred)\n", style.Bold.Render("✓"), polecatName)
-			_ = events.LogFeed(events.TypeSpawn, "gt", events.SpawnPayload(rigName, polecatName))
-
-			effectiveBranch := strings.TrimPrefix(baseBranch, "origin/")
-			if effectiveBranch == "" {
-				effectiveBranch = r.DefaultBranch()
-			}
-			if opts.ResumeBranch != "" {
-				effectiveBranch = opts.ResumeBranch
-			}
-
-			return &SpawnedPolecatInfo{
-				RigName:     rigName,
-				PolecatName: polecatName,
-				ClonePath:   polecatObj.ClonePath,
-				SessionName: sessionName,
-				Pane:        "",
-				BaseBranch:  effectiveBranch,
-				Branch:      polecatObj.Branch,
-				account:     opts.Account,
-				agent:       opts.Agent,
-			}, nil
-		}
+		fmt.Printf("  %v; allocating new...\n", reuseErr)
 	}
 
 	// Per-rig directory cap: prevent unbounded worktree accumulation, but only
@@ -293,33 +418,7 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 	}
 
 	// Determine base branch for polecat worktree.
-	// ResumeBranch (gh#3602) takes precedence: when resuming an existing branch
-	// we must not start from main or auto-detect an integration branch.
-	baseBranch := opts.BaseBranch
-	if opts.ResumeBranch == "" {
-		if baseBranch == "" && opts.HookBead != "" {
-			// Auto-detect: check if the hooked bead's parent epic has an integration branch
-			settingsPath := filepath.Join(r.Path, "settings", "config.json")
-			polecatIntegrationEnabled := true
-			if settings, err := config.LoadRigSettings(settingsPath); err == nil && settings.MergeQueue != nil {
-				polecatIntegrationEnabled = settings.MergeQueue.IsPolecatIntegrationEnabled()
-			}
-			if polecatIntegrationEnabled {
-				repoGit, repoErr := getRigGit(r.Path)
-				if repoErr == nil {
-					bd := beads.New(r.Path)
-					detected, detectErr := beads.DetectIntegrationBranch(bd, repoGit, opts.HookBead)
-					if detectErr == nil && detected != "" {
-						baseBranch = "origin/" + detected
-						fmt.Printf("  Auto-detected integration branch: %s\n", detected)
-					}
-				}
-			}
-		}
-		if baseBranch != "" && !strings.HasPrefix(baseBranch, "origin/") {
-			baseBranch = "origin/" + baseBranch
-		}
-	}
+	baseBranch := resolveSlingBaseBranch(r, opts)
 
 	// Build add options with hook_bead set atomically at spawn time
 	addOpts := polecat.AddOptions{

--- a/internal/cmd/sling_resume_idle_polecat_test.go
+++ b/internal/cmd/sling_resume_idle_polecat_test.go
@@ -130,6 +130,62 @@ func TestResumeOptionsForPolecat_DefaultsToThePolecatsOwnBranch(t *testing.T) {
 	}
 }
 
+// D, and the narrowing the Mayor ruled on 2026-07-29: carrying the branch over
+// because it merely LOOKS like work admits cross-bead contamination. Idle keeper
+// sits on si-aka.37's branch; slinging si-aka.99 to keeper must NOT land
+// si-aka.99's work there. Nothing fails loudly if it does — the sling succeeds
+// and the only symptom is two beads' work on one ref, with si-aka.37's MR
+// contaminated.
+func TestResumeOptionsForPolecat_DoesNotCarryAnotherBeadsBranch(t *testing.T) {
+	got := resumeOptionsForPolecat("polecat/keeper/si-aka.37+ms43gm2z", "main", SlingSpawnOptions{HookBead: "si-aka.99"})
+	if got.ResumeBranch != "" {
+		t.Fatalf("ResumeBranch = %q for a sling of si-aka.99: si-aka.37's branch was carried over, "+
+			"which puts two beads on one ref and contaminates si-aka.37's MR", got.ResumeBranch)
+	}
+}
+
+// The parent/child case the ruling calls out: si-aka.9 and si-aka.9.1 are
+// different beads. Prefer an exact match; ambiguity resolves to fresh.
+func TestResumeOptionsForPolecat_ParentAndChildIdsAreNotTheSameBead(t *testing.T) {
+	got := resumeOptionsForPolecat("polecat/dag/si-aka.9+ms43eli5", "main", SlingSpawnOptions{HookBead: "si-aka.9.1"})
+	if got.ResumeBranch != "" {
+		t.Fatalf("ResumeBranch = %q: si-aka.9.1 is a different bead from si-aka.9", got.ResumeBranch)
+	}
+}
+
+// A branch that does not decode carries no answer about which bead it holds, so
+// it is not resumable either.
+func TestResumeOptionsForPolecat_UnparseableBranchIsNotResumed(t *testing.T) {
+	got := resumeOptionsForPolecat("wip/experiment", "main", SlingSpawnOptions{HookBead: "si-aka.9"})
+	if got.ResumeBranch != "" {
+		t.Fatalf("ResumeBranch = %q for a branch whose bead cannot be read; fresh is recoverable, "+
+			"contamination is not", got.ResumeBranch)
+	}
+}
+
+// ...including when no bead is being slung, which is the only case where the
+// unparseable check is doing the work on its own. With a bead present the
+// bead-match test already rejects an undecodable branch, so a test that passes
+// a bead cannot tell whether this check exists. The two rules in the ruling
+// overlap here — "no bead slung -> carry over" and "ambiguous -> fresh" — and
+// ambiguity wins.
+func TestResumeOptionsForPolecat_UnparseableBranchIsNotResumedWithNoBeadEither(t *testing.T) {
+	got := resumeOptionsForPolecat("wip/experiment", "main", SlingSpawnOptions{})
+	if got.ResumeBranch != "" {
+		t.Fatalf("ResumeBranch = %q: a branch whose bead cannot be read is ambiguous, and ambiguity "+
+			"resolves to a fresh branch even when no bead is being slung", got.ResumeBranch)
+	}
+}
+
+// With no bead being slung there is nothing to contaminate, so a plain wake of
+// an idle polecat still lands on its own branch.
+func TestResumeOptionsForPolecat_NoBeadSlungStillResumesItsBranch(t *testing.T) {
+	got := resumeOptionsForPolecat("polecat/dag/si-aka.9+ms43eli5", "main", SlingSpawnOptions{})
+	if got.ResumeBranch != "polecat/dag/si-aka.9+ms43eli5" {
+		t.Fatalf("ResumeBranch = %q, want the polecat's own branch when no bead is being slung", got.ResumeBranch)
+	}
+}
+
 // D, denominator: a polecat parked on the rig default branch has nothing to
 // resume, so reuse must mint a fresh polecat/<name>/<bead> branch as usual.
 func TestResumeOptionsForPolecat_DefaultBranchIsNotResumed(t *testing.T) {

--- a/internal/cmd/sling_resume_idle_polecat_test.go
+++ b/internal/cmd/sling_resume_idle_polecat_test.go
@@ -1,0 +1,348 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/rig"
+)
+
+// si-n7vl: `gt sling <bead> <rig>/<polecat>` could not resume an IDLE polecat.
+// It either errored ("getting pane for si-keeper: exit status 1") or, when the
+// dead-polecat fallback did fire, spawned a FRESH polecat on a FRESH branch —
+// so the worktree and branch you were trying to resume were never reattached.
+// That is why operators reached for --branch, which is what collided two
+// worktrees onto one ref (si-d6kw).
+//
+// The tests below cover the four acceptance items on si-n7vl:
+//
+//	A. sling to an idle polecat by name -> resumes ITS worktree (ClonePath)
+//	B. the 2-part rig/polecat form works without --create for an EXISTING
+//	   polecat, and still refuses a nonexistent one
+//	C. denominator: a polecat with no usable worktree still takes fresh-spawn
+//	D. the resumed polecat reaches its branch with no --branch from the caller
+
+func mkPolecatDir(t *testing.T, townRoot, rigName, name string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(townRoot, rigName, "polecats", name), 0755); err != nil {
+		t.Fatalf("mkdir polecat dir: %v", err)
+	}
+}
+
+func mkCrewDir(t *testing.T, townRoot, rigName, name string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(townRoot, rigName, "crew", name), 0755); err != nil {
+		t.Fatalf("mkdir crew dir: %v", err)
+	}
+}
+
+// B: the shorthand form must resolve an EXISTING polecat even though --create
+// was not passed. --create means "make one that does not exist"; this one does.
+func TestPolecatTargetRigAndName_ShorthandResolvesExistingPolecatWithoutCreate(t *testing.T) {
+	townRoot := t.TempDir()
+	mkPolecatDir(t, townRoot, "silicon", "keeper")
+
+	rigName, polecatName, ok := polecatTargetRigAndName("silicon/keeper", false /* allowShorthand */, townRoot)
+	if !ok {
+		t.Fatalf("silicon/keeper not recognised as a polecat target without --create; " +
+			"this is the exact case that surfaced 'getting pane for si-keeper: exit status 1'")
+	}
+	if rigName != "silicon" || polecatName != "keeper" {
+		t.Fatalf("got rig=%q polecat=%q, want rig=silicon polecat=keeper", rigName, polecatName)
+	}
+}
+
+// B, denominator: a name with no polecat directory must still be refused when
+// --create was not passed. Without this the test above passes for the wrong
+// reason (everything 2-part accepted).
+func TestPolecatTargetRigAndName_ShorthandRefusesNonexistentPolecatWithoutCreate(t *testing.T) {
+	townRoot := t.TempDir()
+	mkPolecatDir(t, townRoot, "silicon", "keeper")
+
+	if rigName, polecatName, ok := polecatTargetRigAndName("silicon/ghost", false, townRoot); ok {
+		t.Fatalf("silicon/ghost accepted without --create (rig=%q polecat=%q); a polecat that does not exist "+
+			"must still require --create", rigName, polecatName)
+	}
+}
+
+// --create keeps its old meaning: mint a polecat that does not exist yet.
+func TestPolecatTargetRigAndName_ShorthandWithCreateAcceptsNonexistentPolecat(t *testing.T) {
+	townRoot := t.TempDir()
+
+	rigName, polecatName, ok := polecatTargetRigAndName("silicon/ghost", true, townRoot)
+	if !ok {
+		t.Fatal("silicon/ghost refused with --create; --create must still allow minting a new polecat")
+	}
+	if rigName != "silicon" || polecatName != "ghost" {
+		t.Fatalf("got rig=%q polecat=%q, want rig=silicon polecat=ghost", rigName, polecatName)
+	}
+}
+
+// Regression guard: a crew member is not a polecat, with or without --create.
+func TestPolecatTargetRigAndName_CrewMemberIsNotAPolecatTarget(t *testing.T) {
+	townRoot := t.TempDir()
+	mkCrewDir(t, townRoot, "silicon", "alice")
+
+	for _, allowShorthand := range []bool{false, true} {
+		if _, _, ok := polecatTargetRigAndName("silicon/alice", allowShorthand, townRoot); ok {
+			t.Fatalf("silicon/alice treated as a polecat target (allowShorthand=%v); it is a crew member", allowShorthand)
+		}
+	}
+}
+
+// Regression guard: a role second segment is never a polecat name.
+func TestPolecatTargetRigAndName_KnownRoleIsNotAPolecatTarget(t *testing.T) {
+	townRoot := t.TempDir()
+	mkPolecatDir(t, townRoot, "silicon", "crew")
+
+	if _, _, ok := polecatTargetRigAndName("silicon/crew", true, townRoot); ok {
+		t.Fatal("silicon/crew treated as a polecat target; 'crew' is a role, not a polecat name")
+	}
+}
+
+// The explicit 3-part form must yield the polecat NAME, not just the rig — the
+// old signature returned only the rig, which is why the fallback could not tell
+// which polecat to resume.
+func TestPolecatTargetRigAndName_ThreePartFormYieldsPolecatName(t *testing.T) {
+	rigName, polecatName, ok := polecatTargetRigAndName("silicon/polecats/keeper", false, "")
+	if !ok {
+		t.Fatal("silicon/polecats/keeper not recognised as a polecat target")
+	}
+	if rigName != "silicon" || polecatName != "keeper" {
+		t.Fatalf("got rig=%q polecat=%q, want rig=silicon polecat=keeper", rigName, polecatName)
+	}
+}
+
+// D: with no --branch and no --base-branch, a named resume lands on the
+// polecat's OWN branch. That is the entire point of the bead: recovery must
+// never require the caller to name a branch, because naming one is what
+// collided two worktrees onto a single ref.
+func TestResumeOptionsForPolecat_DefaultsToThePolecatsOwnBranch(t *testing.T) {
+	got := resumeOptionsForPolecat("polecat/dag/si-aka.9+ms43eli5", "main", SlingSpawnOptions{HookBead: "si-aka.9"})
+	if got.ResumeBranch != "polecat/dag/si-aka.9+ms43eli5" {
+		t.Fatalf("ResumeBranch = %q, want the polecat's existing branch; a fresh branch off main "+
+			"loses the work the operator is trying to resume", got.ResumeBranch)
+	}
+	if got.HookBead != "si-aka.9" {
+		t.Fatalf("HookBead = %q, want si-aka.9 carried through untouched", got.HookBead)
+	}
+}
+
+// D, denominator: a polecat parked on the rig default branch has nothing to
+// resume, so reuse must mint a fresh polecat/<name>/<bead> branch as usual.
+func TestResumeOptionsForPolecat_DefaultBranchIsNotResumed(t *testing.T) {
+	if got := resumeOptionsForPolecat("main", "main", SlingSpawnOptions{}); got.ResumeBranch != "" {
+		t.Fatalf("ResumeBranch = %q, want empty: a worktree sitting on the default branch has no work to resume", got.ResumeBranch)
+	}
+}
+
+// D, denominator: a detached or unreadable HEAD is not a branch to resume.
+func TestResumeOptionsForPolecat_EmptyCurrentBranchIsNotResumed(t *testing.T) {
+	if got := resumeOptionsForPolecat("", "main", SlingSpawnOptions{}); got.ResumeBranch != "" {
+		t.Fatalf("ResumeBranch = %q, want empty for a detached HEAD", got.ResumeBranch)
+	}
+}
+
+// An explicit caller flag still wins over the polecat's current branch.
+func TestResumeOptionsForPolecat_ExplicitFlagsWin(t *testing.T) {
+	got := resumeOptionsForPolecat("polecat/dag/old", "main", SlingSpawnOptions{ResumeBranch: "fix/pr-head"})
+	if got.ResumeBranch != "fix/pr-head" {
+		t.Fatalf("ResumeBranch = %q, want the explicitly requested fix/pr-head", got.ResumeBranch)
+	}
+
+	got = resumeOptionsForPolecat("polecat/dag/old", "main", SlingSpawnOptions{BaseBranch: "develop"})
+	if got.ResumeBranch != "" {
+		t.Fatalf("ResumeBranch = %q, want empty: --base-branch asks for fresh work off develop", got.ResumeBranch)
+	}
+}
+
+// A + D, at the call site: ResumePolecatForSling must actually HAND the
+// polecat's own branch to reuse. resumeOptionsForPolecat deciding correctly is
+// worth nothing if the decision is computed and dropped.
+func TestResumePolecatForSlingPassesThePolecatsOwnBranchToReuse(t *testing.T) {
+	rigDir := t.TempDir()
+	env := &slingPolecatEnv{
+		townRoot: filepath.Dir(rigDir),
+		rigName:  "silicon",
+		rig:      &rig.Rig{Name: "silicon", Path: rigDir},
+	}
+	if got := env.rig.DefaultBranch(); got != "main" {
+		t.Fatalf("test fixture rig default branch = %q, want main", got)
+	}
+
+	prevEnv := resolveSlingPolecatEnvFn
+	prevBranch := polecatResumableBranchFn
+	prevReuse := reuseIdlePolecatForSlingFn
+	t.Cleanup(func() {
+		resolveSlingPolecatEnvFn = prevEnv
+		polecatResumableBranchFn = prevBranch
+		reuseIdlePolecatForSlingFn = prevReuse
+	})
+
+	resolveSlingPolecatEnvFn = func(rigName string, opts SlingSpawnOptions) (*slingPolecatEnv, error) {
+		return env, nil
+	}
+	polecatResumableBranchFn = func(_ *slingPolecatEnv, polecatName string) (string, error) {
+		return "polecat/keeper/si-aka.37+ms43gm2z", nil
+	}
+	var gotOpts SlingSpawnOptions
+	var gotName string
+	reuseIdlePolecatForSlingFn = func(_ *slingPolecatEnv, polecatName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		gotName = polecatName
+		gotOpts = opts
+		return &SpawnedPolecatInfo{RigName: "silicon", PolecatName: polecatName}, nil
+	}
+
+	// No --branch and no --base-branch: exactly the invocation that used to fail.
+	if _, err := ResumePolecatForSling("silicon", "keeper", SlingSpawnOptions{HookBead: "si-aka.37"}); err != nil {
+		t.Fatalf("ResumePolecatForSling: %v", err)
+	}
+	if gotName != "keeper" {
+		t.Fatalf("reuse called for %q, want keeper", gotName)
+	}
+	if gotOpts.ResumeBranch != "polecat/keeper/si-aka.37+ms43gm2z" {
+		t.Fatalf("reuse got ResumeBranch=%q, want the polecat's own branch — without it reuse resets the "+
+			"worktree to origin/main and mints a fresh branch, which is the work being recovered", gotOpts.ResumeBranch)
+	}
+	if gotOpts.HookBead != "si-aka.37" {
+		t.Fatalf("reuse got HookBead=%q, want si-aka.37", gotOpts.HookBead)
+	}
+}
+
+// Denominator for the above: nothing resumable means nothing is invented.
+func TestResumePolecatForSlingFailsWhenThereIsNoWorktreeToResume(t *testing.T) {
+	prevEnv := resolveSlingPolecatEnvFn
+	prevBranch := polecatResumableBranchFn
+	prevReuse := reuseIdlePolecatForSlingFn
+	t.Cleanup(func() {
+		resolveSlingPolecatEnvFn = prevEnv
+		polecatResumableBranchFn = prevBranch
+		reuseIdlePolecatForSlingFn = prevReuse
+	})
+
+	resolveSlingPolecatEnvFn = func(rigName string, opts SlingSpawnOptions) (*slingPolecatEnv, error) {
+		return &slingPolecatEnv{rigName: rigName, rig: &rig.Rig{Name: rigName, Path: t.TempDir()}}, nil
+	}
+	polecatResumableBranchFn = func(_ *slingPolecatEnv, polecatName string) (string, error) {
+		return "", errors.New("has no usable worktree")
+	}
+	reuseIdlePolecatForSlingFn = func(_ *slingPolecatEnv, polecatName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		t.Fatal("reuse attempted for a polecat with no worktree")
+		return nil, nil
+	}
+
+	if _, err := ResumePolecatForSling("silicon", "ghost", SlingSpawnOptions{}); err == nil {
+		t.Fatal("ResumePolecatForSling succeeded with no worktree to resume")
+	}
+}
+
+// A: slinging to a named idle polecat resumes ITS worktree. The pre-existing
+// ClonePath must come back, and no fresh polecat may be spawned.
+func TestResolveTargetResumesNamedIdlePolecat(t *testing.T) {
+	townRoot := t.TempDir()
+	mkPolecatDir(t, townRoot, "silicon", "keeper")
+	existingClone := filepath.Join(townRoot, "silicon", "polecats", "keeper", "silicon")
+
+	prevResolve := resolveTargetAgentFn
+	prevResume := resumePolecatForSlingFn
+	prevSpawn := spawnPolecatForSling
+	t.Cleanup(func() {
+		resolveTargetAgentFn = prevResolve
+		resumePolecatForSlingFn = prevResume
+		spawnPolecatForSling = prevSpawn
+	})
+
+	resolveTargetAgentFn = func(target string) (string, string, string, error) {
+		return "", "", "", errors.New("getting pane for si-keeper: exit status 1")
+	}
+	resumeCalls := 0
+	var gotRig, gotPolecat string
+	resumePolecatForSlingFn = func(rigName, polecatName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		resumeCalls++
+		gotRig, gotPolecat = rigName, polecatName
+		return &SpawnedPolecatInfo{
+			RigName:     rigName,
+			PolecatName: polecatName,
+			ClonePath:   existingClone,
+			Branch:      "polecat/keeper/si-aka.37+ms43gm2z",
+		}, nil
+	}
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		t.Fatalf("spawnPolecatForSling called for a resumable named polecat; " +
+			"spawning fresh is the defect si-n7vl fixes")
+		return nil, nil
+	}
+
+	res, err := resolveTarget("silicon/keeper", ResolveTargetOptions{
+		TownRoot: townRoot,
+		NoBoot:   true,
+		HookBead: "si-aka.37",
+	})
+	if err != nil {
+		t.Fatalf("resolveTarget: %v", err)
+	}
+	if resumeCalls != 1 {
+		t.Fatalf("resume called %d times, want 1", resumeCalls)
+	}
+	if gotRig != "silicon" || gotPolecat != "keeper" {
+		t.Fatalf("resumed rig=%q polecat=%q, want silicon/keeper", gotRig, gotPolecat)
+	}
+	if res.WorkDir != existingClone {
+		t.Fatalf("WorkDir = %q, want the polecat's pre-existing worktree %q", res.WorkDir, existingClone)
+	}
+	if res.Agent != "silicon/polecats/keeper" {
+		t.Fatalf("Agent = %q, want silicon/polecats/keeper", res.Agent)
+	}
+	if res.NewPolecatInfo == nil || res.NewPolecatInfo.Branch != "polecat/keeper/si-aka.37+ms43gm2z" {
+		t.Fatalf("resumed polecat info did not carry the existing branch: %+v", res.NewPolecatInfo)
+	}
+}
+
+// C, denominator: when the named polecat cannot be resumed — no worktree on
+// disk, needs recovery — the fresh-spawn path must still run. Without this the
+// test above could pass while every sling silently hard-failed.
+func TestResolveTargetSpawnsFreshWhenNamedPolecatCannotResume(t *testing.T) {
+	townRoot := t.TempDir()
+	mkPolecatDir(t, townRoot, "silicon", "keeper")
+
+	prevResolve := resolveTargetAgentFn
+	prevResume := resumePolecatForSlingFn
+	prevSpawn := spawnPolecatForSling
+	t.Cleanup(func() {
+		resolveTargetAgentFn = prevResolve
+		resumePolecatForSlingFn = prevResume
+		spawnPolecatForSling = prevSpawn
+	})
+
+	resolveTargetAgentFn = func(target string) (string, string, string, error) {
+		return "", "", "", errors.New("simulated dead target")
+	}
+	resumePolecatForSlingFn = func(rigName, polecatName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		return nil, errors.New("idle polecat worktree not found")
+	}
+	spawnCalls := 0
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		spawnCalls++
+		return &SpawnedPolecatInfo{
+			RigName:     rigName,
+			PolecatName: "toast",
+			ClonePath:   filepath.Join(townRoot, "silicon", "polecats", "toast", "silicon"),
+		}, nil
+	}
+
+	res, err := resolveTarget("silicon/polecats/keeper", ResolveTargetOptions{
+		TownRoot: townRoot,
+		NoBoot:   true,
+	})
+	if err != nil {
+		t.Fatalf("resolveTarget: %v", err)
+	}
+	if spawnCalls != 1 {
+		t.Fatalf("spawnPolecatForSling called %d times, want 1 — an unresumable polecat must still get a fresh one", spawnCalls)
+	}
+	if res.Agent != "silicon/polecats/toast" {
+		t.Fatalf("Agent = %q, want the freshly spawned silicon/polecats/toast", res.Agent)
+	}
+}

--- a/internal/cmd/sling_target.go
+++ b/internal/cmd/sling_target.go
@@ -14,6 +14,9 @@ import (
 // spawnPolecatForSling is a seam for tests. Production uses SpawnPolecatForSling.
 var spawnPolecatForSling = SpawnPolecatForSling
 
+// resumePolecatForSlingFn is a seam for tests. Production uses ResumePolecatForSling.
+var resumePolecatForSlingFn = ResumePolecatForSling
+
 // resolveTargetAgentFn is a seam for tests. Production uses resolveTargetAgent.
 var resolveTargetAgentFn = resolveTargetAgent
 
@@ -261,7 +264,7 @@ func resolveTarget(target string, opts ResolveTargetOptions) (*ResolvedTarget, e
 	// resolve here, getting their pane for nudge delivery (gt-in7b).
 	agentID, pane, workDir, err := resolveTargetAgentFn(target)
 	if err != nil {
-		if rigName, ok := missingPolecatTargetRig(target, opts.Create, opts.TownRoot); ok {
+		if rigName, polecatName, ok := polecatTargetRigAndName(target, opts.Create, opts.TownRoot); ok {
 			if opts.BeadID != "" && !opts.Force {
 				if err := checkCrossRigGuard(opts.BeadID, rigName+"/polecats/_", opts.TownRoot); err != nil {
 					return nil, err
@@ -271,6 +274,39 @@ func resolveTarget(target string, opts ResolveTargetOptions) (*ResolvedTarget, e
 				if err := verifyBeadExistsInTargetRigDatabase(opts.BeadID, rigName, opts.TownRoot); err != nil {
 					return nil, err
 				}
+			}
+			// The named polecat may still exist on disk with its worktree and its
+			// branch — an idle polecat keeps both, it has only lost its tmux
+			// session. Reattach to it rather than replacing it (si-n7vl). Spawning
+			// a fresh polecat here is what left --branch as the only way back onto
+			// the original work, and naming a branch is what collided two worktrees
+			// onto one ref (si-d6kw).
+			if polecatName != "" {
+				resumeOpts := SlingSpawnOptions{
+					TownRoot:      opts.TownRoot,
+					Force:         opts.Force,
+					Account:       opts.Account,
+					Create:        opts.Create,
+					HookBead:      opts.HookBead,
+					Agent:         opts.Agent,
+					BaseBranch:    opts.BaseBranch,
+					ResumeBranch:  opts.ResumeBranch,
+					SkipAdmission: opts.SkipPolecatAdmission,
+				}
+				resumeInfo, resumeErr := resumePolecatForSlingFn(rigName, polecatName, resumeOpts)
+				if resumeErr == nil {
+					result.Agent = resumeInfo.AgentID()
+					result.NewPolecatInfo = resumeInfo
+					result.WorkDir = resumeInfo.ClonePath
+					result.HookSetAtomically = opts.HookBead != ""
+					if !opts.NoBoot {
+						wakeRigAgents(rigName)
+					}
+					return result, nil
+				}
+				// Fall through to a fresh polecat, but say why: a silent
+				// substitution is how "resume keeper" became "here is toast".
+				fmt.Printf("Cannot resume polecat '%s': %v\n", polecatName, resumeErr)
 			}
 			fmt.Printf("Target polecat has no active session, spawning fresh polecat in rig '%s'...\n", rigName)
 			spawnOpts := SlingSpawnOptions{
@@ -320,25 +356,40 @@ func resolveTarget(target string, opts ResolveTargetOptions) (*ResolvedTarget, e
 	return result, nil
 }
 
-func missingPolecatTargetRig(target string, allowShorthand bool, townRoot string) (string, bool) {
-	if isPolecatTarget(target) {
-		parts := strings.Split(target, "/")
-		return parts[0], true
-	}
-	if !allowShorthand {
-		return "", false
-	}
+// polecatTargetRigAndName resolves a sling target that names a specific polecat
+// to its rig and polecat name. It accepts the explicit "rig/polecats/name" form
+// and the "rig/name" shorthand.
+//
+// The NAME matters, not just the rig: the caller uses it to resume that
+// polecat's own worktree. Returning only the rig is what forced the dead-polecat
+// fallback to spawn a fresh polecat instead (si-n7vl).
+//
+// allowShorthand comes from --create. An EXISTING polecat resolves by shorthand
+// whether or not it was passed — --create means "make one that does not exist",
+// and this one does. Requiring it there is what made `gt sling <bead>
+// silicon/keeper` fail with a raw "getting pane for si-keeper: exit status 1"
+// for exactly the idle polecats an operator is trying to recover.
+func polecatTargetRigAndName(target string, allowShorthand bool, townRoot string) (string, string, bool) {
 	parts := strings.Split(target, "/")
+	if isPolecatTarget(target) {
+		return parts[0], parts[2], true
+	}
 	if len(parts) != 2 || knownRoles[strings.ToLower(parts[1])] {
-		return "", false
+		return "", "", false
 	}
 	if townRoot == "" {
 		townRoot = detectTownRootFromCwd()
 	}
 	if townRoot != "" {
 		if info, err := os.Stat(filepath.Join(townRoot, parts[0], "crew", parts[1])); err == nil && info.IsDir() {
-			return "", false
+			return "", "", false
+		}
+		if info, err := os.Stat(filepath.Join(townRoot, parts[0], "polecats", parts[1])); err == nil && info.IsDir() {
+			return parts[0], parts[1], true
 		}
 	}
-	return parts[0], true
+	if !allowShorthand {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
 }


### PR DESCRIPTION
The compounding half of si-d6kw. #4619 makes the dangerous route (`--branch`
onto a ref another worktree holds) refuse instead of corrupt. It does not make
recovery possible — this does.

## The defect, two layers

`gt sling <bead> <rig>/<polecat>` could not resume an idle polecat:

1. **The 2-part `silicon/keeper` form was only accepted with `--create`.**
   Without it the raw pane error surfaced: `resolving target: getting pane for
   si-keeper: exit status 1`. That is the exact message the operator hit.
2. **When the dead-polecat fallback *did* fire, it replaced the polecat.** It
   called `SpawnPolecatForSling`, which allocates a fresh polecat on a fresh
   branch off main. The named polecat's worktree and branch — the work being
   recovered — were never reattached.

So naming a branch was the only route back onto the original work, and naming a
branch is precisely what put two worktrees on one ref.

## The change

- `polecatTargetRigAndName` (was `missingPolecatTargetRig`) returns the polecat
  **name**, not just the rig, and accepts the shorthand for a polecat that
  **exists** whether or not `--create` was passed. `--create` means "make one
  that does not exist"; this one does.
- `ResumePolecatForSling` reattaches to that polecat: its own worktree, its own
  branch, no `git worktree add`, no new clone. With no `--branch` and no
  `--base-branch` it carries over the branch the worktree is currently on — read
  off the worktree, not off the polecat record, because the record can lag it.
  A worktree parked on the rig default branch or on a detached HEAD has nothing
  to resume and takes the normal fresh-branch path.
- The reuse block `SpawnPolecatForSling` already had is **extracted, not
  copied**, so the pool path and the named path compute the base branch and the
  reuse result identically.

Nothing routes through `git worktree add`, so this path cannot create the
collision #4619 guards against: the polecat already holds its own branch in its
own worktree.

## Behaviour that is deliberately unchanged

An unresumable polecat still gets a fresh one — now with a printed reason,
because a silent substitution is how "resume keeper" became "here is toast".
`--create` still mints a polecat that does not exist. A crew member and a role
name are still not polecat targets. One tightening: a failure *after* reuse
succeeded (missing polecat record, unverifiable worktree) is now a hard error
rather than being papered over with a fresh allocation.

## Verification

`CGO_ENABLED=0 go test ./internal/cmd/` — two failures, both pre-existing and
environmental (macOS `/private/var` symlink in `agent_tracking_beads_test.go`);
both reproduce identically on a clean `origin/main` worktree at 649b832b, which
was run as a baseline before making the claim.

Eight mutations, eight kills — each turned a specific test red:

| mutation | killed by |
|---|---|
| drop the existing-polecat shorthand acceptance | `ShorthandResolvesExistingPolecatWithoutCreate` |
| accept any 2-part target regardless of `--create` | `ShorthandRefusesNonexistentPolecatWithoutCreate` |
| never attempt resume (always spawn fresh) | `TestResolveTargetResumesNamedIdlePolecat` |
| hard-fail instead of falling through to fresh spawn | `SpawnsFreshWhenNamedPolecatCannotResume` |
| never adopt the polecat's own branch | `DefaultsToThePolecatsOwnBranch` |
| drop the default-branch exclusion | `DefaultBranchIsNotResumed` |
| compute the branch decision and discard it | `PassesThePolecatsOwnBranchToReuse` |
| ignore a missing worktree | `FailsWhenThereIsNoWorktreeToResume` |

The first version of this change did **not** kill the "computed and discarded"
mutation: the decision was pure-tested but its call site was not. That is why
`ResumePolecatForSling` is seamed — the hole was found by running the mutation,
not by reading the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)