### PR TITLE
enforce: block teardown when polecat needs recovery (gt-225)

### DIFF
--- a/.gastown/model-escalation.json
+++ b/.gastown/model-escalation.json
@@ -1,0 +1,50 @@
+{
+  "type": "model-escalation",
+  "version": 1,
+  "enabled": true,
+  "rules": [
+    {
+      "from_agent": "opencode-local",
+      "to_agent": "opencode-go",
+      "promote_after_failures": 1
+    }
+  ],
+  "validation_failure": {
+    "enabled": true,
+    "local_agent": "opencode-local",
+    "max_local_attempts": 1,
+    "to_agent": "opencode-go",
+    "max_hosted_attempts": 1,
+    "repair_priority": 1
+  },
+  "recovery": {
+    "nudge_after": "15m",
+    "local_restart_after": "30m",
+    "go_escalate_after": "60m",
+    "max_local_restarts": 1,
+    "max_go_attempts": 1,
+    "break_glass": {
+      "enabled": true,
+      "scope": "infrastructure-only",
+      "agents": [
+        "claude",
+        "codex"
+      ],
+      "max_attempts_per_agent": 1,
+      "timeout": "10m",
+      "automatic": true,
+      "tier_policy": {
+        "claude": {
+          "max_attempts": 1,
+          "timeout": "10m",
+          "mode": "automatic"
+        },
+        "codex": {
+          "max_attempts": 1,
+          "timeout": "10m",
+          "mode": "automatic"
+        }
+      }
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,10 @@ check-install-path:
 
 install: check-up-to-date build
 	@mkdir -p $(INSTALL_DIR)
-	@rm -f $(INSTALL_DIR)/$(BINARY)
-	@cp $(BUILD_DIR)/$(BINARY) $(INSTALL_DIR)/$(BINARY)
+	@tmp="$(INSTALL_DIR)/.$(BINARY).install.$$$$"; \
+		cp $(BUILD_DIR)/$(BINARY) "$$tmp" && \
+		chmod 755 "$$tmp" && \
+		mv -f "$$tmp" $(INSTALL_DIR)/$(BINARY)
 	@# Nuke any stale go-install binaries that shadow the canonical location
 	@for bad in $(HOME)/go/bin/$(BINARY) $(HOME)/bin/$(BINARY); do \
 		if [ -f "$$bad" ]; then \

--- a/internal/cmd/crew.go
+++ b/internal/cmd/crew.go
@@ -395,6 +395,7 @@ func init() {
 	crewRestartCmd.Flags().StringVar(&crewRig, "rig", "", "Rig to use (filter when using --all)")
 	crewRestartCmd.Flags().BoolVar(&crewAll, "all", false, "Restart all running crew sessions")
 	crewRestartCmd.Flags().BoolVar(&crewDryRun, "dry-run", false, "Show what would be restarted without restarting")
+	crewRestartCmd.Flags().StringVar(&crewAgentOverride, "agent", "", "Agent alias to run restarted crew with (overrides rig/town default)")
 
 	crewStartCmd.Flags().StringVar(&crewRig, "rig", "", "Rig to start crew in (alternative to positional rig arg)")
 	crewStartCmd.Flags().BoolVar(&crewAll, "all", false, "Start all crew members in the rig")

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -219,6 +219,7 @@ func newDoctorForCommand(rig string) *doctor.Doctor {
 	d.Register(doctor.NewDaemonCheck())
 	d.Register(doctor.NewTmuxGlobalEnvCheck())
 	d.Register(doctor.NewBootHealthCheck())
+	d.Register(doctor.NewModelCrashRecoveryCheck())
 	d.Register(doctor.NewTownBeadsConfigCheck())
 	d.Register(doctor.NewCustomTypesCheck())
 	d.Register(doctor.NewCustomStatusesCheck())

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -230,6 +230,7 @@ func newDoctorForCommand(rig string) *doctor.Doctor {
 	d.Register(doctor.NewRigConfigSyncCheck())      // Check all registered rigs have config.json
 	d.Register(doctor.NewStaleDoltPortCheck())      // Check for stale Dolt port files
 	d.Register(doctor.NewStaleSQLServerInfoCheck()) // Check for stale sql-server.info files (GH#2770)
+	d.Register(doctor.NewStaleTestDoltCheck())      // Check for ownership-proven test Dolt leaks
 	d.Register(doctor.NewPrefixMismatchCheck())
 	d.Register(doctor.NewDatabasePrefixCheck())
 	d.Register(doctor.NewIdleTimeoutCheck()) // Verify dolt.idle-timeout: "0" for all rigs

--- a/internal/cmd/hooks_sync.go
+++ b/internal/cmd/hooks_sync.go
@@ -164,7 +164,7 @@ func runHooksSync(cmd *cobra.Command, args []string) error {
 			if loc.Rig == "" || useSettingsDir {
 				syncDirs = []string{loc.Dir}
 			} else {
-				syncDirs = hooks.DiscoverWorktrees(loc.Dir)
+				syncDirs = hooks.DiscoverWorktreesForRole(loc.Dir, loc.Role)
 			}
 
 			for _, dir := range syncDirs {

--- a/internal/cmd/mail.go
+++ b/internal/cmd/mail.go
@@ -16,10 +16,11 @@ var (
 	mailType          string
 	mailReplyTo       string
 	mailNotify        bool
-	mailNoNotify      bool // Suppress auto-nudge notification to recipient
-	mailTo            string   // --to flag (alternative to positional arg)
-	mailFrom          string   // --from flag (override sender, for relay/bridge use)
+	mailNoNotify      bool   // Suppress auto-nudge notification to recipient
+	mailTo            string // --to flag (alternative to positional arg)
+	mailFrom          string // --from flag (override sender, for relay/bridge use)
 	mailSendSelf      bool
+	mailSendHuman     bool
 	mailCC            []string // CC recipients
 	mailInboxJSON     bool
 	mailReadJSON      bool
@@ -134,6 +135,7 @@ Examples:
   gt mail send greenplace/Toast -s "Urgent" -m "Help!" --urgent
   gt mail send mayor/ -s "Re: Status" -m "Done" --reply-to msg-abc123
   gt mail send --self -s "Handoff" -m "Context for next session"
+  gt mail send --human -s "Recovery alert" -m "Manual intervention required"
   gt mail send greenplace/Toast -s "Update" -m "Progress report" --cc overseer
   gt mail send list:oncall -s "Alert" -m "System down"
 
@@ -476,6 +478,7 @@ func init() {
 	mailSendCmd.Flags().StringVar(&mailTo, "to", "", "Recipient address (alternative to positional argument)")
 	mailSendCmd.Flags().StringVar(&mailFrom, "from", "", "Override sender address (for relay/bridge use)")
 	mailSendCmd.Flags().BoolVar(&mailSendSelf, "self", false, "Send to self (auto-detect from cwd)")
+	mailSendCmd.Flags().BoolVar(&mailSendHuman, "human", false, "Send an urgent permanent alert to the human overseer")
 	mailSendCmd.Flags().StringArrayVar(&mailCC, "cc", nil, "CC recipients (can be used multiple times)")
 	_ = mailSendCmd.MarkFlagRequired("subject") // cobra flags: error only at runtime if missing
 

--- a/internal/cmd/mail_send.go
+++ b/internal/cmd/mail_send.go
@@ -32,7 +32,13 @@ func runMailSend(cmd *cobra.Command, args []string) error {
 
 	var to string
 
-	if mailSendSelf {
+	humanTarget, humanRoute, err := resolveHumanMailTarget(args)
+	if err != nil {
+		return err
+	}
+	if humanRoute {
+		to = humanTarget
+	} else if mailSendSelf {
 		// Auto-detect identity from cwd
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -245,6 +251,19 @@ func runMailSend(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func resolveHumanMailTarget(args []string) (target string, handled bool, err error) {
+	if !mailSendHuman {
+		return "", false, nil
+	}
+	if mailSendSelf || mailTo != "" || len(args) > 0 {
+		return "", true, fmt.Errorf("--human cannot be combined with an address, --to, or --self")
+	}
+	// Recovery alerts must survive session restarts and wisp collection.
+	mailPermanent = true
+	mailUrgent = true
+	return "overseer", true, nil
 }
 
 // generateThreadID creates a random thread ID for new message threads.

--- a/internal/cmd/mail_test.go
+++ b/internal/cmd/mail_test.go
@@ -30,6 +30,41 @@ func TestMailHelpUsesTownRootMessagingConfig(t *testing.T) {
 	}
 }
 
+func TestMailSendHumanFlagIsPermanentOverseerRoute(t *testing.T) {
+	flag := mailSendCmd.Flags().Lookup("human")
+	if flag == nil {
+		t.Fatal("mail send command missing --human flag")
+	}
+	if !strings.Contains(flag.Usage, "urgent") || !strings.Contains(flag.Usage, "permanent") {
+		t.Fatalf("--human help does not describe urgent permanent delivery: %q", flag.Usage)
+	}
+
+	oldHuman, oldSelf, oldTo, oldPermanent, oldUrgent := mailSendHuman, mailSendSelf, mailTo, mailPermanent, mailUrgent
+	t.Cleanup(func() {
+		mailSendHuman, mailSendSelf, mailTo, mailPermanent = oldHuman, oldSelf, oldTo, oldPermanent
+		mailUrgent = oldUrgent
+	})
+
+	mailSendHuman = true
+	mailSendSelf = false
+	mailTo = ""
+	mailPermanent = false
+	mailUrgent = false
+
+	to, handled, err := resolveHumanMailTarget(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !handled || to != "overseer" || !mailPermanent || !mailUrgent {
+		t.Fatalf("--human handled=%v target=%q permanent=%v urgent=%v, want true/overseer/true/true",
+			handled, to, mailPermanent, mailUrgent)
+	}
+
+	if _, _, err := resolveHumanMailTarget([]string{"mayor/"}); err == nil {
+		t.Fatal("--human accepted a conflicting positional address")
+	}
+}
+
 // TestClaimPatternMatching tests claim pattern matching via the beads package.
 // This verifies that the pattern matching used for queue eligibility works correctly.
 func TestClaimPatternMatching(t *testing.T) {

--- a/internal/cmd/mq.go
+++ b/internal/cmd/mq.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/deacon"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/refinery"
 	"github.com/steveyegge/gastown/internal/rig"
@@ -575,6 +576,17 @@ func runMQPostMerge(_ *cobra.Command, args []string) error {
 
 	if branchCleanup.LocalDeleted {
 		fmt.Printf("  %s Deleted local branch: %s\n", style.Success.Render("✓"), mr.Branch)
+	}
+
+	if result.SourceIssueID != "" {
+		townRoot := filepath.Dir(r.Path)
+		if resolved, resolveErr := deacon.ResolveValidationIncidents(
+			townRoot, "", rigName, result.SourceIssueID, "pre-merge",
+		); resolveErr != nil {
+			fmt.Printf("  %s Could not resolve validation incident: %v\n", style.Dim.Render("○"), resolveErr)
+		} else if resolved > 0 {
+			fmt.Printf("  %s Resolved %d validation incident(s)\n", style.Success.Render("✓"), resolved)
+		}
 	}
 
 	return nil

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -246,6 +246,24 @@ func runPrime(cmd *cobra.Command, args []string) (retErr error) {
 }
 
 func ensureRoleWorktreeIntegrity(cwd, townRoot string, role Role) error {
+	// The canonical Witness home is intentionally clone-free. Do not search
+	// upward and accidentally validate a customer/town repository ancestor.
+	// Legacy witness/rig workdirs still flow through strict validation below.
+	cleanCWD := filepath.Clean(cwd)
+	if role == RoleWitness &&
+		filepath.Base(cleanCWD) == "witness" &&
+		filepath.Dir(filepath.Dir(cleanCWD)) == filepath.Clean(townRoot) {
+		rootGit := filepath.Join(cleanCWD, ".git")
+		if _, err := os.Lstat(rootGit); err == nil {
+			return fmt.Errorf(
+				"invalid Witness layout: %s is a misplaced product worktree; canonical witness/ must be clone-free (legacy Git belongs at witness/rig/.git)\nRemediation: preserve any product changes, remove the misplaced root worktree, then run `gt doctor`",
+				rootGit,
+			)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect canonical Witness Git marker %s: %w", rootGit, err)
+		}
+		return nil
+	}
 	if err := worktreeintegrity.Validate(cwd, worktreeintegrity.IntegrityOptions{
 		TownRoot: townRoot,
 		Require:  roleRequiresWorktreeIntegrity(role),

--- a/internal/cmd/prime_clonefree_witness_test.go
+++ b/internal/cmd/prime_clonefree_witness_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureRoleWorktreeIntegrity_CloneFreeWitnessSkipsGitRequirement(t *testing.T) {
+	townRoot := t.TempDir()
+	witnessDir := filepath.Join(townRoot, "testrig", "witness")
+	if err := os.MkdirAll(witnessDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Clone-free Witness priming must not inherit or validate unrelated git
+	// metadata from an ancestor/customer workspace.
+	if err := os.WriteFile(filepath.Join(townRoot, ".git"), []byte("not worktree metadata\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureRoleWorktreeIntegrity(witnessDir, townRoot, RoleWitness); err != nil {
+		t.Fatalf("canonical clone-free witness prime should not require .git: %v", err)
+	}
+}
+
+func TestEnsureRoleWorktreeIntegrity_WorktreeRolesRemainStrict(t *testing.T) {
+	townRoot := t.TempDir()
+	for _, role := range []Role{RolePolecat, RoleCrew} {
+		workDir := filepath.Join(townRoot, string(role))
+		if err := os.MkdirAll(workDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := ensureRoleWorktreeIntegrity(workDir, townRoot, role); err == nil {
+			t.Fatalf("%s prime accepted a missing .git marker", role)
+		}
+	}
+}
+
+func TestEnsureRoleWorktreeIntegrity_ArbitraryWitnessDirectoryRemainsStrict(t *testing.T) {
+	townRoot := t.TempDir()
+	unmanagedWitness := filepath.Join(t.TempDir(), "customer", "witness")
+	if err := os.MkdirAll(unmanagedWitness, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureRoleWorktreeIntegrity(unmanagedWitness, townRoot, RoleWitness); err == nil {
+		t.Fatal("unmanaged directory named witness bypassed worktree integrity")
+	}
+}
+
+func TestEnsureRoleWorktreeIntegrity_LegacyWitnessCloneStillValidated(t *testing.T) {
+	townRoot := t.TempDir()
+	legacyDir := filepath.Join(townRoot, "testrig", "witness", "rig")
+	gitDir := filepath.Join(legacyDir, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureRoleWorktreeIntegrity(legacyDir, townRoot, RoleWitness); err != nil {
+		t.Fatalf("legacy witness clone should remain valid: %v", err)
+	}
+}
+
+func TestEnsureRoleWorktreeIntegrity_MisplacedRootWitnessGitIsRejected(t *testing.T) {
+	for _, markerKind := range []string{"directory", "file"} {
+		t.Run(markerKind, func(t *testing.T) {
+			townRoot := t.TempDir()
+			witnessDir := filepath.Join(townRoot, "testrig", "witness")
+			rootGit := filepath.Join(witnessDir, ".git")
+			if markerKind == "directory" {
+				if err := os.MkdirAll(rootGit, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(
+					filepath.Join(rootGit, "HEAD"),
+					[]byte("ref: refs/heads/main\n"),
+					0o644,
+				); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err := os.MkdirAll(witnessDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(rootGit, []byte("gitdir: /product/worktree\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			err := ensureRoleWorktreeIntegrity(witnessDir, townRoot, RoleWitness)
+			if err == nil {
+				t.Fatal("misplaced witness/.git product worktree bypassed canonical clone-free integrity")
+			}
+			if !strings.Contains(err.Error(), "witness/.git") ||
+				!strings.Contains(strings.ToLower(err.Error()), "clone-free") {
+				t.Fatalf("misplaced root git error was not actionable: %v", err)
+			}
+		})
+	}
+}

--- a/internal/cmd/recovery.go
+++ b/internal/cmd/recovery.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/daemon"
+	"github.com/steveyegge/gastown/internal/deacon"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+var (
+	recoveryJSON bool
+
+	recoveryCmd = &cobra.Command{
+		Use:     "recovery",
+		GroupID: GroupDiag,
+		Short:   "Inspect the local-first recovery ladder",
+		RunE:    requireSubcommand,
+	}
+
+	recoveryStatusCmd = &cobra.Command{
+		Use:   "status",
+		Short: "Show session, validation, and infrastructure recovery incidents",
+		RunE:  runRecoveryStatus,
+	}
+)
+
+type recoveryStatusIncident struct {
+	ID             string    `json:"id"`
+	Class          string    `json:"class"`
+	Identity       string    `json:"identity,omitempty"`
+	Rig            string    `json:"rig,omitempty"`
+	WorkUnit       string    `json:"work_unit,omitempty"`
+	Tier           string    `json:"tier,omitempty"`
+	Status         string    `json:"status"`
+	LeaseOwner     string    `json:"lease_owner,omitempty"`
+	LocalAttempts  int       `json:"local_attempts,omitempty"`
+	HostedAttempts int       `json:"hosted_attempts,omitempty"`
+	Nudges         int       `json:"nudges,omitempty"`
+	NextActionAt   time.Time `json:"next_action_at,omitempty"`
+	Evidence       string    `json:"evidence,omitempty"`
+	Terminal       bool      `json:"terminal,omitempty"`
+}
+
+type recoveryStatusOutput struct {
+	GeneratedAt    time.Time                `json:"generated_at"`
+	Infrastructure map[string]any           `json:"infrastructure,omitempty"`
+	Incidents      []recoveryStatusIncident `json:"incidents"`
+}
+
+func init() {
+	recoveryCmd.AddCommand(recoveryStatusCmd)
+	recoveryStatusCmd.Flags().BoolVar(&recoveryJSON, "json", false, "Output as JSON")
+	rootCmd.AddCommand(recoveryCmd)
+	beadsExemptCommands["recovery"] = true
+	branchCheckExemptCommands["recovery"] = true
+}
+
+func runRecoveryStatus(_ *cobra.Command, _ []string) error {
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+	out := recoveryStatusOutput{GeneratedAt: time.Now().UTC()}
+
+	sessionIncidents, err := daemon.LoadModelCrashRecoveryIncidents(townRoot)
+	if err != nil {
+		return fmt.Errorf("loading session recovery state: %w", err)
+	}
+	for _, incident := range sessionIncidents {
+		out.Incidents = append(out.Incidents, recoveryStatusIncident{
+			ID:             incident.IncidentID,
+			Class:          incident.Kind,
+			Identity:       incident.Identity,
+			WorkUnit:       incident.WorkUnit,
+			Tier:           incident.Tier,
+			Status:         incident.RecoveryAction,
+			LeaseOwner:     incident.LeaseOwner,
+			LocalAttempts:  incident.LocalRestarts + incident.ControlProbes,
+			HostedAttempts: incident.GoContinuations,
+			Nudges:         incident.StallNudges,
+			NextActionAt:   incident.NextActionAt,
+			Terminal:       incident.RecoveryExhausted,
+		})
+	}
+
+	validation, err := deacon.LoadValidationState(townRoot)
+	if err != nil {
+		return fmt.Errorf("loading validation recovery state: %w", err)
+	}
+	for _, incident := range validation.Incidents {
+		if incident == nil {
+			continue
+		}
+		tier := "local"
+		if incident.HostedAttempts > 0 {
+			tier = "go"
+		}
+		out.Incidents = append(out.Incidents, recoveryStatusIncident{
+			ID:             incident.ID,
+			Class:          "validation",
+			Rig:            incident.Rig,
+			WorkUnit:       incident.SourceIssue,
+			Tier:           tier,
+			Status:         incident.Status,
+			LeaseOwner:     "deacon/validation-recovery",
+			LocalAttempts:  incident.LocalAttempts,
+			HostedAttempts: incident.HostedAttempts,
+			Evidence:       incident.LastEvent.Summary,
+			Terminal:       incident.Status == "resolved" || incident.Status == "escalated",
+		})
+	}
+
+	watchdogPath := filepath.Join(townRoot, "deacon", "lmstudio-watchdog.json")
+	if data, readErr := os.ReadFile(watchdogPath); readErr == nil {
+		var state map[string]any
+		if json.Unmarshal(data, &state) == nil {
+			out.Infrastructure = state
+		}
+	}
+
+	sort.Slice(out.Incidents, func(i, j int) bool {
+		if out.Incidents[i].Class != out.Incidents[j].Class {
+			return out.Incidents[i].Class < out.Incidents[j].Class
+		}
+		return out.Incidents[i].ID < out.Incidents[j].ID
+	})
+
+	if recoveryJSON {
+		data, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+	if len(out.Incidents) == 0 {
+		fmt.Println("No recovery incidents recorded")
+	} else {
+		for _, incident := range out.Incidents {
+			fmt.Printf("%s  class=%s tier=%s status=%s", incident.ID, incident.Class, incident.Tier, incident.Status)
+			if incident.WorkUnit != "" {
+				fmt.Printf(" work=%s", incident.WorkUnit)
+			}
+			if incident.NextActionAt.IsZero() {
+				fmt.Println()
+			} else {
+				fmt.Printf(" next=%s\n", incident.NextActionAt.Format(time.RFC3339))
+			}
+		}
+	}
+	if status, ok := out.Infrastructure["status"].(string); ok {
+		fmt.Printf("infrastructure  status=%s\n", status)
+	}
+	return nil
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -77,6 +77,7 @@ var beadsExemptCommands = map[string]bool{
 	"health":        true, // Health check doesn't require beads
 	"upgrade":       true, // Post-install migration orchestrator
 	"heartbeat":     true, // Heartbeat state update — must be fast and dependency-free
+	"validation":    true, // Recovery command performs its own bd checks only when needed
 }
 
 // Commands exempt from the town root branch warning.

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/daemon"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/polecat"
 	"github.com/steveyegge/gastown/internal/rig"
@@ -34,7 +35,36 @@ var (
 	sessionStatusJSON          bool
 	sessionHealthJSON          bool
 	sessionHealthMaxInactivity time.Duration
+	sessionRestartAgent        string
 )
+
+type sessionRestartManager interface {
+	IsRunning(string) (bool, error)
+	Stop(string, bool) error
+	Start(string, polecat.SessionStartOptions) error
+}
+
+var sessionRestartManagerForRig = func(rigName string) (sessionRestartManager, error) {
+	manager, _, err := getSessionManager(rigName)
+	if err != nil {
+		return nil, err
+	}
+	return manager, nil
+}
+
+var sessionRestartValidateAgent = func(rigName, agent string) error {
+	if agent == "" {
+		return nil
+	}
+	townRoot, targetRig, err := getRig(rigName)
+	if err != nil {
+		return err
+	}
+	if _, _, err := config.ResolveAgentConfigWithOverride(townRoot, targetRig.Path, agent); err != nil {
+		return fmt.Errorf("invalid agent override %q: %w", agent, err)
+	}
+	return nil
+}
 
 var sessionCmd = &cobra.Command{
 	Use:     "session",
@@ -209,6 +239,7 @@ func init() {
 
 	// Restart flags
 	sessionRestartCmd.Flags().BoolVarP(&sessionForce, "force", "f", false, "Force immediate shutdown")
+	sessionRestartCmd.Flags().StringVar(&sessionRestartAgent, "agent", "", "Agent alias for the restarted polecat (overrides rig/town default)")
 
 	// Status flags
 	sessionStatusCmd.Flags().BoolVar(&sessionStatusJSON, "json", false, "Output as JSON")
@@ -233,11 +264,16 @@ func init() {
 }
 
 type sessionHealthReport struct {
-	Session              string `json:"session"`
-	Status               string `json:"status"`
-	Healthy              bool   `json:"healthy"`
-	Zombie               bool   `json:"zombie"`
-	MaxInactivitySeconds int64  `json:"max_inactivity_seconds"`
+	Session               string `json:"session"`
+	Status                string `json:"status"`
+	Healthy               bool   `json:"healthy"`
+	Zombie                bool   `json:"zombie"`
+	MaxInactivitySeconds  int64  `json:"max_inactivity_seconds"`
+	ModelCrash            bool   `json:"model_crash"`
+	ModelCrashFingerprint string `json:"model_crash_fingerprint,omitempty"`
+	IncidentID            string `json:"incident_id"`
+	RecoveryAction        string `json:"recovery_action"`
+	RecoveryExhausted     bool   `json:"recovery_exhausted"`
 }
 
 func newSessionHealthReport(session string, status tmux.ZombieStatus, maxInactivity time.Duration) sessionHealthReport {
@@ -248,6 +284,13 @@ func newSessionHealthReport(session string, status tmux.ZombieStatus, maxInactiv
 		Zombie:               status.IsZombie(),
 		MaxInactivitySeconds: int64(maxInactivity.Seconds()),
 	}
+}
+
+func applyModelCrashHealth(report *sessionHealthReport, fingerprint string) {
+	report.Status = "model-crashed"
+	report.Healthy = false
+	report.ModelCrash = true
+	report.ModelCrashFingerprint = fingerprint
 }
 
 // parseAddress parses "rig/polecat" format.
@@ -553,8 +596,11 @@ func runSessionRestart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if err := sessionRestartValidateAgent(rigName, sessionRestartAgent); err != nil {
+		return err
+	}
 
-	polecatMgr, _, err := getSessionManager(rigName)
+	polecatMgr, err := sessionRestartManagerForRig(rigName)
 	if err != nil {
 		return err
 	}
@@ -590,7 +636,7 @@ func runSessionRestart(cmd *cobra.Command, args []string) error {
 
 	// Start fresh session
 	fmt.Printf("Starting session for %s/%s...\n", rigName, polecatName)
-	opts := polecat.SessionStartOptions{}
+	opts := polecat.SessionStartOptions{Agent: sessionRestartAgent}
 	if err := polecatMgr.Start(polecatName, opts); err != nil {
 		return fmt.Errorf("starting session: %w", err)
 	}
@@ -652,8 +698,25 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 
 func runSessionHealth(cmd *cobra.Command, args []string) error {
 	sessionName := args[0]
-	status := tmux.NewTmux().CheckSessionHealth(sessionName, sessionHealthMaxInactivity)
+	t := tmux.NewTmux()
+	status := t.CheckSessionHealth(sessionName, sessionHealthMaxInactivity)
 	report := newSessionHealthReport(sessionName, status, sessionHealthMaxInactivity)
+	if output, err := t.CapturePane(sessionName, 80); err == nil {
+		if fingerprint, crashed := session.DetectModelCrash(output); crashed {
+			applyModelCrashHealth(&report, fingerprint)
+		}
+	}
+	townRoot, _ := t.GetEnvironment(sessionName, "GT_ROOT")
+	if townRoot == "" {
+		townRoot, _ = workspace.FindFromCwd()
+	}
+	if townRoot != "" {
+		if recovery, err := daemon.LoadModelCrashSessionHealth(townRoot, sessionName); err == nil {
+			report.IncidentID = recovery.IncidentID
+			report.RecoveryAction = recovery.RecoveryAction
+			report.RecoveryExhausted = recovery.RecoveryExhausted
+		}
+	}
 
 	if sessionHealthJSON {
 		enc := json.NewEncoder(os.Stdout)

--- a/internal/cmd/session_test.go
+++ b/internal/cmd/session_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -81,6 +82,120 @@ func TestSessionHealthCmdFlagWiring(t *testing.T) {
 	}
 }
 
+func TestSessionRestartCmdAgentFlagWiring(t *testing.T) {
+	f := sessionRestartCmd.Flags().Lookup("agent")
+	if f == nil {
+		t.Fatal("session restart command missing --agent flag")
+	}
+	if f.DefValue != "" {
+		t.Errorf("--agent default = %q, want empty", f.DefValue)
+	}
+}
+
+type fakeSessionRestartManager struct {
+	running    bool
+	stopped    bool
+	started    bool
+	force      bool
+	startName  string
+	startOpts  polecat.SessionStartOptions
+	worktree   string
+	branch     string
+	hook       string
+	assignment string
+}
+
+func (m *fakeSessionRestartManager) IsRunning(string) (bool, error) {
+	return m.running && !m.stopped, nil
+}
+
+func (m *fakeSessionRestartManager) Stop(_ string, force bool) error {
+	m.stopped = true
+	m.force = force
+	return nil
+}
+
+func (m *fakeSessionRestartManager) Start(name string, opts polecat.SessionStartOptions) error {
+	m.started = true
+	m.startName = name
+	m.startOpts = opts
+	return nil
+}
+
+func TestRunSessionRestartAgentOverridePreservesPolecatState(t *testing.T) {
+	manager := &fakeSessionRestartManager{
+		running:    true,
+		worktree:   "/town/rig/polecats/toast",
+		branch:     "polecat/toast",
+		hook:       "gt-work",
+		assignment: "gt-work",
+	}
+	originalFactory := sessionRestartManagerForRig
+	originalValidator := sessionRestartValidateAgent
+	originalAgent := sessionRestartAgent
+	originalForce := sessionForce
+	t.Cleanup(func() {
+		sessionRestartManagerForRig = originalFactory
+		sessionRestartValidateAgent = originalValidator
+		sessionRestartAgent = originalAgent
+		sessionForce = originalForce
+	})
+	var requestedRig string
+	sessionRestartManagerForRig = func(rigName string) (sessionRestartManager, error) {
+		requestedRig = rigName
+		return manager, nil
+	}
+	sessionRestartValidateAgent = func(string, string) error { return nil }
+	sessionRestartAgent = "opencode-go"
+	sessionForce = true
+
+	if err := runSessionRestart(nil, []string{"rig/toast"}); err != nil {
+		t.Fatal(err)
+	}
+	if requestedRig != "rig" || !manager.stopped || !manager.force || !manager.started || manager.startName != "toast" {
+		t.Fatalf("restart lifecycle rig=%q manager=%#v", requestedRig, manager)
+	}
+	wantOpts := polecat.SessionStartOptions{Agent: "opencode-go"}
+	if manager.startOpts != wantOpts {
+		t.Fatalf("restart options = %#v, want only agent override %#v", manager.startOpts, wantOpts)
+	}
+	if manager.worktree != "/town/rig/polecats/toast" || manager.branch != "polecat/toast" ||
+		manager.hook != "gt-work" || manager.assignment != "gt-work" {
+		t.Fatalf("restart mutated polecat state: %#v", manager)
+	}
+}
+
+func TestRunSessionRestartValidatesAgentBeforeStopping(t *testing.T) {
+	manager := &fakeSessionRestartManager{running: true}
+	originalFactory := sessionRestartManagerForRig
+	originalValidator := sessionRestartValidateAgent
+	originalAgent := sessionRestartAgent
+	t.Cleanup(func() {
+		sessionRestartManagerForRig = originalFactory
+		sessionRestartValidateAgent = originalValidator
+		sessionRestartAgent = originalAgent
+	})
+	sessionRestartManagerForRig = func(string) (sessionRestartManager, error) {
+		return manager, nil
+	}
+	validated := false
+	sessionRestartValidateAgent = func(rigName, agent string) error {
+		validated = rigName == "rig" && agent == "not-configured"
+		return fmt.Errorf("unknown agent %q", agent)
+	}
+	sessionRestartAgent = "not-configured"
+
+	if err := runSessionRestart(nil, []string{"rig/toast"}); err == nil {
+		t.Fatal("invalid agent override restarted session")
+	}
+	if !validated {
+		t.Fatal("agent override was not validated")
+	}
+	if manager.stopped || manager.started {
+		t.Fatalf("invalid agent stopped or started session: %#v", manager)
+	}
+}
+
 func TestSessionHealthReportJSONContract(t *testing.T) {
 	report := newSessionHealthReport("gt-vault", tmux.AgentDead, 30*time.Minute)
 	data, err := json.Marshal(report)
@@ -106,6 +221,29 @@ func TestSessionHealthReportJSONContract(t *testing.T) {
 	}
 	if parsed["max_inactivity_seconds"] != float64(1800) {
 		t.Errorf("max_inactivity_seconds = %v, want 1800", parsed["max_inactivity_seconds"])
+	}
+	if _, ok := parsed["model_crash"]; !ok {
+		t.Fatal("session health JSON missing additive model_crash visibility")
+	}
+	for _, field := range []string{"incident_id", "recovery_action", "recovery_exhausted"} {
+		if _, ok := parsed[field]; !ok {
+			t.Fatalf("session health JSON missing additive %s visibility", field)
+		}
+	}
+}
+
+func TestSessionHealthCurrentModelCrashOverridesProcessHealth(t *testing.T) {
+	report := newSessionHealthReport("gt-vault", tmux.SessionHealthy, 0)
+	applyModelCrashHealth(&report, "sha256:fatal")
+
+	if report.Healthy {
+		t.Fatal("current model crash retained healthy=true")
+	}
+	if report.Status != "model-crashed" {
+		t.Fatalf("status = %q, want model-crashed", report.Status)
+	}
+	if !report.ModelCrash || report.ModelCrashFingerprint != "sha256:fatal" {
+		t.Fatalf("model crash visibility = %#v", report)
 	}
 }
 

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -133,7 +133,7 @@ type AgentRuntime struct {
 	NotificationLevel string `json:"notification_level,omitempty"` // Notification level (verbose, normal, muted)
 	UnreadMail        int    `json:"unread_mail"`                  // Number of unread messages
 	FirstSubject      string `json:"first_subject,omitempty"`      // Subject of first unread message
-	AgentAlias        string `json:"agent_alias,omitempty"`        // Configured agent name (e.g., "opus-46", "pi")
+	AgentAlias        string `json:"agent_alias,omitempty"`        // Effective running agent, or configured agent when stopped
 	AgentInfo         string `json:"agent_info,omitempty"`         // Runtime summary (e.g., "claude/opus", "pi/kimi-k2p5")
 }
 
@@ -179,10 +179,18 @@ type StatusSum struct {
 	ActiveHooks   int `json:"active_hooks"`
 }
 
-// resolveAgentDisplay inspects the actual running process in the tmux session
-// to determine what runtime and model are being used. Falls back to config
-// when the session isn't running.
-func resolveAgentDisplay(townRoot string, townSettings *config.TownSettings, role string, sessionName string, running bool) (alias, info string) {
+var statusSessionEnvironment = func(sessionName, key string) (string, error) {
+	return tmux.NewTmux().GetEnvironment(sessionName, key)
+}
+
+var statusRuntimeDetector = detectRuntimeFromSession
+
+// resolveAgentDisplay reports the effective runtime for a running session and
+// the effective configured runtime for a stopped agent. GT_AGENT is set from
+// the final runtime config (including --agent overrides), so it is more
+// authoritative than the workspace default and works on platforms without
+// /proc process inspection.
+func resolveAgentDisplay(townRoot, rigPath, role, agentName, sessionName string, running bool) (alias, info string) {
 	// Map legacy role names to config role names
 	configRole := role
 	switch role {
@@ -192,12 +200,18 @@ func resolveAgentDisplay(townRoot string, townSettings *config.TownSettings, rol
 		configRole = constants.RoleDeacon
 	}
 
-	// Get alias from config
-	if townSettings != nil {
-		alias = townSettings.RoleAgents[configRole]
-		if alias == "" {
-			alias = townSettings.DefaultAgent
+	var configuredRuntime *config.RuntimeConfig
+	if (configRole == constants.RolePolecat || configRole == constants.RoleCrew) && agentName != "" {
+		configuredRuntime = config.ResolveWorkerAgentConfig(agentName, townRoot, rigPath)
+		if configuredRuntime != nil {
+			alias = configuredRuntime.ResolvedAgent
 		}
+	}
+	if configuredRuntime == nil {
+		configuredRuntime = config.ResolveRoleAgentConfig(configRole, townRoot, rigPath)
+	}
+	if alias == "" {
+		alias, _ = config.ResolveRoleAgentName(configRole, townRoot, rigPath)
 	}
 
 	// If mayor is in ACP mode, use the ACP agent name instead
@@ -207,24 +221,45 @@ func resolveAgentDisplay(townRoot string, townSettings *config.TownSettings, rol
 		}
 	}
 
-	// If session is running, inspect the actual process
+	// A running session records the final selected alias, including recovery
+	// overrides such as opencode-go.
 	if running && sessionName != "" {
-		if detected := detectRuntimeFromSession(sessionName); detected != "" {
+		if activeAlias, err := statusSessionEnvironment(sessionName, "GT_AGENT"); err == nil && activeAlias != "" {
+			alias = activeAlias
+			if content, envErr := statusSessionEnvironment(sessionName, "OPENCODE_CONFIG_CONTENT"); envErr == nil {
+				info = openCodeModelInfo(content)
+			}
+			if info == "" {
+				if activeRuntime, _, resolveErr := config.ResolveAgentConfigWithOverride(townRoot, rigPath, activeAlias); resolveErr == nil {
+					info = buildInfoFromConfig(activeRuntime)
+				}
+			}
+		}
+		if detected := statusRuntimeDetector(sessionName); detected != "" && info == "" {
 			info = detected
-			return alias, info
 		}
 	}
 
 	// Fall back to config-based display
-	if townSettings != nil && alias != "" {
-		rc := townSettings.Agents[alias]
-		if rc != nil {
-			info = buildInfoFromConfig(rc)
-		} else {
-			info = alias
-		}
+	if info == "" && configuredRuntime != nil {
+		info = buildInfoFromConfig(configuredRuntime)
+	}
+	if info == "" {
+		info = alias
 	}
 	return alias, info
+}
+
+// openCodeModelInfo extracts only the non-sensitive model identifier from
+// OPENCODE_CONFIG_CONTENT. The full session configuration is never exposed.
+func openCodeModelInfo(content string) string {
+	var cfg struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal([]byte(content), &cfg); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.Model)
 }
 
 // detectRuntimeFromSession inspects the actual process tree in a tmux session
@@ -429,6 +464,11 @@ func readPiDefaults() string {
 
 // buildInfoFromConfig builds display info from a RuntimeConfig (fallback when not running).
 func buildInfoFromConfig(rc *config.RuntimeConfig) string {
+	if content := rc.Env["OPENCODE_CONFIG_CONTENT"]; content != "" {
+		if model := openCodeModelInfo(content); model != "" {
+			return model
+		}
+	}
 	if rc.Command == "" {
 		return "claude"
 	}
@@ -638,9 +678,6 @@ func gatherStatus() (TownStatus, error) {
 		rigsConfig = &config.RigsConfig{Rigs: make(map[string]config.RigEntry)}
 	}
 
-	// Load town settings for agent display info
-	townSettings, _ := config.LoadOrCreateTownSettings(config.TownSettingsPath(townRoot))
-
 	// Create rig manager
 	g := git.NewGit(townRoot)
 	mgr := rig.NewManager(townRoot, rigsConfig, g)
@@ -678,6 +715,10 @@ func gatherStatus() (TownStatus, error) {
 	rigs, err := mgr.DiscoverRigs()
 	if err != nil {
 		return TownStatus{}, fmt.Errorf("discovering rigs: %w", err)
+	}
+	rigPaths := make(map[string]string, len(rigs))
+	for _, r := range rigs {
+		rigPaths[r.Name] = r.Path
 	}
 
 	// Pre-fetch agent beads across all rig-specific beads DBs. If another status
@@ -952,14 +993,15 @@ func gatherStatus() (TownStatus, error) {
 	// Enrich agents with runtime info — inspect actual running processes
 	for i := range status.Agents {
 		a := &status.Agents[i]
-		alias, info := resolveAgentDisplay(townRoot, townSettings, a.Role, a.Session, a.Running)
+		alias, info := resolveAgentDisplay(townRoot, "", a.Role, a.Name, a.Session, a.Running)
 		a.AgentAlias = alias
 		a.AgentInfo = info
 	}
 	for i := range status.Rigs {
+		rigPath := rigPaths[status.Rigs[i].Name]
 		for j := range status.Rigs[i].Agents {
 			a := &status.Rigs[i].Agents[j]
-			alias, info := resolveAgentDisplay(townRoot, townSettings, a.Role, a.Session, a.Running)
+			alias, info := resolveAgentDisplay(townRoot, rigPath, a.Role, a.Name, a.Session, a.Running)
 			a.AgentAlias = alias
 			a.AgentInfo = info
 		}

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -1001,8 +1001,8 @@ func gatherStatus() (TownStatus, error) {
 			rigWg.Wait()
 
 			activeHooks := 0
-			for _, hook := range rs.Hooks {
-				if hook.HasWork {
+			for _, agent := range rs.Agents {
+				if agent.HasWork {
 					activeHooks++
 				}
 			}
@@ -1013,6 +1013,7 @@ func gatherStatus() (TownStatus, error) {
 	}
 
 	wg.Wait()
+	applyRecoveryAgentStates(townRoot, &status)
 
 	// Enrich agents with runtime info — inspect actual running processes
 	for i := range status.Agents {
@@ -1046,6 +1047,44 @@ func gatherStatus() (TownStatus, error) {
 	status.Summary.RigCount = len(rigs)
 
 	return status, nil
+}
+
+func applyRecoveryAgentStates(townRoot string, status *TownStatus) {
+	incidents, err := daemon.LoadModelCrashRecoveryIncidents(townRoot)
+	if err != nil {
+		return
+	}
+	bySession := make(map[string]daemon.ModelCrashRecoveryIncident, len(incidents))
+	for _, incident := range incidents {
+		bySession[incident.SessionName] = incident
+	}
+	apply := func(agent *AgentRuntime) {
+		incident, ok := bySession[agent.Session]
+		if !ok {
+			return
+		}
+		if strings.Contains(incident.RecoveryAction, "pending") ||
+			strings.Contains(incident.RecoveryAction, "restart") ||
+			strings.Contains(incident.RecoveryAction, "continuation") ||
+			strings.Contains(incident.RecoveryAction, "probe") {
+			agent.State = "recovering"
+			return
+		}
+		switch incident.Kind {
+		case "session-stall":
+			agent.State = "stalled"
+		case "session-fatal", "":
+			agent.State = "crashed"
+		}
+	}
+	for i := range status.Agents {
+		apply(&status.Agents[i])
+	}
+	for i := range status.Rigs {
+		for j := range status.Rigs[i].Agents {
+			apply(&status.Rigs[i].Agents[j])
+		}
+	}
 }
 
 func loadModelCrashRecoveryStatus(townRoot string) *ModelCrashRecoveryStatus {

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -63,17 +64,39 @@ func init() {
 
 // TownStatus represents the overall status of the workspace.
 type TownStatus struct {
-	Name     string         `json:"name"`
-	Location string         `json:"location"`
-	Overseer *OverseerInfo  `json:"overseer,omitempty"` // Human operator
-	DND      *DNDInfo       `json:"dnd,omitempty"`      // Current agent DND status
-	Daemon   *ServiceInfo   `json:"daemon,omitempty"`   // Daemon status
-	Dolt     *DoltInfo      `json:"dolt,omitempty"`     // Dolt server status
-	Tmux     *TmuxInfo      `json:"tmux,omitempty"`     // Tmux server status
-	ACP      *ServiceInfo   `json:"acp,omitempty"`      // ACP mayor status
-	Agents   []AgentRuntime `json:"agents"`             // Global agents (Mayor, Deacon)
-	Rigs     []RigStatus    `json:"rigs"`
-	Summary  StatusSum      `json:"summary"`
+	Name               string                    `json:"name"`
+	Location           string                    `json:"location"`
+	Overseer           *OverseerInfo             `json:"overseer,omitempty"` // Human operator
+	DND                *DNDInfo                  `json:"dnd,omitempty"`      // Current agent DND status
+	Daemon             *ServiceInfo              `json:"daemon,omitempty"`   // Daemon status
+	Dolt               *DoltInfo                 `json:"dolt,omitempty"`     // Dolt server status
+	Tmux               *TmuxInfo                 `json:"tmux,omitempty"`     // Tmux server status
+	ACP                *ServiceInfo              `json:"acp,omitempty"`      // ACP mayor status
+	Agents             []AgentRuntime            `json:"agents"`             // Global agents (Mayor, Deacon)
+	Rigs               []RigStatus               `json:"rigs"`
+	Summary            StatusSum                 `json:"summary"`
+	ModelCrashRecovery *ModelCrashRecoveryStatus `json:"model_crash_recovery,omitempty"`
+}
+
+// ModelCrashRecoveryStatus is additive durable recovery visibility for
+// confirmed local-model crashes and exhausted supervisor actions.
+type ModelCrashRecoveryStatus struct {
+	Confirmed           int                        `json:"confirmed"`
+	Exhausted           int                        `json:"exhausted"`
+	Incidents           []ModelCrashStatusIncident `json:"incidents,omitempty"`
+	WatchdogUnavailable bool                       `json:"watchdog_unavailable,omitempty"`
+	WatchdogError       string                     `json:"watchdog_error,omitempty"`
+	Error               string                     `json:"error,omitempty"`
+}
+
+// ModelCrashStatusIncident is the status-safe projection of one durable
+// supervisor incident.
+type ModelCrashStatusIncident struct {
+	Identity          string `json:"identity"`
+	SessionName       string `json:"session_name"`
+	IncidentID        string `json:"incident_id"`
+	RecoveryAction    string `json:"recovery_action"`
+	RecoveryExhausted bool   `json:"recovery_exhausted"`
 }
 
 // ServiceInfo represents a background service status.
@@ -838,11 +861,12 @@ func gatherStatus() (TownStatus, error) {
 
 	// Build status - parallel fetch global agents and rigs
 	status := TownStatus{
-		Name:     townConfig.Name,
-		Location: townRoot,
-		Overseer: overseerInfo,
-		DND:      detectCurrentDNDStatus(townRoot),
-		Rigs:     make([]RigStatus, len(rigs)),
+		Name:               townConfig.Name,
+		Location:           townRoot,
+		Overseer:           overseerInfo,
+		DND:                detectCurrentDNDStatus(townRoot),
+		Rigs:               make([]RigStatus, len(rigs)),
+		ModelCrashRecovery: loadModelCrashRecoveryStatus(townRoot),
 	}
 
 	// Daemon status
@@ -1024,6 +1048,47 @@ func gatherStatus() (TownStatus, error) {
 	return status, nil
 }
 
+func loadModelCrashRecoveryStatus(townRoot string) *ModelCrashRecoveryStatus {
+	if !daemon.IsModelCrashRecoveryProvisioned(townRoot) {
+		return nil
+	}
+	recovery := &ModelCrashRecoveryStatus{}
+	if err := daemon.ValidateModelCrashWatchdog(townRoot, time.Now()); err != nil {
+		recovery.WatchdogUnavailable = true
+		recovery.WatchdogError = err.Error()
+	}
+	incidents, err := daemon.LoadModelCrashRecoveryIncidents(townRoot)
+	if err != nil {
+		recovery.Error = err.Error()
+		return recovery
+	}
+	for _, incident := range incidents {
+		if !incident.Confirmed && !incident.RecoveryExhausted {
+			continue
+		}
+		if incident.Confirmed {
+			recovery.Confirmed++
+		}
+		if incident.RecoveryExhausted {
+			recovery.Exhausted++
+		}
+		recovery.Incidents = append(recovery.Incidents, ModelCrashStatusIncident{
+			Identity:          incident.Identity,
+			SessionName:       incident.SessionName,
+			IncidentID:        incident.IncidentID,
+			RecoveryAction:    incident.RecoveryAction,
+			RecoveryExhausted: incident.RecoveryExhausted,
+		})
+	}
+	if len(recovery.Incidents) == 0 && !recovery.WatchdogUnavailable {
+		return nil
+	}
+	sort.Slice(recovery.Incidents, func(i, j int) bool {
+		return recovery.Incidents[i].Identity < recovery.Incidents[j].Identity
+	})
+	return recovery
+}
+
 func outputStatusJSON(status TownStatus) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
@@ -1111,6 +1176,27 @@ func outputStatusText(w io.Writer, status TownStatus) error {
 			}
 		}
 		fmt.Fprintf(w, "%s\n", strings.Join(parts, "  "))
+		fmt.Fprintln(w)
+	}
+
+	if recovery := status.ModelCrashRecovery; recovery != nil {
+		fmt.Fprintf(w, "%s %s", style.Warning.Render("⚠"),
+			style.Bold.Render("Model crash recovery:"))
+		if recovery.WatchdogUnavailable {
+			fmt.Fprintf(w, " %s", style.Warning.Render("watchdog unavailable: "+recovery.WatchdogError))
+		}
+		fmt.Fprintln(w)
+		if recovery.Error != "" {
+			fmt.Fprintf(w, "   %s\n", style.Warning.Render("state unreadable: "+recovery.Error))
+		} else {
+			fmt.Fprintf(w, "   %d confirmed, %d exhausted\n",
+				recovery.Confirmed, recovery.Exhausted)
+			for _, incident := range recovery.Incidents {
+				fmt.Fprintf(w, "   %s incident=%s action=%s exhausted=%t\n",
+					incident.Identity, incident.IncidentID,
+					incident.RecoveryAction, incident.RecoveryExhausted)
+			}
+		}
 		fmt.Fprintln(w)
 	}
 

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -204,6 +205,83 @@ func TestOutputStatusText_IncludesDNDSection(t *testing.T) {
 	}
 	if !strings.Contains(out, "on") {
 		t.Fatalf("expected DND state 'on' in status output, got: %q", out)
+	}
+}
+
+func TestModelCrashRecoveryStatusSurfacesConfirmedAndExhaustedIncidents(t *testing.T) {
+	townRoot := t.TempDir()
+	stateDir := filepath.Join(townRoot, "deacon")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	state := `{
+		"version": 1,
+		"sessions": {
+			"rig/polecats/toast": {
+				"session_name": "gt-toast",
+				"incident_id": "model-crash-toast",
+				"local_restarts": 1,
+				"recovery_action": "local-restart",
+				"recovery_exhausted": false
+			},
+			"deacon": {
+				"session_name": "gt-deacon",
+				"incident_id": "model-crash-deacon",
+				"local_restarts": 1,
+				"recovery_action": "awaiting-local-probe",
+				"recovery_exhausted": true
+			}
+		},
+		"alerts": {}
+	}`
+	if err := os.WriteFile(filepath.Join(stateDir, "model-crash-supervisor.json"), []byte(state), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	recovery := loadModelCrashRecoveryStatus(townRoot)
+	if recovery == nil || recovery.Confirmed != 2 || recovery.Exhausted != 1 {
+		t.Fatalf("model-crash status summary = %#v, want 2 confirmed / 1 exhausted", recovery)
+	}
+	if !recovery.WatchdogUnavailable || recovery.WatchdogError == "" {
+		t.Fatalf("provisioned status hid unavailable watchdog: %#v", recovery)
+	}
+	status := TownStatus{Name: "gt", Location: townRoot, ModelCrashRecovery: recovery}
+	data, err := json.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"model_crash_recovery"`, `"model-crash-toast"`, `"recovery_exhausted":true`, `"watchdog_unavailable":true`} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("status JSON missing %q: %s", want, data)
+		}
+	}
+
+	var out bytes.Buffer
+	if err := outputStatusText(&out, status); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Model crash recovery:", "watchdog unavailable", "2 confirmed", "1 exhausted", "rig/polecats/toast", "deacon"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("status text missing %q: %s", want, out.String())
+		}
+	}
+}
+
+func TestModelCrashRecoveryStatusOmitsUnprovisionedTown(t *testing.T) {
+	townRoot := t.TempDir()
+	if got := loadModelCrashRecoveryStatus(townRoot); got != nil {
+		t.Fatalf("unprovisioned town exposed local watchdog failure: %#v", got)
+	}
+	marker := filepath.Join(townRoot, "bin", "gt-lmstudio-watchdog")
+	if err := os.MkdirAll(filepath.Dir(marker), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(marker, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	got := loadModelCrashRecoveryStatus(townRoot)
+	if got == nil || !got.WatchdogUnavailable {
+		t.Fatalf("installed watchdog contract silently opted out: %#v", got)
 	}
 }
 

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -394,6 +394,74 @@ func TestParseRuntimeInfo_PiBare(t *testing.T) {
 	}
 }
 
+func TestOpenCodeModelInfo(t *testing.T) {
+	t.Parallel()
+	if got := openCodeModelInfo(`{"lsp":true,"model":"opencode-go/qwen3.7-max"}`); got != "opencode-go/qwen3.7-max" {
+		t.Fatalf("openCodeModelInfo() = %q, want opencode-go/qwen3.7-max", got)
+	}
+	if got := openCodeModelInfo(`{"lsp":true}`); got != "" {
+		t.Fatalf("openCodeModelInfo() without model = %q, want empty", got)
+	}
+	if got := openCodeModelInfo(`not-json`); got != "" {
+		t.Fatalf("openCodeModelInfo() invalid JSON = %q, want empty", got)
+	}
+}
+
+func TestResolveAgentDisplay_RunningSessionUsesEffectiveAliasAndModel(t *testing.T) {
+	oldEnvironment := statusSessionEnvironment
+	oldDetector := statusRuntimeDetector
+	t.Cleanup(func() {
+		statusSessionEnvironment = oldEnvironment
+		statusRuntimeDetector = oldDetector
+	})
+
+	statusSessionEnvironment = func(_ string, key string) (string, error) {
+		switch key {
+		case "GT_AGENT":
+			return "opencode-go", nil
+		case "OPENCODE_CONFIG_CONTENT":
+			return `{"lsp":true,"model":"opencode-go/qwen3.7-max"}`, nil
+		default:
+			return "", os.ErrNotExist
+		}
+	}
+	statusRuntimeDetector = func(string) string { return "" }
+
+	alias, info := resolveAgentDisplay(t.TempDir(), "", "polecat", "jasper", "cy-jasper", true)
+	if alias != "opencode-go" {
+		t.Fatalf("alias = %q, want opencode-go", alias)
+	}
+	if info != "opencode-go/qwen3.7-max" {
+		t.Fatalf("info = %q, want opencode-go/qwen3.7-max", info)
+	}
+}
+
+func TestResolveAgentDisplay_StoppedAgentUsesRigRoleSetting(t *testing.T) {
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "canary")
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	townSettings := config.NewTownSettings()
+	townSettings.DefaultAgent = "claude"
+	if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatalf("save town settings: %v", err)
+	}
+	rigSettings := config.NewRigSettings()
+	rigSettings.Agent = "codex"
+	rigSettings.RoleAgents = make(map[string]string)
+	rigSettings.RoleAgents["witness"] = "gemini"
+	if err := config.SaveRigSettings(config.RigSettingsPath(rigPath), rigSettings); err != nil {
+		t.Fatalf("save rig settings: %v", err)
+	}
+
+	alias, _ := resolveAgentDisplay(townRoot, rigPath, "witness", "witness", "", false)
+	if alias != "gemini" {
+		t.Fatalf("alias = %q, want rig role alias gemini", alias)
+	}
+}
+
 func TestBuildInfoFromConfig(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -420,6 +488,16 @@ func TestBuildInfoFromConfig(t *testing.T) {
 			name: "opencode with -m",
 			rc:   &config.RuntimeConfig{Command: "opencode", Args: []string{"-m", "gpt-5"}},
 			want: "opencode/gpt-5",
+		},
+		{
+			name: "opencode model from environment config",
+			rc: &config.RuntimeConfig{
+				Command: "gt-opencode",
+				Env: map[string]string{
+					"OPENCODE_CONFIG_CONTENT": `{"lsp":true,"model":"lmstudio/qwen/qwen3.6-35b-a3b"}`,
+				},
+			},
+			want: "lmstudio/qwen/qwen3.6-35b-a3b",
 		},
 		{
 			name: "empty command",

--- a/internal/cmd/validation.go
+++ b/internal/cmd/validation.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/deacon"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+var validationCmd = &cobra.Command{
+	Use:     "validation",
+	GroupID: GroupWork,
+	Short:   "Report and inspect confirmed validation failures",
+	RunE:    requireSubcommand,
+}
+
+var validationReportCmd = &cobra.Command{
+	Use:   "report",
+	Short: "Record a confirmed regression and invoke the configured recovery policy",
+	Long: `Record a deterministic validation failure after flaky retries and baseline
+comparison have ruled out transient, infrastructure, and pre-existing failures.
+
+Pre-merge reports preserve and reassign the existing branch. Post-merge reports
+create a forward-fix bug. Each incident receives at most the configured number
+of hosted repair attempts.`,
+	RunE: runValidationReport,
+}
+
+var validationStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show validation recovery incidents and main-branch state",
+	RunE:  runValidationStatus,
+}
+
+var validationResolveCmd = &cobra.Command{
+	Use:   "resolve",
+	Short: "Mark matching validation recovery incidents resolved",
+	RunE:  runValidationResolve,
+}
+
+var (
+	validationRig          string
+	validationKind         string
+	validationSummary      string
+	validationCommit       string
+	validationSourceIssue  string
+	validationMergeRequest string
+	validationBranch       string
+	validationPhase        string
+	validationCommand      string
+	validationExitCode     int
+	validationEvidenceFile string
+	validationEvidence     string
+	validationIncidentID   string
+	validationJSON         bool
+
+	resolveValidationRig         string
+	resolveValidationSourceIssue string
+	resolveValidationPhase       string
+	resolveValidationIncidentID  string
+)
+
+func init() {
+	validationCmd.AddCommand(validationReportCmd)
+	validationCmd.AddCommand(validationStatusCmd)
+	validationCmd.AddCommand(validationResolveCmd)
+
+	validationReportCmd.Flags().StringVar(&validationRig, "rig", "", "Rig containing the failed work (required)")
+	validationReportCmd.Flags().StringVar(&validationKind, "kind", "", "Failure kind: functional, test, build, lint, or typecheck (required)")
+	validationReportCmd.Flags().StringVar(&validationSummary, "summary", "", "Concise failure summary (required)")
+	validationReportCmd.Flags().StringVar(&validationCommit, "commit", "", "Failing commit SHA (required for post-merge)")
+	validationReportCmd.Flags().StringVar(&validationSourceIssue, "source-issue", "", "Original source issue (required for pre-merge)")
+	validationReportCmd.Flags().StringVar(&validationMergeRequest, "merge-request", "", "Merge-request bead ID")
+	validationReportCmd.Flags().StringVar(&validationBranch, "branch", "", "Existing repair branch (required for pre-merge)")
+	validationReportCmd.Flags().StringVar(&validationPhase, "phase", "post-merge", "Failure phase: pre-merge or post-merge")
+	validationReportCmd.Flags().StringVar(&validationCommand, "command", "", "Command or check that failed")
+	validationReportCmd.Flags().IntVar(&validationExitCode, "exit-code", 0, "Failing command exit code")
+	validationReportCmd.Flags().StringVar(&validationEvidenceFile, "evidence-file", "", "File containing bounded failure evidence")
+	validationReportCmd.Flags().StringVar(&validationEvidence, "evidence", "", "Inline failure evidence (for automated producers)")
+	validationReportCmd.Flags().StringVar(&validationIncidentID, "incident", "", "Existing incident ID for a hosted repair result")
+	validationReportCmd.Flags().BoolVar(&validationJSON, "json", false, "Output result as JSON")
+	_ = validationReportCmd.MarkFlagRequired("rig")
+	_ = validationReportCmd.MarkFlagRequired("kind")
+	_ = validationReportCmd.MarkFlagRequired("summary")
+
+	validationStatusCmd.Flags().BoolVar(&validationJSON, "json", false, "Output state as JSON")
+
+	validationResolveCmd.Flags().StringVar(&resolveValidationIncidentID, "incident", "", "Resolve one incident ID")
+	validationResolveCmd.Flags().StringVar(&resolveValidationRig, "rig", "", "Limit resolution to a rig")
+	validationResolveCmd.Flags().StringVar(&resolveValidationSourceIssue, "source-issue", "", "Resolve incidents for a source or repair issue")
+	validationResolveCmd.Flags().StringVar(&resolveValidationPhase, "phase", "", "Limit resolution to pre-merge or post-merge")
+
+	rootCmd.AddCommand(validationCmd)
+}
+
+func runValidationReport(cmd *cobra.Command, args []string) error {
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+
+	evidence := validationEvidence
+	if validationEvidenceFile != "" {
+		data, readErr := os.ReadFile(validationEvidenceFile) //nolint:gosec // operator-supplied evidence file
+		if readErr != nil {
+			return fmt.Errorf("reading evidence file: %w", readErr)
+		}
+		if evidence != "" {
+			evidence += "\n"
+		}
+		evidence += string(data)
+	}
+
+	result := deacon.ProcessValidationFailure(townRoot, deacon.ValidationFailure{
+		IncidentID:   validationIncidentID,
+		Rig:          validationRig,
+		SourceIssue:  validationSourceIssue,
+		MergeRequest: validationMergeRequest,
+		Branch:       validationBranch,
+		Commit:       validationCommit,
+		Phase:        validationPhase,
+		Kind:         validationKind,
+		Command:      validationCommand,
+		ExitCode:     validationExitCode,
+		Summary:      validationSummary,
+		Evidence:     evidence,
+	})
+	if validationJSON {
+		out := struct {
+			IncidentID string `json:"incident_id,omitempty"`
+			Action     string `json:"action"`
+			RepairBead string `json:"repair_bead,omitempty"`
+			Message    string `json:"message,omitempty"`
+			Error      string `json:"error,omitempty"`
+		}{
+			IncidentID: result.IncidentID,
+			Action:     result.Action,
+			RepairBead: result.RepairBead,
+			Message:    result.Message,
+		}
+		if result.Error != nil {
+			out.Error = result.Error.Error()
+		}
+		data, _ := json.MarshalIndent(out, "", "  ")
+		fmt.Println(string(data))
+	} else if result.IncidentID != "" || result.Error == nil {
+		fmt.Printf("%s: %s", result.Action, result.IncidentID)
+		if result.RepairBead != "" {
+			fmt.Printf(" repair=%s", result.RepairBead)
+		}
+		if result.Message != "" {
+			fmt.Printf(" — %s", result.Message)
+		}
+		fmt.Println()
+	}
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.Action == "disabled" {
+		return errors.New(result.Message)
+	}
+	return nil
+}
+
+func runValidationStatus(cmd *cobra.Command, args []string) error {
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+	state, err := deacon.LoadValidationState(townRoot)
+	if err != nil {
+		return err
+	}
+	if validationJSON {
+		data, err := json.MarshalIndent(state, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+	if len(state.Incidents) == 0 && len(state.MainBranches) == 0 {
+		fmt.Println("No validation recovery state recorded")
+		return nil
+	}
+	ids := make([]string, 0, len(state.Incidents))
+	for id := range state.Incidents {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		incident := state.Incidents[id]
+		fmt.Printf("%s  rig=%s phase=%s status=%s hosted=%d/%d",
+			id, incident.Rig, incident.Phase, incident.Status,
+			incident.HostedAttempts, incident.MaxHostedAttempts)
+		if incident.SourceIssue != "" {
+			fmt.Printf(" source=%s", incident.SourceIssue)
+		}
+		if incident.RepairBead != "" {
+			fmt.Printf(" repair=%s", incident.RepairBead)
+		}
+		fmt.Println()
+	}
+	rigs := make([]string, 0, len(state.MainBranches))
+	for rigName := range state.MainBranches {
+		rigs = append(rigs, rigName)
+	}
+	sort.Strings(rigs)
+	for _, rigName := range rigs {
+		mainState := state.MainBranches[rigName]
+		fmt.Printf("main/%s  green=%s tested=%s\n", rigName, mainState.LastGreenSHA, mainState.LastTestedSHA)
+	}
+	return nil
+}
+
+func runValidationResolve(cmd *cobra.Command, args []string) error {
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+	if strings.TrimSpace(resolveValidationIncidentID) == "" &&
+		strings.TrimSpace(resolveValidationSourceIssue) == "" {
+		return errors.New("provide --incident or --source-issue")
+	}
+	if resolveValidationPhase != "" &&
+		resolveValidationPhase != "pre-merge" &&
+		resolveValidationPhase != "post-merge" {
+		return fmt.Errorf("invalid phase %q", resolveValidationPhase)
+	}
+	count, err := deacon.ResolveValidationIncidents(
+		townRoot,
+		resolveValidationIncidentID,
+		resolveValidationRig,
+		resolveValidationSourceIssue,
+		resolveValidationPhase,
+	)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Resolved %d validation incident(s)\n", count)
+	return nil
+}

--- a/internal/config/operational.go
+++ b/internal/config/operational.go
@@ -395,6 +395,14 @@ func (d *DaemonThresholds) BootIdleSuppressionD() time.Duration {
 	return DefaultBootIdleSuppression
 }
 
+// BootAutoSpawnV reports whether daemon heartbeats may spawn AI Boot sessions.
+func (d *DaemonThresholds) BootAutoSpawnV() bool {
+	if d != nil && d.BootAutoSpawn != nil {
+		return *d.BootAutoSpawn
+	}
+	return true
+}
+
 // DeaconGracePeriodD returns the configured or default deacon grace period.
 func (d *DaemonThresholds) DeaconGracePeriodD() time.Duration {
 	if d != nil {

--- a/internal/config/operational_test.go
+++ b/internal/config/operational_test.go
@@ -470,6 +470,25 @@ func TestPressureThresholds_NilReceiver(t *testing.T) {
 	}
 }
 
+func TestBootAutoSpawn_DefaultAndOverride(t *testing.T) {
+	t.Parallel()
+
+	var nilThresholds *DaemonThresholds
+	if !nilThresholds.BootAutoSpawnV() {
+		t.Fatal("nil daemon thresholds should enable automatic Boot spawning")
+	}
+
+	disabled := false
+	if (&DaemonThresholds{BootAutoSpawn: &disabled}).BootAutoSpawnV() {
+		t.Fatal("boot_auto_spawn=false should disable automatic Boot spawning")
+	}
+
+	enabled := true
+	if !(&DaemonThresholds{BootAutoSpawn: &enabled}).BootAutoSpawnV() {
+		t.Fatal("boot_auto_spawn=true should enable automatic Boot spawning")
+	}
+}
+
 func TestPressureThresholds_JSON(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -859,6 +859,18 @@ func (rc *RuntimeConfig) BuildCommand() string {
 	return cmd
 }
 
+// unwrappedCommandBase returns the basename of command with any "gt-" wrapper
+// prefix stripped, so a wrapper script like "gt-opencode" (which execs the
+// real "opencode" binary after running setup, e.g. `gt prime`) is recognized
+// as its wrapped agent. Mirrors the unwrapping convention already used by
+// ResolveProcessNames (see agents.go) for liveness/process-name matching —
+// prompt-delivery detection must agree with it, or a wrapped agent silently
+// gets the wrong prompt-delivery mechanism.
+func unwrappedCommandBase(command string) string {
+	base := filepath.Base(command)
+	return strings.TrimPrefix(base, "gt-")
+}
+
 // BuildCommandWithPrompt returns the full command line with an initial prompt.
 // If the config has an InitialPrompt, it's appended as a quoted argument.
 // If prompt is provided, it overrides the config's InitialPrompt.
@@ -885,22 +897,24 @@ func (rc *RuntimeConfig) BuildCommandWithPrompt(prompt string) string {
 		return base
 	}
 
+	cmdBase := unwrappedCommandBase(resolved.Command)
+
 	// OpenCode requires --prompt flag for initial prompt in interactive mode.
-	// Positional argument causes opencode to exit immediately.
-	// Match both "opencode" and full paths like "/home/user/.opencode/bin/opencode".
-	if resolved.Command == "opencode" || filepath.Base(resolved.Command) == "opencode" {
+	// Positional argument causes opencode to exit immediately (it's interpreted
+	// as a project directory to open).
+	if cmdBase == "opencode" {
 		return base + " --prompt " + quoteForShell(p)
 	}
 
 	// Copilot requires -i flag for initial prompt in interactive mode.
-	if resolved.Command == "copilot" || filepath.Base(resolved.Command) == "copilot" {
+	if cmdBase == "copilot" {
 		return base + " -i " + quoteForShell(p)
 	}
 
 	// Gemini requires -i (--prompt-interactive) to auto-execute the prompt
 	// while staying in interactive mode. Positional args populate the input
 	// field but don't execute, and -p runs headless (exits after completion).
-	if resolved.Command == "gemini" || filepath.Base(resolved.Command) == "gemini" {
+	if cmdBase == "gemini" {
 		return base + " -i " + quoteForShell(p)
 	}
 
@@ -919,7 +933,7 @@ func (rc *RuntimeConfig) BuildArgsWithPrompt(prompt string) []string {
 	}
 
 	if p != "" && resolved.PromptMode != "none" {
-		switch resolved.Command {
+		switch unwrappedCommandBase(resolved.Command) {
 		case "opencode":
 			args = append(args, "--prompt", p)
 		case "copilot", "gemini":

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -356,6 +356,11 @@ type DaemonThresholds struct {
 	// (deacon was healthy). Prevents burning API calls when deacon is running fine (default "15m").
 	BootIdleSuppression string `json:"boot_idle_suppression,omitempty"`
 
+	// BootAutoSpawn controls daemon-triggered AI Boot sessions (default true).
+	// Disable when an independent mechanical watchdog invokes Boot only for
+	// confirmed recovery incidents.
+	BootAutoSpawn *bool `json:"boot_auto_spawn,omitempty"`
+
 	// DeaconGracePeriod is time to wait after starting Deacon before checking heartbeat (default "5m").
 	DeaconGracePeriod string `json:"deacon_grace_period,omitempty"`
 

--- a/internal/daemon/boot_spawn_frequency_test.go
+++ b/internal/daemon/boot_spawn_frequency_test.go
@@ -105,6 +105,50 @@ func TestEnsureBootRunning_DoesNotSpawnEveryTick(t *testing.T) {
 	}
 }
 
+func TestEnsureBootRunning_AutoSpawnDisabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows — fake tmux requires bash")
+	}
+	townRoot := t.TempDir()
+	settingsDir := filepath.Join(townRoot, "settings")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := `{
+		"type": "town-settings",
+		"version": 1,
+		"operational": {"daemon": {"boot_auto_spawn": false}}
+	}`
+	if err := os.WriteFile(filepath.Join(settingsDir, "config.json"), []byte(settings), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBinDir := t.TempDir()
+	tmuxLog := filepath.Join(t.TempDir(), "tmux.log")
+	if err := os.WriteFile(tmuxLog, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeTmux(t, fakeBinDir)
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_LOG", tmuxLog)
+	t.Setenv("GT_DEGRADED", "false")
+
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		logger: log.New(io.Discard, "", 0),
+		tmux:   tmux.NewTmux(),
+	}
+	d.ensureBootRunning()
+
+	data, err := os.ReadFile(tmuxLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "new-session ") {
+		t.Fatalf("automatic Boot spawned despite boot_auto_spawn=false:\n%s", data)
+	}
+}
+
 // Regression test for gt-qu883c:
 // daemon should suppress Boot spawns when Boot's last action was "nothing" (deacon healthy).
 func TestEnsureBootRunning_SuppressesWhenDeaconHealthy(t *testing.T) {

--- a/internal/daemon/convoy_dispatch_circuit.go
+++ b/internal/daemon/convoy_dispatch_circuit.go
@@ -19,7 +19,22 @@ type convoyDispatchFailureKind string
 const (
 	convoyDispatchRespawnExhausted    convoyDispatchFailureKind = "respawn-exhausted"
 	convoyDispatchRigPrefixUnresolved convoyDispatchFailureKind = "rig-prefix-unresolved"
+	convoyDispatchAssignmentChurn     convoyDispatchFailureKind = "assignment-churn"
 )
+
+const (
+	convoyDispatchLeaseDuration = 60 * time.Minute
+	convoyDispatchChurnLimit    = 2
+)
+
+type convoyDispatchLease struct {
+	ConvoyID   string    `json:"convoy_id"`
+	IssueID    string    `json:"issue_id"`
+	Owner      string    `json:"owner"`
+	Attempts   int       `json:"attempts"`
+	AcquiredAt time.Time `json:"acquired_at"`
+	ExpiresAt  time.Time `json:"expires_at"`
+}
 
 type convoyDispatchCircuitEntry struct {
 	ConvoyID     string                    `json:"convoy_id"`
@@ -33,6 +48,7 @@ type convoyDispatchCircuitEntry struct {
 
 type convoyDispatchCircuitState struct {
 	Circuits    map[string]*convoyDispatchCircuitEntry `json:"circuits"`
+	Leases      map[string]*convoyDispatchLease        `json:"leases,omitempty"`
 	LastUpdated time.Time                              `json:"last_updated"`
 }
 
@@ -55,6 +71,7 @@ func newConvoyDispatchCircuitBreaker(townRoot string, now func() time.Time) *con
 		now:      now,
 		state: convoyDispatchCircuitState{
 			Circuits: make(map[string]*convoyDispatchCircuitEntry),
+			Leases:   make(map[string]*convoyDispatchLease),
 		},
 	}
 	b.loadErr = b.load()
@@ -98,7 +115,66 @@ func (b *convoyDispatchCircuitBreaker) load() error {
 	if b.state.Circuits == nil {
 		b.state.Circuits = make(map[string]*convoyDispatchCircuitEntry)
 	}
+	if b.state.Leases == nil {
+		b.state.Leases = make(map[string]*convoyDispatchLease)
+	}
 	return nil
+}
+
+// TryAcquireLease writes the assignment intent before gt sling runs. A live
+// lease suppresses convoy rescans across daemon restarts. If the same issue
+// becomes dispatchable again after two completed lease windows, the circuit
+// opens instead of alternating polecats indefinitely.
+func (b *convoyDispatchCircuitBreaker) TryAcquireLease(
+	convoyID, issueID, owner, churnFingerprint string,
+) (acquired bool, churned bool, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	key := convoyDispatchCircuitKey(convoyID, issueID)
+	now := b.now().UTC()
+	attempts := 1
+	if existing := b.state.Leases[key]; existing != nil {
+		if now.Before(existing.ExpiresAt) {
+			return false, false, nil
+		}
+		attempts = existing.Attempts + 1
+	}
+	if attempts > convoyDispatchChurnLimit {
+		delete(b.state.Leases, key)
+		b.state.Circuits[key] = &convoyDispatchCircuitEntry{
+			ConvoyID:     convoyID,
+			IssueID:      issueID,
+			Kind:         convoyDispatchAssignmentChurn,
+			Fingerprint:  churnFingerprint,
+			Error:        fmt.Sprintf("work returned to the ready queue after %d assignment leases", attempts-1),
+			LatchedAt:    now,
+			AlertPending: true,
+		}
+		return false, true, b.saveLocked()
+	}
+	b.state.Leases[key] = &convoyDispatchLease{
+		ConvoyID:   convoyID,
+		IssueID:    issueID,
+		Owner:      owner,
+		Attempts:   attempts,
+		AcquiredAt: now,
+		ExpiresAt:  now.Add(convoyDispatchLeaseDuration),
+	}
+	return true, false, b.saveLocked()
+}
+
+// ReleaseLease allows a failed sling to be retried; successful dispatch keeps
+// its lease so stale convoy reads cannot resling the same work.
+func (b *convoyDispatchCircuitBreaker) ReleaseLease(convoyID, issueID string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	key := convoyDispatchCircuitKey(convoyID, issueID)
+	if b.state.Leases[key] == nil {
+		return nil
+	}
+	delete(b.state.Leases, key)
+	return b.saveLocked()
 }
 
 func (b *convoyDispatchCircuitBreaker) corruptionAlertWasDelivered() bool {

--- a/internal/daemon/convoy_dispatch_circuit.go
+++ b/internal/daemon/convoy_dispatch_circuit.go
@@ -1,0 +1,351 @@
+package daemon
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+type convoyDispatchFailureKind string
+
+const (
+	convoyDispatchRespawnExhausted    convoyDispatchFailureKind = "respawn-exhausted"
+	convoyDispatchRigPrefixUnresolved convoyDispatchFailureKind = "rig-prefix-unresolved"
+)
+
+type convoyDispatchCircuitEntry struct {
+	ConvoyID     string                    `json:"convoy_id"`
+	IssueID      string                    `json:"issue_id"`
+	Kind         convoyDispatchFailureKind `json:"kind"`
+	Fingerprint  string                    `json:"fingerprint"`
+	Error        string                    `json:"error"`
+	LatchedAt    time.Time                 `json:"latched_at"`
+	AlertPending bool                      `json:"alert_pending,omitempty"`
+}
+
+type convoyDispatchCircuitState struct {
+	Circuits    map[string]*convoyDispatchCircuitEntry `json:"circuits"`
+	LastUpdated time.Time                              `json:"last_updated"`
+}
+
+type convoyDispatchCircuitBreaker struct {
+	mu                 sync.Mutex
+	townRoot           string
+	now                func() time.Time
+	state              convoyDispatchCircuitState
+	loadErr            error
+	loadFingerprint    string
+	loadAlertDelivered bool
+}
+
+func newConvoyDispatchCircuitBreaker(townRoot string, now func() time.Time) *convoyDispatchCircuitBreaker {
+	if now == nil {
+		now = time.Now
+	}
+	b := &convoyDispatchCircuitBreaker{
+		townRoot: townRoot,
+		now:      now,
+		state: convoyDispatchCircuitState{
+			Circuits: make(map[string]*convoyDispatchCircuitEntry),
+		},
+	}
+	b.loadErr = b.load()
+	if b.loadErr != nil {
+		b.loadAlertDelivered = b.corruptionAlertWasDelivered()
+	} else {
+		// A successfully loaded (or absent) main state ends the previous
+		// corruption incident. The same bytes becoming corrupt later should
+		// produce a new alert.
+		_ = os.Remove(convoyDispatchCorruptionAlertStateFile(townRoot))
+	}
+	return b
+}
+
+func convoyDispatchCircuitStateFile(townRoot string) string {
+	return filepath.Join(townRoot, "daemon", "convoy-dispatch-circuits.json")
+}
+
+func convoyDispatchCorruptionAlertStateFile(townRoot string) string {
+	return filepath.Join(townRoot, "daemon", "convoy-dispatch-circuit-corruption-alert.json")
+}
+
+func convoyDispatchCircuitKey(convoyID, issueID string) string {
+	return convoyID + "::" + issueID
+}
+
+func (b *convoyDispatchCircuitBreaker) load() error {
+	data, err := os.ReadFile(convoyDispatchCircuitStateFile(b.townRoot)) //nolint:gosec // trusted town root
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		b.loadFingerprint = fmt.Sprintf("read-error:%x", sha256.Sum256([]byte(err.Error())))
+		return err
+	}
+	b.loadFingerprint = fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+	if err := json.Unmarshal(data, &b.state); err != nil {
+		return err
+	}
+	b.loadFingerprint = ""
+	if b.state.Circuits == nil {
+		b.state.Circuits = make(map[string]*convoyDispatchCircuitEntry)
+	}
+	return nil
+}
+
+func (b *convoyDispatchCircuitBreaker) corruptionAlertWasDelivered() bool {
+	var marker struct {
+		Fingerprint string `json:"fingerprint"`
+	}
+	data, err := os.ReadFile(convoyDispatchCorruptionAlertStateFile(b.townRoot)) //nolint:gosec // trusted town root
+	if err != nil || json.Unmarshal(data, &marker) != nil {
+		return false
+	}
+	return marker.Fingerprint != "" && marker.Fingerprint == b.loadFingerprint
+}
+
+func (b *convoyDispatchCircuitBreaker) saveLocked() error {
+	path := convoyDispatchCircuitStateFile(b.townRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	b.state.LastUpdated = b.now().UTC()
+	data, err := json.MarshalIndent(&b.state, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".convoy-dispatch-circuits-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// Record latches a permanent failure. duplicate is true when the exact
+// convoy+issue+fingerprint is already persisted.
+func (b *convoyDispatchCircuitBreaker) Record(
+	convoyID, issueID string,
+	kind convoyDispatchFailureKind,
+	fingerprint, errText string,
+) (duplicate bool, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	key := convoyDispatchCircuitKey(convoyID, issueID)
+	if existing := b.state.Circuits[key]; existing != nil &&
+		existing.Kind == kind &&
+		existing.Fingerprint == fingerprint {
+		return true, nil
+	}
+	b.state.Circuits[key] = &convoyDispatchCircuitEntry{
+		ConvoyID:     convoyID,
+		IssueID:      issueID,
+		Kind:         kind,
+		Fingerprint:  fingerprint,
+		Error:        errText,
+		LatchedAt:    b.now().UTC(),
+		AlertPending: true,
+	}
+	return false, b.saveLocked()
+}
+
+func (b *convoyDispatchCircuitBreaker) LoadError() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.loadErr
+}
+
+func (b *convoyDispatchCircuitBreaker) CorruptionAlertPending() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.loadErr != nil && !b.loadAlertDelivered
+}
+
+func (b *convoyDispatchCircuitBreaker) MarkCorruptionAlertDelivered() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	path := convoyDispatchCorruptionAlertStateFile(b.townRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(struct {
+		Fingerprint string    `json:"fingerprint"`
+		AlertedAt   time.Time `json:"alerted_at"`
+	}{
+		Fingerprint: b.loadFingerprint,
+		AlertedAt:   b.now().UTC(),
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".convoy-dispatch-corruption-alert-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	b.loadAlertDelivered = true
+	return nil
+}
+
+// FailureKind returns the currently persisted failure class for a convoy issue.
+func (b *convoyDispatchCircuitBreaker) FailureKind(convoyID, issueID string) convoyDispatchFailureKind {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if entry := b.state.Circuits[convoyDispatchCircuitKey(convoyID, issueID)]; entry != nil {
+		return entry.Kind
+	}
+	return ""
+}
+
+func (b *convoyDispatchCircuitBreaker) AlertPending(convoyID, issueID string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry := b.state.Circuits[convoyDispatchCircuitKey(convoyID, issueID)]
+	return entry != nil && entry.AlertPending
+}
+
+func (b *convoyDispatchCircuitBreaker) AlertDetail(convoyID, issueID string) string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry := b.state.Circuits[convoyDispatchCircuitKey(convoyID, issueID)]
+	if entry == nil {
+		return ""
+	}
+	return entry.Error
+}
+
+func (b *convoyDispatchCircuitBreaker) MarkAlertDelivered(convoyID, issueID string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	key := convoyDispatchCircuitKey(convoyID, issueID)
+	entry := b.state.Circuits[key]
+	if entry == nil || !entry.AlertPending {
+		return nil
+	}
+	entry.AlertPending = false
+	if err := b.saveLocked(); err != nil {
+		entry.AlertPending = true
+		return err
+	}
+	return nil
+}
+
+// ShouldSuppress reports whether the relevant state fingerprint is unchanged.
+// A changed fingerprint clears the old latch so exactly one new dispatch can
+// be attempted against the new state.
+func (b *convoyDispatchCircuitBreaker) ShouldSuppress(
+	convoyID, issueID, currentFingerprint string,
+) (bool, convoyDispatchFailureKind) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	key := convoyDispatchCircuitKey(convoyID, issueID)
+	entry := b.state.Circuits[key]
+	if entry == nil {
+		return false, ""
+	}
+	if entry.Fingerprint == currentFingerprint {
+		return true, entry.Kind
+	}
+	delete(b.state.Circuits, key)
+	if err := b.saveLocked(); err != nil {
+		// Fail closed: if the reset cannot be persisted, retain the circuit
+		// rather than retrying on every daemon scan/restart.
+		b.state.Circuits[key] = entry
+		return true, entry.Kind
+	}
+	return false, entry.Kind
+}
+
+func classifyPermanentConvoyDispatchError(errText string) convoyDispatchFailureKind {
+	if strings.Contains(strings.ToLower(errText), "respawn limit reached for") {
+		return convoyDispatchRespawnExhausted
+	}
+	return ""
+}
+
+func classifyUnresolvedConvoyRig(prefix, rig string) convoyDispatchFailureKind {
+	if prefix != "" && rig == "" {
+		return convoyDispatchRigPrefixUnresolved
+	}
+	return ""
+}
+
+// convoyRouteFingerprint hashes only the route relevant to prefix. Changes to
+// unrelated routes must not reopen this circuit.
+func convoyRouteFingerprint(townRoot, prefix string) string {
+	routes, err := beads.LoadRoutes(filepath.Join(townRoot, ".beads"))
+	if err != nil {
+		return fmt.Sprintf("route:%s:error:%s", prefix, err)
+	}
+	for _, route := range routes {
+		if route.Prefix == prefix {
+			return fmt.Sprintf("route:%s:%s", prefix, route.Path)
+		}
+	}
+	return fmt.Sprintf("route:%s:<missing>", prefix)
+}
+
+// convoyRespawnFingerprint includes only this issue's count and configured
+// threshold. Resetting the issue or changing the threshold reopens dispatch;
+// another issue's respawn activity does not.
+func convoyRespawnFingerprint(townRoot, issueID string) string {
+	var state struct {
+		Beads map[string]struct {
+			Count int `json:"count"`
+		} `json:"beads"`
+	}
+	prefix := beads.ExtractPrefix(issueID)
+	rig := beads.GetRigNameForPrefix(townRoot, prefix)
+	stateRoot := townRoot
+	if rig != "" {
+		stateRoot = filepath.Join(townRoot, rig)
+	}
+	data, err := os.ReadFile(filepath.Join(stateRoot, "witness", "bead-respawn-counts.json")) //nolint:gosec // trusted town root
+	if err == nil {
+		_ = json.Unmarshal(data, &state)
+	}
+	count := 0
+	if rec, ok := state.Beads[issueID]; ok {
+		count = rec.Count
+	}
+	maxRespawns := config.LoadOperationalConfig(townRoot).GetWitnessConfig().MaxBeadRespawnsV()
+	return fmt.Sprintf("respawn:%d/%d", count, maxRespawns)
+}

--- a/internal/daemon/convoy_dispatch_circuit_test.go
+++ b/internal/daemon/convoy_dispatch_circuit_test.go
@@ -1,0 +1,474 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	beadsdk "github.com/steveyegge/beads"
+)
+
+func TestPermanentConvoyDispatchErrorClassification(t *testing.T) {
+	tests := []struct {
+		name string
+		err  string
+		want convoyDispatchFailureKind
+	}{
+		{
+			name: "respawn exhausted",
+			err:  "respawn limit reached for gt-123 (3 attempts)",
+			want: convoyDispatchRespawnExhausted,
+		},
+		{
+			name: "ordinary transient dispatch error",
+			err:  "tmux server temporarily unavailable",
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyPermanentConvoyDispatchError(tc.err); got != tc.want {
+				t.Fatalf("classification = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	if got := classifyUnresolvedConvoyRig("old-", ""); got != convoyDispatchRigPrefixUnresolved {
+		t.Fatalf("removed/unknown rig prefix classification = %q, want %q", got, convoyDispatchRigPrefixUnresolved)
+	}
+	if got := classifyUnresolvedConvoyRig("gt-", "gastown"); got != "" {
+		t.Fatalf("resolved rig prefix classified permanent: %q", got)
+	}
+}
+
+func TestConvoyDispatchCircuitPersistsAndRetriesOnlyAfterFingerprintChange(t *testing.T) {
+	root := t.TempDir()
+	clock := func() time.Time {
+		return time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	}
+	breaker := newConvoyDispatchCircuitBreaker(root, clock)
+
+	const (
+		convoyID    = "hq-convoy"
+		issueID     = "gt-123"
+		fingerprint = "respawn:3/3"
+	)
+	if duplicate, err := breaker.Record(
+		convoyID, issueID, convoyDispatchRespawnExhausted, fingerprint,
+		"respawn limit reached",
+	); err != nil {
+		t.Fatalf("Record: %v", err)
+	} else if duplicate {
+		t.Fatal("first permanent failure was marked duplicate")
+	}
+
+	statePath := filepath.Join(root, "daemon", "convoy-dispatch-circuits.json")
+	if info, err := os.Stat(statePath); err != nil {
+		t.Fatalf("persistent state missing: %v", err)
+	} else if info.Mode().Perm() != 0o600 {
+		t.Fatalf("state mode = %o, want 600", info.Mode().Perm())
+	}
+
+	reloaded := newConvoyDispatchCircuitBreaker(root, clock)
+	if suppress, kind := reloaded.ShouldSuppress(convoyID, issueID, fingerprint); !suppress || kind != convoyDispatchRespawnExhausted {
+		t.Fatalf("persisted circuit = (%v, %q), want (true, %q)", suppress, kind, convoyDispatchRespawnExhausted)
+	}
+	if duplicate, err := reloaded.Record(
+		convoyID, issueID, convoyDispatchRespawnExhausted, fingerprint,
+		"same failure on next scan",
+	); err != nil {
+		t.Fatalf("duplicate Record: %v", err)
+	} else if !duplicate {
+		t.Fatal("same convoy+issue+fingerprint was not deduplicated")
+	}
+
+	if suppress, _ := reloaded.ShouldSuppress(convoyID, issueID, "respawn:0/3"); suppress {
+		t.Fatal("circuit remained open after relevant respawn fingerprint changed")
+	}
+	if suppress, _ := reloaded.ShouldSuppress(convoyID, issueID, "respawn:0/3"); suppress {
+		t.Fatal("changed fingerprint was not cleared for retry")
+	}
+}
+
+func TestConvoyRouteFingerprintChangesOnlyForRelevantPrefix(t *testing.T) {
+	root := t.TempDir()
+	routesDir := filepath.Join(root, ".beads")
+	if err := os.MkdirAll(routesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	routesFile := filepath.Join(routesDir, "routes.jsonl")
+	if err := os.WriteFile(routesFile, []byte(`{"prefix":"bd-","path":"beads/.beads"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	before := convoyRouteFingerprint(root, "gt-")
+	if err := os.WriteFile(routesFile, []byte(
+		`{"prefix":"bd-","path":"renamed-beads/.beads"}`+"\n",
+	), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if afterIrrelevant := convoyRouteFingerprint(root, "gt-"); afterIrrelevant != before {
+		t.Fatalf("unrelated route changed fingerprint: before %q after %q", before, afterIrrelevant)
+	}
+
+	if err := os.WriteFile(routesFile, []byte(
+		`{"prefix":"bd-","path":"renamed-beads/.beads"}`+"\n"+
+			`{"prefix":"gt-","path":"gastown/.beads"}`+"\n",
+	), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if afterRelevant := convoyRouteFingerprint(root, "gt-"); afterRelevant == before {
+		t.Fatal("relevant route addition did not change fingerprint")
+	}
+}
+
+func TestConvoyRespawnFingerprintUsesResolvedRigWitnessState(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, ".beads", "routes.jsonl"),
+		[]byte(`{"prefix":"gt-","path":"gastown/.beads"}`+"\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	for path, count := range map[string]int{
+		filepath.Join(root, "witness", "bead-respawn-counts.json"):            1,
+		filepath.Join(root, "gastown", "witness", "bead-respawn-counts.json"): 3,
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := `{"beads":{"gt-123":{"count":` + strconv.Itoa(count) + `}}}`
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := convoyRespawnFingerprint(root, "gt-123"); got != "respawn:3/3" {
+		t.Fatalf("fingerprint = %q, want resolved rig count 3/3", got)
+	}
+}
+
+func TestConvoyTrackedStateFingerprintChangesForApprovedResetState(t *testing.T) {
+	base := strandedConvoyInfo{
+		ID:           "hq-convoy",
+		TrackedCount: 2,
+		ReadyCount:   1,
+		ReadyIssues:  []string{"gt-123"},
+		BaseBranch:   "main",
+	}
+	before := convoyTrackedStateFingerprint(base)
+	changed := base
+	changed.ReadyCount = 2
+	changed.ReadyIssues = []string{"gt-123", "gt-456"}
+	if after := convoyTrackedStateFingerprint(changed); after == before {
+		t.Fatal("tracked-issue state change did not reopen fingerprint")
+	}
+}
+
+func TestConvoyIssueStateFingerprintChangesOnIssueUpdate(t *testing.T) {
+	issue := &beadsdk.Issue{
+		ID:        "gt-123",
+		Status:    beadsdk.StatusOpen,
+		UpdatedAt: time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC),
+	}
+	before := convoyIssueStateFingerprint(issue)
+	issue.UpdatedAt = issue.UpdatedAt.Add(time.Minute)
+	if after := convoyIssueStateFingerprint(issue); after == before {
+		t.Fatal("issue update did not change dispatch state fingerprint")
+	}
+}
+
+func TestFeedFirstReadyUnknownPrefixCircuitRetriesOnlyAfterRelevantRouteChange(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	routesFile := filepath.Join(root, ".beads", "routes.jsonl")
+	if err := os.WriteFile(routesFile, []byte(`{"prefix":"bd-","path":"beads/.beads"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(t.TempDir(), "gt.log")
+	gtPath := filepath.Join(t.TempDir(), "gt")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> " + logPath + "\n"
+	if err := os.WriteFile(gtPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var logs []string
+	m := NewConvoyManager(root, func(format string, args ...interface{}) {
+		logs = append(logs, format)
+	}, gtPath, time.Minute, nil, nil, nil)
+	c := strandedConvoyInfo{ID: "hq-convoy", ReadyIssues: []string{"gt-123"}}
+
+	m.feedFirstReady(c) // records and alerts once
+	logsAfterLatch := len(logs)
+	m.feedFirstReady(c) // unchanged state: quiet
+	if len(logs) != logsAfterLatch {
+		t.Fatalf("unchanged scan logged again: before=%d after=%d logs=%v", logsAfterLatch, len(logs), logs)
+	}
+	if err := os.WriteFile(routesFile, []byte(`{"prefix":"bd-","path":"renamed/.beads"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m.feedFirstReady(c) // unrelated route change: still quiet
+	if len(logs) != logsAfterLatch {
+		t.Fatalf("unrelated route change reopened/logged circuit: before=%d after=%d logs=%v", logsAfterLatch, len(logs), logs)
+	}
+
+	if err := os.WriteFile(routesFile, []byte(
+		`{"prefix":"bd-","path":"renamed/.beads"}`+"\n"+
+			`{"prefix":"gt-","path":"gastown/.beads"}`+"\n",
+	), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m.feedFirstReady(c) // relevant route change: retry and dispatch
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	var slingCount, mailCount int
+	for _, line := range lines {
+		if strings.HasPrefix(line, "sling ") {
+			slingCount++
+		}
+		if strings.HasPrefix(line, "mail send --human ") {
+			mailCount++
+		}
+	}
+	if slingCount != 1 {
+		t.Fatalf("sling count = %d, want 1 after relevant route change; calls=%q", slingCount, data)
+	}
+	if mailCount != 1 {
+		t.Fatalf("alert count = %d, want 1 for unchanged permanent failure; calls=%q", mailCount, data)
+	}
+}
+
+func TestFeedFirstReadyRespawnCircuitRetriesAfterTargetReset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, ".beads", "routes.jsonl"),
+		[]byte(`{"prefix":"gt-","path":"gastown/.beads"}`+"\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	respawnPath := filepath.Join(root, "gastown", "witness", "bead-respawn-counts.json")
+	if err := os.MkdirAll(filepath.Dir(respawnPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRespawnState := func(targetCount, unrelatedCount int) {
+		t.Helper()
+		body := `{"beads":{"gt-123":{"count":` + strconv.Itoa(targetCount) +
+			`},"gt-other":{"count":` + strconv.Itoa(unrelatedCount) + `}}}`
+		if err := os.WriteFile(respawnPath, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeRespawnState(3, 0)
+
+	logPath := filepath.Join(t.TempDir(), "gt.log")
+	gtPath := filepath.Join(t.TempDir(), "gt")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> " + logPath + "\n" +
+		"if [ \"$1\" = sling ]; then echo 'respawn limit reached for gt-123 (3 attempts)' >&2; exit 1; fi\n"
+	if err := os.WriteFile(gtPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewConvoyManager(root, func(string, ...interface{}) {}, gtPath, time.Minute, nil, nil, nil)
+	c := strandedConvoyInfo{
+		ID:           "hq-convoy",
+		TrackedCount: 1,
+		ReadyCount:   1,
+		ReadyIssues:  []string{"gt-123"},
+	}
+	m.feedFirstReady(c)
+	m.feedFirstReady(c)
+	writeRespawnState(3, 2) // unrelated issue must not reopen
+	m.feedFirstReady(c)
+	writeRespawnState(0, 2) // explicit target reset reopens
+	m.feedFirstReady(c)
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var slingCount, mailCount int
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if strings.HasPrefix(line, "sling ") {
+			slingCount++
+		}
+		if strings.HasPrefix(line, "mail send --human ") {
+			mailCount++
+		}
+	}
+	if slingCount != 2 {
+		t.Fatalf("sling count = %d, want initial + target-reset retry; calls=%q", slingCount, data)
+	}
+	if mailCount != 2 {
+		t.Fatalf("alert count = %d, want one per distinct fingerprint; calls=%q", mailCount, data)
+	}
+}
+
+func TestConvoyFailedHumanAlertPersistsAndRetriesWithoutRedispatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, ".beads", "routes.jsonl"),
+		[]byte(`{"prefix":"gt-","path":"gastown/.beads"}`+"\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(t.TempDir(), "gt.log")
+	mailMarker := filepath.Join(t.TempDir(), "mail-failed")
+	gtPath := filepath.Join(t.TempDir(), "gt")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> " + logPath + "\n" +
+		"if [ \"$1\" = sling ]; then echo 'respawn limit reached for gt-123 (3 attempts)' >&2; exit 1; fi\n" +
+		"if [ \"$1\" = mail ] && [ ! -f " + mailMarker + " ]; then touch " + mailMarker + "; exit 1; fi\n"
+	if err := os.WriteFile(gtPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := NewConvoyManager(root, func(string, ...interface{}) {}, gtPath, time.Minute, nil, nil, nil)
+	c := strandedConvoyInfo{ID: "hq-convoy", TrackedCount: 1, ReadyCount: 1, ReadyIssues: []string{"gt-123"}}
+
+	m.feedFirstReady(c) // sling fails permanently; first mail fails
+	m = NewConvoyManager(root, func(string, ...interface{}) {}, gtPath, time.Minute, nil, nil, nil)
+	m.feedFirstReady(c) // no sling retry; mail retries successfully
+	m.feedFirstReady(c) // circuit and delivered alert both quiet
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var slingCount, mailCount int
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if strings.HasPrefix(line, "sling ") {
+			slingCount++
+		}
+		if strings.HasPrefix(line, "mail send --human ") {
+			mailCount++
+		}
+	}
+	if slingCount != 1 || mailCount != 2 {
+		t.Fatalf("calls: sling=%d mail=%d, want sling=1 mail=2; all=%q", slingCount, mailCount, data)
+	}
+}
+
+func TestConvoyCorruptCircuitStateFailsClosedAndAlertsOnce(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "daemon"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		convoyDispatchCircuitStateFile(root),
+		[]byte(`{"circuits":`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(t.TempDir(), "gt.log")
+	gtPath := filepath.Join(t.TempDir(), "gt")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> " + logPath + "\n"
+	if err := os.WriteFile(gtPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var logs []string
+	m := NewConvoyManager(root, func(format string, args ...interface{}) {
+		logs = append(logs, format)
+	}, gtPath, time.Minute, nil, nil, nil)
+	c := strandedConvoyInfo{ID: "hq-convoy", ReadyCount: 1, ReadyIssues: []string{"gt-123"}}
+
+	m.feedFirstReady(c)
+	// Recreate the manager to model a daemon restart. The unchanged corrupt
+	// state must remain fail-closed without re-alerting.
+	m = NewConvoyManager(root, func(format string, args ...interface{}) {
+		logs = append(logs, format)
+	}, gtPath, time.Minute, nil, nil, nil)
+	m.feedFirstReady(c)
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var slingCount, mailCount int
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if strings.HasPrefix(line, "sling ") {
+			slingCount++
+		}
+		if strings.HasPrefix(line, "mail send --human ") {
+			mailCount++
+		}
+	}
+	if slingCount != 0 || mailCount != 1 {
+		t.Fatalf("corrupt-state calls: sling=%d mail=%d, want sling=0 mail=1; all=%q", slingCount, mailCount, data)
+	}
+	foundSurface := false
+	for _, entry := range logs {
+		if strings.Contains(entry, "corrupt") || strings.Contains(entry, "load") {
+			foundSurface = true
+		}
+	}
+	if !foundSurface {
+		t.Fatalf("corrupt state was not surfaced in logs: %v", logs)
+	}
+}
+
+func TestConvoyCorruptCircuitAlertFingerprintPersistsAndChanges(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "daemon"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	statePath := convoyDispatchCircuitStateFile(root)
+	if err := os.WriteFile(statePath, []byte(`{"circuits":`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	breaker := newConvoyDispatchCircuitBreaker(root, time.Now)
+	if !breaker.CorruptionAlertPending() {
+		t.Fatal("first corruption fingerprint did not require an alert")
+	}
+	if err := breaker.MarkCorruptionAlertDelivered(); err != nil {
+		t.Fatalf("persist corruption alert marker: %v", err)
+	}
+
+	reloaded := newConvoyDispatchCircuitBreaker(root, time.Now)
+	if reloaded.CorruptionAlertPending() {
+		t.Fatal("unchanged corruption fingerprint re-alerted after reload")
+	}
+
+	if err := os.WriteFile(statePath, []byte(`{"different":`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	changed := newConvoyDispatchCircuitBreaker(root, time.Now)
+	if !changed.CorruptionAlertPending() {
+		t.Fatal("changed corruption fingerprint did not reopen alert")
+	}
+}

--- a/internal/daemon/convoy_dispatch_circuit_test.go
+++ b/internal/daemon/convoy_dispatch_circuit_test.go
@@ -94,6 +94,66 @@ func TestConvoyDispatchCircuitPersistsAndRetriesOnlyAfterFingerprintChange(t *te
 	}
 }
 
+func TestConvoyDispatchLeasePersistsAndOpensChurnCircuit(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	breaker := newConvoyDispatchCircuitBreaker(root, clock)
+
+	const (
+		convoyID    = "hq-convoy"
+		issueID     = "gt-123"
+		fingerprint = "issue:open:unassigned"
+	)
+	acquired, churned, err := breaker.TryAcquireLease(
+		convoyID, issueID, "convoy/hq-convoy@gastown", fingerprint,
+	)
+	if err != nil || !acquired || churned {
+		t.Fatalf("first lease = (%v, %v, %v), want acquired", acquired, churned, err)
+	}
+
+	reloaded := newConvoyDispatchCircuitBreaker(root, clock)
+	acquired, churned, err = reloaded.TryAcquireLease(
+		convoyID, issueID, "convoy/hq-convoy@gastown", fingerprint,
+	)
+	if err != nil || acquired || churned {
+		t.Fatalf("live persisted lease = (%v, %v, %v), want suppressed", acquired, churned, err)
+	}
+
+	now = now.Add(convoyDispatchLeaseDuration + time.Second)
+	acquired, churned, err = reloaded.TryAcquireLease(
+		convoyID, issueID, "convoy/hq-convoy@gastown", fingerprint,
+	)
+	if err != nil || !acquired || churned {
+		t.Fatalf("second lease = (%v, %v, %v), want acquired", acquired, churned, err)
+	}
+
+	now = now.Add(convoyDispatchLeaseDuration + time.Second)
+	acquired, churned, err = reloaded.TryAcquireLease(
+		convoyID, issueID, "convoy/hq-convoy@gastown", fingerprint,
+	)
+	if err != nil || acquired || !churned {
+		t.Fatalf("third lease = (%v, %v, %v), want churn circuit", acquired, churned, err)
+	}
+	if got := reloaded.FailureKind(convoyID, issueID); got != convoyDispatchAssignmentChurn {
+		t.Fatalf("failure kind = %q, want %q", got, convoyDispatchAssignmentChurn)
+	}
+}
+
+func TestConvoyFailedDispatchReleasesLease(t *testing.T) {
+	root := t.TempDir()
+	breaker := newConvoyDispatchCircuitBreaker(root, time.Now)
+	if acquired, _, err := breaker.TryAcquireLease("hq-cv", "gt-1", "owner", "fp"); err != nil || !acquired {
+		t.Fatalf("TryAcquireLease: acquired=%v err=%v", acquired, err)
+	}
+	if err := breaker.ReleaseLease("hq-cv", "gt-1"); err != nil {
+		t.Fatalf("ReleaseLease: %v", err)
+	}
+	if acquired, _, err := breaker.TryAcquireLease("hq-cv", "gt-1", "owner", "fp"); err != nil || !acquired {
+		t.Fatalf("lease after failed dispatch: acquired=%v err=%v", acquired, err)
+	}
+}
+
 func TestConvoyRouteFingerprintChangesOnlyForRelevantPrefix(t *testing.T) {
 	root := t.TempDir()
 	routesDir := filepath.Join(root, ".beads")

--- a/internal/daemon/convoy_manager.go
+++ b/internal/daemon/convoy_manager.go
@@ -599,6 +599,28 @@ func (m *ConvoyManager) feedFirstReady(c strandedConvoyInfo) {
 			continue
 		}
 
+		churnFingerprint := m.convoyDispatchFingerprint(
+			c, issueID, prefix, rig, convoyDispatchAssignmentChurn,
+		)
+		leased, churned, leaseErr := m.dispatchCircuits.TryAcquireLease(
+			c.ID, issueID, "convoy/"+c.ID+"@"+rig, churnFingerprint,
+		)
+		if leaseErr != nil {
+			m.logger("Convoy %s: assignment lease persistence failed for %s; failing closed: %v",
+				c.ID, issueID, leaseErr)
+			continue
+		}
+		if churned {
+			m.logger("Convoy %s: repeated assignment churn for %s; circuit opened and work parked",
+				c.ID, issueID)
+			m.retryPermanentConvoyDispatchAlert(c.ID, issueID, convoyDispatchAssignmentChurn)
+			continue
+		}
+		if !leased {
+			m.logger("Convoy %s: active assignment lease suppresses resling of %s", c.ID, issueID)
+			continue
+		}
+
 		m.logger("Convoy %s: feeding %s to %s", c.ID, issueID, rig)
 
 		slingArgs := []string{"sling", issueID, rig, "--no-boot"}
@@ -613,6 +635,10 @@ func (m *ConvoyManager) feedFirstReady(c strandedConvoyInfo) {
 		cmd.Stderr = &stderr
 
 		if err := cmd.Run(); err != nil {
+			if releaseErr := m.dispatchCircuits.ReleaseLease(c.ID, issueID); releaseErr != nil {
+				m.logger("Convoy %s: failed to release assignment lease for %s: %v",
+					c.ID, issueID, releaseErr)
+			}
 			errText := util.FirstLine(stderr.String())
 			if kind := classifyPermanentConvoyDispatchError(errText); kind != "" {
 				fingerprint := m.convoyDispatchFingerprint(c, issueID, prefix, rig, kind)

--- a/internal/daemon/convoy_manager.go
+++ b/internal/daemon/convoy_manager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -112,6 +113,11 @@ type ConvoyManager struct {
 	// been handled. This allows the 1s overlap window above without replaying
 	// the same lifecycle events on every poll.
 	processedLifecycleEvents sync.Map // map[string]bool
+
+	// dispatchCircuits persist permanent dispatch failures so the 30-second
+	// stranded scan stays quiet until the relevant route or respawn state
+	// changes.
+	dispatchCircuits *convoyDispatchCircuitBreaker
 }
 
 // NewConvoyManager creates a new convoy manager.
@@ -131,15 +137,16 @@ func NewConvoyManager(townRoot string, logger func(format string, args ...interf
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return &ConvoyManager{
-		townRoot:     townRoot,
-		scanInterval: scanInterval,
-		ctx:          ctx,
-		cancel:       cancel,
-		logger:       logger,
-		stores:       stores,
-		openStores:   openStores,
-		isRigParked:  isRigParked,
-		gtPath:       gtPath,
+		townRoot:         townRoot,
+		scanInterval:     scanInterval,
+		ctx:              ctx,
+		cancel:           cancel,
+		logger:           logger,
+		stores:           stores,
+		openStores:       openStores,
+		isRigParked:      isRigParked,
+		gtPath:           gtPath,
+		dispatchCircuits: newConvoyDispatchCircuitBreaker(townRoot, time.Now),
 	}
 }
 
@@ -539,7 +546,19 @@ func (m *ConvoyManager) feedFirstReady(c strandedConvoyInfo) {
 	if len(c.ReadyIssues) == 0 {
 		return
 	}
+	if loadErr := m.dispatchCircuits.LoadError(); loadErr != nil {
+		if m.dispatchCircuits.CorruptionAlertPending() {
+			m.logger("Convoy dispatch circuit state load failed; failing closed: %v", loadErr)
+			if err := m.alertConvoyCircuitCorruption(loadErr); err == nil {
+				if err := m.dispatchCircuits.MarkCorruptionAlertDelivered(); err != nil {
+					m.logger("Convoy dispatch circuit corruption alert marker could not persist: %v", err)
+				}
+			}
+		}
+		return
+	}
 
+	nonCircuitCandidate := false
 	for _, issueID := range c.ReadyIssues {
 		prefix := beads.ExtractPrefix(issueID)
 		if prefix == "" {
@@ -548,8 +567,30 @@ func (m *ConvoyManager) feedFirstReady(c strandedConvoyInfo) {
 		}
 
 		rig := beads.GetRigNameForPrefix(m.townRoot, prefix)
+		if kind := m.dispatchCircuits.FailureKind(c.ID, issueID); kind != "" {
+			m.retryPermanentConvoyDispatchAlert(c.ID, issueID, kind)
+			fingerprint := m.convoyDispatchFingerprint(c, issueID, prefix, rig, kind)
+			if suppress, _ := m.dispatchCircuits.ShouldSuppress(c.ID, issueID, fingerprint); suppress {
+				continue
+			}
+		}
+		nonCircuitCandidate = true
+
 		if rig == "" {
-			m.logger("Convoy %s: no rig for %s (prefix %s), skipping", c.ID, issueID, prefix)
+			kind := classifyUnresolvedConvoyRig(prefix, rig)
+			fingerprint := m.convoyDispatchFingerprint(c, issueID, prefix, rig, kind)
+			duplicate, err := m.dispatchCircuits.Record(
+				c.ID, issueID, kind, fingerprint,
+				fmt.Sprintf("no rig for prefix %s", prefix),
+			)
+			if err != nil {
+				m.logger("Convoy %s: failed to persist dispatch circuit for %s: %v", c.ID, issueID, err)
+			}
+			if !duplicate {
+				message := fmt.Sprintf("unknown or removed rig prefix %s", prefix)
+				m.logger("Convoy %s: permanent dispatch failure for %s: %s; circuit opened, skipping until state changes", c.ID, issueID, message)
+			}
+			m.retryPermanentConvoyDispatchAlert(c.ID, issueID, kind)
 			continue
 		}
 
@@ -572,13 +613,134 @@ func (m *ConvoyManager) feedFirstReady(c strandedConvoyInfo) {
 		cmd.Stderr = &stderr
 
 		if err := cmd.Run(); err != nil {
-			m.logger("Convoy %s: sling %s failed: %s", c.ID, issueID, util.FirstLine(stderr.String()))
+			errText := util.FirstLine(stderr.String())
+			if kind := classifyPermanentConvoyDispatchError(errText); kind != "" {
+				fingerprint := m.convoyDispatchFingerprint(c, issueID, prefix, rig, kind)
+				duplicate, persistErr := m.dispatchCircuits.Record(c.ID, issueID, kind, fingerprint, errText)
+				if persistErr != nil {
+					m.logger("Convoy %s: failed to persist dispatch circuit for %s: %v", c.ID, issueID, persistErr)
+				}
+				if !duplicate {
+					m.logger("Convoy %s: permanent dispatch failure for %s: %s; circuit opened", c.ID, issueID, errText)
+				}
+				m.retryPermanentConvoyDispatchAlert(c.ID, issueID, kind)
+				continue
+			}
+			m.logger("Convoy %s: sling %s failed: %s", c.ID, issueID, errText)
 			continue
 		}
 		return // Successfully dispatched one issue
 	}
 
-	m.logger("Convoy %s: no dispatchable issues (all %d skipped)", c.ID, len(c.ReadyIssues))
+	if nonCircuitCandidate {
+		m.logger("Convoy %s: no dispatchable issues (all %d skipped)", c.ID, len(c.ReadyIssues))
+	}
+}
+
+func (m *ConvoyManager) convoyDispatchFingerprint(
+	c strandedConvoyInfo,
+	issueID, prefix, rig string,
+	kind convoyDispatchFailureKind,
+) string {
+	var failureState string
+	switch kind {
+	case convoyDispatchRigPrefixUnresolved:
+		failureState = convoyRouteFingerprint(m.townRoot, prefix)
+	case convoyDispatchRespawnExhausted:
+		failureState = convoyRespawnFingerprint(m.townRoot, issueID)
+	}
+	return strings.Join([]string{
+		failureState,
+		m.convoyIssueStateFingerprint(issueID, rig),
+		convoyTrackedStateFingerprint(c),
+	}, "|")
+}
+
+func (m *ConvoyManager) convoyIssueStateFingerprint(issueID, rig string) string {
+	m.storesMu.Lock()
+	store := m.stores[rig]
+	if store == nil && rig == "" {
+		store = m.stores["hq"]
+	}
+	m.storesMu.Unlock()
+	if store == nil {
+		return "issue:<unavailable>"
+	}
+	issue, err := store.GetIssue(m.ctx, issueID)
+	if err != nil || issue == nil {
+		return "issue:<unavailable>"
+	}
+	return convoyIssueStateFingerprint(issue)
+}
+
+func convoyIssueStateFingerprint(issue *beadsdk.Issue) string {
+	if issue == nil {
+		return "issue:<unavailable>"
+	}
+	return fmt.Sprintf("issue:%s:%s:%s",
+		issue.Status, issue.Assignee, issue.UpdatedAt.UTC().Format(time.RFC3339Nano))
+}
+
+func convoyTrackedStateFingerprint(c strandedConvoyInfo) string {
+	ready := append([]string(nil), c.ReadyIssues...)
+	sort.Strings(ready)
+	return fmt.Sprintf("convoy:%d:%d:%s:%s",
+		c.TrackedCount, c.ReadyCount, strings.Join(ready, ","), c.BaseBranch)
+}
+
+func (m *ConvoyManager) alertPermanentConvoyDispatch(
+	convoyID, issueID string,
+	kind convoyDispatchFailureKind,
+	detail string,
+) error {
+	subject := fmt.Sprintf("CONVOY_DISPATCH_BLOCKED: %s / %s", convoyID, issueID)
+	body := fmt.Sprintf(
+		"Permanent convoy dispatch failure latched.\n\nconvoy: %s\nissue: %s\nkind: %s\ndetail: %s\n\nAutomatic retry is blocked until the relevant state fingerprint changes.",
+		convoyID, issueID, kind, detail,
+	)
+	cmd := exec.CommandContext(m.ctx, m.gtPath, "mail", "send", "--human", "-s", subject, "-m", body)
+	cmd.Dir = m.townRoot
+	cmd.Env = bdMutationRoutingEnv(m.townRoot)
+	util.SetProcessGroup(cmd)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		m.logger("Convoy %s: permanent dispatch alert failed for %s: %v (%s)",
+			convoyID, issueID, err, util.FirstLine(string(output)))
+		return err
+	}
+	return nil
+}
+
+func (m *ConvoyManager) retryPermanentConvoyDispatchAlert(
+	convoyID, issueID string,
+	kind convoyDispatchFailureKind,
+) {
+	if !m.dispatchCircuits.AlertPending(convoyID, issueID) {
+		return
+	}
+	detail := m.dispatchCircuits.AlertDetail(convoyID, issueID)
+	if err := m.alertPermanentConvoyDispatch(convoyID, issueID, kind, detail); err != nil {
+		return
+	}
+	if err := m.dispatchCircuits.MarkAlertDelivered(convoyID, issueID); err != nil {
+		m.logger("Convoy %s: failed to persist delivered alert for %s: %v", convoyID, issueID, err)
+	}
+}
+
+func (m *ConvoyManager) alertConvoyCircuitCorruption(loadErr error) error {
+	subject := "CONVOY_DISPATCH_CIRCUIT_STATE_CORRUPT"
+	body := fmt.Sprintf(
+		"Convoy dispatch circuit state could not be loaded and dispatch is failing closed.\n\nstate: %s\nerror: %v",
+		convoyDispatchCircuitStateFile(m.townRoot), loadErr,
+	)
+	cmd := exec.CommandContext(m.ctx, m.gtPath, "mail", "send", "--human", "-s", subject, "-m", body)
+	cmd.Dir = m.townRoot
+	cmd.Env = bdMutationRoutingEnv(m.townRoot)
+	util.SetProcessGroup(cmd)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		m.logger("Convoy dispatch circuit corruption alert failed: %v (%s)", err, util.FirstLine(string(output)))
+		return err
+	}
+	return nil
 }
 
 // checkConvoyCompletion runs gt convoy check to auto-close a convoy whose

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -396,7 +396,19 @@ func New(config *Config) (*Daemon, error) {
 		metrics:         dm,
 		rigPool:         newRigWorkerPool(0, 0, logger), // defaults: 10 workers, 30s timeout
 	}
+	d.ensureRigWispConfigs()
 	return d, nil
+}
+
+// ensureRigWispConfigs reconciles the optional local config layer once at
+// daemon startup. Missing files represent an empty operational config, so
+// create that canonical state instead of warning on every patrol cycle.
+func (d *Daemon) ensureRigWispConfigs() {
+	for _, rigName := range d.getKnownRigs() {
+		if err := wisp.NewConfig(d.config.TownRoot, rigName).Ensure(); err != nil {
+			d.logger.Printf("Warning: failed to initialize wisp config for %s: %v", rigName, err)
+		}
+	}
 }
 
 func applyDoltServerConfigEnv(config *DoltServerConfig) {
@@ -2192,11 +2204,6 @@ func (d *Daemon) getPatrolRigs(patrol string) []string {
 // (daemon cannot import cmd).
 func (d *Daemon) isRigOperational(rigName string) (bool, string) {
 	cfg := wisp.NewConfig(d.config.TownRoot, rigName)
-
-	// Warn if wisp config is missing - parked/docked state may have been lost
-	if _, err := os.Stat(cfg.ConfigPath()); os.IsNotExist(err) {
-		d.logger.Printf("Warning: no wisp config for %s - parked state may have been lost", rigName)
-	}
 
 	// Check wisp layer first (local/ephemeral overrides)
 	status := cfg.GetString("status")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -351,7 +351,7 @@ func New(config *Config) (*Daemon, error) {
 	}
 	restartTracker := NewRestartTracker(config.TownRoot, rtCfg)
 	if err := restartTracker.Load(); err != nil {
-		logger.Printf("Warning: failed to load restart state: %v", err)
+		logger.Printf("Warning: failed to load restart state; restart authorization is fail-closed: %v", err)
 	}
 
 	// Initialize OpenTelemetry (best-effort — telemetry failure never blocks startup).
@@ -729,6 +729,17 @@ func (d *Daemon) Run() (err error) {
 		d.logger.Printf("Quota dog ticker started (interval %v)", interval)
 	}
 
+	// Scan local agent panes independently of the general heartbeat. A living
+	// OpenCode process can retain a terminal after its model has fatally
+	// crashed, so process liveness alone is insufficient.
+	modelCrashExecutor := &daemonModelCrashExecutor{daemon: d}
+	modelCrashSupervisor := newModelCrashSupervisor(
+		modelCrashStateFile(d.config.TownRoot), realModelCrashClock{}, modelCrashExecutor)
+	modelCrashTicker := time.NewTicker(modelCrashScanInterval)
+	modelCrashChan := modelCrashTicker.C
+	defer modelCrashTicker.Stop()
+	d.logger.Printf("Local model-crash supervisor started (interval %v)", modelCrashScanInterval)
+
 	// Note: PATCH-010 uses per-session hooks in deacon/manager.go (SetAutoRespawnHook).
 	// Global pane-died hooks don't fire reliably in tmux 3.2a, so we rely on the
 	// per-session approach which has been tested to work for continuous recovery.
@@ -753,7 +764,7 @@ func (d *Daemon) Run() (err error) {
 				d.logger.Println("Received reload-restart signal, reloading restart tracker from disk")
 				if d.restartTracker != nil {
 					if err := d.restartTracker.Load(); err != nil {
-						d.logger.Printf("Warning: failed to reload restart tracker: %v", err)
+						d.logger.Printf("Warning: failed to reload restart tracker; restart authorization remains fail-closed: %v", err)
 					}
 				}
 			} else {
@@ -836,6 +847,13 @@ func (d *Daemon) Run() (err error) {
 			// rotates credentials to available accounts via keychain swap.
 			if !d.isShutdownInProgress() {
 				d.runQuotaDog()
+			}
+
+		case <-modelCrashChan:
+			if !d.isShutdownInProgress() && !estop.IsActive(d.config.TownRoot) {
+				if err := modelCrashSupervisor.Scan(); err != nil {
+					d.logger.Printf("Local model-crash supervisor scan failed: %v", err)
+				}
 			}
 
 		case <-timer.C:
@@ -1335,6 +1353,13 @@ func (d *Daemon) ensureBootRunning() {
 		return
 	}
 
+	// A Deacon crash-loop latch is handled by RestartTracker's local watchdog
+	// probe gate. Never promote this infrastructure loop to hosted Boot.
+	if d.restartTracker != nil && d.restartTracker.IsInCrashLoop("deacon") {
+		d.logger.Println("Deacon crash loop latched; hosted Boot suppressed (local watchdog probe only)")
+		return
+	}
+
 	// Cooldown gate: skip if Boot was spawned recently (fixes #2084)
 	if !d.bootLastSpawned.IsZero() && time.Since(d.bootLastSpawned) < d.bootSpawnCooldown() {
 		d.logger.Printf("Boot spawned %s ago, within cooldown (%s), skipping",
@@ -1478,28 +1503,50 @@ func (d *Daemon) runDegradedBootTriage(b *boot.Boot) {
 // ensureDeaconRunning ensures the Deacon is running.
 // Uses deacon.Manager for consistent startup behavior (WaitForShellReady, GUPP, etc.).
 func (d *Daemon) ensureDeaconRunning() {
+	d.ensureDeaconRunningWithManager(deacon.NewManager(d.config.TownRoot))
+}
+
+type deaconProbeManager interface {
+	Start(string) error
+	Stop() error
+}
+
+func (d *Daemon) ensureDeaconRunningWithManager(mgr deaconProbeManager) {
 	const agentID = "deacon"
 
-	// Check restart tracker for backoff/crash loop
-	if d.restartTracker != nil {
-		if d.restartTracker.IsInCrashLoop(agentID) {
-			d.logger.Printf("Deacon is in crash loop, skipping restart (use 'gt daemon clear-backoff deacon' to reset)")
-			return
-		}
-		if !d.restartTracker.CanRestart(agentID) {
-			remaining := d.restartTracker.GetBackoffRemaining(agentID)
-			d.logger.Printf("Deacon restart in backoff, %s remaining", remaining.Round(time.Second))
-			return
-		}
+	d.retryDeaconCrashLoopAlertWithNotification(agentID, sendModelCrashNotification)
+
+	allowed, crashLoopProbe := d.authorizeDeaconRestartDecision(agentID)
+	if !allowed {
+		return
 	}
 
-	mgr := deacon.NewManager(d.config.TownRoot)
+	if crashLoopProbe && d.deaconHeartbeatFresh(d.restartTracker.now()) {
+		d.restartTracker.RecordSuccess(agentID)
+		if err := d.restartTracker.Save(); err != nil {
+			d.logger.Printf("Warning: failed to persist stable Deacon crash-loop recovery: %v", err)
+		}
+		return
+	}
 
-	if err := mgr.Start(""); err != nil {
+	agentOverride := ""
+	if crashLoopProbe {
+		if err := mgr.Stop(); err != nil && err != deacon.ErrNotRunning {
+			d.logger.Printf("Deacon local probe could not stop stale session: %v", err)
+			return
+		}
+		agentOverride = "opencode-local"
+	}
+
+	if err := mgr.Start(agentOverride); err != nil {
 		if err == deacon.ErrAlreadyRunning {
-			// Deacon is running - record success to reset backoff
-			if d.restartTracker != nil {
+			// Only an ordinary check may treat an existing process as success.
+			// A crash-loop probe with a stale heartbeat must keep the latch.
+			if d.restartTracker != nil && !crashLoopProbe {
 				d.restartTracker.RecordSuccess(agentID)
+				if saveErr := d.restartTracker.Save(); saveErr != nil {
+					d.logger.Printf("Warning: failed to persist Deacon restart success: %v", saveErr)
+				}
 			}
 			return
 		}
@@ -1509,18 +1556,87 @@ func (d *Daemon) ensureDeaconRunning() {
 
 	// Record this restart attempt for backoff tracking
 	if d.restartTracker != nil {
-		d.restartTracker.RecordRestart(agentID)
+		newlyLatched := d.restartTracker.RecordRestart(agentID)
 		if err := d.restartTracker.Save(); err != nil {
 			d.logger.Printf("Warning: failed to save restart state: %v", err)
+		}
+		if newlyLatched {
+			d.retryDeaconCrashLoopAlertWithNotification(agentID, sendModelCrashNotification)
 		}
 	}
 
 	// Track when we started the Deacon to prevent race condition in checkDeaconHeartbeat.
 	// The heartbeat file will still be stale until the Deacon runs a full patrol cycle.
 	d.deaconLastStarted = time.Now()
-	d.metrics.recordRestart(d.ctx, "deacon")
+	if d.metrics != nil {
+		d.metrics.recordRestart(d.ctx, "deacon")
+	}
 	telemetry.RecordDaemonRestart(d.ctx, "deacon")
 	d.logger.Println("Deacon started successfully")
+}
+
+// authorizeDeaconRestart applies ordinary backoff plus the stricter
+// crash-loop probe gate. A latched probe is local-only, requires a fresh
+// healthy LM Studio watchdog observation, and bypasses CanRestart exactly once
+// because CanRestart deliberately remains false while the latch persists.
+func (d *Daemon) authorizeDeaconRestart(agentID string) bool {
+	allowed, _ := d.authorizeDeaconRestartDecision(agentID)
+	return allowed
+}
+
+func (d *Daemon) authorizeDeaconRestartDecision(agentID string) (allowed, crashLoopProbe bool) {
+	if d.restartTracker == nil {
+		return true, false
+	}
+	if !d.restartTracker.IsInCrashLoop(agentID) {
+		if d.restartTracker.CanRestart(agentID) {
+			return true, false
+		}
+		remaining := d.restartTracker.GetBackoffRemaining(agentID)
+		d.logger.Printf("Deacon restart in backoff, %s remaining", remaining.Round(time.Second))
+		return false, false
+	}
+
+	if !d.localModelWatchdogHealthy(d.restartTracker.now()) {
+		d.logger.Printf("Deacon crash-loop probe blocked: LM Studio watchdog is not fresh and healthy")
+		return false, false
+	}
+	taken, err := d.restartTracker.TakeWatchdogProbePersisted(agentID)
+	if err != nil {
+		d.logger.Printf("Deacon crash-loop probe blocked: failed to persist consumed probe: %v", err)
+		return false, false
+	}
+	if !taken {
+		d.logger.Printf("Deacon is in crash loop, local watchdog probe remains in cooldown (use 'gt daemon clear-backoff deacon' to reset)")
+		return false, false
+	}
+	d.logger.Printf("Deacon crash-loop cooldown elapsed with healthy local watchdog; allowing one local probe")
+	return true, true
+}
+
+func (d *Daemon) deaconHeartbeatFresh(now time.Time) bool {
+	hb := deacon.ReadHeartbeat(d.config.TownRoot)
+	if hb == nil || hb.Timestamp.IsZero() {
+		return false
+	}
+	age := now.Sub(hb.Timestamp)
+	return age >= 0 && age < deacon.HeartbeatStaleThreshold
+}
+
+func (d *Daemon) localModelWatchdogHealthy(now time.Time) bool {
+	data, err := os.ReadFile(filepath.Join(d.config.TownRoot, "deacon", "lmstudio-watchdog.json"))
+	if err != nil {
+		return false
+	}
+	var state struct {
+		Status    string    `json:"status"`
+		CheckedAt time.Time `json:"checked_at"`
+	}
+	if json.Unmarshal(data, &state) != nil || state.Status != "healthy" || state.CheckedAt.IsZero() {
+		return false
+	}
+	age := now.Sub(state.CheckedAt)
+	return age >= 0 && age <= 2*time.Minute
 }
 
 // deaconGracePeriod returns the config-driven deacon grace period.
@@ -1662,7 +1778,6 @@ func (d *Daemon) restartStuckDeacon(sessionName, reason string) {
 	if d.restartTracker != nil {
 		if d.restartTracker.IsInCrashLoop(agentID) {
 			d.logger.Printf("Stuck-agent-dog: Deacon in crash loop, not restarting (use 'gt daemon clear-backoff deacon')")
-			d.notifySlack("admin", "critical", fmt.Sprintf("Deacon crash loop detected — manual intervention required. Reason: %s", reason))
 			return
 		}
 		if !d.restartTracker.CanRestart(agentID) {
@@ -1714,6 +1829,48 @@ func (d *Daemon) restartStuckDeacon(sessionName, reason string) {
 
 	d.logger.Printf("Stuck-agent-dog: Deacon restarted successfully")
 	d.notifySlack("admin", "high", fmt.Sprintf("Deacon was stuck (%s) — auto-restarted successfully", reason))
+}
+
+func (d *Daemon) alertDeaconCrashLoopLatch() {
+	_ = d.alertDeaconCrashLoopLatchWithNotification(sendModelCrashNotification)
+}
+
+func (d *Daemon) alertDeaconCrashLoopLatchWithNotification(notify func(string, string) error) error {
+	const message = "Deacon crash loop latched after rapid local restart failures. Hosted promotion is disabled; one local watchdog probe is allowed every 30 minutes."
+	const subject = "DEACON_CRASH_LOOP_LATCHED"
+	d.logger.Printf("DEACON CRASH LOOP LATCHED: %s", message)
+	d.notifySlack("admin", "critical", message)
+
+	cmd := exec.Command(d.gtPath, "mail", "send", "--human",
+		"-s", subject,
+		"-m", message) //nolint:gosec // daemon-owned binary path and fixed arguments
+	setSysProcAttr(cmd)
+	cmd.Dir = d.config.TownRoot
+	cmd.Env = append(os.Environ(), "BD_ACTOR=daemon")
+	var mailErr error
+	if output, err := cmd.CombinedOutput(); err != nil {
+		d.logger.Printf("Warning: failed to send Deacon crash-loop latch alert: %v (%s)",
+			err, util.FirstLine(string(output)))
+		mailErr = err
+	}
+	if notify != nil {
+		if err := notify(subject, message); err != nil {
+			d.logger.Printf("Warning: failed to send Deacon crash-loop macOS notification: %v", err)
+		}
+	}
+	return mailErr
+}
+
+func (d *Daemon) retryDeaconCrashLoopAlertWithNotification(agentID string, notify func(string, string) error) {
+	if d.restartTracker == nil || !d.restartTracker.CrashLoopAlertPending(agentID) {
+		return
+	}
+	if err := d.alertDeaconCrashLoopLatchWithNotification(notify); err != nil {
+		return
+	}
+	if err := d.restartTracker.MarkCrashLoopAlertDeliveredPersisted(agentID); err != nil {
+		d.logger.Printf("Warning: failed to persist delivered Deacon crash-loop alert: %v", err)
+	}
 }
 
 // notifySlack sends a notification via gt-notify (zero token cost).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1330,6 +1330,11 @@ func (d *Daemon) bootSpawnCooldown() time.Duration {
 }
 
 func (d *Daemon) ensureBootRunning() {
+	if !d.loadOperationalConfig().GetDaemonConfig().BootAutoSpawnV() {
+		d.logger.Println("Automatic Boot spawning disabled; waiting for explicit incident triage")
+		return
+	}
+
 	// Cooldown gate: skip if Boot was spawned recently (fixes #2084)
 	if !d.bootLastSpawned.IsZero() && time.Since(d.bootLastSpawned) < d.bootSpawnCooldown() {
 		d.logger.Printf("Boot spawned %s ago, within cooldown (%s), skipping",

--- a/internal/daemon/main_branch_test_runner.go
+++ b/internal/daemon/main_branch_test_runner.go
@@ -2,14 +2,17 @@ package daemon
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/deacon"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/util"
 )
@@ -24,125 +27,129 @@ const (
 // catch regressions from direct-to-main pushes, bad merges, or sequential
 // merge conflicts that individually pass but break together.
 type MainBranchTestConfig struct {
-	// Enabled controls whether the main-branch test runner runs.
-	Enabled bool `json:"enabled"`
-
-	// IntervalStr is how often to run, as a string (e.g., "30m").
-	IntervalStr string `json:"interval,omitempty"`
-
-	// TimeoutStr is the maximum time each rig's test run can take.
-	// Default: "10m".
-	TimeoutStr string `json:"timeout,omitempty"`
-
-	// Rigs limits testing to specific rigs. If empty, all rigs are tested.
-	Rigs []string `json:"rigs,omitempty"`
+	Enabled     bool     `json:"enabled"`
+	IntervalStr string   `json:"interval,omitempty"`
+	TimeoutStr  string   `json:"timeout,omitempty"`
+	Rigs        []string `json:"rigs,omitempty"`
 }
 
-// mainBranchTestInterval returns the configured interval, or the default (30m).
-func mainBranchTestInterval(config *DaemonPatrolConfig) time.Duration {
-	if config != nil && config.Patrols != nil && config.Patrols.MainBranchTest != nil {
-		if config.Patrols.MainBranchTest.IntervalStr != "" {
-			if d, err := time.ParseDuration(config.Patrols.MainBranchTest.IntervalStr); err == nil && d > 0 {
-				return d
+func mainBranchTestInterval(cfg *DaemonPatrolConfig) time.Duration {
+	if cfg != nil && cfg.Patrols != nil && cfg.Patrols.MainBranchTest != nil {
+		if value := cfg.Patrols.MainBranchTest.IntervalStr; value != "" {
+			if duration, err := time.ParseDuration(value); err == nil && duration > 0 {
+				return duration
 			}
 		}
 	}
 	return defaultMainBranchTestInterval
 }
 
-// mainBranchTestTimeout returns the configured per-rig timeout, or the default (10m).
-func mainBranchTestTimeout(config *DaemonPatrolConfig) time.Duration {
-	if config != nil && config.Patrols != nil && config.Patrols.MainBranchTest != nil {
-		if config.Patrols.MainBranchTest.TimeoutStr != "" {
-			if d, err := time.ParseDuration(config.Patrols.MainBranchTest.TimeoutStr); err == nil && d > 0 {
-				return d
+func mainBranchTestTimeout(cfg *DaemonPatrolConfig) time.Duration {
+	if cfg != nil && cfg.Patrols != nil && cfg.Patrols.MainBranchTest != nil {
+		if value := cfg.Patrols.MainBranchTest.TimeoutStr; value != "" {
+			if duration, err := time.ParseDuration(value); err == nil && duration > 0 {
+				return duration
 			}
 		}
 	}
 	return defaultMainBranchTestTimeout
 }
 
-// mainBranchTestRigs returns the configured rig filter, or nil (all rigs).
-func mainBranchTestRigs(config *DaemonPatrolConfig) []string {
-	if config != nil && config.Patrols != nil && config.Patrols.MainBranchTest != nil {
-		return config.Patrols.MainBranchTest.Rigs
+func mainBranchTestRigs(cfg *DaemonPatrolConfig) []string {
+	if cfg != nil && cfg.Patrols != nil && cfg.Patrols.MainBranchTest != nil {
+		return cfg.Patrols.MainBranchTest.Rigs
 	}
 	return nil
 }
 
-// rigGateConfig holds the gate/test configuration extracted from a rig's config.json.
-type rigGateConfig struct {
-	TestCommand string
-	Gates       map[string]string // gate name → command
+type validationCommand struct {
+	Kind    string
+	Label   string
+	Command string
 }
 
-// loadRigGateConfig reads the merge_queue section from a rig's config.json
-// to discover what test/gate commands to run.
+// rigGateConfig is the effective merge-queue validation configuration merged
+// from committed .gastown/settings.json and local rig settings/config.json.
+type rigGateConfig struct {
+	SetupCommand    string
+	Commands        []validationCommand
+	RetryFlakyTests int
+}
+
 func loadRigGateConfig(rigPath string) (*rigGateConfig, error) {
-	configPath := filepath.Join(rigPath, "config.json")
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil // No config, skip
+	var localMQ *config.MergeQueueConfig
+	settingsPath := config.RigSettingsPath(rigPath)
+	if _, err := os.Stat(settingsPath); err == nil {
+		settings, loadErr := config.LoadRigSettings(settingsPath)
+		if loadErr != nil {
+			return nil, fmt.Errorf("loading rig settings: %w", loadErr)
 		}
+		localMQ = settings.MergeQueue
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("checking rig settings: %w", err)
+	}
+
+	projectDir := filepath.Join(rigPath, "refinery", "rig")
+	var repoMQ *config.MergeQueueConfig
+	repoSettings, err := config.LoadRepoSettings(projectDir)
+	if err != nil {
 		return nil, err
 	}
-
-	var raw struct {
-		MergeQueue json.RawMessage `json:"merge_queue"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("parsing config.json: %w", err)
+	if repoSettings != nil {
+		repoMQ = repoSettings.MergeQueue
 	}
 
-	if raw.MergeQueue == nil {
-		return nil, nil // No merge_queue section
+	effective := config.MergeSettingsCommand(repoMQ, localMQ)
+	if effective == nil {
+		return nil, nil
 	}
-
-	var mq struct {
-		TestCommand *string                    `json:"test_command"`
-		Gates       map[string]json.RawMessage `json:"gates"`
+	result := &rigGateConfig{
+		SetupCommand:    strings.TrimSpace(effective.SetupCommand),
+		RetryFlakyTests: effective.RetryFlakyTests,
 	}
-	if err := json.Unmarshal(raw.MergeQueue, &mq); err != nil {
-		return nil, fmt.Errorf("parsing merge_queue: %w", err)
-	}
-
-	cfg := &rigGateConfig{}
-
-	// Extract gates (preferred over legacy test_command)
-	if len(mq.Gates) > 0 {
-		cfg.Gates = make(map[string]string, len(mq.Gates))
-		for name, rawGate := range mq.Gates {
-			var gate struct {
-				Cmd string `json:"cmd"`
-			}
-			if err := json.Unmarshal(rawGate, &gate); err == nil && gate.Cmd != "" {
-				cfg.Gates[name] = gate.Cmd
-			}
+	for _, command := range []validationCommand{
+		{Kind: "build", Label: "build", Command: effective.BuildCommand},
+		{Kind: "lint", Label: "lint", Command: effective.LintCommand},
+		{Kind: "typecheck", Label: "typecheck", Command: effective.TypecheckCommand},
+		{Kind: "test", Label: "test", Command: effective.TestCommand},
+	} {
+		command.Command = strings.TrimSpace(command.Command)
+		if command.Command == "" {
+			continue
 		}
+		if command.Kind == "test" && !effective.IsRunTestsEnabled() {
+			continue
+		}
+		result.Commands = append(result.Commands, command)
 	}
-
-	// Fall back to legacy test_command
-	if mq.TestCommand != nil && *mq.TestCommand != "" {
-		cfg.TestCommand = *mq.TestCommand
+	if result.SetupCommand == "" && len(result.Commands) == 0 {
+		return nil, nil
 	}
-
-	if len(cfg.Gates) == 0 && cfg.TestCommand == "" {
-		return nil, nil // No runnable commands
-	}
-
-	return cfg, nil
+	return result, nil
 }
 
-// runMainBranchTests runs quality gates on each rig's main branch.
-// It fetches the latest main, runs configured gates/tests, and escalates failures.
+type mainCheckFailure struct {
+	Kind           string
+	Label          string
+	Command        string
+	ExitCode       int
+	Evidence       string
+	Infrastructure bool
+}
+
+func (f *mainCheckFailure) Error() string {
+	if f == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s failed (exit %d): %s", f.Label, f.ExitCode, f.Evidence)
+}
+
 func (d *Daemon) runMainBranchTests() {
 	if !d.isPatrolActive("main_branch_test") {
 		return
 	}
 
 	d.logger.Printf("main_branch_test: starting patrol cycle")
-
 	rigNames := d.getKnownRigs()
 	if len(rigNames) == 0 {
 		d.logger.Printf("main_branch_test: no rigs found")
@@ -151,7 +158,6 @@ func (d *Daemon) runMainBranchTests() {
 
 	allowedRigs := mainBranchTestRigs(d.patrolConfig)
 	timeout := mainBranchTestTimeout(d.patrolConfig)
-
 	var tested, failed int
 	var failures []string
 
@@ -159,7 +165,6 @@ func (d *Daemon) runMainBranchTests() {
 		if len(allowedRigs) > 0 && !sliceContains(allowedRigs, rigName) {
 			continue
 		}
-
 		rigPath := filepath.Join(d.config.TownRoot, rigName)
 		if err := d.testRigMainBranch(rigName, rigPath, timeout); err != nil {
 			d.logger.Printf("main_branch_test: %s: FAILED: %v", rigName, err)
@@ -176,122 +181,248 @@ func (d *Daemon) runMainBranchTests() {
 		d.logger.Printf("main_branch_test: escalating %d failure(s)", len(failures))
 		d.escalate("main_branch_test", msg)
 	}
-
 	d.logger.Printf("main_branch_test: patrol cycle complete (%d tested, %d failed)", tested, failed)
 }
 
-// testRigMainBranch tests a single rig's main branch.
+// testRigMainBranch validates current main, compares a failure against the last
+// green commit, attributes the first bad commit, and submits a recovery event.
 func (d *Daemon) testRigMainBranch(rigName, rigPath string, timeout time.Duration) error {
-	// Load gate config from the rig's config.json
 	gateCfg, err := loadRigGateConfig(rigPath)
 	if err != nil {
-		return fmt.Errorf("loading gate config: %w", err)
+		return fmt.Errorf("loading effective gate config: %w", err)
 	}
 	if gateCfg == nil {
-		d.logger.Printf("main_branch_test: %s: no test commands configured, skipping", rigName)
+		d.logger.Printf("main_branch_test: %s: no validation commands configured, skipping", rigName)
 		return nil
 	}
 
-	// Determine default branch
 	defaultBranch := "main"
-	if rigCfg, err := rig.LoadRigConfig(rigPath); err == nil && rigCfg.DefaultBranch != "" {
+	rigCfg, rigCfgErr := rig.LoadRigConfig(rigPath)
+	if rigCfgErr == nil && rigCfg.DefaultBranch != "" {
 		defaultBranch = rigCfg.DefaultBranch
 	}
-
-	// Create a temporary worktree for testing to avoid interfering with
-	// the refinery's working directory.
-	worktreePath := filepath.Join(rigPath, ".main-test-worktree")
 	bareRepoPath := filepath.Join(rigPath, ".repo.git")
-
-	// Verify bare repo exists
-	if _, err := os.Stat(bareRepoPath); os.IsNotExist(err) {
-		return fmt.Errorf("bare repo not found at %s", bareRepoPath)
-	}
-
-	// Clean up stale worktree if it exists
-	if _, err := os.Stat(worktreePath); err == nil {
-		cleanupCmd := exec.Command("git", "worktree", "remove", "--force", worktreePath)
-		cleanupCmd.Dir = bareRepoPath
-		util.SetDetachedProcessGroup(cleanupCmd)
-		_ = cleanupCmd.Run()
+	if _, err := os.Stat(bareRepoPath); err != nil {
+		return fmt.Errorf("infrastructure: bare repo unavailable at %s: %w", bareRepoPath, err)
 	}
 
 	ctx, cancel := context.WithTimeout(d.ctx, timeout)
 	defer cancel()
-
-	// Fetch latest main
-	fetchCmd := exec.CommandContext(ctx, "git", "fetch", "origin", defaultBranch)
-	fetchCmd.Dir = bareRepoPath
-	util.SetDetachedProcessGroup(fetchCmd)
-	if output, err := fetchCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git fetch failed: %v (%s)", err, strings.TrimSpace(string(output)))
+	if output, err := runGit(ctx, bareRepoPath, "fetch", "origin", defaultBranch); err != nil {
+		return fmt.Errorf("infrastructure: git fetch failed: %w (%s)", err, output)
+	}
+	headSHA, err := gitOutput(ctx, bareRepoPath, "rev-parse", "origin/"+defaultBranch)
+	if err != nil {
+		return fmt.Errorf("infrastructure: resolving main head: %w", err)
 	}
 
-	// Create temporary worktree at origin/<default_branch>
-	addCmd := exec.CommandContext(ctx, "git", "worktree", "add", "--detach", worktreePath, "origin/"+defaultBranch)
-	addCmd.Dir = bareRepoPath
-	util.SetDetachedProcessGroup(addCmd)
-	if output, err := addCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git worktree add failed: %v (%s)", err, strings.TrimSpace(string(output)))
+	currentFailure, err := d.validateRigRef(ctx, rigName, rigPath, bareRepoPath, headSHA, gateCfg)
+	if err != nil {
+		return err
+	}
+	if currentFailure == nil {
+		if err := deacon.RecordMainBranchValidation(d.config.TownRoot, rigName, headSHA, true); err != nil {
+			return fmt.Errorf("recording green main: %w", err)
+		}
+		_, _ = deacon.ResolveValidationIncidents(d.config.TownRoot, "", rigName, "", "post-merge")
+		return nil
+	}
+	if err := deacon.RecordMainBranchValidation(d.config.TownRoot, rigName, headSHA, false); err != nil {
+		d.logger.Printf("main_branch_test: %s: warning: recording failed test state: %v", rigName, err)
+	}
+	if currentFailure.Infrastructure {
+		return fmt.Errorf("infrastructure: %w", currentFailure)
 	}
 
-	// Always clean up the worktree
+	mainState, err := deacon.MainBranchValidation(d.config.TownRoot, rigName)
+	if err != nil {
+		return fmt.Errorf("loading last-green state: %w", err)
+	}
+	if mainState.LastGreenSHA == "" {
+		return fmt.Errorf("%w; no known-green baseline, so hosted repair was not dispatched", currentFailure)
+	}
+
+	baselineFailure, err := d.validateRigRef(ctx, rigName, rigPath, bareRepoPath, mainState.LastGreenSHA, gateCfg)
+	if err != nil {
+		return fmt.Errorf("infrastructure while checking last-green baseline: %w", err)
+	}
+	if baselineFailure != nil {
+		return fmt.Errorf("%w; last-green baseline %s now also fails (%v), so this is infrastructure or pre-existing",
+			currentFailure, shortMainSHA(mainState.LastGreenSHA), baselineFailure)
+	}
+
+	firstBadSHA, firstFailure, err := d.findFirstFailingCommit(
+		ctx, rigName, rigPath, bareRepoPath, mainState.LastGreenSHA, headSHA, gateCfg, currentFailure,
+	)
+	if err != nil {
+		return err
+	}
+	sourceIssue := sourceIssueFromCommit(ctx, bareRepoPath, firstBadSHA, rigCfg)
+	result := deacon.ProcessValidationFailure(d.config.TownRoot, deacon.ValidationFailure{
+		Rig:         rigName,
+		SourceIssue: sourceIssue,
+		Commit:      firstBadSHA,
+		Phase:       "post-merge",
+		Kind:        firstFailure.Kind,
+		Command:     firstFailure.Command,
+		ExitCode:    firstFailure.ExitCode,
+		Summary:     fmt.Sprintf("%s regression on %s", firstFailure.Label, shortMainSHA(firstBadSHA)),
+		Evidence: fmt.Sprintf("Last green: %s\nCurrent main: %s\nFirst bad: %s\n%s",
+			mainState.LastGreenSHA, headSHA, firstBadSHA, firstFailure.Evidence),
+	})
+	if result.Error != nil {
+		return fmt.Errorf("%w; validation recovery failed: %v", currentFailure, result.Error)
+	}
+	return fmt.Errorf("%w; recovery=%s incident=%s repair=%s",
+		currentFailure, result.Action, result.IncidentID, result.RepairBead)
+}
+
+func (d *Daemon) findFirstFailingCommit(
+	ctx context.Context,
+	rigName, rigPath, bareRepoPath, lastGreen, headSHA string,
+	gateCfg *rigGateConfig,
+	headFailure *mainCheckFailure,
+) (string, *mainCheckFailure, error) {
+	output, err := gitOutput(ctx, bareRepoPath, "rev-list", "--reverse", lastGreen+".."+headSHA)
+	if err != nil {
+		return "", nil, fmt.Errorf("infrastructure: listing commits since last green: %w", err)
+	}
+	commits := strings.Fields(output)
+	if len(commits) == 0 {
+		return headSHA, headFailure, nil
+	}
+	for _, commit := range commits {
+		if commit == headSHA {
+			return headSHA, headFailure, nil
+		}
+		failure, validateErr := d.validateRigRef(ctx, rigName, rigPath, bareRepoPath, commit, gateCfg)
+		if validateErr != nil {
+			return "", nil, fmt.Errorf("infrastructure while attributing regression at %s: %w", shortMainSHA(commit), validateErr)
+		}
+		if failure != nil {
+			if failure.Infrastructure {
+				return "", nil, fmt.Errorf("infrastructure while attributing regression at %s: %w", shortMainSHA(commit), failure)
+			}
+			return commit, failure, nil
+		}
+	}
+	return headSHA, headFailure, nil
+}
+
+func (d *Daemon) validateRigRef(
+	ctx context.Context,
+	rigName, rigPath, bareRepoPath, ref string,
+	gateCfg *rigGateConfig,
+) (*mainCheckFailure, error) {
+	worktreePath := filepath.Join(rigPath, ".main-test-worktree")
+	if _, err := os.Stat(worktreePath); err == nil {
+		_, _ = runGit(context.Background(), bareRepoPath, "worktree", "remove", "--force", worktreePath)
+	}
+	if output, err := runGit(ctx, bareRepoPath, "worktree", "add", "--detach", worktreePath, ref); err != nil {
+		return nil, fmt.Errorf("git worktree add at %s: %w (%s)", shortMainSHA(ref), err, output)
+	}
 	defer func() {
-		removeCmd := exec.Command("git", "worktree", "remove", "--force", worktreePath)
-		removeCmd.Dir = bareRepoPath
-		util.SetDetachedProcessGroup(removeCmd)
-		if err := removeCmd.Run(); err != nil {
-			d.logger.Printf("main_branch_test: %s: warning: worktree cleanup failed: %v", rigName, err)
+		if output, err := runGit(context.Background(), bareRepoPath, "worktree", "remove", "--force", worktreePath); err != nil {
+			d.logger.Printf("main_branch_test: %s: warning: worktree cleanup failed: %v (%s)", rigName, err, output)
 		}
 	}()
 
-	// Run gates or legacy test command
-	if len(gateCfg.Gates) > 0 {
-		return d.runGatesOnWorktree(ctx, rigName, worktreePath, gateCfg.Gates)
-	}
-	return d.runCommandOnWorktree(ctx, rigName, worktreePath, "test", gateCfg.TestCommand)
-}
-
-// runGatesOnWorktree runs all configured gates sequentially on the given worktree.
-func (d *Daemon) runGatesOnWorktree(ctx context.Context, rigName, workDir string, gates map[string]string) error {
-	var failures []string
-	for name, cmd := range gates {
-		if err := d.runCommandOnWorktree(ctx, rigName, workDir, name, cmd); err != nil {
-			failures = append(failures, fmt.Sprintf("gate %q: %v", name, err))
+	if gateCfg.SetupCommand != "" {
+		if failure := d.runCommandOnWorktree(ctx, rigName, worktreePath, validationCommand{
+			Kind: "build", Label: "setup", Command: gateCfg.SetupCommand,
+		}, 0); failure != nil {
+			return failure, nil
 		}
 	}
-	if len(failures) > 0 {
-		return fmt.Errorf("%s", strings.Join(failures, "; "))
+	for _, command := range gateCfg.Commands {
+		if failure := d.runCommandOnWorktree(ctx, rigName, worktreePath, command, gateCfg.RetryFlakyTests); failure != nil {
+			return failure, nil
+		}
 	}
-	return nil
+	return nil, nil
 }
 
-// runCommandOnWorktree runs a single shell command in the given worktree directory.
-func (d *Daemon) runCommandOnWorktree(ctx context.Context, rigName, workDir, label, command string) error {
-	d.logger.Printf("main_branch_test: %s: running %s: %s", rigName, label, command)
-
-	cmd := exec.CommandContext(ctx, "sh", "-c", command) //nolint:gosec // G204: command is from trusted rig config
-	cmd.Dir = workDir
-	cmd.Env = append(os.Environ(), "CI=true") // Signal test environment
-	util.SetDetachedProcessGroup(cmd)
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		// Truncate output to last 50 lines for the error message
+func (d *Daemon) runCommandOnWorktree(
+	ctx context.Context,
+	rigName, workDir string,
+	command validationCommand,
+	retries int,
+) *mainCheckFailure {
+	for attempt := 0; attempt <= retries; attempt++ {
+		if attempt > 0 {
+			d.logger.Printf("main_branch_test: %s: retrying %s (%d/%d)", rigName, command.Label, attempt, retries)
+		}
+		d.logger.Printf("main_branch_test: %s: running %s: %s", rigName, command.Label, command.Command)
+		cmd := exec.CommandContext(ctx, "sh", "-c", command.Command) //nolint:gosec // trusted rig config
+		cmd.Dir = workDir
+		cmd.Env = append(os.Environ(), "CI=true")
+		util.SetDetachedProcessGroup(cmd)
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		exitCode := -1
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
 		lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-		tail := lines
-		if len(tail) > 50 {
-			tail = tail[len(tail)-50:]
+		if len(lines) > 50 {
+			lines = lines[len(lines)-50:]
 		}
-		return fmt.Errorf("%s failed: %v\n%s", label, err, strings.Join(tail, "\n"))
+		failure := &mainCheckFailure{
+			Kind:           command.Kind,
+			Label:          command.Label,
+			Command:        command.Command,
+			ExitCode:       exitCode,
+			Evidence:       strings.Join(lines, "\n"),
+			Infrastructure: ctx.Err() != nil || exitCode == 126 || exitCode == 127,
+		}
+		if failure.Infrastructure || attempt == retries {
+			return failure
+		}
 	}
 	return nil
 }
 
-// contains checks if a string slice contains a value.
-func sliceContains(slice []string, val string) bool {
-	for _, s := range slice {
-		if s == val {
+func runGit(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	util.SetDetachedProcessGroup(cmd)
+	output, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(output)), err
+}
+
+func gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	output, err := runGit(ctx, dir, args...)
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, output)
+	}
+	return output, nil
+}
+
+func sourceIssueFromCommit(ctx context.Context, bareRepoPath, sha string, rigCfg *rig.RigConfig) string {
+	if rigCfg == nil || rigCfg.Beads == nil || rigCfg.Beads.Prefix == "" {
+		return ""
+	}
+	message, err := gitOutput(ctx, bareRepoPath, "show", "-s", "--format=%B", sha)
+	if err != nil {
+		return ""
+	}
+	pattern := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(rigCfg.Beads.Prefix) + `-[a-z0-9]+\b`)
+	return pattern.FindString(message)
+}
+
+func shortMainSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
+}
+
+func sliceContains(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
 			return true
 		}
 	}

--- a/internal/daemon/main_branch_test_runner_test.go
+++ b/internal/daemon/main_branch_test_runner_test.go
@@ -1,10 +1,14 @@
 package daemon
 
 import (
-	"encoding/json"
+	"context"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"testing"
+
+	gtconfig "github.com/steveyegge/gastown/internal/config"
 )
 
 func TestMainBranchTestInterval(t *testing.T) {
@@ -112,8 +116,10 @@ func TestLoadRigGateConfig(t *testing.T) {
 
 	t.Run("no merge_queue section", func(t *testing.T) {
 		dir := t.TempDir()
-		data := `{"type":"rig","version":1,"name":"test"}`
-		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(data), 0644); err != nil {
+		if err := os.MkdirAll(filepath.Join(dir, "settings"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := gtconfig.SaveRigSettings(gtconfig.RigSettingsPath(dir), gtconfig.NewRigSettings()); err != nil {
 			t.Fatal(err)
 		}
 		cfg, err := loadRigGateConfig(dir)
@@ -127,13 +133,12 @@ func TestLoadRigGateConfig(t *testing.T) {
 
 	t.Run("test_command only", func(t *testing.T) {
 		dir := t.TempDir()
-		data := map[string]interface{}{
-			"merge_queue": map[string]interface{}{
-				"test_command": "go test ./...",
-			},
+		if err := os.MkdirAll(filepath.Join(dir, "settings"), 0755); err != nil {
+			t.Fatal(err)
 		}
-		raw, _ := json.Marshal(data)
-		if err := os.WriteFile(filepath.Join(dir, "config.json"), raw, 0644); err != nil {
+		settings := gtconfig.NewRigSettings()
+		settings.MergeQueue = &gtconfig.MergeQueueConfig{TestCommand: "go test ./..."}
+		if err := gtconfig.SaveRigSettings(gtconfig.RigSettingsPath(dir), settings); err != nil {
 			t.Fatal(err)
 		}
 		cfg, err := loadRigGateConfig(dir)
@@ -143,24 +148,34 @@ func TestLoadRigGateConfig(t *testing.T) {
 		if cfg == nil {
 			t.Fatal("expected non-nil config")
 		}
-		if cfg.TestCommand != "go test ./..." {
-			t.Errorf("expected 'go test ./...', got %q", cfg.TestCommand)
+		if len(cfg.Commands) != 1 || cfg.Commands[0].Command != "go test ./..." {
+			t.Errorf("expected one go test command, got %+v", cfg.Commands)
 		}
 	})
 
-	t.Run("gates configured", func(t *testing.T) {
+	t.Run("effective repo and local settings are merged", func(t *testing.T) {
 		dir := t.TempDir()
-		data := map[string]interface{}{
-			"merge_queue": map[string]interface{}{
-				"gates": map[string]interface{}{
-					"build": map[string]interface{}{"cmd": "go build ./..."},
-					"test":  map[string]interface{}{"cmd": "go test ./..."},
-					"lint":  map[string]interface{}{"cmd": "golangci-lint run"},
-				},
-			},
+		if err := os.MkdirAll(filepath.Join(dir, "settings"), 0755); err != nil {
+			t.Fatal(err)
 		}
-		raw, _ := json.Marshal(data)
-		if err := os.WriteFile(filepath.Join(dir, "config.json"), raw, 0644); err != nil {
+		local := gtconfig.NewRigSettings()
+		local.MergeQueue = &gtconfig.MergeQueueConfig{
+			SetupCommand: "make setup",
+			TestCommand:  "go test ./...",
+		}
+		if err := gtconfig.SaveRigSettings(gtconfig.RigSettingsPath(dir), local); err != nil {
+			t.Fatal(err)
+		}
+		repoSettingsPath := filepath.Join(dir, "refinery", "rig", ".gastown", "settings.json")
+		if err := os.MkdirAll(filepath.Dir(repoSettingsPath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		repo := gtconfig.NewRigSettings()
+		repo.MergeQueue = &gtconfig.MergeQueueConfig{
+			BuildCommand: "go build ./...",
+			LintCommand:  "golangci-lint run",
+		}
+		if err := gtconfig.SaveRigSettings(repoSettingsPath, repo); err != nil {
 			t.Fatal(err)
 		}
 		cfg, err := loadRigGateConfig(dir)
@@ -170,23 +185,25 @@ func TestLoadRigGateConfig(t *testing.T) {
 		if cfg == nil {
 			t.Fatal("expected non-nil config")
 		}
-		if len(cfg.Gates) != 3 {
-			t.Errorf("expected 3 gates, got %d", len(cfg.Gates))
+		if cfg.SetupCommand != "make setup" {
+			t.Errorf("expected setup command, got %q", cfg.SetupCommand)
 		}
-		if cfg.Gates["build"] != "go build ./..." {
-			t.Errorf("expected build gate 'go build ./...', got %q", cfg.Gates["build"])
+		if len(cfg.Commands) != 3 {
+			t.Fatalf("expected build, lint, and test commands, got %+v", cfg.Commands)
+		}
+		if cfg.Commands[0].Command != "go build ./..." || cfg.Commands[2].Command != "go test ./..." {
+			t.Errorf("unexpected effective commands: %+v", cfg.Commands)
 		}
 	})
 
 	t.Run("no test commands", func(t *testing.T) {
 		dir := t.TempDir()
-		data := map[string]interface{}{
-			"merge_queue": map[string]interface{}{
-				"enabled": true,
-			},
+		if err := os.MkdirAll(filepath.Join(dir, "settings"), 0755); err != nil {
+			t.Fatal(err)
 		}
-		raw, _ := json.Marshal(data)
-		if err := os.WriteFile(filepath.Join(dir, "config.json"), raw, 0644); err != nil {
+		settings := gtconfig.NewRigSettings()
+		settings.MergeQueue = &gtconfig.MergeQueueConfig{Enabled: true}
+		if err := gtconfig.SaveRigSettings(gtconfig.RigSettingsPath(dir), settings); err != nil {
 			t.Fatal(err)
 		}
 		cfg, err := loadRigGateConfig(dir)
@@ -208,6 +225,31 @@ func TestContains(t *testing.T) {
 	}
 	if sliceContains(nil, "a") {
 		t.Error("expected false for nil slice")
+	}
+}
+
+func TestRunCommandOnWorktreeRetriesFlakyFailure(t *testing.T) {
+	workDir := t.TempDir()
+	d := &Daemon{logger: log.New(io.Discard, "", 0)}
+	failure := d.runCommandOnWorktree(context.Background(), "canary", workDir, validationCommand{
+		Kind:    "test",
+		Label:   "test",
+		Command: "if [ ! -f retry-marker ]; then touch retry-marker; exit 1; fi",
+	}, 1)
+	if failure != nil {
+		t.Fatalf("expected retry to pass, got %v", failure)
+	}
+}
+
+func TestRunCommandOnWorktreeClassifiesMissingCommandAsInfrastructure(t *testing.T) {
+	d := &Daemon{logger: log.New(io.Discard, "", 0)}
+	failure := d.runCommandOnWorktree(context.Background(), "canary", t.TempDir(), validationCommand{
+		Kind:    "test",
+		Label:   "test",
+		Command: "exec definitely-not-a-command",
+	}, 0)
+	if failure == nil || !failure.Infrastructure || failure.ExitCode != 127 {
+		t.Fatalf("expected exit 127 infrastructure failure, got %+v", failure)
 	}
 }
 

--- a/internal/daemon/model_crash_executor.go
+++ b/internal/daemon/model_crash_executor.go
@@ -9,11 +9,13 @@ import (
 	goruntime "runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/deacon"
 	"github.com/steveyegge/gastown/internal/dog"
+	"github.com/steveyegge/gastown/internal/polecat"
 	"github.com/steveyegge/gastown/internal/util"
 )
 
@@ -99,9 +101,53 @@ func (e *daemonModelCrashExecutor) Sessions() ([]modelCrashSession, error) {
 		candidate.InstanceID = instanceID
 		candidate.WorkDir = workDir
 		candidate.Output = output
+		if hb := polecat.ReadSessionHeartbeat(e.daemon.config.TownRoot, name); hb != nil {
+			candidate.HeartbeatAt = hb.Timestamp
+		}
 		result = append(result, candidate)
 	}
 	return result, nil
+}
+
+func (e *daemonModelCrashExecutor) Nudge(candidate modelCrashSession, message string) error {
+	if candidate.Identity == "" {
+		return fmt.Errorf("cannot nudge session with empty identity")
+	}
+	cmd := exec.Command(e.daemon.gtPath, "nudge", candidate.Identity, message)
+	cmd.Dir = e.daemon.config.TownRoot
+	util.SetDetachedProcessGroup(cmd)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("gt nudge %s: %w: %s",
+			candidate.Identity, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func (e *daemonModelCrashExecutor) RecoveryPolicy(candidate modelCrashSession) modelCrashRecoveryPolicy {
+	result := defaultModelCrashRecoveryPolicy()
+	if candidate.WorkDir == "" {
+		return result
+	}
+	cfg, err := deacon.LoadModelEscalationConfig(candidate.WorkDir)
+	if err != nil || cfg == nil || cfg.Recovery == nil {
+		return result
+	}
+	if parsed, parseErr := time.ParseDuration(cfg.Recovery.NudgeAfter); parseErr == nil && parsed > 0 {
+		result.NudgeAfter = parsed
+	}
+	if parsed, parseErr := time.ParseDuration(cfg.Recovery.LocalRestartAfter); parseErr == nil && parsed > 0 {
+		result.LocalRestartAfter = parsed
+	}
+	if parsed, parseErr := time.ParseDuration(cfg.Recovery.GoEscalateAfter); parseErr == nil && parsed > 0 {
+		result.GoEscalateAfter = parsed
+	}
+	if result.LocalRestartAfter < result.NudgeAfter {
+		result.LocalRestartAfter = result.NudgeAfter
+	}
+	if result.GoEscalateAfter < result.LocalRestartAfter {
+		result.GoEscalateAfter = result.LocalRestartAfter
+	}
+	return result
 }
 
 func (e *daemonModelCrashExecutor) LMWatchdog() (modelCrashWatchdog, error) {

--- a/internal/daemon/model_crash_executor.go
+++ b/internal/daemon/model_crash_executor.go
@@ -1,0 +1,327 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	goruntime "runtime"
+	"strconv"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/deacon"
+	"github.com/steveyegge/gastown/internal/dog"
+	"github.com/steveyegge/gastown/internal/util"
+)
+
+type daemonModelCrashExecutor struct {
+	daemon    *Daemon
+	sendHuman func(string, string) error
+	notify    func(string, string) error
+}
+
+func (e *daemonModelCrashExecutor) Sessions() ([]modelCrashSession, error) {
+	names, err := e.daemon.tmux.ListSessions()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]modelCrashSession, 0, len(names))
+	dogManager := dog.NewManager(e.daemon.config.TownRoot, &config.RigsConfig{})
+	for _, name := range names {
+		agent, err := e.daemon.tmux.GetEnvironment(name, "GT_AGENT")
+		if err != nil || agent != "opencode-local" {
+			continue
+		}
+		identity, err := e.daemon.tmux.GetEnvironment(name, "GT_ROLE")
+		if err != nil || identity == "" {
+			continue
+		}
+		role := config.ExtractSimpleRole(identity)
+		if role == "boot" || identity == "deacon/boot" {
+			continue
+		}
+		dogName := ""
+		if role == "dog" {
+			dogName, err = e.daemon.tmux.GetEnvironment(name, "GT_DOG_NAME")
+			if err != nil || dogName == "" {
+				continue
+			}
+			identity = "deacon/dogs/" + dogName
+		}
+		candidate := modelCrashSession{
+			Name:     name,
+			Identity: identity,
+			Role:     role,
+			Agent:    agent,
+		}
+		switch role {
+		case "polecat":
+			workUnit, active, workErr := e.polecatWorkUnit(candidate)
+			if workErr != nil {
+				continue
+			}
+			if !active {
+				result = append(result, candidate)
+				continue
+			}
+			candidate.WorkUnit = workUnit
+		case "dog":
+			current, workErr := dogManager.Get(dogName)
+			if workErr != nil {
+				continue
+			}
+			workUnit, active := modelCrashDogWorkUnit(current)
+			if !active {
+				result = append(result, candidate)
+				continue
+			}
+			candidate.WorkUnit = workUnit
+		}
+		instanceID, _ := e.daemon.tmux.GetEnvironment(name, "GT_RUN")
+		if instanceID == "" {
+			if info, infoErr := e.daemon.tmux.GetSessionInfo(name); infoErr == nil {
+				instanceID = info.Created
+			}
+		}
+		if instanceID == "" {
+			// Session name alone is a conservative legacy fallback. Current
+			// sessions have GT_RUN; older sessions at least need two scans.
+			instanceID = name
+		}
+		workDir, _ := e.daemon.tmux.GetPaneWorkDir(name)
+		output, captureErr := e.daemon.tmux.CapturePane(name, 80)
+		if captureErr != nil {
+			continue
+		}
+		candidate.InstanceID = instanceID
+		candidate.WorkDir = workDir
+		candidate.Output = output
+		result = append(result, candidate)
+	}
+	return result, nil
+}
+
+func (e *daemonModelCrashExecutor) LMWatchdog() (modelCrashWatchdog, error) {
+	path := filepath.Join(e.daemon.config.TownRoot, "deacon", "lmstudio-watchdog.json")
+	data, err := os.ReadFile(path) //nolint:gosec // path is derived from configured town root
+	if err != nil {
+		return modelCrashWatchdog{}, err
+	}
+	var watchdog modelCrashWatchdog
+	if err := json.Unmarshal(data, &watchdog); err != nil {
+		return modelCrashWatchdog{}, err
+	}
+	return watchdog, nil
+}
+
+func (e *daemonModelCrashExecutor) Restart(candidate modelCrashSession, agent string) error {
+	if candidate.Role == "dog" {
+		return e.restartDog(candidate, agent)
+	}
+	args, err := modelCrashRestartArgs(candidate, agent)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(e.daemon.gtPath, args...)
+	cmd.Dir = e.daemon.config.TownRoot
+	util.SetDetachedProcessGroup(cmd)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("gt %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func (e *daemonModelCrashExecutor) restartDog(candidate modelCrashSession, agent string) error {
+	const prefix = "deacon/dogs/"
+	dogName := strings.TrimPrefix(candidate.Identity, prefix)
+	if dogName == "" || dogName == candidate.Identity || strings.Contains(dogName, "/") {
+		return fmt.Errorf("invalid dog identity %q", candidate.Identity)
+	}
+	manager := dog.NewManager(e.daemon.config.TownRoot, &config.RigsConfig{})
+	current, err := manager.Get(dogName)
+	if err != nil {
+		return fmt.Errorf("loading dog %s: %w", dogName, err)
+	}
+	sessions := dog.NewSessionManager(e.daemon.tmux, e.daemon.config.TownRoot, manager)
+	if err := sessions.Stop(dogName, true); err != nil {
+		return fmt.Errorf("stopping dog %s: %w", dogName, err)
+	}
+	if err := sessions.Start(dogName, dog.SessionStartOptions{
+		WorkDesc:      current.Work,
+		AgentOverride: agent,
+	}); err != nil {
+		return fmt.Errorf("starting dog %s: %w", dogName, err)
+	}
+	return nil
+}
+
+func modelCrashRestartArgs(candidate modelCrashSession, agent string) ([]string, error) {
+	switch candidate.Role {
+	case "mayor", "deacon":
+		return []string{candidate.Role, "restart", "--agent", agent}, nil
+	case "witness", "refinery":
+		parts := strings.Split(candidate.Identity, "/")
+		if len(parts) != 2 || parts[0] == "" {
+			return nil, fmt.Errorf("invalid %s identity %q", candidate.Role, candidate.Identity)
+		}
+		return []string{candidate.Role, "restart", parts[0], "--agent", agent}, nil
+	case "crew":
+		parts := strings.Split(candidate.Identity, "/")
+		if len(parts) != 3 || parts[0] == "" || parts[2] == "" {
+			return nil, fmt.Errorf("invalid crew identity %q", candidate.Identity)
+		}
+		return []string{"crew", "restart", parts[0] + "/" + parts[2], "--agent", agent}, nil
+	case "polecat":
+		parts := strings.Split(candidate.Identity, "/")
+		if len(parts) != 3 || parts[0] == "" || parts[2] == "" {
+			return nil, fmt.Errorf("invalid polecat identity %q", candidate.Identity)
+		}
+		return []string{"session", "restart", parts[0] + "/" + parts[2], "--force", "--agent", agent}, nil
+	default:
+		return nil, fmt.Errorf("no safe restart primitive for role %q (%s)", candidate.Role, candidate.Identity)
+	}
+}
+
+func (e *daemonModelCrashExecutor) ActivePolecat(candidate modelCrashSession) bool {
+	workUnit, active, err := e.polecatWorkUnit(candidate)
+	return err == nil && active && workUnit == strings.TrimSpace(candidate.WorkUnit)
+}
+
+func (e *daemonModelCrashExecutor) polecatWorkUnit(candidate modelCrashSession) (string, bool, error) {
+	if candidate.Role != "polecat" {
+		return "", false, fmt.Errorf("role %q is not a polecat", candidate.Role)
+	}
+	parts := strings.Split(candidate.Identity, "/")
+	if len(parts) != 3 {
+		return "", false, fmt.Errorf("invalid polecat identity %q", candidate.Identity)
+	}
+	rigName, polecatName := parts[0], parts[2]
+	prefix := beads.GetPrefixForRig(e.daemon.config.TownRoot, rigName)
+	agentBeadID := beads.PolecatBeadIDWithPrefix(prefix, rigName, polecatName)
+	info, err := e.daemon.getAgentBeadInfo(agentBeadID)
+	if err != nil {
+		return "", false, err
+	}
+	workUnit, active := modelCrashPolecatWorkUnit(info, false, candidate.Identity, candidate.Identity)
+	if !active {
+		return "", false, nil
+	}
+	assignee, open, err := e.modelCrashHookAssignment(workUnit)
+	if err != nil {
+		return "", false, err
+	}
+	workUnit, active = modelCrashPolecatWorkUnit(info, !open, assignee, candidate.Identity)
+	return workUnit, active, nil
+}
+
+func (e *daemonModelCrashExecutor) modelCrashHookAssignment(beadID string) (string, bool, error) {
+	cmd := exec.Command(e.daemon.bdPath, "show", beadID, "--json") //nolint:gosec // daemon-owned binary and bead ID
+	setSysProcAttr(cmd)
+	cmd.Dir = e.daemon.config.TownRoot
+	cmd.Env = bdReadOnlyRoutingEnv(e.daemon.config.TownRoot)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", false, fmt.Errorf("bd show %s: %w", beadID, err)
+	}
+	var issues []struct {
+		Status   string `json:"status"`
+		Assignee string `json:"assignee"`
+	}
+	if err := json.Unmarshal(output, &issues); err != nil {
+		return "", false, fmt.Errorf("parsing work bead %s: %w", beadID, err)
+	}
+	if len(issues) == 0 {
+		return "", false, fmt.Errorf("work bead not found: %s", beadID)
+	}
+	return strings.TrimSpace(issues[0].Assignee),
+		!strings.EqualFold(strings.TrimSpace(issues[0].Status), "closed"), nil
+}
+
+func modelCrashPolecatWorkUnit(
+	info *AgentBeadInfo,
+	hookClosed bool,
+	hookAssignee, candidateIdentity string,
+) (string, bool) {
+	if info == nil {
+		return "", false
+	}
+	workUnit := strings.TrimSpace(info.HookBead)
+	if workUnit == "" || hookClosed ||
+		strings.TrimSpace(hookAssignee) != strings.TrimSpace(candidateIdentity) {
+		return "", false
+	}
+	switch beads.AgentState(info.State) {
+	case beads.AgentStateDone, beads.AgentStateNuked:
+		return "", false
+	}
+	return workUnit, true
+}
+
+func modelCrashDogWorkUnit(candidate *dog.Dog) (string, bool) {
+	if candidate == nil || candidate.State != dog.StateWorking {
+		return "", false
+	}
+	workUnit := strings.TrimSpace(candidate.Work)
+	return workUnit, workUnit != ""
+}
+
+func (e *daemonModelCrashExecutor) AllowsContinuation(candidate modelCrashSession, fromAgent, toAgent string) bool {
+	if candidate.Role != "polecat" || candidate.WorkDir == "" {
+		return false
+	}
+	policy, err := deacon.LoadModelEscalationConfig(candidate.WorkDir)
+	if err != nil || policy == nil || !policy.Enabled {
+		return false
+	}
+	for _, rule := range policy.Rules {
+		if rule.FromAgent == fromAgent && rule.ToAgent == toAgent && rule.PromoteAfterFailures == 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *daemonModelCrashExecutor) Alert(key, message string) error {
+	subject := "Model crash recovery requires attention"
+	sendHuman := e.sendHuman
+	if sendHuman == nil {
+		sendHuman = e.sendHumanAlert
+	}
+	notify := e.notify
+	if notify == nil {
+		notify = sendModelCrashNotification
+	}
+	mailErr := sendHuman(subject, message)
+	_ = notify(subject, message)
+	if mailErr != nil {
+		return fmt.Errorf("sending model crash alert %s: %w", key, mailErr)
+	}
+	return nil
+}
+
+func (e *daemonModelCrashExecutor) sendHumanAlert(subject, message string) error {
+	cmd := exec.Command(e.daemon.gtPath, modelCrashHumanAlertArgs(subject, message)...)
+	cmd.Dir = e.daemon.config.TownRoot
+	util.SetDetachedProcessGroup(cmd)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func modelCrashHumanAlertArgs(subject, message string) []string {
+	return []string{"mail", "send", "--human", "-s", subject, "-m", message}
+}
+
+func sendModelCrashNotification(title, message string) error {
+	if goruntime.GOOS != "darwin" {
+		return nil
+	}
+	script := "display notification " + strconv.Quote(message) + " with title " + strconv.Quote(title)
+	cmd := exec.Command("osascript", "-e", script)
+	util.SetDetachedProcessGroup(cmd)
+	return cmd.Run()
+}

--- a/internal/daemon/model_crash_supervisor.go
+++ b/internal/daemon/model_crash_supervisor.go
@@ -18,6 +18,9 @@ const (
 	modelCrashWatchdogMaxAge        = 2 * time.Minute
 	modelCrashControlProbeInterval  = 30 * time.Minute
 	modelCrashProgressResetInterval = 30 * time.Minute
+	modelStallNudgeAfter            = 15 * time.Minute
+	modelStallLocalRestartAfter     = 30 * time.Minute
+	modelStallGoEscalateAfter       = 60 * time.Minute
 )
 
 type modelCrashClock interface {
@@ -29,14 +32,15 @@ type realModelCrashClock struct{}
 func (realModelCrashClock) Now() time.Time { return time.Now() }
 
 type modelCrashSession struct {
-	Name       string
-	InstanceID string
-	Identity   string
-	Role       string
-	Agent      string
-	WorkUnit   string
-	WorkDir    string
-	Output     string
+	Name        string
+	InstanceID  string
+	Identity    string
+	Role        string
+	Agent       string
+	WorkUnit    string
+	WorkDir     string
+	Output      string
+	HeartbeatAt time.Time
 }
 
 type modelCrashWatchdog struct {
@@ -44,10 +48,26 @@ type modelCrashWatchdog struct {
 	CheckedAt time.Time `json:"checked_at"`
 }
 
+type modelCrashRecoveryPolicy struct {
+	NudgeAfter        time.Duration
+	LocalRestartAfter time.Duration
+	GoEscalateAfter   time.Duration
+}
+
+func defaultModelCrashRecoveryPolicy() modelCrashRecoveryPolicy {
+	return modelCrashRecoveryPolicy{
+		NudgeAfter:        modelStallNudgeAfter,
+		LocalRestartAfter: modelStallLocalRestartAfter,
+		GoEscalateAfter:   modelStallGoEscalateAfter,
+	}
+}
+
 type modelCrashExecutor interface {
 	Sessions() ([]modelCrashSession, error)
 	LMWatchdog() (modelCrashWatchdog, error)
 	Restart(modelCrashSession, string) error
+	Nudge(modelCrashSession, string) error
+	RecoveryPolicy(modelCrashSession) modelCrashRecoveryPolicy
 	ActivePolecat(modelCrashSession) bool
 	AllowsContinuation(modelCrashSession, string, string) bool
 	Alert(string, string) error
@@ -68,6 +88,11 @@ type modelCrashSessionState struct {
 	NextProbeAt           time.Time `json:"next_probe_at,omitempty"`
 	RecoveryAction        string    `json:"recovery_action,omitempty"`
 	RecoveryExhausted     bool      `json:"recovery_exhausted"`
+	Kind                  string    `json:"kind,omitempty"`
+	Tier                  string    `json:"tier,omitempty"`
+	LeaseOwner            string    `json:"lease_owner,omitempty"`
+	StallStartedAt        time.Time `json:"stall_started_at,omitempty"`
+	StallNudges           int       `json:"stall_nudges,omitempty"`
 }
 
 type modelCrashState struct {
@@ -215,6 +240,10 @@ func (s *modelCrashSupervisor) Scan() error {
 		}
 		fingerprint, fatal := session.DetectModelCrash(candidate.Output)
 		if !fatal {
+			if s.handleStall(candidate, current, now) {
+				changed = true
+				continue
+			}
 			if current == nil || strings.TrimSpace(candidate.Output) == "" {
 				continue
 			}
@@ -233,6 +262,9 @@ func (s *modelCrashSupervisor) Scan() error {
 				SessionName: candidate.Name,
 				IncidentID:  newModelCrashIncidentID(candidate.Identity, now),
 				WorkUnit:    strings.TrimSpace(candidate.WorkUnit),
+				Kind:        "session-fatal",
+				Tier:        "local",
+				LeaseOwner:  "daemon/model-crash-supervisor",
 			}
 			s.state.Sessions[candidate.Identity] = current
 		}
@@ -289,6 +321,7 @@ func (s *modelCrashSupervisor) Scan() error {
 					fmt.Sprintf("Local model-crash restart failed for %s: %v", candidate.Identity, err))
 			} else {
 				current.RecoveryAction = "local-restart"
+				current.Tier = "local"
 				current.RecoveryExhausted = false
 			}
 			continue
@@ -311,6 +344,7 @@ func (s *modelCrashSupervisor) Scan() error {
 					fmt.Sprintf("OpenCode Go continuation failed for %s: %v", candidate.Identity, err))
 			} else {
 				current.RecoveryAction = "go-continuation"
+				current.Tier = "go"
 				current.RecoveryExhausted = false
 			}
 			continue
@@ -327,6 +361,104 @@ func (s *modelCrashSupervisor) Scan() error {
 		return s.save()
 	}
 	return nil
+}
+
+// handleStall advances the time-based local-first ladder for an active worker
+// whose durable heartbeat has stopped. The write-ahead state transitions are
+// the action lease: daemon restarts cannot replay a nudge, restart, or hosted
+// continuation for the same incident.
+func (s *modelCrashSupervisor) handleStall(candidate modelCrashSession, current *modelCrashSessionState, now time.Time) bool {
+	policy := s.executor.RecoveryPolicy(candidate)
+	if strings.TrimSpace(candidate.WorkUnit) == "" || candidate.HeartbeatAt.IsZero() ||
+		now.Before(candidate.HeartbeatAt) || now.Sub(candidate.HeartbeatAt) < policy.NudgeAfter {
+		return false
+	}
+	if current == nil {
+		current = &modelCrashSessionState{
+			SessionName:    candidate.Name,
+			IncidentID:     newModelCrashIncidentID(candidate.Identity+"-stall", now),
+			WorkUnit:       strings.TrimSpace(candidate.WorkUnit),
+			Kind:           "session-stall",
+			Tier:           "local",
+			LeaseOwner:     "daemon/model-crash-supervisor",
+			StallStartedAt: candidate.HeartbeatAt,
+		}
+		s.state.Sessions[candidate.Identity] = current
+	}
+	if current.Kind != "session-stall" {
+		return false
+	}
+	current.SessionName = candidate.Name
+	if current.StallStartedAt.IsZero() {
+		current.StallStartedAt = candidate.HeartbeatAt
+	}
+	stallAge := now.Sub(current.StallStartedAt)
+
+	if stallAge >= policy.GoEscalateAfter && candidate.Role == "polecat" &&
+		current.GoContinuations == 0 && s.executor.ActivePolecat(candidate) &&
+		s.executor.AllowsContinuation(candidate, "opencode-local", "opencode-go") {
+		current.GoContinuations = 1
+		current.Tier = "go"
+		current.NextProbeAt = time.Time{}
+		current.RecoveryAction = "go-continuation-pending"
+		if err := s.save(); err != nil {
+			current.RecoveryAction = "go-continuation-state-failed"
+			current.RecoveryExhausted = true
+			return true
+		}
+		if err := s.executor.Restart(candidate, "opencode-go"); err != nil {
+			current.RecoveryAction = "go-continuation-failed"
+			current.RecoveryExhausted = true
+			s.alertOnce(current.IncidentID+":go-continuation-failed",
+				fmt.Sprintf("OpenCode Go stall continuation failed for %s: %v", candidate.Identity, err))
+		} else {
+			current.RecoveryAction = "go-continuation"
+			current.RecoveryExhausted = false
+		}
+		return true
+	}
+
+	if stallAge >= policy.LocalRestartAfter && current.LocalRestarts == 0 {
+		current.LocalRestarts = 1
+		current.NextProbeAt = current.StallStartedAt.Add(policy.GoEscalateAfter)
+		current.RecoveryAction = "local-restart-pending"
+		if err := s.save(); err != nil {
+			current.RecoveryAction = "local-restart-state-failed"
+			current.RecoveryExhausted = true
+			return true
+		}
+		if err := s.executor.Restart(candidate, "opencode-local"); err != nil {
+			current.RecoveryAction = "local-restart-failed"
+			current.RecoveryExhausted = true
+			s.alertOnce(current.IncidentID+":local-restart-failed",
+				fmt.Sprintf("Local stall restart failed for %s: %v", candidate.Identity, err))
+		} else {
+			current.RecoveryAction = "local-restart"
+			current.RecoveryExhausted = false
+		}
+		return true
+	}
+
+	if current.StallNudges == 0 {
+		current.StallNudges = 1
+		current.NextProbeAt = current.StallStartedAt.Add(policy.LocalRestartAfter)
+		current.RecoveryAction = "nudge-pending"
+		if err := s.save(); err != nil {
+			current.RecoveryAction = "nudge-state-failed"
+			current.RecoveryExhausted = true
+			return true
+		}
+		if err := s.executor.Nudge(candidate,
+			"No durable progress has been observed for 15 minutes. Report progress or the blocking condition."); err != nil {
+			current.RecoveryAction = "nudge-failed"
+			s.alertOnce(current.IncidentID+":nudge-failed",
+				fmt.Sprintf("Stall nudge failed for %s: %v", candidate.Identity, err))
+		} else {
+			current.RecoveryAction = "nudged"
+		}
+		return true
+	}
+	return false
 }
 
 func (s *modelCrashSupervisor) runLocalProbe(candidate modelCrashSession, state *modelCrashSessionState, now time.Time) error {
@@ -451,8 +583,17 @@ type ModelCrashRecoveryIncident struct {
 	Identity          string
 	SessionName       string
 	IncidentID        string
+	Kind              string
+	WorkUnit          string
+	Tier              string
+	LeaseOwner        string
 	RecoveryAction    string
 	RecoveryExhausted bool
+	LocalRestarts     int
+	GoContinuations   int
+	ControlProbes     int
+	StallNudges       int
+	NextActionAt      time.Time
 	Confirmed         bool
 }
 
@@ -478,8 +619,17 @@ func LoadModelCrashRecoveryIncidents(townRoot string) ([]ModelCrashRecoveryIncid
 			Identity:          identity,
 			SessionName:       candidate.SessionName,
 			IncidentID:        candidate.IncidentID,
+			Kind:              candidate.Kind,
+			WorkUnit:          candidate.WorkUnit,
+			Tier:              candidate.Tier,
+			LeaseOwner:        candidate.LeaseOwner,
 			RecoveryAction:    candidate.RecoveryAction,
 			RecoveryExhausted: candidate.RecoveryExhausted,
+			LocalRestarts:     candidate.LocalRestarts,
+			GoContinuations:   candidate.GoContinuations,
+			ControlProbes:     candidate.ControlProbes,
+			StallNudges:       candidate.StallNudges,
+			NextActionAt:      candidate.NextProbeAt,
 			Confirmed: candidate.LocalRestarts > 0 || candidate.GoContinuations > 0 ||
 				candidate.ControlProbes > 0 || candidate.RecoveryAction != "",
 		})

--- a/internal/daemon/model_crash_supervisor.go
+++ b/internal/daemon/model_crash_supervisor.go
@@ -1,0 +1,507 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/atomicfile"
+	"github.com/steveyegge/gastown/internal/session"
+)
+
+const (
+	modelCrashScanInterval          = 60 * time.Second
+	modelCrashObservationMaxGap     = 2 * modelCrashScanInterval
+	modelCrashWatchdogMaxAge        = 2 * time.Minute
+	modelCrashControlProbeInterval  = 30 * time.Minute
+	modelCrashProgressResetInterval = 30 * time.Minute
+)
+
+type modelCrashClock interface {
+	Now() time.Time
+}
+
+type realModelCrashClock struct{}
+
+func (realModelCrashClock) Now() time.Time { return time.Now() }
+
+type modelCrashSession struct {
+	Name       string
+	InstanceID string
+	Identity   string
+	Role       string
+	Agent      string
+	WorkUnit   string
+	WorkDir    string
+	Output     string
+}
+
+type modelCrashWatchdog struct {
+	Status    string    `json:"status"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+type modelCrashExecutor interface {
+	Sessions() ([]modelCrashSession, error)
+	LMWatchdog() (modelCrashWatchdog, error)
+	Restart(modelCrashSession, string) error
+	ActivePolecat(modelCrashSession) bool
+	AllowsContinuation(modelCrashSession, string, string) bool
+	Alert(string, string) error
+}
+
+type modelCrashSessionState struct {
+	SessionName           string    `json:"session_name"`
+	IncidentID            string    `json:"incident_id"`
+	WorkUnit              string    `json:"work_unit,omitempty"`
+	ObservationKey        string    `json:"observation_key,omitempty"`
+	HandledObservationKey string    `json:"handled_observation_key,omitempty"`
+	Consecutive           int       `json:"consecutive_observations"`
+	LastObservedAt        time.Time `json:"last_observed_at,omitempty"`
+	ProgressSince         time.Time `json:"progress_since,omitempty"`
+	LocalRestarts         int       `json:"local_restarts"`
+	GoContinuations       int       `json:"go_continuations"`
+	ControlProbes         int       `json:"control_probes"`
+	NextProbeAt           time.Time `json:"next_probe_at,omitempty"`
+	RecoveryAction        string    `json:"recovery_action,omitempty"`
+	RecoveryExhausted     bool      `json:"recovery_exhausted"`
+}
+
+type modelCrashState struct {
+	Version       int                                `json:"version"`
+	Sessions      map[string]*modelCrashSessionState `json:"sessions"`
+	Alerts        map[string]time.Time               `json:"alerts"`
+	PendingAlerts map[string]string                  `json:"pending_alerts,omitempty"`
+}
+
+type modelCrashSupervisor struct {
+	statePath string
+	clock     modelCrashClock
+	executor  modelCrashExecutor
+	state     modelCrashState
+	loaded    bool
+}
+
+func newModelCrashSupervisor(statePath string, clock modelCrashClock, executor modelCrashExecutor) *modelCrashSupervisor {
+	return &modelCrashSupervisor{
+		statePath: statePath,
+		clock:     clock,
+		executor:  executor,
+		state: modelCrashState{
+			Version:       1,
+			Sessions:      make(map[string]*modelCrashSessionState),
+			Alerts:        make(map[string]time.Time),
+			PendingAlerts: make(map[string]string),
+		},
+	}
+}
+
+func modelCrashStateFile(townRoot string) string {
+	return filepath.Join(townRoot, "deacon", "model-crash-supervisor.json")
+}
+
+func (s *modelCrashSupervisor) load() error {
+	data, err := os.ReadFile(s.statePath) //nolint:gosec // state path is derived from the configured town root
+	if err != nil {
+		if os.IsNotExist(err) {
+			s.loaded = true
+			return nil
+		}
+		return err
+	}
+	if err := json.Unmarshal(data, &s.state); err != nil {
+		return fmt.Errorf("parsing model crash supervisor state: %w", err)
+	}
+	if s.state.Sessions == nil {
+		s.state.Sessions = make(map[string]*modelCrashSessionState)
+	}
+	if s.state.Alerts == nil {
+		s.state.Alerts = make(map[string]time.Time)
+	}
+	if s.state.PendingAlerts == nil {
+		s.state.PendingAlerts = make(map[string]string)
+	}
+	if s.reconcileInterruptedActions() {
+		// Pending recovery actions are write-ahead at-most-once boundaries.
+		// Persist exhaustion and the alert intent before attempting delivery,
+		// so daemon termination cannot replay the action or lose visibility.
+		if err := s.save(); err != nil {
+			return err
+		}
+	}
+	s.loaded = true
+	return nil
+}
+
+func (s *modelCrashSupervisor) reconcileInterruptedActions() bool {
+	changed := false
+	for identity, candidate := range s.state.Sessions {
+		if candidate == nil || !strings.HasSuffix(candidate.RecoveryAction, "-pending") {
+			continue
+		}
+		pendingAction := candidate.RecoveryAction
+		candidate.RecoveryAction = strings.TrimSuffix(pendingAction, "-pending") + "-interrupted"
+		candidate.RecoveryExhausted = true
+		candidate.NextProbeAt = time.Time{}
+		alertID := candidate.IncidentID
+		if alertID == "" {
+			alertID = identity
+		}
+		key := alertID + ":interrupted-action"
+		if _, delivered := s.state.Alerts[key]; !delivered {
+			s.state.PendingAlerts[key] = fmt.Sprintf(
+				"Model-crash recovery action %s for %s was interrupted after its durable at-most-once boundary; it will not be replayed",
+				pendingAction, identity)
+		}
+		changed = true
+	}
+	return changed
+}
+
+func (s *modelCrashSupervisor) save() error {
+	if err := os.MkdirAll(filepath.Dir(s.statePath), 0o700); err != nil {
+		return err
+	}
+	return atomicfile.WriteJSONWithPerm(s.statePath, &s.state, 0o600)
+}
+
+func (s *modelCrashSupervisor) Scan() error {
+	if !s.loaded {
+		if err := s.load(); err != nil {
+			return err
+		}
+	}
+
+	alertsChanged := s.retryPendingAlerts()
+	now := s.clock.Now()
+	watchdog, err := s.executor.LMWatchdog()
+	if err != nil || validateModelCrashWatchdog(watchdog, now) != nil {
+		if alertsChanged {
+			return s.save()
+		}
+		return nil
+	}
+
+	sessions, err := s.executor.Sessions()
+	if err != nil {
+		return err
+	}
+	changed := alertsChanged
+	for _, candidate := range sessions {
+		if candidate.Agent != "opencode-local" || candidate.Identity == "" ||
+			candidate.Role == "boot" || strings.Contains(candidate.Identity, "/boot") {
+			continue
+		}
+		current := s.state.Sessions[candidate.Identity]
+		if candidate.Role == "polecat" || candidate.Role == "dog" {
+			workUnit := strings.TrimSpace(candidate.WorkUnit)
+			if current != nil && current.WorkUnit != workUnit {
+				// A reusable worker's recovery budget belongs to its assigned
+				// work, not its stable role identity. Retire the old incident
+				// before observing or acting on the new assignment.
+				delete(s.state.Sessions, candidate.Identity)
+				current = nil
+				changed = true
+			}
+			if workUnit == "" {
+				// Running but idle workers are inventory, not recovery
+				// candidates. Controls and Crew intentionally have no work
+				// unit requirement.
+				continue
+			}
+		}
+		fingerprint, fatal := session.DetectModelCrash(candidate.Output)
+		if !fatal {
+			if current == nil || strings.TrimSpace(candidate.Output) == "" {
+				continue
+			}
+			if current.ProgressSince.IsZero() {
+				current.ProgressSince = now
+				changed = true
+			} else if now.Sub(current.ProgressSince) >= modelCrashProgressResetInterval {
+				delete(s.state.Sessions, candidate.Identity)
+				changed = true
+			}
+			continue
+		}
+
+		if current == nil {
+			current = &modelCrashSessionState{
+				SessionName: candidate.Name,
+				IncidentID:  newModelCrashIncidentID(candidate.Identity, now),
+				WorkUnit:    strings.TrimSpace(candidate.WorkUnit),
+			}
+			s.state.Sessions[candidate.Identity] = current
+		}
+		current.SessionName = candidate.Name
+		current.ProgressSince = time.Time{}
+		changed = true
+
+		observationKey := candidate.InstanceID + "|" + fingerprint
+		if current.HandledObservationKey == observationKey {
+			if !current.NextProbeAt.IsZero() && !now.Before(current.NextProbeAt) &&
+				current.GoContinuations == 0 {
+				if err := s.runLocalProbe(candidate, current, now); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		if current.ObservationKey != observationKey {
+			current.ObservationKey = observationKey
+			current.Consecutive = 1
+			current.LastObservedAt = now
+			continue
+		}
+		gap := now.Sub(current.LastObservedAt)
+		if gap <= 0 {
+			continue
+		}
+		if gap > modelCrashObservationMaxGap {
+			current.Consecutive = 1
+			current.LastObservedAt = now
+			continue
+		}
+		current.LastObservedAt = now
+		current.Consecutive++
+		if current.Consecutive < 2 {
+			continue
+		}
+		current.HandledObservationKey = observationKey
+		current.Consecutive = 0
+
+		if current.LocalRestarts == 0 {
+			// Write intent before the external restart so daemon termination
+			// cannot replay this one-shot action.
+			current.LocalRestarts = 1
+			current.RecoveryAction = "local-restart-pending"
+			if err := s.save(); err != nil {
+				return err
+			}
+			if err := s.executor.Restart(candidate, "opencode-local"); err != nil {
+				current.RecoveryAction = "local-restart-failed"
+				current.RecoveryExhausted = true
+				current.NextProbeAt = now.Add(modelCrashControlProbeInterval)
+				s.alertOnce(current.IncidentID+":local-restart-failed",
+					fmt.Sprintf("Local model-crash restart failed for %s: %v", candidate.Identity, err))
+			} else {
+				current.RecoveryAction = "local-restart"
+				current.RecoveryExhausted = false
+			}
+			continue
+		}
+
+		if candidate.Role == "polecat" && current.GoContinuations == 0 &&
+			s.executor.ActivePolecat(candidate) &&
+			s.executor.AllowsContinuation(candidate, "opencode-local", "opencode-go") {
+			// Persist the one hosted attempt before dispatch. This is the
+			// at-most-once boundary across daemon crashes and restarts.
+			current.GoContinuations = 1
+			current.RecoveryAction = "go-continuation-pending"
+			if err := s.save(); err != nil {
+				return err
+			}
+			if err := s.executor.Restart(candidate, "opencode-go"); err != nil {
+				current.RecoveryAction = "go-continuation-failed"
+				current.RecoveryExhausted = true
+				s.alertOnce(current.IncidentID+":go-continuation-failed",
+					fmt.Sprintf("OpenCode Go continuation failed for %s: %v", candidate.Identity, err))
+			} else {
+				current.RecoveryAction = "go-continuation"
+				current.RecoveryExhausted = false
+			}
+			continue
+		}
+
+		current.RecoveryAction = "awaiting-local-probe"
+		current.RecoveryExhausted = true
+		current.NextProbeAt = now.Add(modelCrashControlProbeInterval)
+		s.alertOnce(current.IncidentID+":recovery-exhausted",
+			fmt.Sprintf("Model-crash recovery exhausted for %s; hosted continuation is not authorized", candidate.Identity))
+	}
+
+	if changed {
+		return s.save()
+	}
+	return nil
+}
+
+func (s *modelCrashSupervisor) runLocalProbe(candidate modelCrashSession, state *modelCrashSessionState, now time.Time) error {
+	state.ControlProbes++
+	state.NextProbeAt = now.Add(modelCrashControlProbeInterval)
+	state.RecoveryAction = "local-probe-pending"
+	if err := s.save(); err != nil {
+		state.RecoveryAction = "local-probe-state-failed"
+		state.RecoveryExhausted = true
+		return err
+	}
+	if err := s.executor.Restart(candidate, "opencode-local"); err != nil {
+		state.RecoveryAction = "local-probe-failed"
+		state.RecoveryExhausted = true
+		s.alertOnce(state.IncidentID+":local-probe-failed",
+			fmt.Sprintf("Local 30-minute model-crash probe failed for %s: %v", candidate.Identity, err))
+		return nil
+	}
+	state.RecoveryAction = "local-probe"
+	state.RecoveryExhausted = false
+	return nil
+}
+
+func (s *modelCrashSupervisor) alertOnce(key, message string) bool {
+	if _, delivered := s.state.Alerts[key]; delivered {
+		return false
+	}
+	if err := s.executor.Alert(key, message); err != nil {
+		s.state.PendingAlerts[key] = message
+		return false
+	}
+	delete(s.state.PendingAlerts, key)
+	s.state.Alerts[key] = s.clock.Now()
+	return true
+}
+
+func (s *modelCrashSupervisor) retryPendingAlerts() bool {
+	changed := false
+	for key, message := range s.state.PendingAlerts {
+		if _, delivered := s.state.Alerts[key]; delivered {
+			delete(s.state.PendingAlerts, key)
+			changed = true
+			continue
+		}
+		if err := s.executor.Alert(key, message); err != nil {
+			continue
+		}
+		delete(s.state.PendingAlerts, key)
+		s.state.Alerts[key] = s.clock.Now()
+		changed = true
+	}
+	return changed
+}
+
+func newModelCrashIncidentID(identity string, now time.Time) string {
+	replacer := strings.NewReplacer("/", "-", " ", "-", "_", "-")
+	return fmt.Sprintf("model-crash-%d-%s", now.Unix(), replacer.Replace(identity))
+}
+
+// ValidateModelCrashWatchdog verifies the external LM watchdog dependency used
+// by the model-crash supervisor. Recovery remains fail-closed unless the
+// watchdog is readable, healthy, and fresh.
+func ValidateModelCrashWatchdog(townRoot string, now time.Time) error {
+	path := filepath.Join(townRoot, "deacon", "lmstudio-watchdog.json")
+	data, err := os.ReadFile(path) //nolint:gosec // path is derived from discovered town root
+	if err != nil {
+		return fmt.Errorf("reading LM watchdog state: %w", err)
+	}
+	var watchdog modelCrashWatchdog
+	if err := json.Unmarshal(data, &watchdog); err != nil {
+		return fmt.Errorf("parsing LM watchdog state: %w", err)
+	}
+	return validateModelCrashWatchdog(watchdog, now)
+}
+
+// IsModelCrashRecoveryProvisioned reports whether this town has opted into the
+// external local-model recovery contract. A watchdog file or durable
+// supervisor state is provisioning evidence; unrelated installations with
+// neither are not required to run the watchdog.
+func IsModelCrashRecoveryProvisioned(townRoot string) bool {
+	for _, path := range []string{
+		filepath.Join(townRoot, "bin", "gt-lmstudio-watchdog"),
+		filepath.Join(townRoot, "deacon", "lmstudio-watchdog.json"),
+		modelCrashStateFile(townRoot),
+	} {
+		if _, err := os.Lstat(path); err == nil || !os.IsNotExist(err) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateModelCrashWatchdog(watchdog modelCrashWatchdog, now time.Time) error {
+	if watchdog.Status != "healthy" {
+		return fmt.Errorf("LM watchdog status is %q, want healthy", watchdog.Status)
+	}
+	if watchdog.CheckedAt.IsZero() {
+		return fmt.Errorf("LM watchdog has no check timestamp")
+	}
+	age := now.Sub(watchdog.CheckedAt)
+	if age < 0 {
+		return fmt.Errorf("LM watchdog check timestamp is in the future")
+	}
+	if age > modelCrashWatchdogMaxAge {
+		return fmt.Errorf("LM watchdog state is stale (%s old; maximum %s)",
+			age.Round(time.Second), modelCrashWatchdogMaxAge)
+	}
+	return nil
+}
+
+// ModelCrashSessionHealth is additive recovery visibility for `gt session
+// health`. Missing state leaves all fields at their zero values.
+type ModelCrashSessionHealth struct {
+	IncidentID        string
+	RecoveryAction    string
+	RecoveryExhausted bool
+}
+
+// ModelCrashRecoveryIncident is read-only durable recovery visibility for
+// status surfaces such as Doctor.
+type ModelCrashRecoveryIncident struct {
+	Identity          string
+	SessionName       string
+	IncidentID        string
+	RecoveryAction    string
+	RecoveryExhausted bool
+	Confirmed         bool
+}
+
+// LoadModelCrashRecoveryIncidents returns active durable incident records.
+func LoadModelCrashRecoveryIncidents(townRoot string) ([]ModelCrashRecoveryIncident, error) {
+	data, err := os.ReadFile(modelCrashStateFile(townRoot)) //nolint:gosec // path is derived from discovered town root
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var state modelCrashState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	incidents := make([]ModelCrashRecoveryIncident, 0, len(state.Sessions))
+	for identity, candidate := range state.Sessions {
+		if candidate == nil {
+			continue
+		}
+		incidents = append(incidents, ModelCrashRecoveryIncident{
+			Identity:          identity,
+			SessionName:       candidate.SessionName,
+			IncidentID:        candidate.IncidentID,
+			RecoveryAction:    candidate.RecoveryAction,
+			RecoveryExhausted: candidate.RecoveryExhausted,
+			Confirmed: candidate.LocalRestarts > 0 || candidate.GoContinuations > 0 ||
+				candidate.ControlProbes > 0 || candidate.RecoveryAction != "",
+		})
+	}
+	return incidents, nil
+}
+
+// LoadModelCrashSessionHealth returns durable supervisor state for a tmux
+// session without changing that state.
+func LoadModelCrashSessionHealth(townRoot, sessionName string) (ModelCrashSessionHealth, error) {
+	incidents, err := LoadModelCrashRecoveryIncidents(townRoot)
+	if err != nil {
+		return ModelCrashSessionHealth{}, err
+	}
+	for _, candidate := range incidents {
+		if candidate.SessionName == sessionName {
+			return ModelCrashSessionHealth{
+				IncidentID:        candidate.IncidentID,
+				RecoveryAction:    candidate.RecoveryAction,
+				RecoveryExhausted: candidate.RecoveryExhausted,
+			}, nil
+		}
+	}
+	return ModelCrashSessionHealth{}, nil
+}

--- a/internal/daemon/model_crash_supervisor_test.go
+++ b/internal/daemon/model_crash_supervisor_test.go
@@ -24,6 +24,11 @@ func TestModelCrashSupervisorIntervals(t *testing.T) {
 	if modelCrashProgressResetInterval != 30*time.Minute {
 		t.Fatalf("progress reset interval = %v, want 30m", modelCrashProgressResetInterval)
 	}
+	if modelStallNudgeAfter != 15*time.Minute || modelStallLocalRestartAfter != 30*time.Minute ||
+		modelStallGoEscalateAfter != 60*time.Minute {
+		t.Fatalf("stall intervals = %v/%v/%v",
+			modelStallNudgeAfter, modelStallLocalRestartAfter, modelStallGoEscalateAfter)
+	}
 }
 
 func TestModelCrashWorkerWorkUnitExtraction(t *testing.T) {
@@ -108,6 +113,15 @@ func (e *fakeModelCrashExecutor) Restart(s modelCrashSession, agent string) erro
 	return e.restartErr
 }
 
+func (e *fakeModelCrashExecutor) Nudge(s modelCrashSession, message string) error {
+	e.actions = append(e.actions, modelCrashAction{kind: "nudge", identity: s.Identity})
+	return nil
+}
+
+func (e *fakeModelCrashExecutor) RecoveryPolicy(modelCrashSession) modelCrashRecoveryPolicy {
+	return defaultModelCrashRecoveryPolicy()
+}
+
 func (e *fakeModelCrashExecutor) ActivePolecat(s modelCrashSession) bool {
 	return e.activePolecats[s.Identity]
 }
@@ -172,6 +186,55 @@ func TestModelCrashSupervisorRequiresTwoIdenticalObservations(t *testing.T) {
 	}
 	if len(executor.actions) != 1 || executor.actions[0].agent != "opencode-local" {
 		t.Fatalf("second identical observation actions = %#v, want one local restart", executor.actions)
+	}
+}
+
+func TestModelCrashSupervisorStallLadder(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	clock := &fakeModelCrashClock{now: now}
+	candidate := fatalLocalSession("rig/polecats/nux", "polecat", "run-1")
+	candidate.Output = "waiting"
+	candidate.HeartbeatAt = now.Add(-modelStallNudgeAfter)
+	executor := &fakeModelCrashExecutor{
+		sessions:          []modelCrashSession{candidate},
+		watchdog:          healthyWatchdog(now),
+		activePolecats:    map[string]bool{candidate.Identity: true},
+		escalationAllowed: map[string]bool{candidate.Identity: true},
+	}
+	supervisor := newTestModelCrashSupervisor(t, clock, executor)
+
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if len(executor.actions) != 1 || executor.actions[0].kind != "nudge" {
+		t.Fatalf("15m actions = %#v, want one nudge", executor.actions)
+	}
+
+	clock.now = candidate.HeartbeatAt.Add(modelStallLocalRestartAfter)
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if len(executor.actions) != 2 || executor.actions[1].agent != "opencode-local" {
+		t.Fatalf("30m actions = %#v, want local restart", executor.actions)
+	}
+
+	clock.now = candidate.HeartbeatAt.Add(modelStallGoEscalateAfter)
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if len(executor.actions) != 3 || executor.actions[2].agent != "opencode-go" {
+		t.Fatalf("60m actions = %#v, want Go continuation", executor.actions)
+	}
+
+	clock.now = clock.now.Add(time.Minute)
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if len(executor.actions) != 3 {
+		t.Fatalf("ladder replayed action: %#v", executor.actions)
 	}
 }
 

--- a/internal/daemon/model_crash_supervisor_test.go
+++ b/internal/daemon/model_crash_supervisor_test.go
@@ -1,0 +1,832 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/dog"
+	"github.com/steveyegge/gastown/internal/session"
+)
+
+func TestModelCrashSupervisorIntervals(t *testing.T) {
+	if modelCrashScanInterval != 60*time.Second {
+		t.Fatalf("scan interval = %v, want 60s", modelCrashScanInterval)
+	}
+	if modelCrashControlProbeInterval != 30*time.Minute {
+		t.Fatalf("control probe interval = %v, want 30m", modelCrashControlProbeInterval)
+	}
+	if modelCrashProgressResetInterval != 30*time.Minute {
+		t.Fatalf("progress reset interval = %v, want 30m", modelCrashProgressResetInterval)
+	}
+}
+
+func TestModelCrashWorkerWorkUnitExtraction(t *testing.T) {
+	const identity = "rig/polecats/slit"
+	if got, active := modelCrashPolecatWorkUnit(&AgentBeadInfo{
+		HookBead: "gt-hook-a",
+		State:    string(beads.AgentStateWorking),
+	}, false, identity, identity); !active || got != "gt-hook-a" {
+		t.Fatalf("active polecat work unit = %q/%v, want gt-hook-a/true", got, active)
+	}
+	if got, active := modelCrashPolecatWorkUnit(&AgentBeadInfo{
+		HookBead: "gt-hook-a",
+		State:    string(beads.AgentStateWorking),
+	}, false, "rig/polecats/nux", identity); active || got != "" {
+		t.Fatalf("stale reassigned hook became work unit = %q/%v", got, active)
+	}
+	for _, tt := range []struct {
+		name   string
+		info   *AgentBeadInfo
+		closed bool
+	}{
+		{name: "no hook", info: &AgentBeadInfo{}},
+		{name: "done", info: &AgentBeadInfo{HookBead: "gt-hook", State: string(beads.AgentStateDone)}},
+		{name: "closed hook", info: &AgentBeadInfo{HookBead: "gt-hook"}, closed: true},
+	} {
+		t.Run("polecat "+tt.name, func(t *testing.T) {
+			if got, active := modelCrashPolecatWorkUnit(tt.info, tt.closed, identity, identity); active || got != "" {
+				t.Fatalf("idle polecat work unit = %q/%v", got, active)
+			}
+		})
+	}
+
+	if got, active := modelCrashDogWorkUnit(&dog.Dog{
+		State: dog.StateWorking,
+		Work:  "mol-dog-work",
+	}); !active || got != "mol-dog-work" {
+		t.Fatalf("active Dog work unit = %q/%v, want mol-dog-work/true", got, active)
+	}
+	for _, candidate := range []*dog.Dog{
+		{State: dog.StateIdle, Work: "old-work"},
+		{State: dog.StateWorking},
+	} {
+		if got, active := modelCrashDogWorkUnit(candidate); active || got != "" {
+			t.Fatalf("idle Dog work unit = %q/%v", got, active)
+		}
+	}
+}
+
+type fakeModelCrashClock struct {
+	now time.Time
+}
+
+func (c *fakeModelCrashClock) Now() time.Time { return c.now }
+
+type modelCrashAction struct {
+	kind     string
+	identity string
+	agent    string
+}
+
+type fakeModelCrashExecutor struct {
+	sessions          []modelCrashSession
+	watchdog          modelCrashWatchdog
+	watchdogErr       error
+	activePolecats    map[string]bool
+	escalationAllowed map[string]bool
+	actions           []modelCrashAction
+	restartErr        error
+	alertFailures     int
+}
+
+func (e *fakeModelCrashExecutor) Sessions() ([]modelCrashSession, error) {
+	return e.sessions, nil
+}
+
+func (e *fakeModelCrashExecutor) LMWatchdog() (modelCrashWatchdog, error) {
+	return e.watchdog, e.watchdogErr
+}
+
+func (e *fakeModelCrashExecutor) Restart(s modelCrashSession, agent string) error {
+	e.actions = append(e.actions, modelCrashAction{kind: "restart", identity: s.Identity, agent: agent})
+	return e.restartErr
+}
+
+func (e *fakeModelCrashExecutor) ActivePolecat(s modelCrashSession) bool {
+	return e.activePolecats[s.Identity]
+}
+
+func (e *fakeModelCrashExecutor) AllowsContinuation(s modelCrashSession, fromAgent, toAgent string) bool {
+	return e.escalationAllowed[s.Identity] && fromAgent == "opencode-local" && toAgent == "opencode-go"
+}
+
+func (e *fakeModelCrashExecutor) Alert(key, message string) error {
+	e.actions = append(e.actions, modelCrashAction{kind: "alert", identity: key})
+	if e.alertFailures > 0 {
+		e.alertFailures--
+		return errors.New("alert failed")
+	}
+	return nil
+}
+
+func fatalLocalSession(identity, role, instance string) modelCrashSession {
+	candidate := modelCrashSession{
+		Name:       "tmux-" + identity,
+		InstanceID: instance,
+		Identity:   identity,
+		Role:       role,
+		Agent:      "opencode-local",
+		Output:     session.ModelCrashFatalSignature,
+	}
+	if role == "polecat" || role == "dog" {
+		candidate.WorkUnit = "work-" + identity
+	}
+	return candidate
+}
+
+func healthyWatchdog(now time.Time) modelCrashWatchdog {
+	return modelCrashWatchdog{Status: "healthy", CheckedAt: now.Add(-30 * time.Second)}
+}
+
+func newTestModelCrashSupervisor(t *testing.T, clock *fakeModelCrashClock, executor *fakeModelCrashExecutor) *modelCrashSupervisor {
+	t.Helper()
+	return newModelCrashSupervisor(filepath.Join(t.TempDir(), "model-crash-supervisor.json"), clock, executor)
+}
+
+func TestModelCrashSupervisorRequiresTwoIdenticalObservations(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	clock := &fakeModelCrashClock{now: now}
+	executor := &fakeModelCrashExecutor{
+		sessions: []modelCrashSession{fatalLocalSession("rig/polecats/toast", "polecat", "run-1")},
+		watchdog: healthyWatchdog(now),
+	}
+	supervisor := newTestModelCrashSupervisor(t, clock, executor)
+
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if len(executor.actions) != 0 {
+		t.Fatalf("first observation took action: %#v", executor.actions)
+	}
+
+	clock.now = clock.now.Add(modelCrashScanInterval)
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if len(executor.actions) != 1 || executor.actions[0].agent != "opencode-local" {
+		t.Fatalf("second identical observation actions = %#v, want one local restart", executor.actions)
+	}
+}
+
+func TestModelCrashSupervisorCorrelationIncludesSessionInstanceAndFingerprint(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	clock := &fakeModelCrashClock{now: now}
+	executor := &fakeModelCrashExecutor{
+		sessions: []modelCrashSession{fatalLocalSession("deacon", "deacon", "run-1")},
+		watchdog: healthyWatchdog(now),
+	}
+	supervisor := newTestModelCrashSupervisor(t, clock, executor)
+
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	executor.sessions[0].InstanceID = "run-2"
+	clock.now = clock.now.Add(modelCrashScanInterval)
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if len(executor.actions) != 0 {
+		t.Fatalf("different session instance correlated with prior crash: %#v", executor.actions)
+	}
+}
+
+func TestModelCrashSupervisorLongObservationGapRequiresFreshPair(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	clock := &fakeModelCrashClock{now: now}
+	executor := &fakeModelCrashExecutor{
+		sessions: []modelCrashSession{fatalLocalSession("deacon", "deacon", "run-1")},
+		watchdog: healthyWatchdog(now),
+	}
+	supervisor := newTestModelCrashSupervisor(t, clock, executor)
+
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	clock.now = clock.now.Add(2*modelCrashScanInterval + time.Second)
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if len(executor.actions) != 0 {
+		t.Fatalf("stale observation pair took action: %#v", executor.actions)
+	}
+
+	clock.now = clock.now.Add(modelCrashScanInterval)
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if len(executor.actions) != 1 || executor.actions[0].agent != "opencode-local" {
+		t.Fatalf("fresh adjacent pair actions = %#v, want one local restart", executor.actions)
+	}
+}
+
+func TestModelCrashSupervisorRequiresFreshHealthyLMWatchdog(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name     string
+		watchdog modelCrashWatchdog
+		err      error
+	}{
+		{name: "recovering", watchdog: modelCrashWatchdog{Status: "recovering-local", CheckedAt: now}},
+		{name: "stale", watchdog: modelCrashWatchdog{Status: "healthy", CheckedAt: now.Add(-modelCrashWatchdogMaxAge - time.Second)}},
+		{name: "unreadable", err: errors.New("read failed")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clock := &fakeModelCrashClock{now: now}
+			executor := &fakeModelCrashExecutor{
+				sessions:    []modelCrashSession{fatalLocalSession("deacon", "deacon", "run-1")},
+				watchdog:    tt.watchdog,
+				watchdogErr: tt.err,
+			}
+			supervisor := newTestModelCrashSupervisor(t, clock, executor)
+			if err := supervisor.Scan(); err != nil {
+				t.Fatal(err)
+			}
+			clock.now = clock.now.Add(modelCrashScanInterval)
+			if err := supervisor.Scan(); err != nil {
+				t.Fatal(err)
+			}
+			if len(executor.actions) != 0 {
+				t.Fatalf("unsafe watchdog state took action: %#v", executor.actions)
+			}
+		})
+	}
+}
+
+func TestModelCrashSupervisorCoversLocalRolesButExcludesBoot(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	clock := &fakeModelCrashClock{now: now}
+	executor := &fakeModelCrashExecutor{
+		sessions: []modelCrashSession{
+			fatalLocalSession("mayor", "mayor", "mayor-1"),
+			fatalLocalSession("deacon", "deacon", "deacon-1"),
+			fatalLocalSession("rig/witness", "witness", "witness-1"),
+			fatalLocalSession("rig/refinery", "refinery", "refinery-1"),
+			fatalLocalSession("rig/crew/max", "crew", "crew-1"),
+			fatalLocalSession("rig/polecats/toast", "polecat", "polecat-1"),
+			fatalLocalSession("deacon/dogs/scout", "dog", "dog-1"),
+			fatalLocalSession("deacon/boot", "boot", "boot-1"),
+			{Name: "hosted", InstanceID: "hosted-1", Identity: "rig/crew/hosted", Role: "crew", Agent: "opencode-go", Output: session.ModelCrashFatalSignature},
+		},
+		watchdog: healthyWatchdog(now),
+	}
+	supervisor := newTestModelCrashSupervisor(t, clock, executor)
+
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	clock.now = clock.now.Add(modelCrashScanInterval)
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+
+	restarts := 0
+	for _, action := range executor.actions {
+		if action.kind == "restart" {
+			restarts++
+			if action.identity == "deacon/boot" || action.identity == "rig/crew/hosted" {
+				t.Fatalf("excluded session restarted: %#v", action)
+			}
+		}
+	}
+	if restarts != 7 {
+		t.Fatalf("local role restart count = %d, want 7; actions=%#v", restarts, executor.actions)
+	}
+}
+
+func TestModelCrashSupervisorEscalatesActivePolecatExactlyOnceAfterRepeat(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	identity := "rig/polecats/toast"
+	clock := &fakeModelCrashClock{now: now}
+	executor := &fakeModelCrashExecutor{
+		sessions:          []modelCrashSession{fatalLocalSession(identity, "polecat", "run-local")},
+		watchdog:          healthyWatchdog(now),
+		activePolecats:    map[string]bool{identity: true},
+		escalationAllowed: map[string]bool{identity: true},
+	}
+	supervisor := newTestModelCrashSupervisor(t, clock, executor)
+
+	scanTwice := func(instance string) {
+		t.Helper()
+		executor.sessions[0].InstanceID = instance
+		for i := 0; i < 2; i++ {
+			executor.watchdog = healthyWatchdog(clock.now)
+			if err := supervisor.Scan(); err != nil {
+				t.Fatal(err)
+			}
+			clock.now = clock.now.Add(modelCrashScanInterval)
+		}
+	}
+	scanTwice("run-local")
+	scanTwice("run-repeat")
+	scanTwice("run-go-repeat")
+
+	var local, hosted int
+	for _, action := range executor.actions {
+		if action.kind != "restart" {
+			continue
+		}
+		switch action.agent {
+		case "opencode-local":
+			local++
+		case "opencode-go":
+			hosted++
+		}
+	}
+	if local != 1 || hosted != 1 {
+		t.Fatalf("restart counts local=%d hosted=%d, want 1/1; actions=%#v", local, hosted, executor.actions)
+	}
+}
+
+func TestModelCrashSupervisorWorkUnitChangeResetsPolecatBudgets(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	identity := "rig/polecats/toast"
+	clock := &fakeModelCrashClock{now: now}
+	candidate := fatalLocalSession(identity, "polecat", "work-a-local")
+	candidate.WorkUnit = "hook-a"
+	executor := &fakeModelCrashExecutor{
+		sessions:          []modelCrashSession{candidate},
+		watchdog:          healthyWatchdog(now),
+		activePolecats:    map[string]bool{identity: true},
+		escalationAllowed: map[string]bool{identity: true},
+	}
+	supervisor := newTestModelCrashSupervisor(t, clock, executor)
+
+	scanPair := func(instance, workUnit string) {
+		t.Helper()
+		executor.sessions[0].InstanceID = instance
+		executor.sessions[0].WorkUnit = workUnit
+		for i := 0; i < 2; i++ {
+			executor.watchdog = healthyWatchdog(clock.now)
+			if err := supervisor.Scan(); err != nil {
+				t.Fatal(err)
+			}
+			clock.now = clock.now.Add(modelCrashScanInterval)
+		}
+	}
+
+	scanPair("work-a-local", "hook-a")
+	scanPair("work-a-repeat", "hook-a")
+	scanPair("work-b-local", "hook-b")
+	scanPair("work-b-repeat", "hook-b")
+
+	var local, hosted int
+	for _, action := range executor.actions {
+		if action.kind != "restart" {
+			continue
+		}
+		switch action.agent {
+		case "opencode-local":
+			local++
+		case "opencode-go":
+			hosted++
+		}
+	}
+	if local != 2 || hosted != 2 {
+		t.Fatalf("work-unit restart budgets local=%d hosted=%d, want 2/2; actions=%#v",
+			local, hosted, executor.actions)
+	}
+	state := supervisor.state.Sessions[identity]
+	if state == nil || state.WorkUnit != "hook-b" ||
+		state.LocalRestarts != 1 || state.GoContinuations != 1 {
+		t.Fatalf("current work unit did not own fresh budgets: %#v", state)
+	}
+	data, err := os.ReadFile(supervisor.statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var persisted modelCrashState
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if got := persisted.Sessions[identity]; got == nil || got.WorkUnit != "hook-b" {
+		t.Fatalf("current work unit was not durable: %#v", got)
+	}
+}
+
+func TestModelCrashSupervisorIgnoresIdleWorkersButCoversControlsAndCrew(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	clock := &fakeModelCrashClock{now: now}
+	idlePolecat := fatalLocalSession("rig/polecats/idle", "polecat", "polecat-1")
+	idlePolecat.WorkUnit = ""
+	idleDog := fatalLocalSession("deacon/dogs/idle", "dog", "dog-1")
+	idleDog.WorkUnit = ""
+	executor := &fakeModelCrashExecutor{
+		sessions: []modelCrashSession{
+			idlePolecat,
+			idleDog,
+			fatalLocalSession("deacon", "deacon", "deacon-1"),
+			fatalLocalSession("rig/crew/max", "crew", "crew-1"),
+		},
+		watchdog: healthyWatchdog(now),
+	}
+	supervisor := newTestModelCrashSupervisor(t, clock, executor)
+
+	for i := 0; i < 2; i++ {
+		executor.watchdog = healthyWatchdog(clock.now)
+		if err := supervisor.Scan(); err != nil {
+			t.Fatal(err)
+		}
+		clock.now = clock.now.Add(modelCrashScanInterval)
+	}
+	for _, action := range executor.actions {
+		if action.identity == idlePolecat.Identity || action.identity == idleDog.Identity {
+			t.Fatalf("idle worker took recovery action: %#v", executor.actions)
+		}
+	}
+	if len(executor.actions) != 2 {
+		t.Fatalf("control/Crew restart actions = %#v, want 2", executor.actions)
+	}
+	if supervisor.state.Sessions[idlePolecat.Identity] != nil ||
+		supervisor.state.Sessions[idleDog.Identity] != nil {
+		t.Fatalf("idle workers gained incidents: %#v", supervisor.state.Sessions)
+	}
+}
+
+func TestModelCrashSupervisorDeniesHostedContinuationWithoutActivePolicy(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		role    string
+		active  bool
+		allowed bool
+	}{
+		{name: "control role", role: "deacon", active: true, allowed: true},
+		{name: "dog role", role: "dog", active: true, allowed: true},
+		{name: "inactive polecat", role: "polecat", active: false, allowed: true},
+		{name: "missing worktree policy", role: "polecat", active: true, allowed: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			identity := "rig/polecats/toast"
+			if tt.role != "polecat" {
+				identity = tt.role
+			}
+			clock := &fakeModelCrashClock{now: now}
+			executor := &fakeModelCrashExecutor{
+				sessions:          []modelCrashSession{fatalLocalSession(identity, tt.role, "run-local")},
+				watchdog:          healthyWatchdog(now),
+				activePolecats:    map[string]bool{identity: tt.active},
+				escalationAllowed: map[string]bool{identity: tt.allowed},
+			}
+			supervisor := newTestModelCrashSupervisor(t, clock, executor)
+
+			for _, instance := range []string{"run-local", "run-repeat"} {
+				executor.sessions[0].InstanceID = instance
+				for i := 0; i < 2; i++ {
+					executor.watchdog = healthyWatchdog(clock.now)
+					if err := supervisor.Scan(); err != nil {
+						t.Fatal(err)
+					}
+					clock.now = clock.now.Add(modelCrashScanInterval)
+				}
+			}
+			for _, action := range executor.actions {
+				if action.kind == "restart" && action.agent == "opencode-go" {
+					t.Fatalf("unauthorized hosted continuation: %#v", executor.actions)
+				}
+			}
+
+			state := supervisor.state.Sessions[identity]
+			if state == nil || state.NextProbeAt.Sub(clock.now) > modelCrashControlProbeInterval {
+				t.Fatalf("local-only session missing bounded 30m probe state: %#v", state)
+			}
+
+			restartsBeforeProbe := len(executor.actions)
+			clock.now = state.NextProbeAt.Add(-time.Second)
+			executor.watchdog = healthyWatchdog(clock.now)
+			if err := supervisor.Scan(); err != nil {
+				t.Fatal(err)
+			}
+			if len(executor.actions) != restartsBeforeProbe {
+				t.Fatalf("control probe ran before 30m cooldown: %#v", executor.actions)
+			}
+
+			clock.now = state.NextProbeAt
+			executor.watchdog = healthyWatchdog(clock.now)
+			if err := supervisor.Scan(); err != nil {
+				t.Fatal(err)
+			}
+			last := executor.actions[len(executor.actions)-1]
+			if last.kind != "restart" || last.agent != "opencode-local" {
+				t.Fatalf("30m control probe action = %#v, want local restart", last)
+			}
+		})
+	}
+}
+
+func TestModelCrashSupervisorControlProbeFailureReentersCooldown(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	clock := &fakeModelCrashClock{now: now}
+	executor := &fakeModelCrashExecutor{
+		sessions: []modelCrashSession{fatalLocalSession("deacon", "deacon", "run-local")},
+		watchdog: healthyWatchdog(now),
+	}
+	supervisor := newTestModelCrashSupervisor(t, clock, executor)
+
+	for _, instance := range []string{"run-local", "run-repeat"} {
+		executor.sessions[0].InstanceID = instance
+		for i := 0; i < 2; i++ {
+			executor.watchdog = healthyWatchdog(clock.now)
+			if err := supervisor.Scan(); err != nil {
+				t.Fatal(err)
+			}
+			clock.now = clock.now.Add(modelCrashScanInterval)
+		}
+	}
+	state := supervisor.state.Sessions["deacon"]
+	executor.restartErr = errors.New("probe restart failed")
+	clock.now = state.NextProbeAt
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if !state.NextProbeAt.Equal(clock.now.Add(modelCrashControlProbeInterval)) {
+		t.Fatalf("next probe = %v, want %v", state.NextProbeAt, clock.now.Add(modelCrashControlProbeInterval))
+	}
+}
+
+func TestModelCrashSupervisorResetsIncidentOnlyAfterObservedProgressWindow(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	identity := "rig/polecats/toast"
+	clock := &fakeModelCrashClock{now: now}
+	executor := &fakeModelCrashExecutor{
+		sessions: []modelCrashSession{fatalLocalSession(identity, "polecat", "run-local")},
+		watchdog: healthyWatchdog(now),
+	}
+	supervisor := newTestModelCrashSupervisor(t, clock, executor)
+
+	for i := 0; i < 2; i++ {
+		executor.watchdog = healthyWatchdog(clock.now)
+		if err := supervisor.Scan(); err != nil {
+			t.Fatal(err)
+		}
+		clock.now = clock.now.Add(modelCrashScanInterval)
+	}
+	executor.sessions[0].Output = "assistant: making verified progress"
+	executor.sessions[0].InstanceID = "run-recovered"
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if supervisor.state.Sessions[identity] == nil {
+		t.Fatal("incident reset immediately instead of waiting for observed progress window")
+	}
+
+	clock.now = clock.now.Add(modelCrashProgressResetInterval - time.Second)
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if supervisor.state.Sessions[identity] == nil {
+		t.Fatal("incident reset before 30m observed progress")
+	}
+
+	clock.now = clock.now.Add(time.Second)
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	if supervisor.state.Sessions[identity] != nil {
+		t.Fatalf("incident persisted after 30m observed progress: %#v", supervisor.state.Sessions[identity])
+	}
+}
+
+func TestModelCrashSupervisorPersistsStateAndDeduplicatesAlerts(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	identity := "deacon"
+	townRoot := t.TempDir()
+	statePath := modelCrashStateFile(townRoot)
+	clock := &fakeModelCrashClock{now: now}
+	executor := &fakeModelCrashExecutor{
+		sessions: []modelCrashSession{fatalLocalSession(identity, "deacon", "run-1")},
+		watchdog: healthyWatchdog(now),
+	}
+
+	supervisor := newModelCrashSupervisor(statePath, clock, executor)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+	clock.now = clock.now.Add(modelCrashScanInterval)
+	executor.watchdog = healthyWatchdog(clock.now)
+	if err := supervisor.Scan(); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded := newModelCrashSupervisor(statePath, clock, executor)
+	if err := reloaded.load(); err != nil {
+		t.Fatal(err)
+	}
+	if got := reloaded.state.Sessions[identity]; got == nil || got.LocalRestarts != 1 {
+		t.Fatalf("durable local restart state = %#v", got)
+	}
+	health, err := LoadModelCrashSessionHealth(townRoot, executor.sessions[0].Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if health.IncidentID == "" || health.RecoveryAction != "local-restart" || health.RecoveryExhausted {
+		t.Fatalf("additive health state = %#v", health)
+	}
+
+	executor.sessions[0].InstanceID = "run-repeat"
+	for i := 0; i < 4; i++ {
+		executor.watchdog = healthyWatchdog(clock.now)
+		if err := reloaded.Scan(); err != nil {
+			t.Fatal(err)
+		}
+		clock.now = clock.now.Add(modelCrashScanInterval)
+	}
+	alerts := 0
+	for _, action := range executor.actions {
+		if action.kind == "alert" {
+			alerts++
+		}
+	}
+	if alerts != 1 {
+		t.Fatalf("alert count = %d, want one repeat-crash exhaustion alert; actions=%#v", alerts, executor.actions)
+	}
+}
+
+func TestModelCrashSupervisorReloadExhaustsPendingActionsWithoutReplay(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		action          string
+		localRestarts   int
+		goContinuations int
+		controlProbes   int
+	}{
+		{action: "local-restart-pending", localRestarts: 1},
+		{action: "go-continuation-pending", localRestarts: 1, goContinuations: 1},
+		{action: "local-probe-pending", localRestarts: 1, controlProbes: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			identity := "rig/polecats/toast"
+			clock := &fakeModelCrashClock{now: now}
+			executor := &fakeModelCrashExecutor{
+				sessions:      []modelCrashSession{fatalLocalSession(identity, "polecat", "run-1")},
+				watchdog:      healthyWatchdog(now),
+				alertFailures: 1,
+			}
+			statePath := filepath.Join(t.TempDir(), "model-crash-supervisor.json")
+			before := newModelCrashSupervisor(statePath, clock, executor)
+			observationKey := "run-1|" + session.ModelCrashFatalFingerprint
+			before.state.Sessions[identity] = &modelCrashSessionState{
+				SessionName:           "tmux-" + identity,
+				IncidentID:            "model-crash-interrupted",
+				WorkUnit:              executor.sessions[0].WorkUnit,
+				ObservationKey:        observationKey,
+				HandledObservationKey: observationKey,
+				LocalRestarts:         tt.localRestarts,
+				GoContinuations:       tt.goContinuations,
+				ControlProbes:         tt.controlProbes,
+				RecoveryAction:        tt.action,
+			}
+			if err := before.save(); err != nil {
+				t.Fatal(err)
+			}
+
+			reloaded := newModelCrashSupervisor(statePath, clock, executor)
+			if err := reloaded.Scan(); err != nil {
+				t.Fatal(err)
+			}
+			got := reloaded.state.Sessions[identity]
+			if got == nil || !got.RecoveryExhausted || strings.HasSuffix(got.RecoveryAction, "-pending") {
+				t.Fatalf("reloaded pending action was not exhausted: %#v", got)
+			}
+			for _, action := range executor.actions {
+				if action.kind == "restart" {
+					t.Fatalf("reloaded pending action was replayed: %#v", executor.actions)
+				}
+			}
+			if len(reloaded.state.PendingAlerts) != 1 {
+				t.Fatalf("failed interruption alert was not durable: %#v", reloaded.state)
+			}
+
+			executor.alertFailures = 0
+			again := newModelCrashSupervisor(statePath, clock, executor)
+			if err := again.Scan(); err != nil {
+				t.Fatal(err)
+			}
+			if len(again.state.PendingAlerts) != 0 || len(again.state.Alerts) != 1 {
+				t.Fatalf("interruption alert was not retried and deduplicated: %#v", again.state)
+			}
+			for _, action := range executor.actions {
+				if action.kind == "restart" {
+					t.Fatalf("pending action replayed after second reload: %#v", executor.actions)
+				}
+			}
+		})
+	}
+}
+
+func TestModelCrashSupervisorRetriesFailedAlertThenDeduplicatesSuccess(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	clock := &fakeModelCrashClock{now: now}
+	executor := &fakeModelCrashExecutor{alertFailures: 1}
+	supervisor := newTestModelCrashSupervisor(t, clock, executor)
+
+	if supervisor.alertOnce("incident:exhausted", "recovery exhausted") {
+		t.Fatal("failed alert reported as delivered")
+	}
+	if !supervisor.alertOnce("incident:exhausted", "recovery exhausted") {
+		t.Fatal("retry after failed alert was suppressed")
+	}
+	if supervisor.alertOnce("incident:exhausted", "recovery exhausted") {
+		t.Fatal("successful alert was not deduplicated")
+	}
+	if got := len(executor.actions); got != 2 {
+		t.Fatalf("alert attempts = %d, want 2", got)
+	}
+}
+
+func TestModelCrashRestartArgsUseSafeRolePrimitives(t *testing.T) {
+	tests := []struct {
+		session modelCrashSession
+		want    string
+	}{
+		{session: modelCrashSession{Role: "mayor", Identity: "mayor"}, want: "mayor restart --agent opencode-local"},
+		{session: modelCrashSession{Role: "deacon", Identity: "deacon"}, want: "deacon restart --agent opencode-local"},
+		{session: modelCrashSession{Role: "witness", Identity: "rig/witness"}, want: "witness restart rig --agent opencode-local"},
+		{session: modelCrashSession{Role: "refinery", Identity: "rig/refinery"}, want: "refinery restart rig --agent opencode-local"},
+		{session: modelCrashSession{Role: "crew", Identity: "rig/crew/max"}, want: "crew restart rig/max --agent opencode-local"},
+		{session: modelCrashSession{Role: "polecat", Identity: "rig/polecats/toast"}, want: "session restart rig/toast --force --agent opencode-local"},
+	}
+	for _, tt := range tests {
+		args, err := modelCrashRestartArgs(tt.session, "opencode-local")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := strings.Join(args, " "); got != tt.want {
+			t.Fatalf("restart args = %q, want %q", got, tt.want)
+		}
+	}
+	if _, err := modelCrashRestartArgs(modelCrashSession{Role: "boot", Identity: "deacon/boot"}, "opencode-local"); err == nil {
+		t.Fatal("Boot unexpectedly has a model-crash restart primitive")
+	}
+}
+
+func TestModelCrashContinuationRequiresExplicitWorktreePolicy(t *testing.T) {
+	workDir := t.TempDir()
+	executor := &daemonModelCrashExecutor{daemon: &Daemon{config: &Config{TownRoot: t.TempDir()}}}
+	candidate := modelCrashSession{Role: "polecat", WorkDir: workDir}
+
+	if executor.AllowsContinuation(candidate, "opencode-local", "opencode-go") {
+		t.Fatal("missing policy authorized hosted continuation")
+	}
+	if err := os.MkdirAll(filepath.Join(workDir, ".gastown"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	policy := `{
+		"type": "model-escalation",
+		"version": 1,
+		"enabled": true,
+		"rules": [{
+			"from_agent": "opencode-local",
+			"to_agent": "opencode-go",
+			"promote_after_failures": 1
+		}]
+	}`
+	if err := os.WriteFile(filepath.Join(workDir, ".gastown", "model-escalation.json"), []byte(policy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !executor.AllowsContinuation(candidate, "opencode-local", "opencode-go") {
+		t.Fatal("explicit local-to-Go worktree policy did not authorize continuation")
+	}
+}
+
+func TestModelCrashAlertUsesDurableHumanRouteAndBestEffortNotification(t *testing.T) {
+	if got := strings.Join(modelCrashHumanAlertArgs("subject", "message"), " "); got != "mail send --human -s subject -m message" {
+		t.Fatalf("human alert args = %q", got)
+	}
+	var mailed, notified bool
+	executor := &daemonModelCrashExecutor{
+		sendHuman: func(subject, message string) error {
+			mailed = subject != "" && message == "recovery exhausted"
+			return nil
+		},
+		notify: func(subject, message string) error {
+			notified = subject != "" && message == "recovery exhausted"
+			return errors.New("notifications unavailable")
+		},
+	}
+	if err := executor.Alert("incident:exhausted", "recovery exhausted"); err != nil {
+		t.Fatalf("best-effort notification made durable alert fail: %v", err)
+	}
+	if !mailed || !notified {
+		t.Fatalf("alert routes mailed=%v notified=%v, want both attempted", mailed, notified)
+	}
+}

--- a/internal/daemon/patrol_rigs_filter_test.go
+++ b/internal/daemon/patrol_rigs_filter_test.go
@@ -1,14 +1,48 @@
 package daemon
 
 import (
+	"bytes"
 	"log"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/wisp"
 )
+
+func TestEnsureRigWispConfigs_CreatesMissingAndPreservesExisting(t *testing.T) {
+	townRoot := t.TempDir()
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0o755); err != nil {
+		t.Fatalf("mkdir mayor dir: %v", err)
+	}
+	rigsJSON := `{"rigs":{"alpha":{},"beta":{}}}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0o644); err != nil {
+		t.Fatalf("write rigs.json: %v", err)
+	}
+	if err := wisp.NewConfig(townRoot, "beta").Set("status", "parked"); err != nil {
+		t.Fatalf("set beta parked: %v", err)
+	}
+
+	var logs bytes.Buffer
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		logger: log.New(&logs, "", 0),
+	}
+	d.ensureRigWispConfigs()
+
+	if _, err := os.Stat(wisp.NewConfig(townRoot, "alpha").ConfigPath()); err != nil {
+		t.Fatalf("alpha config was not created: %v", err)
+	}
+	if got := wisp.NewConfig(townRoot, "beta").GetString("status"); got != "parked" {
+		t.Fatalf("beta status = %q, want parked", got)
+	}
+	if strings.Contains(logs.String(), "no wisp config") {
+		t.Fatalf("unexpected repeated missing-config warning: %s", logs.String())
+	}
+}
 
 // Regression test for gt-arz:
 // getPatrolRigs should filter parked/docked rigs at list-building time.

--- a/internal/daemon/restart_tracker.go
+++ b/internal/daemon/restart_tracker.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/atomicfile"
 )
 
 // RestartTrackerConfig holds configurable parameters for restart tracking.
@@ -38,18 +40,24 @@ type RestartTrackerConfig struct {
 	// quota_dog patrol to rotate accounts (5m cadence), short enough to
 	// recover quickly when the limit resets.
 	PauseBackoff time.Duration `json:"pause_backoff,omitempty"`
+
+	// CrashLoopProbeInterval is the minimum time between local watchdog
+	// probes after a crash-loop latch (default 30m). These probes never
+	// authorize hosted-agent promotion.
+	CrashLoopProbeInterval time.Duration `json:"crash_loop_probe_interval,omitempty"`
 }
 
 // DefaultRestartTrackerConfig returns the default restart tracker configuration.
 func DefaultRestartTrackerConfig() RestartTrackerConfig {
 	return RestartTrackerConfig{
-		InitialBackoff:    30 * time.Second,
-		MaxBackoff:        10 * time.Minute,
-		BackoffMultiplier: 2.0,
-		CrashLoopWindow:   15 * time.Minute,
-		CrashLoopCount:    5,
-		StabilityPeriod:   30 * time.Minute,
-		PauseBackoff:      60 * time.Second,
+		InitialBackoff:         30 * time.Second,
+		MaxBackoff:             10 * time.Minute,
+		BackoffMultiplier:      2.0,
+		CrashLoopWindow:        15 * time.Minute,
+		CrashLoopCount:         5,
+		StabilityPeriod:        30 * time.Minute,
+		PauseBackoff:           60 * time.Second,
+		CrashLoopProbeInterval: 30 * time.Minute,
 	}
 }
 
@@ -77,6 +85,9 @@ func (c RestartTrackerConfig) withDefaults() RestartTrackerConfig {
 	if c.PauseBackoff <= 0 {
 		c.PauseBackoff = d.PauseBackoff
 	}
+	if c.CrashLoopProbeInterval <= 0 {
+		c.CrashLoopProbeInterval = d.CrashLoopProbeInterval
+	}
 	return c
 }
 
@@ -87,6 +98,8 @@ type RestartTracker struct {
 	townRoot string
 	config   RestartTrackerConfig
 	state    *RestartState
+	now      func() time.Time
+	loadErr  error
 }
 
 // RestartState persists restart tracking data.
@@ -96,19 +109,30 @@ type RestartState struct {
 
 // AgentRestartInfo tracks restart info for a single agent.
 type AgentRestartInfo struct {
-	LastRestart    time.Time `json:"last_restart"`
-	RestartCount   int       `json:"restart_count"`
-	BackoffUntil   time.Time `json:"backoff_until"`
-	CrashLoopSince time.Time `json:"crash_loop_since,omitempty"`
+	LastRestart           time.Time   `json:"last_restart"`
+	RestartCount          int         `json:"restart_count"`
+	RecentRestarts        []time.Time `json:"recent_restarts,omitempty"`
+	BackoffUntil          time.Time   `json:"backoff_until"`
+	CrashLoopSince        time.Time   `json:"crash_loop_since,omitempty"`
+	LastWatchdogProbe     time.Time   `json:"last_watchdog_probe,omitempty"`
+	CrashLoopAlertPending bool        `json:"crash_loop_alert_pending,omitempty"`
 }
 
 // NewRestartTracker creates a new restart tracker with the given config.
 // Zero-valued config fields are filled with defaults.
 func NewRestartTracker(townRoot string, cfg RestartTrackerConfig) *RestartTracker {
+	return newRestartTrackerWithClock(townRoot, cfg, time.Now)
+}
+
+func newRestartTrackerWithClock(townRoot string, cfg RestartTrackerConfig, now func() time.Time) *RestartTracker {
+	if now == nil {
+		now = time.Now
+	}
 	return &RestartTracker{
 		townRoot: townRoot,
 		config:   cfg.withDefaults(),
 		state:    &RestartState{Agents: make(map[string]*AgentRestartInfo)},
+		now:      now,
 	}
 }
 
@@ -125,25 +149,56 @@ func (rt *RestartTracker) Load() error {
 	data, err := os.ReadFile(rt.restartStateFile())
 	if err != nil {
 		if os.IsNotExist(err) {
+			rt.state = &RestartState{Agents: make(map[string]*AgentRestartInfo)}
+			rt.loadErr = nil
 			return nil // No state file yet
 		}
+		rt.loadErr = err
 		return err
 	}
 
-	return json.Unmarshal(data, rt.state)
+	// Decode into a temporary value so malformed JSON cannot partially mutate
+	// live restart authorization state.
+	var next *RestartState
+	if err := json.Unmarshal(data, &next); err != nil {
+		rt.loadErr = err
+		return err
+	}
+	if next == nil {
+		err := fmt.Errorf("restart state is null")
+		rt.loadErr = err
+		return err
+	}
+	if next.Agents == nil {
+		next.Agents = make(map[string]*AgentRestartInfo)
+	}
+	for agentID, info := range next.Agents {
+		if info == nil {
+			err := fmt.Errorf("restart state for agent %q is null", agentID)
+			rt.loadErr = err
+			return err
+		}
+	}
+	rt.state = next
+	rt.loadErr = nil
+	return nil
 }
 
 // Save persists the restart state to disk.
 func (rt *RestartTracker) Save() error {
 	rt.mu.RLock()
 	defer rt.mu.RUnlock()
+	return rt.saveLocked()
+}
 
-	data, err := json.MarshalIndent(rt.state, "", "  ")
-	if err != nil {
+func (rt *RestartTracker) saveLocked() error {
+	if rt.loadErr != nil {
+		return fmt.Errorf("restart state unavailable after failed load: %w", rt.loadErr)
+	}
+	if err := os.MkdirAll(filepath.Dir(rt.restartStateFile()), 0o700); err != nil {
 		return err
 	}
-
-	return os.WriteFile(rt.restartStateFile(), data, 0600)
+	return atomicfile.WriteJSONWithPerm(rt.restartStateFile(), rt.state, 0o600)
 }
 
 // CanRestart checks if an agent can be restarted (not in backoff).
@@ -151,6 +206,9 @@ func (rt *RestartTracker) CanRestart(agentID string) bool {
 	rt.mu.RLock()
 	defer rt.mu.RUnlock()
 
+	if rt.loadErr != nil {
+		return false
+	}
 	info, exists := rt.state.Agents[agentID]
 	if !exists {
 		return true
@@ -162,15 +220,17 @@ func (rt *RestartTracker) CanRestart(agentID string) bool {
 	}
 
 	// Check backoff period
-	return time.Now().After(info.BackoffUntil)
+	return !rt.now().Before(info.BackoffUntil)
 }
 
-// RecordRestart records a restart attempt and calculates next backoff.
-func (rt *RestartTracker) RecordRestart(agentID string) {
+// RecordRestart records a restart attempt and calculates next backoff. It
+// returns true only when this call newly latches a crash loop, allowing the
+// caller to emit one deduplicated alert.
+func (rt *RestartTracker) RecordRestart(agentID string) bool {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 
-	now := time.Now()
+	now := rt.now()
 	info, exists := rt.state.Agents[agentID]
 	if !exists {
 		info = &AgentRestartInfo{}
@@ -178,14 +238,28 @@ func (rt *RestartTracker) RecordRestart(agentID string) {
 	}
 
 	// Check if previous restart was stable (long ago)
-	if !info.LastRestart.IsZero() && now.Sub(info.LastRestart) > rt.config.StabilityPeriod {
+	// A crash-loop latch is persistent: the 30-minute local probes must not
+	// clear it merely because they are intentionally far apart.
+	if info.CrashLoopSince.IsZero() &&
+		!info.LastRestart.IsZero() &&
+		now.Sub(info.LastRestart) > rt.config.StabilityPeriod {
 		// Reset backoff - agent was stable
 		info.RestartCount = 0
-		info.CrashLoopSince = time.Time{}
+		info.RecentRestarts = nil
 	}
 
 	info.LastRestart = now
 	info.RestartCount++
+	if info.CrashLoopSince.IsZero() {
+		cutoff := now.Add(-rt.config.CrashLoopWindow)
+		recent := info.RecentRestarts[:0]
+		for _, restart := range info.RecentRestarts {
+			if restart.After(cutoff) {
+				recent = append(recent, restart)
+			}
+		}
+		info.RecentRestarts = append(recent, now)
+	}
 
 	// Calculate backoff with exponential increase
 	backoffDuration := rt.config.InitialBackoff
@@ -198,12 +272,13 @@ func (rt *RestartTracker) RecordRestart(agentID string) {
 	info.BackoffUntil = now.Add(backoffDuration)
 
 	// Check for crash loop
-	if info.RestartCount >= rt.config.CrashLoopCount {
-		windowStart := now.Add(-rt.config.CrashLoopWindow)
-		if info.LastRestart.After(windowStart) {
-			info.CrashLoopSince = now
-		}
+	newlyLatched := false
+	if info.CrashLoopSince.IsZero() && len(info.RecentRestarts) >= rt.config.CrashLoopCount {
+		info.CrashLoopSince = now
+		info.CrashLoopAlertPending = true
+		newlyLatched = true
 	}
+	return newlyLatched
 }
 
 // RecordPause records that an agent is paused due to a transient external
@@ -218,7 +293,7 @@ func (rt *RestartTracker) RecordPause(agentID string) {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 
-	now := time.Now()
+	now := rt.now()
 	info, exists := rt.state.Agents[agentID]
 	if !exists {
 		info = &AgentRestartInfo{}
@@ -241,10 +316,12 @@ func (rt *RestartTracker) RecordSuccess(agentID string) {
 	}
 
 	// If agent has been stable for the stability period, reset tracking
-	if time.Since(info.LastRestart) > rt.config.StabilityPeriod {
+	if rt.now().Sub(info.LastRestart) >= rt.config.StabilityPeriod {
 		info.RestartCount = 0
+		info.RecentRestarts = nil
 		info.CrashLoopSince = time.Time{}
 		info.BackoffUntil = time.Time{}
+		info.LastWatchdogProbe = time.Time{}
 	}
 }
 
@@ -253,6 +330,11 @@ func (rt *RestartTracker) IsInCrashLoop(agentID string) bool {
 	rt.mu.RLock()
 	defer rt.mu.RUnlock()
 
+	// Unknown persisted state is an authorization failure, including for
+	// hosted Boot suppression paths that consult only the crash-loop latch.
+	if rt.loadErr != nil {
+		return true
+	}
 	info, exists := rt.state.Agents[agentID]
 	if !exists {
 		return false
@@ -270,11 +352,91 @@ func (rt *RestartTracker) GetBackoffRemaining(agentID string) time.Duration {
 		return 0
 	}
 
-	remaining := time.Until(info.BackoffUntil)
+	remaining := info.BackoffUntil.Sub(rt.now())
 	if remaining < 0 {
 		return 0
 	}
 	return remaining
+}
+
+// TakeWatchdogProbe atomically consumes one local-only recovery probe for a
+// crash-looping agent when its cooldown has elapsed. It never clears the latch
+// and carries no model or hosted-promotion semantics.
+func (rt *RestartTracker) TakeWatchdogProbe(agentID string) bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	if rt.loadErr != nil {
+		return false
+	}
+	info, exists := rt.state.Agents[agentID]
+	if !exists || info.CrashLoopSince.IsZero() {
+		return false
+	}
+
+	last := info.LastWatchdogProbe
+	if last.IsZero() {
+		last = info.CrashLoopSince
+	}
+	now := rt.now()
+	if now.Before(last.Add(rt.config.CrashLoopProbeInterval)) {
+		return false
+	}
+	info.LastWatchdogProbe = now
+	return true
+}
+
+// TakeWatchdogProbePersisted consumes a probe only if the updated gate can be
+// durably saved. Persistence failure rolls the in-memory timestamp back so the
+// daemon fails closed without starting a local probe.
+func (rt *RestartTracker) TakeWatchdogProbePersisted(agentID string) (bool, error) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	if rt.loadErr != nil {
+		return false, fmt.Errorf("restart state unavailable after failed load: %w", rt.loadErr)
+	}
+	info, exists := rt.state.Agents[agentID]
+	if !exists || info.CrashLoopSince.IsZero() {
+		return false, nil
+	}
+	last := info.LastWatchdogProbe
+	if last.IsZero() {
+		last = info.CrashLoopSince
+	}
+	now := rt.now()
+	if now.Before(last.Add(rt.config.CrashLoopProbeInterval)) {
+		return false, nil
+	}
+	previous := info.LastWatchdogProbe
+	info.LastWatchdogProbe = now
+	if err := rt.saveLocked(); err != nil {
+		info.LastWatchdogProbe = previous
+		return false, err
+	}
+	return true, nil
+}
+
+func (rt *RestartTracker) CrashLoopAlertPending(agentID string) bool {
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+	info := rt.state.Agents[agentID]
+	return info != nil && info.CrashLoopAlertPending
+}
+
+func (rt *RestartTracker) MarkCrashLoopAlertDeliveredPersisted(agentID string) error {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	info := rt.state.Agents[agentID]
+	if info == nil || !info.CrashLoopAlertPending {
+		return nil
+	}
+	info.CrashLoopAlertPending = false
+	if err := rt.saveLocked(); err != nil {
+		info.CrashLoopAlertPending = true
+		return err
+	}
+	return nil
 }
 
 // ClearCrashLoop manually clears the crash loop state for an agent.
@@ -286,7 +448,10 @@ func (rt *RestartTracker) ClearCrashLoop(agentID string) {
 	if exists {
 		info.CrashLoopSince = time.Time{}
 		info.RestartCount = 0
+		info.RecentRestarts = nil
 		info.BackoffUntil = time.Time{}
+		info.LastWatchdogProbe = time.Time{}
+		info.CrashLoopAlertPending = false
 	}
 }
 

--- a/internal/daemon/restart_tracker_cooldown_test.go
+++ b/internal/daemon/restart_tracker_cooldown_test.go
@@ -1,0 +1,597 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/deacon"
+)
+
+type restartTrackerTestClock struct {
+	now time.Time
+}
+
+func (c *restartTrackerTestClock) Now() time.Time {
+	return c.now
+}
+
+func (c *restartTrackerTestClock) Advance(d time.Duration) {
+	c.now = c.now.Add(d)
+}
+
+func TestRestartTrackerCrashLoopLatchAndWatchdogProbeCooldown(t *testing.T) {
+	clock := &restartTrackerTestClock{now: time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)}
+	cfg := RestartTrackerConfig{
+		InitialBackoff:         time.Second,
+		MaxBackoff:             time.Minute,
+		BackoffMultiplier:      2,
+		CrashLoopWindow:        15 * time.Minute,
+		CrashLoopCount:         3,
+		StabilityPeriod:        30 * time.Minute,
+		CrashLoopProbeInterval: 30 * time.Minute,
+	}
+	rt := newRestartTrackerWithClock(t.TempDir(), cfg, clock.Now)
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		newlyLatched := rt.RecordRestart("deacon")
+		if got, want := newlyLatched, attempt == 3; got != want {
+			t.Fatalf("attempt %d newlyLatched = %v, want %v", attempt, got, want)
+		}
+		if attempt < 3 {
+			clock.Advance(time.Minute)
+		}
+	}
+	if !rt.IsInCrashLoop("deacon") {
+		t.Fatal("rapid retry threshold did not latch crash loop")
+	}
+
+	if rt.TakeWatchdogProbe("deacon") {
+		t.Fatal("watchdog probe allowed before 30-minute cooldown")
+	}
+	clock.Advance(29 * time.Minute)
+	if rt.TakeWatchdogProbe("deacon") {
+		t.Fatal("watchdog probe allowed one minute before cooldown")
+	}
+	clock.Advance(time.Minute)
+	if !rt.TakeWatchdogProbe("deacon") {
+		t.Fatal("watchdog probe not allowed at 30-minute cooldown")
+	}
+	if rt.TakeWatchdogProbe("deacon") {
+		t.Fatal("second watchdog probe allowed in same cooldown window")
+	}
+
+	// A local watchdog probe is still part of the latched crash incident. It
+	// must not clear the latch merely because the ordinary stability period
+	// elapsed, and it must not emit another latch alert.
+	if newlyLatched := rt.RecordRestart("deacon"); newlyLatched {
+		t.Fatal("watchdog probe restart emitted a duplicate latch transition")
+	}
+	if !rt.IsInCrashLoop("deacon") {
+		t.Fatal("watchdog probe restart cleared persistent crash-loop latch")
+	}
+
+	clock.Advance(30 * time.Minute)
+	if !rt.TakeWatchdogProbe("deacon") {
+		t.Fatal("next watchdog probe not allowed after another 30 minutes")
+	}
+}
+
+func TestRestartTrackerWatchdogProbePersistsAcrossReload(t *testing.T) {
+	clock := &restartTrackerTestClock{now: time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)}
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "daemon"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := RestartTrackerConfig{
+		CrashLoopCount:         1,
+		CrashLoopProbeInterval: 30 * time.Minute,
+	}
+	rt := newRestartTrackerWithClock(root, cfg, clock.Now)
+	if !rt.RecordRestart("deacon") {
+		t.Fatal("single-restart threshold did not latch")
+	}
+	clock.Advance(30 * time.Minute)
+	if !rt.TakeWatchdogProbe("deacon") {
+		t.Fatal("expected first watchdog probe")
+	}
+	if err := rt.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	reloaded := newRestartTrackerWithClock(root, cfg, clock.Now)
+	if err := reloaded.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if reloaded.TakeWatchdogProbe("deacon") {
+		t.Fatal("reload forgot consumed watchdog probe")
+	}
+	clock.Advance(30 * time.Minute)
+	if !reloaded.TakeWatchdogProbe("deacon") {
+		t.Fatal("reloaded tracker did not reopen probe gate after cooldown")
+	}
+}
+
+func TestRestartTrackerWidelySpacedRestartsDoNotLatch(t *testing.T) {
+	clock := &restartTrackerTestClock{now: time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)}
+	rt := newRestartTrackerWithClock(t.TempDir(), RestartTrackerConfig{
+		CrashLoopCount:  3,
+		CrashLoopWindow: 15 * time.Minute,
+		StabilityPeriod: time.Hour,
+	}, clock.Now)
+
+	for attempt := 0; attempt < 3; attempt++ {
+		if rt.RecordRestart("deacon") {
+			t.Fatalf("widely spaced attempt %d latched", attempt+1)
+		}
+		clock.Advance(10 * time.Minute)
+	}
+	if rt.IsInCrashLoop("deacon") {
+		t.Fatal("three restarts spanning more than CrashLoopWindow latched")
+	}
+}
+
+func TestRestartTrackerCrashLoopWindowPersistsAcrossReload(t *testing.T) {
+	clock := &restartTrackerTestClock{now: time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)}
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "daemon"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := RestartTrackerConfig{
+		CrashLoopCount:  3,
+		CrashLoopWindow: 15 * time.Minute,
+		StabilityPeriod: time.Hour,
+	}
+	rt := newRestartTrackerWithClock(root, cfg, clock.Now)
+	rt.RecordRestart("deacon")
+	clock.Advance(5 * time.Minute)
+	rt.RecordRestart("deacon")
+	if err := rt.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded := newRestartTrackerWithClock(root, cfg, clock.Now)
+	if err := reloaded.Load(); err != nil {
+		t.Fatal(err)
+	}
+	clock.Advance(5 * time.Minute)
+	if !reloaded.RecordRestart("deacon") {
+		t.Fatal("reloaded tracker forgot rapid-restart window history")
+	}
+}
+
+func TestRestartTrackerCorruptLoadPreservesStateAndFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "daemon")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	rt := NewRestartTracker(root, RestartTrackerConfig{})
+	rt.state.Agents["preserved"] = &AgentRestartInfo{CrashLoopSince: time.Now()}
+	corrupt := `{"agents":{"injected":{"restart_count":9}}} trailing garbage`
+	if err := os.WriteFile(filepath.Join(stateDir, "restart_state.json"), []byte(corrupt), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rt.Load(); err == nil {
+		t.Fatal("corrupt restart state loaded successfully")
+	}
+	if _, ok := rt.state.Agents["preserved"]; !ok {
+		t.Fatalf("failed load replaced prior live state: %#v", rt.state)
+	}
+	if _, ok := rt.state.Agents["injected"]; ok {
+		t.Fatalf("failed load partially mutated live state: %#v", rt.state)
+	}
+	if rt.CanRestart("unknown") {
+		t.Fatal("corrupt restart state failed open for an unknown agent")
+	}
+	if !rt.IsInCrashLoop("unknown") {
+		t.Fatal("corrupt restart state did not expose a fail-closed crash-loop latch")
+	}
+	if err := rt.Save(); err == nil {
+		t.Fatal("tracker overwrote corrupt state after failed load")
+	}
+
+	var logs bytes.Buffer
+	d := &Daemon{
+		config:         &Config{TownRoot: root},
+		ctx:            context.Background(),
+		restartTracker: rt,
+		logger:         log.New(&logs, "", 0),
+	}
+	if d.authorizeDeaconRestart("deacon") {
+		t.Fatal("daemon resumed restart authorization after tracker load failure")
+	}
+	if err := os.MkdirAll(filepath.Join(root, "settings"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "settings", "config.json"),
+		[]byte(`{"operational":{"daemon":{"boot_auto_spawn":true}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	d.ensureBootRunning()
+	if !strings.Contains(logs.String(), "hosted Boot suppressed") {
+		t.Fatalf("corrupt state did not suppress hosted Boot: %s", logs.String())
+	}
+}
+
+func TestRestartTrackerSaveIsAtomicAndMode0600(t *testing.T) {
+	root := t.TempDir()
+	rt := NewRestartTracker(root, RestartTrackerConfig{})
+	rt.RecordRestart("deacon")
+	if err := rt.Save(); err != nil {
+		t.Fatalf("Save without precreated daemon directory: %v", err)
+	}
+	path := filepath.Join(root, "daemon", "restart_state.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("restart state mode = %04o, want 0600", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state RestartState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("saved restart state is not valid JSON: %v", err)
+	}
+	temps, err := filepath.Glob(path + ".tmp.*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(temps) != 0 {
+		t.Fatalf("atomic save leaked temporary files: %v", temps)
+	}
+}
+
+func TestRestartTrackerRejectsSemanticallyInvalidJSON(t *testing.T) {
+	for _, body := range []string{
+		`null`,
+		`{"agents":{"deacon":null}}`,
+	} {
+		t.Run(body, func(t *testing.T) {
+			root := t.TempDir()
+			stateDir := filepath.Join(root, "daemon")
+			if err := os.MkdirAll(stateDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(stateDir, "restart_state.json"), []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			rt := NewRestartTracker(root, RestartTrackerConfig{})
+			if err := rt.Load(); err == nil {
+				t.Fatalf("semantically invalid restart state loaded: %s", body)
+			}
+			if rt.CanRestart("deacon") || !rt.IsInCrashLoop("deacon") {
+				t.Fatalf("semantically invalid state did not fail closed: %s", body)
+			}
+		})
+	}
+}
+
+func TestEnsureBootRunningCrashLoopSuppressesHostedPromotion(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "settings"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, "settings", "config.json"),
+		[]byte(`{"operational":{"daemon":{"boot_auto_spawn":true}}}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := NewRestartTracker(root, RestartTrackerConfig{})
+	rt.state.Agents["deacon"] = &AgentRestartInfo{
+		CrashLoopSince: time.Now().Add(-time.Minute),
+	}
+	var logs bytes.Buffer
+	d := &Daemon{
+		config:         &Config{TownRoot: root},
+		ctx:            context.Background(),
+		logger:         log.New(&logs, "", 0),
+		restartTracker: rt,
+	}
+
+	d.ensureBootRunning()
+
+	if !strings.Contains(logs.String(), "hosted Boot suppressed") {
+		t.Fatalf("missing local-only crash-loop guard log: %s", logs.String())
+	}
+}
+
+func TestDeaconCrashLoopProbeRequiresFreshHealthyLocalWatchdog(t *testing.T) {
+	clock := &restartTrackerTestClock{now: time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)}
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "daemon"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rt := newRestartTrackerWithClock(root, RestartTrackerConfig{
+		CrashLoopCount:         1,
+		CrashLoopProbeInterval: 30 * time.Minute,
+	}, clock.Now)
+	rt.RecordRestart("deacon")
+	clock.Advance(30 * time.Minute)
+
+	d := &Daemon{
+		config:         &Config{TownRoot: root},
+		logger:         log.New(&bytes.Buffer{}, "", 0),
+		restartTracker: rt,
+	}
+	writeLocalWatchdogState(t, root, "recovering-local", clock.now)
+	if d.authorizeDeaconRestart("deacon") {
+		t.Fatal("unhealthy local watchdog authorized crash-loop probe")
+	}
+	if !rt.state.Agents["deacon"].LastWatchdogProbe.IsZero() {
+		t.Fatal("unhealthy watchdog consumed crash-loop probe")
+	}
+
+	writeLocalWatchdogState(t, root, "healthy", clock.now.Add(-3*time.Minute))
+	if d.authorizeDeaconRestart("deacon") {
+		t.Fatal("stale local watchdog authorized crash-loop probe")
+	}
+	if !rt.state.Agents["deacon"].LastWatchdogProbe.IsZero() {
+		t.Fatal("stale watchdog consumed crash-loop probe")
+	}
+
+	writeLocalWatchdogState(t, root, "healthy", clock.now.Add(-time.Minute))
+	if !d.authorizeDeaconRestart("deacon") {
+		t.Fatal("fresh healthy watchdog did not authorize local crash-loop probe")
+	}
+	if rt.state.Agents["deacon"].LastWatchdogProbe.IsZero() {
+		t.Fatal("authorized probe was not consumed")
+	}
+	if rt.CanRestart("deacon") {
+		t.Fatal("test requires persistent latch; authorization must bypass ordinary CanRestart")
+	}
+	if d.authorizeDeaconRestart("deacon") {
+		t.Fatal("second restart authorized in same probe interval")
+	}
+}
+
+func TestDeaconCrashLoopProbePersistenceFailureFailsClosed(t *testing.T) {
+	clock := &restartTrackerTestClock{now: time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)}
+	root := t.TempDir()
+	// A regular file at daemon/ makes restart_state.json unwritable.
+	if err := os.WriteFile(filepath.Join(root, "daemon"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rt := newRestartTrackerWithClock(root, RestartTrackerConfig{
+		CrashLoopCount:         1,
+		CrashLoopProbeInterval: 30 * time.Minute,
+	}, clock.Now)
+	rt.RecordRestart("deacon")
+	// This test isolates probe-token persistence; alert retries have their own
+	// coverage and would attempt an unrelated external command here.
+	rt.state.Agents["deacon"].CrashLoopAlertPending = false
+	clock.Advance(30 * time.Minute)
+	writeLocalWatchdogState(t, root, "healthy", clock.now)
+	d := &Daemon{
+		config:         &Config{TownRoot: root},
+		ctx:            context.Background(),
+		logger:         log.New(&bytes.Buffer{}, "", 0),
+		restartTracker: rt,
+	}
+
+	mgr := &fakeDeaconProbeManager{}
+	d.ensureDeaconRunningWithManager(mgr)
+	if len(mgr.startAgents) != 0 || mgr.stopCalls != 0 {
+		t.Fatalf("manager acted despite failed probe persistence: starts=%v stops=%d",
+			mgr.startAgents, mgr.stopCalls)
+	}
+	if !rt.state.Agents["deacon"].LastWatchdogProbe.IsZero() {
+		t.Fatal("failed persistence consumed probe in memory")
+	}
+}
+
+type fakeDeaconProbeManager struct {
+	startAgents []string
+	stopCalls   int
+	startErr    error
+	stopErr     error
+}
+
+func (m *fakeDeaconProbeManager) Start(agent string) error {
+	m.startAgents = append(m.startAgents, agent)
+	return m.startErr
+}
+
+func (m *fakeDeaconProbeManager) Stop() error {
+	m.stopCalls++
+	return m.stopErr
+}
+
+func TestDeaconCrashLoopProbeFreshHeartbeatStabilizesButStaleForcesLocalRestart(t *testing.T) {
+	newDaemon := func(t *testing.T) (*Daemon, *RestartTracker, *restartTrackerTestClock, string) {
+		t.Helper()
+		clock := &restartTrackerTestClock{now: time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)}
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, "daemon"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		rt := newRestartTrackerWithClock(root, RestartTrackerConfig{
+			CrashLoopCount:         1,
+			CrashLoopProbeInterval: 30 * time.Minute,
+			StabilityPeriod:        30 * time.Minute,
+		}, clock.Now)
+		rt.RecordRestart("deacon")
+		if err := rt.MarkCrashLoopAlertDeliveredPersisted("deacon"); err != nil {
+			t.Fatal(err)
+		}
+		clock.Advance(31 * time.Minute)
+		writeLocalWatchdogState(t, root, "healthy", clock.now)
+		return &Daemon{
+			config:         &Config{TownRoot: root},
+			ctx:            context.Background(),
+			logger:         log.New(&bytes.Buffer{}, "", 0),
+			restartTracker: rt,
+		}, rt, clock, root
+	}
+
+	t.Run("fresh heartbeat clears only after stability", func(t *testing.T) {
+		d, rt, clock, root := newDaemon(t)
+		if err := deacon.WriteHeartbeat(root, &deacon.Heartbeat{Timestamp: clock.now.Add(-time.Minute)}); err != nil {
+			t.Fatal(err)
+		}
+		mgr := &fakeDeaconProbeManager{}
+		d.ensureDeaconRunningWithManager(mgr)
+		if len(mgr.startAgents) != 0 || mgr.stopCalls != 0 {
+			t.Fatalf("fresh live Deacon was restarted: starts=%v stops=%d", mgr.startAgents, mgr.stopCalls)
+		}
+		if rt.IsInCrashLoop("deacon") {
+			t.Fatal("fresh heartbeat after 30m stability did not clear latch")
+		}
+	})
+
+	t.Run("stale existing process forces pinned local restart", func(t *testing.T) {
+		d, rt, clock, root := newDaemon(t)
+		if err := deacon.WriteHeartbeat(root, &deacon.Heartbeat{Timestamp: clock.now.Add(-10 * time.Minute)}); err != nil {
+			t.Fatal(err)
+		}
+		mgr := &fakeDeaconProbeManager{}
+		d.ensureDeaconRunningWithManager(mgr)
+		if mgr.stopCalls != 1 {
+			t.Fatalf("stop calls = %d, want 1", mgr.stopCalls)
+		}
+		if len(mgr.startAgents) != 1 || mgr.startAgents[0] != "opencode-local" {
+			t.Fatalf("start agents = %v, want [opencode-local]", mgr.startAgents)
+		}
+		if !rt.IsInCrashLoop("deacon") {
+			t.Fatal("forced local probe cleared crash-loop latch")
+		}
+	})
+
+	t.Run("stale already-running result preserves latch", func(t *testing.T) {
+		d, rt, clock, root := newDaemon(t)
+		if err := deacon.WriteHeartbeat(root, &deacon.Heartbeat{Timestamp: clock.now.Add(-10 * time.Minute)}); err != nil {
+			t.Fatal(err)
+		}
+		mgr := &fakeDeaconProbeManager{startErr: deacon.ErrAlreadyRunning}
+		d.ensureDeaconRunningWithManager(mgr)
+		if mgr.stopCalls != 1 {
+			t.Fatalf("stop calls = %d, want 1", mgr.stopCalls)
+		}
+		if len(mgr.startAgents) != 1 || mgr.startAgents[0] != "opencode-local" {
+			t.Fatalf("start agents = %v, want [opencode-local]", mgr.startAgents)
+		}
+		if !rt.IsInCrashLoop("deacon") {
+			t.Fatal("stale ErrAlreadyRunning result cleared crash-loop latch")
+		}
+	})
+}
+
+func writeLocalWatchdogState(t *testing.T, root, status string, checkedAt time.Time) {
+	t.Helper()
+	dir := filepath.Join(root, "deacon")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"status":"` + status + `","checked_at":"` + checkedAt.UTC().Format(time.RFC3339) + `"}`
+	if err := os.WriteFile(filepath.Join(dir, "lmstudio-watchdog.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAlertDeaconCrashLoopLatchUsesMockedHumanMailRoute(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("shell fixture requires Unix")
+	}
+	root := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "gt.log")
+	gtPath := filepath.Join(t.TempDir(), "gt")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> " + logPath + "\n"
+	if err := os.WriteFile(gtPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	d := &Daemon{
+		config: &Config{TownRoot: root},
+		logger: log.New(&bytes.Buffer{}, "", 0),
+		gtPath: gtPath,
+	}
+
+	notifyCalls := 0
+	d.alertDeaconCrashLoopLatchWithNotification(func(title, message string) error {
+		notifyCalls++
+		if title != "DEACON_CRASH_LOOP_LATCHED" || message == "" {
+			t.Fatalf("unexpected notification: title=%q message=%q", title, message)
+		}
+		return errors.New("mock notification unavailable")
+	})
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls := strings.TrimSpace(string(data)); !strings.HasPrefix(calls, "mail send --human ") {
+		t.Fatalf("alert did not use supported human mail route: %q", calls)
+	}
+	if notifyCalls != 1 {
+		t.Fatalf("notification calls = %d, want 1", notifyCalls)
+	}
+}
+
+func TestFailedDeaconCrashLoopHumanAlertPersistsAndRetries(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("shell fixture requires Unix")
+	}
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "daemon"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(t.TempDir(), "gt.log")
+	failMarker := filepath.Join(t.TempDir(), "fail-once")
+	gtPath := filepath.Join(t.TempDir(), "gt")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> " + logPath + "\n" +
+		"if [ ! -f " + failMarker + " ]; then touch " + failMarker + "; exit 1; fi\n"
+	if err := os.WriteFile(gtPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rt := NewRestartTracker(root, RestartTrackerConfig{CrashLoopCount: 1})
+	if !rt.RecordRestart("deacon") {
+		t.Fatal("expected latch")
+	}
+	if err := rt.Save(); err != nil {
+		t.Fatal(err)
+	}
+	d := &Daemon{
+		config:         &Config{TownRoot: root},
+		logger:         log.New(&bytes.Buffer{}, "", 0),
+		gtPath:         gtPath,
+		restartTracker: rt,
+	}
+	notify := func(string, string) error { return nil }
+
+	d.retryDeaconCrashLoopAlertWithNotification("deacon", notify)
+	if !rt.CrashLoopAlertPending("deacon") {
+		t.Fatal("failed durable alert was marked delivered")
+	}
+	reloaded := NewRestartTracker(root, RestartTrackerConfig{CrashLoopCount: 1})
+	if err := reloaded.Load(); err != nil {
+		t.Fatal(err)
+	}
+	d.restartTracker = reloaded
+	d.retryDeaconCrashLoopAlertWithNotification("deacon", notify)
+	if reloaded.CrashLoopAlertPending("deacon") {
+		t.Fatal("successful durable alert remained pending")
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls := len(strings.Split(strings.TrimSpace(string(data)), "\n")); calls != 2 {
+		t.Fatalf("human mail attempts = %d, want 2; calls=%q", calls, data)
+	}
+}

--- a/internal/deacon/redispatch.go
+++ b/internal/deacon/redispatch.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -86,9 +87,39 @@ type ModelEscalationConfig struct {
 	Enabled           bool                      `json:"enabled"`
 	Description       string                    `json:"description,omitempty"`
 	Rules             []ModelEscalationRule     `json:"rules"`
+	Recovery          *RecoveryPolicy           `json:"recovery,omitempty"`
 	ValidationFailure *ValidationRecoveryConfig `json:"validation_failure,omitempty"`
 	MaxTotalAttempts  int                       `json:"max_total_attempts,omitempty"`
 	Fallback          string                    `json:"fallback,omitempty"`
+}
+
+// RecoveryPolicy configures the bounded local-first recovery ladder. Duration
+// values use Go duration syntax. Omitted values retain daemon defaults.
+type RecoveryPolicy struct {
+	NudgeAfter        string           `json:"nudge_after,omitempty"`
+	LocalRestartAfter string           `json:"local_restart_after,omitempty"`
+	GoEscalateAfter   string           `json:"go_escalate_after,omitempty"`
+	MaxLocalRestarts  int              `json:"max_local_restarts,omitempty"`
+	MaxGoAttempts     int              `json:"max_go_attempts,omitempty"`
+	BreakGlass        BreakGlassPolicy `json:"break_glass,omitempty"`
+}
+
+// BreakGlassPolicy is deliberately scoped to restoring infrastructure.
+// Ordinary product work stops after its bounded Go attempt.
+type BreakGlassPolicy struct {
+	Enabled     bool                            `json:"enabled,omitempty"`
+	Scope       string                          `json:"scope,omitempty"`
+	Agents      []string                        `json:"agents,omitempty"`
+	MaxAttempts int                             `json:"max_attempts_per_agent,omitempty"`
+	Timeout     string                          `json:"timeout,omitempty"`
+	Automatic   bool                            `json:"automatic,omitempty"`
+	TierPolicy  map[string]BreakGlassTierPolicy `json:"tier_policy,omitempty"`
+}
+
+type BreakGlassTierPolicy struct {
+	MaxAttempts int    `json:"max_attempts"`
+	Timeout     string `json:"timeout"`
+	Mode        string `json:"mode"` // automatic or approval
 }
 
 // ModelEscalationConfigPath is the path within a rig project directory where
@@ -430,7 +461,81 @@ func LoadModelEscalationConfig(rigProjectDir string) (*ModelEscalationConfig, er
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parsing model escalation config %s: %w", path, err)
 	}
+	if err := validateRecoveryPolicy(cfg.Recovery); err != nil {
+		return nil, fmt.Errorf("invalid recovery policy %s: %w", path, err)
+	}
 	return &cfg, nil
+}
+
+func validateRecoveryPolicy(policy *RecoveryPolicy) error {
+	if policy == nil {
+		return nil
+	}
+	parse := func(name, value string) (time.Duration, error) {
+		if value == "" {
+			return 0, nil
+		}
+		result, err := time.ParseDuration(value)
+		if err != nil || result <= 0 {
+			return 0, fmt.Errorf("%s must be a positive duration", name)
+		}
+		return result, nil
+	}
+	nudge, err := parse("nudge_after", policy.NudgeAfter)
+	if err != nil {
+		return err
+	}
+	restart, err := parse("local_restart_after", policy.LocalRestartAfter)
+	if err != nil {
+		return err
+	}
+	hosted, err := parse("go_escalate_after", policy.GoEscalateAfter)
+	if err != nil {
+		return err
+	}
+	if nudge > 0 && restart > 0 && restart < nudge {
+		return fmt.Errorf("local_restart_after must not precede nudge_after")
+	}
+	if restart > 0 && hosted > 0 && hosted < restart {
+		return fmt.Errorf("go_escalate_after must not precede local_restart_after")
+	}
+	if policy.MaxLocalRestarts < 0 || policy.MaxLocalRestarts > 1 {
+		return fmt.Errorf("max_local_restarts must be 0 or 1")
+	}
+	if policy.MaxGoAttempts < 0 || policy.MaxGoAttempts > 1 {
+		return fmt.Errorf("max_go_attempts must be 0 or 1")
+	}
+	bg := policy.BreakGlass
+	if bg.Enabled {
+		if bg.Scope != "infrastructure-only" {
+			return fmt.Errorf("break_glass.scope must be infrastructure-only")
+		}
+		if !slices.Equal(bg.Agents, []string{"claude", "codex"}) {
+			return fmt.Errorf("break_glass.agents must be [claude, codex]")
+		}
+		if bg.MaxAttempts != 1 {
+			return fmt.Errorf("break_glass.max_attempts_per_agent must be 1")
+		}
+		if _, err := parse("break_glass.timeout", bg.Timeout); err != nil {
+			return err
+		}
+		for _, agent := range bg.Agents {
+			tier, ok := bg.TierPolicy[agent]
+			if !ok {
+				return fmt.Errorf("break_glass.tier_policy.%s is required", agent)
+			}
+			if tier.MaxAttempts != 1 {
+				return fmt.Errorf("break_glass.tier_policy.%s.max_attempts must be 1", agent)
+			}
+			if _, err := parse("break_glass.tier_policy."+agent+".timeout", tier.Timeout); err != nil {
+				return err
+			}
+			if tier.Mode != "automatic" && tier.Mode != "approval" {
+				return fmt.Errorf("break_glass.tier_policy.%s.mode must be automatic or approval", agent)
+			}
+		}
+	}
+	return nil
 }
 
 // resolveAgentForRedispatch determines which agent alias to use when re-dispatching

--- a/internal/deacon/redispatch.go
+++ b/internal/deacon/redispatch.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/util"
 )
 
@@ -80,13 +81,14 @@ type ModelEscalationRule struct {
 // ModelEscalationConfig defines per-rig agent promotion rules for re-dispatch.
 // Loaded from <rig>/refinery/rig/.gastown/model-escalation.json.
 type ModelEscalationConfig struct {
-	Type             string                `json:"type"`
-	Version          int                   `json:"version"`
-	Enabled          bool                  `json:"enabled"`
-	Description      string                `json:"description,omitempty"`
-	Rules            []ModelEscalationRule `json:"rules"`
-	MaxTotalAttempts int                   `json:"max_total_attempts,omitempty"`
-	Fallback         string                `json:"fallback,omitempty"`
+	Type              string                    `json:"type"`
+	Version           int                       `json:"version"`
+	Enabled           bool                      `json:"enabled"`
+	Description       string                    `json:"description,omitempty"`
+	Rules             []ModelEscalationRule     `json:"rules"`
+	ValidationFailure *ValidationRecoveryConfig `json:"validation_failure,omitempty"`
+	MaxTotalAttempts  int                       `json:"max_total_attempts,omitempty"`
+	Fallback          string                    `json:"fallback,omitempty"`
 }
 
 // ModelEscalationConfigPath is the path within a rig project directory where
@@ -302,8 +304,28 @@ func Redispatch(townRoot, beadID, sourceRig string, maxAttempts int, cooldown ti
 		return result
 	}
 
+	// Determine the agent that failed. After a re-dispatch, LastAgent is the
+	// durable source of truth. On the first recovery, use the configured polecat
+	// agent for the rig. This lets from_agent rules prevent a hosted worker from
+	// being sent back to the hosted relief valve indefinitely.
+	fromAgent := beadState.LastAgent
+	if fromAgent == "" {
+		fromAgent = configuredPolecatAgent(townRoot, targetRig)
+	}
+
 	// Determine agent override from model escalation config (if any).
-	escalationAgent := resolveAgentForRedispatch(townRoot, targetRig, beadState)
+	escalationAgent, matchedRule := resolveAgentDecision(townRoot, targetRig, beadState, fromAgent)
+	if fromAgent != "" && !matchedRule {
+		result.Action = "escalated"
+		result.Message = fmt.Sprintf("no crash-recovery rule matches failed agent %q; escalated to Mayor", fromAgent)
+		if err := escalateToMayor(townRoot, beadID, beadState); err != nil {
+			result.Error = fmt.Errorf("escalating unmatched agent to mayor: %w", err)
+		} else {
+			beadState.RecordEscalation()
+		}
+		_ = SaveRedispatchState(townRoot, state)
+		return result
+	}
 
 	// Re-dispatch via gt sling
 	err = slingBead(townRoot, beadID, targetRig, escalationAgent)
@@ -420,13 +442,25 @@ func LoadModelEscalationConfig(rigProjectDir string) (*ModelEscalationConfig, er
 //
 // Returns "" (empty) if no escalation is configured or no rule applies — the caller
 // should omit the --agent flag and let the rig use its default.
-func resolveAgentForRedispatch(townRoot, targetRig string, beadState *BeadRedispatchState) string {
+func resolveAgentForRedispatch(townRoot, targetRig string, beadState *BeadRedispatchState, fromAgent ...string) string {
+	source := ""
+	if len(fromAgent) > 0 {
+		source = fromAgent[0]
+	}
+	agent, _ := resolveAgentDecision(townRoot, targetRig, beadState, source)
+	return agent
+}
+
+// resolveAgentDecision returns the target agent and whether an escalation rule
+// matched. fromAgent is enforced when present; an empty from_agent in config is
+// a wildcard for backwards compatibility.
+func resolveAgentDecision(townRoot, targetRig string, beadState *BeadRedispatchState, fromAgent string) (string, bool) {
 	// Rig project dir is <townRoot>/<rig>/refinery/rig
 	rigProjectDir := filepath.Join(townRoot, targetRig, "refinery", "rig")
 
 	cfg, err := LoadModelEscalationConfig(rigProjectDir)
 	if err != nil || cfg == nil || !cfg.Enabled || len(cfg.Rules) == 0 {
-		return ""
+		return "", true
 	}
 
 	// Total failures = prior re-dispatch attempts + 1 (initial failure that triggered
@@ -434,12 +468,31 @@ func resolveAgentForRedispatch(townRoot, targetRig string, beadState *BeadRedisp
 	// it reflects the number of completed re-dispatches, not the current one.
 	totalFailures := beadState.AttemptCount + 1
 
+	matchedSource := false
 	for _, rule := range cfg.Rules {
+		if rule.FromAgent != "" && fromAgent != "" && rule.FromAgent != fromAgent {
+			continue
+		}
+		matchedSource = true
 		if totalFailures >= rule.PromoteAfterFailures {
-			return rule.ToAgent
+			return rule.ToAgent, true
 		}
 	}
-	return ""
+	return "", matchedSource
+}
+
+// configuredPolecatAgent returns the rig's effective local worker alias when it
+// is explicitly configured. Validation setups pin this value so a first crash
+// can be matched against from_agent without relying on a dead tmux session.
+func configuredPolecatAgent(townRoot, rigName string) string {
+	settings, err := config.LoadRigSettings(config.RigSettingsPath(filepath.Join(townRoot, rigName)))
+	if err != nil || settings == nil {
+		return ""
+	}
+	if agent := strings.TrimSpace(settings.RoleAgents["polecat"]); agent != "" {
+		return agent
+	}
+	return strings.TrimSpace(settings.Agent)
 }
 
 // slingBead dispatches a bead to a rig via gt sling.

--- a/internal/deacon/redispatch_test.go
+++ b/internal/deacon/redispatch_test.go
@@ -254,6 +254,59 @@ func TestLoadModelEscalationConfig(t *testing.T) {
 			t.Errorf("expected ToAgent=claude, got %q", cfg.Rules[0].ToAgent)
 		}
 	})
+
+	t.Run("loads bounded local first policy", func(t *testing.T) {
+		dir := t.TempDir()
+		gastown := filepath.Join(dir, ".gastown")
+		if err := os.MkdirAll(gastown, 0755); err != nil {
+			t.Fatal(err)
+		}
+		content := `{
+			"type":"model-escalation","version":2,"enabled":true,"rules":[],
+			"recovery":{
+				"nudge_after":"15m","local_restart_after":"30m","go_escalate_after":"60m",
+				"max_local_restarts":1,"max_go_attempts":1,
+				"break_glass":{"enabled":true,"scope":"infrastructure-only",
+					"agents":["claude","codex"],"max_attempts_per_agent":1,
+					"timeout":"10m","automatic":true,
+					"tier_policy":{
+						"claude":{"max_attempts":1,"timeout":"10m","mode":"automatic"},
+						"codex":{"max_attempts":1,"timeout":"10m","mode":"automatic"}
+					}}
+			}
+		}`
+		if err := os.WriteFile(filepath.Join(gastown, "model-escalation.json"), []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadModelEscalationConfig(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Recovery == nil || cfg.Recovery.GoEscalateAfter != "60m" {
+			t.Fatalf("recovery policy = %#v", cfg.Recovery)
+		}
+	})
+
+	t.Run("rejects product scoped break glass", func(t *testing.T) {
+		dir := t.TempDir()
+		gastown := filepath.Join(dir, ".gastown")
+		if err := os.MkdirAll(gastown, 0755); err != nil {
+			t.Fatal(err)
+		}
+		content := `{"enabled":true,"rules":[],"recovery":{"break_glass":{
+			"enabled":true,"scope":"all-work","agents":["claude","codex"],
+			"max_attempts_per_agent":1,"timeout":"10m",
+			"tier_policy":{
+				"claude":{"max_attempts":1,"timeout":"10m","mode":"automatic"},
+				"codex":{"max_attempts":1,"timeout":"10m","mode":"automatic"}
+			}}}}`
+		if err := os.WriteFile(filepath.Join(gastown, "model-escalation.json"), []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadModelEscalationConfig(dir); err == nil {
+			t.Fatal("expected unsafe break-glass policy to be rejected")
+		}
+	})
 }
 
 func TestResolveAgentForRedispatch(t *testing.T) {

--- a/internal/deacon/redispatch_test.go
+++ b/internal/deacon/redispatch_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestParseRecoveredBeadSubject(t *testing.T) {
 	tests := []struct {
-		subject  string
-		wantID   string
-		wantOK   bool
+		subject string
+		wantID  string
+		wantOK  bool
 	}{
 		{"RECOVERED_BEAD gt-abc123", "gt-abc123", true},
 		{"RECOVERED_BEAD bd-xyz", "bd-xyz", true},
@@ -316,6 +316,35 @@ func TestResolveAgentForRedispatch_NoConfig(t *testing.T) {
 	got := resolveAgentForRedispatch(t.TempDir(), "myrig", state)
 	if got != "" {
 		t.Errorf("expected empty agent when no config, got %q", got)
+	}
+}
+
+func TestResolveAgentForRedispatch_EnforcesFromAgent(t *testing.T) {
+	townDir := t.TempDir()
+	rigName := "myrig"
+	rigProjectDir := filepath.Join(townDir, rigName, "refinery", "rig", ".gastown")
+	if err := os.MkdirAll(rigProjectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configContent := `{
+		"type": "model-escalation",
+		"version": 1,
+		"enabled": true,
+		"rules": [{
+			"from_agent": "opencode-local",
+			"to_agent": "opencode-go",
+			"promote_after_failures": 1
+		}]
+	}`
+	if err := os.WriteFile(filepath.Join(rigProjectDir, "model-escalation.json"), []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+	state := &BeadRedispatchState{BeadID: "gt-test"}
+	if got := resolveAgentForRedispatch(townDir, rigName, state, "opencode-local"); got != "opencode-go" {
+		t.Fatalf("local failure target = %q, want opencode-go", got)
+	}
+	if got := resolveAgentForRedispatch(townDir, rigName, state, "opencode-go"); got != "" {
+		t.Fatalf("hosted failure must not match local rule, got %q", got)
 	}
 }
 

--- a/internal/deacon/validation_recovery.go
+++ b/internal/deacon/validation_recovery.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gofrs/flock"
 	"github.com/steveyegge/gastown/internal/atomicfile"
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/util"
 )
 
@@ -30,6 +31,8 @@ const (
 // quality failures. It lives under validation_failure in model-escalation.json.
 type ValidationRecoveryConfig struct {
 	Enabled           bool   `json:"enabled"`
+	LocalAgent        string `json:"local_agent,omitempty"`
+	MaxLocalAttempts  int    `json:"max_local_attempts,omitempty"`
 	ToAgent           string `json:"to_agent"`
 	MaxHostedAttempts int    `json:"max_hosted_attempts"`
 	RepairPriority    int    `json:"repair_priority"`
@@ -74,7 +77,9 @@ type ValidationIncident struct {
 	InitialCommit     string                  `json:"initial_commit,omitempty"`
 	RepairBead        string                  `json:"repair_bead,omitempty"`
 	TargetAgent       string                  `json:"target_agent,omitempty"`
+	LocalAttempts     int                     `json:"local_attempts"`
 	HostedAttempts    int                     `json:"hosted_attempts"`
+	MaxLocalAttempts  int                     `json:"max_local_attempts"`
 	MaxHostedAttempts int                     `json:"max_hosted_attempts"`
 	Status            string                  `json:"status"`
 	LastError         string                  `json:"last_error,omitempty"`
@@ -288,6 +293,12 @@ func loadValidationRecoveryConfig(townRoot, rigName string) (*ValidationRecovery
 	if result.ToAgent == "" {
 		result.ToAgent = "opencode-go"
 	}
+	if result.LocalAgent == "" {
+		result.LocalAgent = "opencode-local"
+	}
+	if result.MaxLocalAttempts <= 0 {
+		result.MaxLocalAttempts = 1
+	}
 	if result.MaxHostedAttempts <= 0 {
 		result.MaxHostedAttempts = 1
 	}
@@ -341,6 +352,7 @@ func ProcessValidationFailure(townRoot string, raw ValidationFailure) *Validatio
 					Branch:            event.Branch,
 					InitialCommit:     event.Commit,
 					TargetAgent:       cfg.ToAgent,
+					MaxLocalAttempts:  cfg.MaxLocalAttempts,
 					MaxHostedAttempts: cfg.MaxHostedAttempts,
 					Status:            "recorded",
 					FirstEvent:        event,
@@ -380,7 +392,8 @@ func ProcessValidationFailure(townRoot string, raw ValidationFailure) *Validatio
 		})
 		incident.UpdatedAt = time.Now().UTC()
 
-		if incident.HostedAttempts >= incident.MaxHostedAttempts {
+		if incident.LocalAttempts >= incident.MaxLocalAttempts &&
+			incident.HostedAttempts >= incident.MaxHostedAttempts {
 			if incident.Status == "escalated" {
 				action = "already-escalated"
 			} else {
@@ -440,12 +453,21 @@ func ProcessValidationFailure(townRoot string, raw ValidationFailure) *Validatio
 			})
 		}
 	}
+	targetAgent := cfg.LocalAgent
+	hostedAttempt := false
+	if currentState, loadErr := LoadValidationState(townRoot); loadErr == nil {
+		if current := currentState.Incidents[incidentID]; current != nil &&
+			current.LocalAttempts >= current.MaxLocalAttempts {
+			targetAgent = cfg.ToAgent
+			hostedAttempt = true
+		}
+	}
 	if err == nil {
 		beadID := event.SourceIssue
 		if event.Phase == "post-merge" {
 			beadID = repairBead
 		}
-		err = dispatchValidationRepairFn(townRoot, beadID, event.Rig, event.Branch, cfg.ToAgent, incidentID)
+		err = dispatchValidationRepairFn(townRoot, beadID, event.Rig, event.Branch, targetAgent, incidentID)
 	}
 
 	stateErr := withValidationState(townRoot, func(state *ValidationState) error {
@@ -456,8 +478,13 @@ func ProcessValidationFailure(townRoot string, raw ValidationFailure) *Validatio
 			incident.Status = "dispatch-error"
 			incident.LastError = err.Error()
 		} else {
-			incident.Status = "hosted-dispatched"
-			incident.HostedAttempts++
+			if hostedAttempt {
+				incident.Status = "hosted-dispatched"
+				incident.HostedAttempts++
+			} else {
+				incident.Status = "local-dispatched"
+				incident.LocalAttempts++
+			}
 		}
 		return nil
 	})
@@ -471,7 +498,7 @@ func ProcessValidationFailure(townRoot string, raw ValidationFailure) *Validatio
 		IncidentID: incidentID,
 		Action:     "dispatched",
 		RepairBead: repairBead,
-		Message:    fmt.Sprintf("dispatched one repair attempt with agent %q", cfg.ToAgent),
+		Message:    fmt.Sprintf("dispatched one repair attempt with agent %q", targetAgent),
 	}
 }
 
@@ -529,10 +556,7 @@ Evidence:
 	if event.SourceIssue != "" {
 		args = append(args, "--deps=discovered-from:"+event.SourceIssue)
 	}
-	cmd := exec.Command("bd", args...)
-	cmd.Dir = workDir
-	cmd.Env = deaconMutationRoutingEnv(townRoot)
-	util.SetDetachedProcessGroup(cmd)
+	cmd := beads.Command(workDir, filepath.Join(workDir, ".beads"), beads.MutationRouting, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("creating validation repair bead: %w (%s)", err, strings.TrimSpace(string(output)))

--- a/internal/deacon/validation_recovery.go
+++ b/internal/deacon/validation_recovery.go
@@ -1,0 +1,653 @@
+package deacon
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/steveyegge/gastown/internal/atomicfile"
+	"github.com/steveyegge/gastown/internal/util"
+)
+
+const (
+	validationStateVersion = 1
+	maxValidationEvidence  = 32 * 1024
+
+	// ValidationFailedEventType identifies durable validation recovery events.
+	ValidationFailedEventType = "VALIDATION_FAILED"
+)
+
+// ValidationRecoveryConfig controls the hosted relief valve for confirmed
+// quality failures. It lives under validation_failure in model-escalation.json.
+type ValidationRecoveryConfig struct {
+	Enabled           bool   `json:"enabled"`
+	ToAgent           string `json:"to_agent"`
+	MaxHostedAttempts int    `json:"max_hosted_attempts"`
+	RepairPriority    int    `json:"repair_priority"`
+}
+
+// ValidationFailure is the durable event emitted after a quality failure has
+// been confirmed as a regression rather than flaky, pre-existing, or infra.
+type ValidationFailure struct {
+	Type         string    `json:"type"`
+	IncidentID   string    `json:"incident_id,omitempty"`
+	Rig          string    `json:"rig"`
+	SourceIssue  string    `json:"source_issue,omitempty"`
+	MergeRequest string    `json:"merge_request,omitempty"`
+	Branch       string    `json:"branch,omitempty"`
+	Commit       string    `json:"commit,omitempty"`
+	Phase        string    `json:"phase"` // pre-merge or post-merge
+	Kind         string    `json:"kind"`  // functional, test, build, lint, typecheck
+	Command      string    `json:"command,omitempty"`
+	ExitCode     int       `json:"exit_code,omitempty"`
+	Summary      string    `json:"summary"`
+	Evidence     string    `json:"evidence,omitempty"`
+	ReportedAt   time.Time `json:"reported_at"`
+}
+
+// ValidationObservation records a distinct failing result within an incident.
+type ValidationObservation struct {
+	Fingerprint string    `json:"fingerprint"`
+	Commit      string    `json:"commit,omitempty"`
+	Kind        string    `json:"kind"`
+	ExitCode    int       `json:"exit_code,omitempty"`
+	ObservedAt  time.Time `json:"observed_at"`
+}
+
+// ValidationIncident tracks one local failure and its bounded hosted repair.
+type ValidationIncident struct {
+	ID                string                  `json:"id"`
+	Rig               string                  `json:"rig"`
+	Phase             string                  `json:"phase"`
+	SourceIssue       string                  `json:"source_issue,omitempty"`
+	MergeRequest      string                  `json:"merge_request,omitempty"`
+	Branch            string                  `json:"branch,omitempty"`
+	InitialCommit     string                  `json:"initial_commit,omitempty"`
+	RepairBead        string                  `json:"repair_bead,omitempty"`
+	TargetAgent       string                  `json:"target_agent,omitempty"`
+	HostedAttempts    int                     `json:"hosted_attempts"`
+	MaxHostedAttempts int                     `json:"max_hosted_attempts"`
+	Status            string                  `json:"status"`
+	LastError         string                  `json:"last_error,omitempty"`
+	LastFingerprint   string                  `json:"last_fingerprint,omitempty"`
+	FirstEvent        ValidationFailure       `json:"first_event"`
+	LastEvent         ValidationFailure       `json:"last_event"`
+	Observations      []ValidationObservation `json:"observations,omitempty"`
+	CreatedAt         time.Time               `json:"created_at"`
+	UpdatedAt         time.Time               `json:"updated_at"`
+	EscalatedAt       time.Time               `json:"escalated_at,omitempty"`
+	ResolvedAt        time.Time               `json:"resolved_at,omitempty"`
+}
+
+// MainBranchValidationState stores the last proven-green commit for a rig.
+type MainBranchValidationState struct {
+	LastGreenSHA  string    `json:"last_green_sha,omitempty"`
+	LastTestedSHA string    `json:"last_tested_sha,omitempty"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// ValidationState is persisted at deacon/validation-recovery-state.json.
+type ValidationState struct {
+	Version      int                                   `json:"version"`
+	Incidents    map[string]*ValidationIncident        `json:"incidents"`
+	MainBranches map[string]*MainBranchValidationState `json:"main_branches,omitempty"`
+	LastUpdated  time.Time                             `json:"last_updated"`
+}
+
+// ValidationRecoveryResult describes a report's recovery outcome.
+type ValidationRecoveryResult struct {
+	IncidentID string `json:"incident_id"`
+	Action     string `json:"action"`
+	RepairBead string `json:"repair_bead,omitempty"`
+	Message    string `json:"message,omitempty"`
+	Error      error  `json:"-"`
+}
+
+// ValidationStateFile returns the durable validation recovery ledger path.
+func ValidationStateFile(townRoot string) string {
+	return filepath.Join(townRoot, "deacon", "validation-recovery-state.json")
+}
+
+func validationStateLockFile(townRoot string) string {
+	return ValidationStateFile(townRoot) + ".lock"
+}
+
+// LoadValidationState loads the validation ledger without taking its lock.
+// Callers performing read-modify-write operations must use withValidationState.
+func LoadValidationState(townRoot string) (*ValidationState, error) {
+	data, err := os.ReadFile(ValidationStateFile(townRoot)) //nolint:gosec // trusted town root
+	if errors.Is(err, os.ErrNotExist) {
+		return newValidationState(), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading validation recovery state: %w", err)
+	}
+	var state ValidationState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("parsing validation recovery state: %w", err)
+	}
+	if state.Incidents == nil {
+		state.Incidents = make(map[string]*ValidationIncident)
+	}
+	if state.MainBranches == nil {
+		state.MainBranches = make(map[string]*MainBranchValidationState)
+	}
+	return &state, nil
+}
+
+func newValidationState() *ValidationState {
+	return &ValidationState{
+		Version:      validationStateVersion,
+		Incidents:    make(map[string]*ValidationIncident),
+		MainBranches: make(map[string]*MainBranchValidationState),
+	}
+}
+
+func saveValidationState(townRoot string, state *ValidationState) error {
+	state.Version = validationStateVersion
+	state.LastUpdated = time.Now().UTC()
+	return atomicfile.EnsureDirAndWriteJSONWithPerm(ValidationStateFile(townRoot), state, 0600)
+}
+
+func withValidationState(townRoot string, fn func(*ValidationState) error) error {
+	if err := os.MkdirAll(filepath.Dir(ValidationStateFile(townRoot)), 0755); err != nil {
+		return fmt.Errorf("creating deacon state directory: %w", err)
+	}
+	lock := flock.New(validationStateLockFile(townRoot))
+	if err := lock.Lock(); err != nil {
+		return fmt.Errorf("locking validation recovery state: %w", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	state, err := LoadValidationState(townRoot)
+	if err != nil {
+		return err
+	}
+	if err := fn(state); err != nil {
+		return err
+	}
+	return saveValidationState(townRoot, state)
+}
+
+// NormalizeValidationFailure validates and canonicalizes a report.
+func NormalizeValidationFailure(event ValidationFailure) (ValidationFailure, error) {
+	event.Type = ValidationFailedEventType
+	event.Rig = strings.TrimSpace(event.Rig)
+	event.SourceIssue = strings.TrimSpace(event.SourceIssue)
+	event.MergeRequest = strings.TrimSpace(event.MergeRequest)
+	event.Branch = strings.TrimSpace(event.Branch)
+	event.Commit = strings.TrimSpace(event.Commit)
+	event.Phase = strings.ToLower(strings.TrimSpace(event.Phase))
+	event.Kind = strings.ToLower(strings.TrimSpace(event.Kind))
+	event.Command = strings.TrimSpace(event.Command)
+	event.Summary = strings.TrimSpace(event.Summary)
+	event.IncidentID = strings.TrimSpace(event.IncidentID)
+	event.Evidence = truncateValidationEvidence(event.Evidence)
+
+	if event.Rig == "" {
+		return event, errors.New("rig is required")
+	}
+	if event.Phase != "pre-merge" && event.Phase != "post-merge" {
+		return event, fmt.Errorf("invalid phase %q: expected pre-merge or post-merge", event.Phase)
+	}
+	switch event.Kind {
+	case "functional", "test", "build", "lint", "typecheck":
+	default:
+		return event, fmt.Errorf("invalid kind %q", event.Kind)
+	}
+	if event.Summary == "" {
+		return event, errors.New("summary is required")
+	}
+	if strings.TrimSpace(event.Evidence) == "" {
+		return event, errors.New("failure evidence is required")
+	}
+	if event.Phase == "pre-merge" {
+		if event.SourceIssue == "" {
+			return event, errors.New("source issue is required for pre-merge recovery")
+		}
+		if event.Branch == "" {
+			return event, errors.New("branch is required for pre-merge recovery")
+		}
+	}
+	if event.Phase == "post-merge" && event.Commit == "" {
+		return event, errors.New("commit is required for post-merge recovery")
+	}
+	if event.ReportedAt.IsZero() {
+		event.ReportedAt = time.Now().UTC()
+	}
+	return event, nil
+}
+
+func truncateValidationEvidence(evidence string) string {
+	if len(evidence) <= maxValidationEvidence {
+		return evidence
+	}
+	return "[truncated]\n" + evidence[len(evidence)-maxValidationEvidence:]
+}
+
+func validationFingerprint(event ValidationFailure) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		event.Rig, event.Phase, event.SourceIssue, event.MergeRequest,
+		event.Branch, event.Commit, event.Kind, event.Command,
+		strconv.Itoa(event.ExitCode), event.Summary, event.Evidence,
+	}, "\x00")))
+	return hex.EncodeToString(sum[:])
+}
+
+func validationIncidentID(event ValidationFailure) string {
+	if event.IncidentID != "" {
+		return event.IncidentID
+	}
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		event.Rig, event.Phase, event.SourceIssue, event.MergeRequest,
+		event.Branch, event.Commit, event.Kind,
+	}, "\x00")))
+	return "vf-" + hex.EncodeToString(sum[:8])
+}
+
+func findActiveIncident(state *ValidationState, event ValidationFailure) *ValidationIncident {
+	if event.IncidentID != "" {
+		return state.Incidents[event.IncidentID]
+	}
+	for _, incident := range state.Incidents {
+		if incident.Status == "resolved" || incident.Rig != event.Rig || incident.Phase != event.Phase {
+			continue
+		}
+		if event.SourceIssue != "" && incident.SourceIssue == event.SourceIssue {
+			return incident
+		}
+		if event.MergeRequest != "" && incident.MergeRequest == event.MergeRequest {
+			return incident
+		}
+		if event.Phase == "post-merge" && incident.InitialCommit == event.Commit {
+			return incident
+		}
+	}
+	return nil
+}
+
+func loadValidationRecoveryConfig(townRoot, rigName string) (*ValidationRecoveryConfig, error) {
+	projectDir := filepath.Join(townRoot, rigName, "refinery", "rig")
+	cfg, err := LoadModelEscalationConfig(projectDir)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil || !cfg.Enabled || cfg.ValidationFailure == nil || !cfg.ValidationFailure.Enabled {
+		return nil, nil
+	}
+	result := *cfg.ValidationFailure
+	if result.ToAgent == "" {
+		result.ToAgent = "opencode-go"
+	}
+	if result.MaxHostedAttempts <= 0 {
+		result.MaxHostedAttempts = 1
+	}
+	if result.RepairPriority <= 0 || result.RepairPriority > 4 {
+		result.RepairPriority = 1
+	}
+	return &result, nil
+}
+
+var (
+	dispatchValidationRepairFn = dispatchValidationRepair
+	createValidationRepairFn   = createValidationRepair
+	escalateValidationFn       = escalateValidationToMayor
+)
+
+// ProcessValidationFailure records a confirmed failure before taking action,
+// deduplicates repeat observations, and enforces the hosted-attempt boundary.
+func ProcessValidationFailure(townRoot string, raw ValidationFailure) *ValidationRecoveryResult {
+	event, err := NormalizeValidationFailure(raw)
+	if err != nil {
+		return &ValidationRecoveryResult{Action: "error", Error: err}
+	}
+	cfg, err := loadValidationRecoveryConfig(townRoot, event.Rig)
+	if err != nil {
+		return &ValidationRecoveryResult{Action: "error", Error: err}
+	}
+	if cfg == nil {
+		return &ValidationRecoveryResult{Action: "disabled", Message: "validation recovery is not enabled for this rig"}
+	}
+
+	fingerprint := validationFingerprint(event)
+	var incidentID string
+	var repairBead string
+	var action string
+
+	err = withValidationState(townRoot, func(state *ValidationState) error {
+		incident := findActiveIncident(state, event)
+		if incident == nil {
+			incidentID = validationIncidentID(event)
+			event.IncidentID = incidentID
+			if existing := state.Incidents[incidentID]; existing != nil && existing.Status != "resolved" {
+				incident = existing
+			} else {
+				now := time.Now().UTC()
+				incident = &ValidationIncident{
+					ID:                incidentID,
+					Rig:               event.Rig,
+					Phase:             event.Phase,
+					SourceIssue:       event.SourceIssue,
+					MergeRequest:      event.MergeRequest,
+					Branch:            event.Branch,
+					InitialCommit:     event.Commit,
+					TargetAgent:       cfg.ToAgent,
+					MaxHostedAttempts: cfg.MaxHostedAttempts,
+					Status:            "recorded",
+					FirstEvent:        event,
+					LastEvent:         event,
+					CreatedAt:         now,
+					UpdatedAt:         now,
+				}
+				state.Incidents[incidentID] = incident
+			}
+		}
+		incidentID = incident.ID
+		event.IncidentID = incident.ID
+		repairBead = incident.RepairBead
+
+		if incident.Status == "resolved" {
+			action = "resolved"
+			return nil
+		}
+		if incident.Status == "dispatching" || incident.Status == "escalating" {
+			action = "in-progress"
+			return nil
+		}
+		if incident.LastFingerprint == fingerprint &&
+			incident.Status != "dispatch-error" &&
+			incident.Status != "escalation-error" {
+			action = "duplicate"
+			return nil
+		}
+		incident.LastFingerprint = fingerprint
+		incident.LastEvent = event
+		incident.Observations = append(incident.Observations, ValidationObservation{
+			Fingerprint: fingerprint,
+			Commit:      event.Commit,
+			Kind:        event.Kind,
+			ExitCode:    event.ExitCode,
+			ObservedAt:  event.ReportedAt,
+		})
+		incident.UpdatedAt = time.Now().UTC()
+
+		if incident.HostedAttempts >= incident.MaxHostedAttempts {
+			if incident.Status == "escalated" {
+				action = "already-escalated"
+			} else {
+				incident.Status = "escalating"
+				action = "escalate"
+			}
+			return nil
+		}
+
+		incident.Status = "dispatching"
+		incident.LastError = ""
+		action = "dispatch"
+		return nil
+	})
+	if err != nil {
+		return &ValidationRecoveryResult{IncidentID: incidentID, Action: "error", Error: err}
+	}
+
+	switch action {
+	case "duplicate":
+		return &ValidationRecoveryResult{IncidentID: incidentID, Action: "duplicate", RepairBead: repairBead, Message: "failure observation already processed"}
+	case "resolved":
+		return &ValidationRecoveryResult{IncidentID: incidentID, Action: "resolved", RepairBead: repairBead, Message: "incident is already resolved"}
+	case "in-progress":
+		return &ValidationRecoveryResult{IncidentID: incidentID, Action: "in-progress", RepairBead: repairBead, Message: "incident recovery is already in progress"}
+	case "already-escalated":
+		return &ValidationRecoveryResult{IncidentID: incidentID, Action: "already-escalated", RepairBead: repairBead, Message: "incident already escalated to Mayor"}
+	case "escalate":
+		err = escalateValidationFn(townRoot, incidentID, event)
+		stateErr := withValidationState(townRoot, func(state *ValidationState) error {
+			incident := state.Incidents[incidentID]
+			if err != nil {
+				incident.Status = "escalation-error"
+				incident.LastError = err.Error()
+			} else {
+				incident.Status = "escalated"
+				incident.EscalatedAt = time.Now().UTC()
+			}
+			incident.UpdatedAt = time.Now().UTC()
+			return nil
+		})
+		if err == nil && stateErr != nil {
+			err = fmt.Errorf("persisting validation escalation result: %w", stateErr)
+		}
+		if err != nil {
+			return &ValidationRecoveryResult{IncidentID: incidentID, Action: "error", RepairBead: repairBead, Error: err}
+		}
+		return &ValidationRecoveryResult{IncidentID: incidentID, Action: "escalated", RepairBead: repairBead, Message: "hosted repair allowance exhausted; escalated to Mayor"}
+	}
+
+	if event.Phase == "post-merge" && repairBead == "" {
+		repairBead, err = createValidationRepairFn(townRoot, event, cfg.RepairPriority, incidentID)
+		if err == nil {
+			err = withValidationState(townRoot, func(state *ValidationState) error {
+				state.Incidents[incidentID].RepairBead = repairBead
+				return nil
+			})
+		}
+	}
+	if err == nil {
+		beadID := event.SourceIssue
+		if event.Phase == "post-merge" {
+			beadID = repairBead
+		}
+		err = dispatchValidationRepairFn(townRoot, beadID, event.Rig, event.Branch, cfg.ToAgent, incidentID)
+	}
+
+	stateErr := withValidationState(townRoot, func(state *ValidationState) error {
+		incident := state.Incidents[incidentID]
+		incident.UpdatedAt = time.Now().UTC()
+		incident.RepairBead = repairBead
+		if err != nil {
+			incident.Status = "dispatch-error"
+			incident.LastError = err.Error()
+		} else {
+			incident.Status = "hosted-dispatched"
+			incident.HostedAttempts++
+		}
+		return nil
+	})
+	if err == nil && stateErr != nil {
+		err = fmt.Errorf("persisting validation dispatch result: %w", stateErr)
+	}
+	if err != nil {
+		return &ValidationRecoveryResult{IncidentID: incidentID, Action: "error", RepairBead: repairBead, Error: err}
+	}
+	return &ValidationRecoveryResult{
+		IncidentID: incidentID,
+		Action:     "dispatched",
+		RepairBead: repairBead,
+		Message:    fmt.Sprintf("dispatched one repair attempt with agent %q", cfg.ToAgent),
+	}
+}
+
+func dispatchValidationRepair(townRoot, beadID, rigName, branch, agent, incidentID string) error {
+	if beadID == "" {
+		return errors.New("repair bead is empty")
+	}
+	args := []string{"sling", beadID, rigName, "--force", "--no-convoy", "--agent", agent}
+	if branch != "" {
+		args = append(args, "--branch", branch)
+	}
+	args = append(args, "--args", fmt.Sprintf(
+		"Validation recovery incident %s. Reproduce the recorded failure first, repair it without weakening validation, then run the failing check and the full configured suite.",
+		incidentID,
+	))
+	cmd := exec.Command("gt", args...)
+	cmd.Dir = townRoot
+	cmd.Env = deaconMutationRoutingEnv(townRoot)
+	util.SetDetachedProcessGroup(cmd)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("dispatching validation repair: %w (%s)", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func createValidationRepair(townRoot string, event ValidationFailure, priority int, incidentID string) (string, error) {
+	// The refinery project worktree always carries the rig's .beads redirect.
+	// Mayor worktrees are optional and may not have one on docked/minimal rigs.
+	workDir := filepath.Join(townRoot, event.Rig, "refinery", "rig")
+	if _, err := os.Stat(workDir); err != nil {
+		return "", fmt.Errorf("repair issue workspace: %w", err)
+	}
+	title := fmt.Sprintf("Repair validation regression from %s", shortValidationSHA(event.Commit))
+	description := fmt.Sprintf(`Validation recovery incident: %s
+Rig: %s
+Failing commit: %s
+Source issue: %s
+Failure kind: %s
+Command: %s
+Exit code: %d
+Summary: %s
+
+Evidence:
+%s`, incidentID, event.Rig, event.Commit, event.SourceIssue, event.Kind, event.Command, event.ExitCode, event.Summary, event.Evidence)
+	acceptance := "Reproduce the reported regression; make the failing check pass; run the rig's full configured validation suite; do not remove or weaken valid tests."
+	args := []string{
+		"create", "--silent",
+		"--title=" + title,
+		"--type=bug",
+		fmt.Sprintf("--priority=%d", priority),
+		"--description=" + description,
+		"--acceptance=" + acceptance,
+	}
+	if event.SourceIssue != "" {
+		args = append(args, "--deps=discovered-from:"+event.SourceIssue)
+	}
+	cmd := exec.Command("bd", args...)
+	cmd.Dir = workDir
+	cmd.Env = deaconMutationRoutingEnv(townRoot)
+	util.SetDetachedProcessGroup(cmd)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("creating validation repair bead: %w (%s)", err, strings.TrimSpace(string(output)))
+	}
+	id := strings.TrimSpace(string(output))
+	if fields := strings.Fields(id); len(fields) > 0 {
+		id = fields[len(fields)-1]
+	}
+	if id == "" {
+		return "", errors.New("bd create returned an empty repair bead id")
+	}
+	return id, nil
+}
+
+func shortValidationSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	if sha == "" {
+		return "unknown"
+	}
+	return sha
+}
+
+func escalateValidationToMayor(townRoot, incidentID string, event ValidationFailure) error {
+	subject := fmt.Sprintf("VALIDATION_REPAIR_FAILED %s", incidentID)
+	body := fmt.Sprintf(`Validation incident %s still fails after its hosted repair attempt.
+
+Rig: %s
+Phase: %s
+Source issue: %s
+Merge request: %s
+Branch: %s
+Commit: %s
+Kind: %s
+Command: %s
+Exit code: %d
+Summary: %s
+
+Evidence:
+%s
+
+Automatic dispatch is stopped. Investigate manually; do not weaken valid validation.`,
+		incidentID, event.Rig, event.Phase, event.SourceIssue, event.MergeRequest,
+		event.Branch, event.Commit, event.Kind, event.Command, event.ExitCode,
+		event.Summary, event.Evidence)
+	cmd := exec.Command("gt", "mail", "send", "mayor/", "-s", subject, "-m", body)
+	cmd.Dir = townRoot
+	cmd.Env = deaconMutationRoutingEnv(townRoot)
+	util.SetDetachedProcessGroup(cmd)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("escalating validation incident to Mayor: %w (%s)", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// ResolveValidationIncidents marks matching active incidents resolved.
+func ResolveValidationIncidents(townRoot, incidentID, rigName, sourceIssue, phase string) (int, error) {
+	resolved := 0
+	err := withValidationState(townRoot, func(state *ValidationState) error {
+		now := time.Now().UTC()
+		for id, incident := range state.Incidents {
+			if incidentID != "" && id != incidentID {
+				continue
+			}
+			if rigName != "" && incident.Rig != rigName {
+				continue
+			}
+			if sourceIssue != "" && incident.SourceIssue != sourceIssue && incident.RepairBead != sourceIssue {
+				continue
+			}
+			if phase != "" && incident.Phase != phase {
+				continue
+			}
+			if incident.Status == "resolved" {
+				continue
+			}
+			incident.Status = "resolved"
+			incident.ResolvedAt = now
+			incident.UpdatedAt = now
+			resolved++
+		}
+		return nil
+	})
+	return resolved, err
+}
+
+// MainBranchValidation returns a copy of a rig's main-branch state.
+func MainBranchValidation(townRoot, rigName string) (*MainBranchValidationState, error) {
+	state, err := LoadValidationState(townRoot)
+	if err != nil {
+		return nil, err
+	}
+	current := state.MainBranches[rigName]
+	if current == nil {
+		return &MainBranchValidationState{}, nil
+	}
+	copy := *current
+	return &copy, nil
+}
+
+// RecordMainBranchValidation updates a rig's tested and optionally green SHA.
+func RecordMainBranchValidation(townRoot, rigName, testedSHA string, green bool) error {
+	return withValidationState(townRoot, func(state *ValidationState) error {
+		current := state.MainBranches[rigName]
+		if current == nil {
+			current = &MainBranchValidationState{}
+			state.MainBranches[rigName] = current
+		}
+		current.LastTestedSHA = testedSHA
+		if green {
+			current.LastGreenSHA = testedSHA
+		}
+		current.UpdatedAt = time.Now().UTC()
+		return nil
+	})
+}

--- a/internal/deacon/validation_recovery_test.go
+++ b/internal/deacon/validation_recovery_test.go
@@ -1,0 +1,257 @@
+package deacon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeValidationPolicy(t *testing.T, townRoot, rigName string) {
+	t.Helper()
+	dir := filepath.Join(townRoot, rigName, "refinery", "rig", ".gastown")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data := `{
+		"type": "model-escalation",
+		"version": 1,
+		"enabled": true,
+		"rules": [],
+		"validation_failure": {
+			"enabled": true,
+			"to_agent": "opencode-go",
+			"max_hosted_attempts": 1,
+			"repair_priority": 1
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(dir, "model-escalation.json"), []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNormalizeValidationFailure(t *testing.T) {
+	event, err := NormalizeValidationFailure(ValidationFailure{
+		Rig:         " canary ",
+		SourceIssue: "c-123",
+		Branch:      "polecat/test",
+		Phase:       "PRE-MERGE",
+		Kind:        "TEST",
+		Summary:     "fails",
+		Evidence:    strings.Repeat("x", maxValidationEvidence+100),
+	})
+	if err != nil {
+		t.Fatalf("NormalizeValidationFailure: %v", err)
+	}
+	if event.Rig != "canary" || event.Phase != "pre-merge" || event.Kind != "test" {
+		t.Fatalf("event was not normalized: %+v", event)
+	}
+	if len(event.Evidence) > maxValidationEvidence+32 {
+		t.Fatalf("evidence was not bounded: %d", len(event.Evidence))
+	}
+	if event.ReportedAt.IsZero() {
+		t.Fatal("reported_at was not populated")
+	}
+}
+
+func TestProcessValidationFailureDispatchDeduplicateEscalate(t *testing.T) {
+	townRoot := t.TempDir()
+	writeValidationPolicy(t, townRoot, "canary")
+
+	originalDispatch := dispatchValidationRepairFn
+	originalEscalate := escalateValidationFn
+	t.Cleanup(func() {
+		dispatchValidationRepairFn = originalDispatch
+		escalateValidationFn = originalEscalate
+	})
+
+	dispatches := 0
+	escalations := 0
+	dispatchValidationRepairFn = func(townRoot, beadID, rigName, branch, agent, incidentID string) error {
+		dispatches++
+		if beadID != "c-123" || rigName != "canary" || branch != "polecat/test" || agent != "opencode-go" {
+			t.Fatalf("unexpected dispatch: bead=%s rig=%s branch=%s agent=%s", beadID, rigName, branch, agent)
+		}
+		return nil
+	}
+	escalateValidationFn = func(townRoot, incidentID string, event ValidationFailure) error {
+		escalations++
+		return nil
+	}
+
+	first := ValidationFailure{
+		Rig:          "canary",
+		SourceIssue:  "c-123",
+		MergeRequest: "mr-1",
+		Branch:       "polecat/test",
+		Commit:       "aaaaaaaa",
+		Phase:        "pre-merge",
+		Kind:         "test",
+		Command:      "go test ./...",
+		ExitCode:     1,
+		Summary:      "unit test failed",
+		Evidence:     "first output",
+	}
+	result := ProcessValidationFailure(townRoot, first)
+	if result.Action != "dispatched" || result.Error != nil {
+		t.Fatalf("first result = %+v", result)
+	}
+	if dispatches != 1 || escalations != 0 {
+		t.Fatalf("dispatches=%d escalations=%d", dispatches, escalations)
+	}
+
+	duplicate := ProcessValidationFailure(townRoot, first)
+	if duplicate.Action != "duplicate" {
+		t.Fatalf("duplicate action = %q", duplicate.Action)
+	}
+	if dispatches != 1 || escalations != 0 {
+		t.Fatalf("duplicate caused side effect: dispatches=%d escalations=%d", dispatches, escalations)
+	}
+
+	second := first
+	second.Commit = "bbbbbbbb"
+	second.Evidence = "hosted repair still fails"
+	secondResult := ProcessValidationFailure(townRoot, second)
+	if secondResult.Action != "escalated" || secondResult.Error != nil {
+		t.Fatalf("second result = %+v", secondResult)
+	}
+	if dispatches != 1 || escalations != 1 {
+		t.Fatalf("dispatches=%d escalations=%d", dispatches, escalations)
+	}
+
+	state, err := LoadValidationState(townRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	incident := state.Incidents[result.IncidentID]
+	if incident == nil || incident.HostedAttempts != 1 || incident.Status != "escalated" {
+		t.Fatalf("unexpected incident: %+v", incident)
+	}
+	if len(incident.Observations) != 2 {
+		t.Fatalf("observations=%d, want 2", len(incident.Observations))
+	}
+}
+
+func TestProcessPostMergeCreatesOneRepairBead(t *testing.T) {
+	townRoot := t.TempDir()
+	writeValidationPolicy(t, townRoot, "canary")
+
+	originalDispatch := dispatchValidationRepairFn
+	originalCreate := createValidationRepairFn
+	t.Cleanup(func() {
+		dispatchValidationRepairFn = originalDispatch
+		createValidationRepairFn = originalCreate
+	})
+
+	creates := 0
+	createValidationRepairFn = func(townRoot string, event ValidationFailure, priority int, incidentID string) (string, error) {
+		creates++
+		if priority != 1 || event.SourceIssue != "c-source" {
+			t.Fatalf("unexpected repair request: priority=%d event=%+v", priority, event)
+		}
+		return "c-repair", nil
+	}
+	dispatchValidationRepairFn = func(townRoot, beadID, rigName, branch, agent, incidentID string) error {
+		if beadID != "c-repair" || branch != "" {
+			t.Fatalf("unexpected repair dispatch: bead=%s branch=%s", beadID, branch)
+		}
+		return nil
+	}
+
+	event := ValidationFailure{
+		Rig:         "canary",
+		SourceIssue: "c-source",
+		Commit:      "deadbeef",
+		Phase:       "post-merge",
+		Kind:        "functional",
+		Summary:     "endpoint returns 500",
+		Evidence:    "reproduced twice",
+	}
+	first := ProcessValidationFailure(townRoot, event)
+	if first.Action != "dispatched" || first.RepairBead != "c-repair" {
+		t.Fatalf("first result = %+v", first)
+	}
+	second := ProcessValidationFailure(townRoot, event)
+	if second.Action != "duplicate" || creates != 1 {
+		t.Fatalf("second result=%+v creates=%d", second, creates)
+	}
+}
+
+func TestCreateValidationRepairUsesRefineryWorktree(t *testing.T) {
+	townRoot := t.TempDir()
+	workDir := filepath.Join(townRoot, "canary", "refinery", "rig")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	cwdLog := filepath.Join(t.TempDir(), "cwd")
+	script := "#!/bin/sh\npwd > \"$BD_CWD_LOG\"\nprintf 'cy-repair\\n'\n"
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BD_CWD_LOG", cwdLog)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	id, err := createValidationRepair(townRoot, ValidationFailure{
+		Rig:         "canary",
+		SourceIssue: "cy-source",
+		Commit:      "deadbeef",
+		Kind:        "test",
+		Command:     "go test ./...",
+		Summary:     "tests fail",
+		Evidence:    "failure output",
+	}, 1, "vf-test")
+	if err != nil {
+		t.Fatalf("createValidationRepair: %v", err)
+	}
+	if id != "cy-repair" {
+		t.Fatalf("repair id = %q", id)
+	}
+	logged, err := os.ReadFile(cwdLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDir, err := filepath.EvalSymlinks(workDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotDir, err := filepath.EvalSymlinks(strings.TrimSpace(string(logged)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotDir != wantDir {
+		t.Fatalf("bd cwd = %q, want %q", gotDir, wantDir)
+	}
+}
+
+func TestValidationStateIsJSONAndResolutionIsDurable(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := withValidationState(townRoot, func(state *ValidationState) error {
+		state.Incidents["vf-test"] = &ValidationIncident{
+			ID:          "vf-test",
+			Rig:         "canary",
+			Phase:       "pre-merge",
+			SourceIssue: "c-1",
+			Status:      "hosted-dispatched",
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := ResolveValidationIncidents(townRoot, "", "canary", "c-1", "pre-merge")
+	if err != nil || resolved != 1 {
+		t.Fatalf("resolved=%d err=%v", resolved, err)
+	}
+	data, err := os.ReadFile(ValidationStateFile(townRoot))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded ValidationState
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("state is not valid JSON: %v", err)
+	}
+	if decoded.Incidents["vf-test"].Status != "resolved" {
+		t.Fatalf("incident not resolved: %+v", decoded.Incidents["vf-test"])
+	}
+}

--- a/internal/deacon/validation_recovery_test.go
+++ b/internal/deacon/validation_recovery_test.go
@@ -21,6 +21,8 @@ func writeValidationPolicy(t *testing.T, townRoot, rigName string) {
 		"rules": [],
 		"validation_failure": {
 			"enabled": true,
+			"local_agent": "opencode-local",
+			"max_local_attempts": 1,
 			"to_agent": "opencode-go",
 			"max_hosted_attempts": 1,
 			"repair_priority": 1
@@ -66,11 +68,11 @@ func TestProcessValidationFailureDispatchDeduplicateEscalate(t *testing.T) {
 		escalateValidationFn = originalEscalate
 	})
 
-	dispatches := 0
+	var dispatchedAgents []string
 	escalations := 0
 	dispatchValidationRepairFn = func(townRoot, beadID, rigName, branch, agent, incidentID string) error {
-		dispatches++
-		if beadID != "c-123" || rigName != "canary" || branch != "polecat/test" || agent != "opencode-go" {
+		dispatchedAgents = append(dispatchedAgents, agent)
+		if beadID != "c-123" || rigName != "canary" || branch != "polecat/test" {
 			t.Fatalf("unexpected dispatch: bead=%s rig=%s branch=%s agent=%s", beadID, rigName, branch, agent)
 		}
 		return nil
@@ -97,27 +99,38 @@ func TestProcessValidationFailureDispatchDeduplicateEscalate(t *testing.T) {
 	if result.Action != "dispatched" || result.Error != nil {
 		t.Fatalf("first result = %+v", result)
 	}
-	if dispatches != 1 || escalations != 0 {
-		t.Fatalf("dispatches=%d escalations=%d", dispatches, escalations)
+	if len(dispatchedAgents) != 1 || dispatchedAgents[0] != "opencode-local" || escalations != 0 {
+		t.Fatalf("dispatches=%v escalations=%d", dispatchedAgents, escalations)
 	}
 
 	duplicate := ProcessValidationFailure(townRoot, first)
 	if duplicate.Action != "duplicate" {
 		t.Fatalf("duplicate action = %q", duplicate.Action)
 	}
-	if dispatches != 1 || escalations != 0 {
-		t.Fatalf("duplicate caused side effect: dispatches=%d escalations=%d", dispatches, escalations)
+	if len(dispatchedAgents) != 1 || escalations != 0 {
+		t.Fatalf("duplicate caused side effect: dispatches=%v escalations=%d", dispatchedAgents, escalations)
 	}
 
 	second := first
 	second.Commit = "bbbbbbbb"
 	second.Evidence = "hosted repair still fails"
 	secondResult := ProcessValidationFailure(townRoot, second)
-	if secondResult.Action != "escalated" || secondResult.Error != nil {
+	if secondResult.Action != "dispatched" || secondResult.Error != nil {
 		t.Fatalf("second result = %+v", secondResult)
 	}
-	if dispatches != 1 || escalations != 1 {
-		t.Fatalf("dispatches=%d escalations=%d", dispatches, escalations)
+	if len(dispatchedAgents) != 2 || dispatchedAgents[1] != "opencode-go" || escalations != 0 {
+		t.Fatalf("dispatches=%v escalations=%d", dispatchedAgents, escalations)
+	}
+
+	third := second
+	third.Commit = "cccccccc"
+	third.Evidence = "Go repair still fails"
+	thirdResult := ProcessValidationFailure(townRoot, third)
+	if thirdResult.Action != "escalated" || thirdResult.Error != nil {
+		t.Fatalf("third result = %+v", thirdResult)
+	}
+	if len(dispatchedAgents) != 2 || escalations != 1 {
+		t.Fatalf("dispatches=%v escalations=%d", dispatchedAgents, escalations)
 	}
 
 	state, err := LoadValidationState(townRoot)
@@ -125,11 +138,11 @@ func TestProcessValidationFailureDispatchDeduplicateEscalate(t *testing.T) {
 		t.Fatal(err)
 	}
 	incident := state.Incidents[result.IncidentID]
-	if incident == nil || incident.HostedAttempts != 1 || incident.Status != "escalated" {
+	if incident == nil || incident.LocalAttempts != 1 || incident.HostedAttempts != 1 || incident.Status != "escalated" {
 		t.Fatalf("unexpected incident: %+v", incident)
 	}
-	if len(incident.Observations) != 2 {
-		t.Fatalf("observations=%d, want 2", len(incident.Observations))
+	if len(incident.Observations) != 3 {
+		t.Fatalf("observations=%d, want 3", len(incident.Observations))
 	}
 }
 

--- a/internal/doctor/hooks_sync_check.go
+++ b/internal/doctor/hooks_sync_check.go
@@ -128,7 +128,7 @@ func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 			if loc.Rig == "" || useSettingsDir {
 				checkDirs = []string{loc.Dir}
 			} else {
-				checkDirs = hooks.DiscoverWorktrees(loc.Dir)
+				checkDirs = hooks.DiscoverWorktreesForRole(loc.Dir, loc.Role)
 			}
 
 			for _, dir := range checkDirs {

--- a/internal/doctor/model_crash_recovery_check.go
+++ b/internal/doctor/model_crash_recovery_check.go
@@ -56,11 +56,15 @@ func (c *ModelCrashRecoveryCheck) Run(ctx *CheckContext) *CheckResult {
 
 	details := make([]string, 0, len(incidents))
 	active := 0
+	exhausted := 0
 	for _, incident := range incidents {
 		if !incident.Confirmed && !incident.RecoveryExhausted {
 			continue
 		}
 		active++
+		if incident.RecoveryExhausted {
+			exhausted++
+		}
 		details = append(details, fmt.Sprintf(
 			"%s: incident=%s action=%s exhausted=%t session=%s",
 			incident.Identity, incident.IncidentID, incident.RecoveryAction,
@@ -74,10 +78,16 @@ func (c *ModelCrashRecoveryCheck) Run(ctx *CheckContext) *CheckResult {
 			Category: CategoryInfrastructure,
 		}
 	}
+	status := StatusWarning
+	message := fmt.Sprintf("%d model-crash recovery incident(s) are being observed", active)
+	if exhausted > 0 {
+		status = StatusError
+		message = fmt.Sprintf("%d exhausted model-crash recovery incident(s) require attention", exhausted)
+	}
 	return &CheckResult{
 		Name:     c.Name(),
-		Status:   StatusError,
-		Message:  fmt.Sprintf("%d confirmed model-crash recovery incident(s) require attention", active),
+		Status:   status,
+		Message:  message,
 		Details:  details,
 		FixHint:  "Inspect with 'gt session health <tmux-session> --json'; recovery actions are supervisor-owned",
 		Category: CategoryInfrastructure,

--- a/internal/doctor/model_crash_recovery_check.go
+++ b/internal/doctor/model_crash_recovery_check.go
@@ -1,0 +1,85 @@
+package doctor
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/daemon"
+)
+
+// ModelCrashRecoveryCheck surfaces durable local-session model recovery
+// incidents without mutating supervisor state.
+type ModelCrashRecoveryCheck struct {
+	BaseCheck
+}
+
+func NewModelCrashRecoveryCheck() *ModelCrashRecoveryCheck {
+	return &ModelCrashRecoveryCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "model-crash-recovery",
+			CheckDescription: "Check local model-crash supervisor recovery state",
+			CheckCategory:    CategoryInfrastructure,
+		},
+	}
+}
+
+func (c *ModelCrashRecoveryCheck) Run(ctx *CheckContext) *CheckResult {
+	if !daemon.IsModelCrashRecoveryProvisioned(ctx.TownRoot) {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusOK,
+			Message:  "Local model-crash recovery is not provisioned",
+			Category: CategoryInfrastructure,
+		}
+	}
+	if err := daemon.ValidateModelCrashWatchdog(ctx.TownRoot, time.Now()); err != nil {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusError,
+			Message:  "Model-crash recovery is fail-closed because the LM watchdog is unavailable",
+			Details:  []string{err.Error()},
+			FixHint:  "Restore a fresh healthy deacon/lmstudio-watchdog.json before relying on automatic local-session recovery",
+			Category: CategoryInfrastructure,
+		}
+	}
+
+	incidents, err := daemon.LoadModelCrashRecoveryIncidents(ctx.TownRoot)
+	if err != nil {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusError,
+			Message:  "Failed to read model-crash supervisor state",
+			Details:  []string{err.Error()},
+			Category: CategoryInfrastructure,
+		}
+	}
+
+	details := make([]string, 0, len(incidents))
+	active := 0
+	for _, incident := range incidents {
+		if !incident.Confirmed && !incident.RecoveryExhausted {
+			continue
+		}
+		active++
+		details = append(details, fmt.Sprintf(
+			"%s: incident=%s action=%s exhausted=%t session=%s",
+			incident.Identity, incident.IncidentID, incident.RecoveryAction,
+			incident.RecoveryExhausted, incident.SessionName))
+	}
+	if active == 0 {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusOK,
+			Message:  "No confirmed model-crash recovery incidents",
+			Category: CategoryInfrastructure,
+		}
+	}
+	return &CheckResult{
+		Name:     c.Name(),
+		Status:   StatusError,
+		Message:  fmt.Sprintf("%d confirmed model-crash recovery incident(s) require attention", active),
+		Details:  details,
+		FixHint:  "Inspect with 'gt session health <tmux-session> --json'; recovery actions are supervisor-owned",
+		Category: CategoryInfrastructure,
+	}
+}

--- a/internal/doctor/model_crash_recovery_check_test.go
+++ b/internal/doctor/model_crash_recovery_check_test.go
@@ -1,0 +1,150 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestModelCrashRecoveryCheckPassesWithoutState(t *testing.T) {
+	townRoot := t.TempDir()
+	writeHealthyModelCrashWatchdog(t, townRoot)
+	check := NewModelCrashRecoveryCheck()
+	result := check.Run(&CheckContext{TownRoot: townRoot})
+	if result.Status != StatusOK {
+		t.Fatalf("status = %s, want OK: %#v", result.Status, result)
+	}
+}
+
+func TestModelCrashRecoveryCheckSkipsUnprovisionedTown(t *testing.T) {
+	result := NewModelCrashRecoveryCheck().Run(&CheckContext{TownRoot: t.TempDir()})
+	if result.Status != StatusOK {
+		t.Fatalf("unprovisioned town reported watchdog failure: %#v", result)
+	}
+}
+
+func TestModelCrashRecoveryCheckContractMarkerRequiresWatchdog(t *testing.T) {
+	townRoot := t.TempDir()
+	marker := filepath.Join(townRoot, "bin", "gt-lmstudio-watchdog")
+	if err := os.MkdirAll(filepath.Dir(marker), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(marker, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	result := NewModelCrashRecoveryCheck().Run(&CheckContext{TownRoot: townRoot})
+	if result.Status != StatusError {
+		t.Fatalf("installed watchdog contract without state was not strict: %#v", result)
+	}
+}
+
+func TestModelCrashRecoveryCheckSurfacesUnavailableWatchdog(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(*testing.T, string)
+	}{
+		{name: "missing"},
+		{name: "malformed", write: func(t *testing.T, townRoot string) {
+			writeModelCrashWatchdogFile(t, townRoot, []byte(`{"status":`))
+		}},
+		{name: "stale", write: func(t *testing.T, townRoot string) {
+			checkedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339Nano)
+			writeModelCrashWatchdogFile(t, townRoot, []byte(`{"status":"healthy","checked_at":"`+checkedAt+`"}`))
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			townRoot := t.TempDir()
+			writeModelCrashSupervisorMarker(t, townRoot)
+			if tt.write != nil {
+				tt.write(t, townRoot)
+			}
+			result := NewModelCrashRecoveryCheck().Run(&CheckContext{TownRoot: townRoot})
+			if result.Status != StatusError || len(result.Details) == 0 {
+				t.Fatalf("unavailable watchdog was not visible: %#v", result)
+			}
+		})
+	}
+}
+
+func TestModelCrashRecoveryCheckFailsForConfirmedOrExhaustedIncident(t *testing.T) {
+	tests := []struct {
+		name      string
+		action    string
+		exhausted bool
+	}{
+		{name: "confirmed recovery active", action: "local-restart"},
+		{name: "recovery exhausted", action: "awaiting-local-probe", exhausted: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			townRoot := t.TempDir()
+			writeHealthyModelCrashWatchdog(t, townRoot)
+			stateDir := filepath.Join(townRoot, "deacon")
+			if err := os.MkdirAll(stateDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			state := `{
+				"version": 1,
+				"sessions": {
+					"rig/polecats/toast": {
+						"session_name": "gt-toast",
+						"incident_id": "model-crash-1-toast",
+						"local_restarts": 1,
+						"recovery_action": "` + tt.action + `",
+						"recovery_exhausted": ` + boolJSON(tt.exhausted) + `
+					}
+				},
+				"alerts": {}
+			}`
+			if err := os.WriteFile(filepath.Join(stateDir, "model-crash-supervisor.json"), []byte(state), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			check := NewModelCrashRecoveryCheck()
+			result := check.Run(&CheckContext{TownRoot: townRoot})
+			if result.Status != StatusError {
+				t.Fatalf("status = %s, want Error: %#v", result.Status, result)
+			}
+			if result.Message == "" || len(result.Details) == 0 {
+				t.Fatalf("doctor result lacks incident visibility: %#v", result)
+			}
+		})
+	}
+}
+
+func writeModelCrashSupervisorMarker(t *testing.T, townRoot string) {
+	t.Helper()
+	stateDir := filepath.Join(townRoot, "deacon")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "model-crash-supervisor.json"), []byte(`{"version":1,"sessions":{},"alerts":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeHealthyModelCrashWatchdog(t *testing.T, townRoot string) {
+	t.Helper()
+	checkedAt := time.Now().Add(-30 * time.Second).UTC().Format(time.RFC3339Nano)
+	writeModelCrashWatchdogFile(t, townRoot, []byte(`{"status":"healthy","checked_at":"`+checkedAt+`"}`))
+}
+
+func writeModelCrashWatchdogFile(t *testing.T, townRoot string, data []byte) {
+	t.Helper()
+	stateDir := filepath.Join(townRoot, "deacon")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "lmstudio-watchdog.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func boolJSON(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/doctor/model_crash_recovery_check_test.go
+++ b/internal/doctor/model_crash_recovery_check_test.go
@@ -68,14 +68,15 @@ func TestModelCrashRecoveryCheckSurfacesUnavailableWatchdog(t *testing.T) {
 	}
 }
 
-func TestModelCrashRecoveryCheckFailsForConfirmedOrExhaustedIncident(t *testing.T) {
+func TestModelCrashRecoveryCheckDistinguishesActiveAndExhaustedIncident(t *testing.T) {
 	tests := []struct {
 		name      string
 		action    string
 		exhausted bool
+		want      CheckStatus
 	}{
-		{name: "confirmed recovery active", action: "local-restart"},
-		{name: "recovery exhausted", action: "awaiting-local-probe", exhausted: true},
+		{name: "confirmed recovery active", action: "local-restart", want: StatusWarning},
+		{name: "recovery exhausted", action: "awaiting-local-probe", exhausted: true, want: StatusError},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -104,8 +105,8 @@ func TestModelCrashRecoveryCheckFailsForConfirmedOrExhaustedIncident(t *testing.
 
 			check := NewModelCrashRecoveryCheck()
 			result := check.Run(&CheckContext{TownRoot: townRoot})
-			if result.Status != StatusError {
-				t.Fatalf("status = %s, want Error: %#v", result.Status, result)
+			if result.Status != tt.want {
+				t.Fatalf("status = %s, want %s: %#v", result.Status, tt.want, result)
 			}
 			if result.Message == "" || len(result.Details) == 0 {
 				t.Fatalf("doctor result lacks incident visibility: %#v", result)

--- a/internal/doctor/rig_check.go
+++ b/internal/doctor/rig_check.go
@@ -371,8 +371,12 @@ type WitnessExistsCheck struct {
 	FixableCheck
 	rigPath     string
 	needsCreate bool
-	needsClone  bool
-	needsMail   bool
+}
+
+// CanFix is state-dependent: creating a missing directory is safe, but
+// replacing an unexpected file at witness/ requires manual inspection.
+func (c *WitnessExistsCheck) CanFix() bool {
+	return c.needsCreate
 }
 
 // NewWitnessExistsCheck creates a new witness exists check.
@@ -400,30 +404,34 @@ func (c *WitnessExistsCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 
 	witnessDir := filepath.Join(c.rigPath, "witness")
-	rigClone := filepath.Join(witnessDir, "rig")
-	mailInbox := filepath.Join(witnessDir, "mail", "inbox.jsonl")
-
 	var issues []string
+	misplacedRootGit := false
 	c.needsCreate = false
-	c.needsClone = false
-	c.needsMail = false
 
-	// Check witness/ directory
-	if _, err := os.Stat(witnessDir); os.IsNotExist(err) {
+	// witness/ is the canonical clone-free working directory. Older towns may
+	// still have a witness/rig git clone; the witness manager supports that
+	// layout, but a clone is no longer a structural requirement. Runtime
+	// settings and hooks are intentionally owned by their dedicated checks.
+	info, err := os.Stat(witnessDir)
+	if os.IsNotExist(err) {
 		issues = append(issues, "Missing: witness/")
 		c.needsCreate = true
+	} else if err != nil {
+		issues = append(issues, fmt.Sprintf("Cannot inspect witness/: %v", err))
+	} else if !info.IsDir() {
+		issues = append(issues, "Invalid: witness/ is not a directory")
 	} else {
-		// Check witness/rig/ clone
-		rigGit := filepath.Join(rigClone, ".git")
-		if _, err := os.Stat(rigGit); os.IsNotExist(err) {
-			issues = append(issues, "Missing: witness/rig/ (git clone)")
-			c.needsClone = true
-		}
-
-		// Check witness/mail/inbox.jsonl
-		if _, err := os.Stat(mailInbox); os.IsNotExist(err) {
-			issues = append(issues, "Missing: witness/mail/inbox.jsonl")
-			c.needsMail = true
+		// Canonical Witness homes are clone-free at witness/ itself. A Git
+		// marker here means a product worktree was misplaced one level too
+		// high; only the supported legacy witness/rig/.git layout may contain
+		// product Git metadata.
+		rootGit := filepath.Join(witnessDir, ".git")
+		if _, err := os.Lstat(rootGit); err == nil {
+			misplacedRootGit = true
+			issues = append(issues,
+				"Invalid: witness/.git is a misplaced product worktree; canonical witness/ must be clone-free (legacy Git belongs at witness/rig/.git)")
+		} else if !os.IsNotExist(err) {
+			issues = append(issues, fmt.Sprintf("Cannot inspect witness/.git: %v", err))
 		}
 	}
 
@@ -435,39 +443,32 @@ func (c *WitnessExistsCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
+	fixHint := "Replace the invalid witness/ path with a directory after preserving any file contents"
+	if c.needsCreate {
+		fixHint = "Run 'gt doctor --fix' to create missing structure"
+	} else if misplacedRootGit {
+		fixHint = "Preserve any product changes, then remove the misplaced witness/.git worktree; use clone-free witness/ or supported legacy witness/rig/.git"
+	}
 	return &CheckResult{
 		Name:    c.Name(),
 		Status:  StatusWarning,
 		Message: "Witness structure incomplete",
 		Details: issues,
-		FixHint: "Run 'gt doctor --fix' to create missing structure",
+		FixHint: fixHint,
 	}
 }
 
 // Fix creates missing witness structure.
 func (c *WitnessExistsCheck) Fix(ctx *CheckContext) error {
+	if !c.needsCreate {
+		return ErrCannotFix
+	}
 	witnessDir := filepath.Join(c.rigPath, "witness")
 
 	if c.needsCreate {
 		if err := os.MkdirAll(witnessDir, 0755); err != nil {
 			return fmt.Errorf("failed to create witness/: %w", err)
 		}
-	}
-
-	if c.needsMail {
-		mailDir := filepath.Join(witnessDir, "mail")
-		if err := os.MkdirAll(mailDir, 0755); err != nil {
-			return fmt.Errorf("failed to create witness/mail/: %w", err)
-		}
-		inboxPath := filepath.Join(mailDir, "inbox.jsonl")
-		if err := os.WriteFile(inboxPath, []byte{}, 0644); err != nil {
-			return fmt.Errorf("failed to create inbox.jsonl: %w", err)
-		}
-	}
-
-	// Note: Cannot auto-fix clone without knowing the repo URL
-	if c.needsClone {
-		return fmt.Errorf("cannot auto-create witness/rig/ clone (requires repo URL)")
 	}
 
 	return nil

--- a/internal/doctor/stale_test_dolt_check.go
+++ b/internal/doctor/stale_test_dolt_check.go
@@ -1,0 +1,58 @@
+package doctor
+
+import (
+	"fmt"
+
+	"github.com/steveyegge/gastown/internal/doltserver"
+)
+
+const staleTestDoltErrorThreshold = 3
+
+var staleOwnedTestServersFn = doltserver.StaleOwnedTestServers
+
+// StaleTestDoltCheck reports native Dolt test servers whose durable ownership
+// metadata proves that their test parent has exited.
+type StaleTestDoltCheck struct {
+	BaseCheck
+}
+
+func NewStaleTestDoltCheck() *StaleTestDoltCheck {
+	return &StaleTestDoltCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "stale-test-dolt",
+			CheckDescription: "Detect test-owned Dolt servers that outlived their test process",
+			CheckCategory:    CategoryInfrastructure,
+		},
+	}
+}
+
+func (c *StaleTestDoltCheck) Run(_ *CheckContext) *CheckResult {
+	stale := staleOwnedTestServersFn()
+	if len(stale) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No test-owned Dolt servers outlived their tests",
+		}
+	}
+
+	details := make([]string, 0, len(stale))
+	for _, process := range stale {
+		details = append(details, fmt.Sprintf(
+			"PID %d owner=%s parent=%d root=%s started=%s",
+			process.PID, process.Owner, process.ParentPID, process.TownRoot,
+			process.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
+		))
+	}
+	status := StatusWarning
+	if len(stale) > staleTestDoltErrorThreshold {
+		status = StatusError
+	}
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  status,
+		Message: fmt.Sprintf("%d test-owned Dolt server(s) outlived their tests", len(stale)),
+		Details: details,
+		FixHint: "Reap only the listed ownership-proven test roots; never kill Dolt by name or port",
+	}
+}

--- a/internal/doctor/stale_test_dolt_check_test.go
+++ b/internal/doctor/stale_test_dolt_check_test.go
@@ -1,0 +1,26 @@
+package doctor
+
+import (
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/doltserver"
+)
+
+func TestStaleTestDoltCheckThreshold(t *testing.T) {
+	original := staleOwnedTestServersFn
+	t.Cleanup(func() { staleOwnedTestServersFn = original })
+
+	staleOwnedTestServersFn = func() []doltserver.TestServerOwnerMetadata {
+		return make([]doltserver.TestServerOwnerMetadata, staleTestDoltErrorThreshold)
+	}
+	if got := NewStaleTestDoltCheck().Run(&CheckContext{}); got.Status != StatusWarning {
+		t.Fatalf("threshold status = %v, want warning", got.Status)
+	}
+
+	staleOwnedTestServersFn = func() []doltserver.TestServerOwnerMetadata {
+		return make([]doltserver.TestServerOwnerMetadata, staleTestDoltErrorThreshold+1)
+	}
+	if got := NewStaleTestDoltCheck().Run(&CheckContext{}); got.Status != StatusError {
+		t.Fatalf("above-threshold status = %v, want error", got.Status)
+	}
+}

--- a/internal/doctor/witness_exists_clonefree_test.go
+++ b/internal/doctor/witness_exists_clonefree_test.go
@@ -1,0 +1,138 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWitnessExistsCheck_AcceptsCanonicalCloneFreeLayout(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "testrig"
+	witnessDir := filepath.Join(townRoot, rigName, "witness")
+	if err := os.MkdirAll(witnessDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Settings and hooks are owned by their dedicated doctor checks. Their
+	// absence must not make the structural witness check demand a repo clone.
+	check := NewWitnessExistsCheck()
+	result := check.Run(&CheckContext{TownRoot: townRoot, RigName: rigName})
+	if result.Status != StatusOK {
+		t.Fatalf("clone-free witness should be healthy, got %s: %s (%v)",
+			result.Status, result.Message, result.Details)
+	}
+}
+
+func TestWitnessExistsCheck_AcceptsLegacyRigClone(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "testrig"
+	legacyGitDir := filepath.Join(townRoot, rigName, "witness", "rig", ".git")
+	if err := os.MkdirAll(legacyGitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewWitnessExistsCheck()
+	result := check.Run(&CheckContext{TownRoot: townRoot, RigName: rigName})
+	if result.Status != StatusOK {
+		t.Fatalf("legacy witness/rig clone should remain supported, got %s: %s (%v)",
+			result.Status, result.Message, result.Details)
+	}
+}
+
+func TestWitnessExistsCheck_RejectsMisplacedRootGitWorktree(t *testing.T) {
+	for _, markerKind := range []string{"directory", "file"} {
+		t.Run(markerKind, func(t *testing.T) {
+			townRoot := t.TempDir()
+			rigName := "testrig"
+			witnessDir := filepath.Join(townRoot, rigName, "witness")
+			rootGit := filepath.Join(witnessDir, ".git")
+			if markerKind == "directory" {
+				if err := os.MkdirAll(rootGit, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(
+					filepath.Join(rootGit, "HEAD"),
+					[]byte("ref: refs/heads/main\n"),
+					0o644,
+				); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err := os.MkdirAll(witnessDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(rootGit, []byte("gitdir: /product/worktree\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			check := NewWitnessExistsCheck()
+			result := check.Run(&CheckContext{TownRoot: townRoot, RigName: rigName})
+			if result.Status == StatusOK {
+				t.Fatal("misplaced witness/.git product worktree passed canonical layout check")
+			}
+			if check.CanFix() {
+				t.Fatal("misplaced witness/.git was advertised as automatically fixable")
+			}
+			details := strings.Join(result.Details, "\n")
+			if !strings.Contains(details, "witness/.git") ||
+				!strings.Contains(strings.ToLower(details), "clone-free") {
+				t.Fatalf("misplaced root git was not clearly classified: %#v", result)
+			}
+		})
+	}
+}
+
+func TestWitnessExistsCheck_FixCreatesCanonicalLayoutOnly(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "testrig"
+	ctx := &CheckContext{TownRoot: townRoot, RigName: rigName}
+	check := NewWitnessExistsCheck()
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("missing witness should warn, got %s", result.Status)
+	}
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("clone-free witness fix failed: %v", err)
+	}
+
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Fatalf("fixed canonical witness should pass, got %s: %v", result.Status, result.Details)
+	}
+	if _, err := os.Stat(filepath.Join(townRoot, rigName, "witness", "rig")); !os.IsNotExist(err) {
+		t.Fatalf("fix should not synthesize legacy witness/rig clone, stat err=%v", err)
+	}
+	for _, detail := range result.Details {
+		if strings.Contains(detail, "settings") || strings.Contains(detail, "hook") {
+			t.Fatalf("structural check leaked settings/hooks concern: %q", detail)
+		}
+	}
+}
+
+func TestWitnessExistsCheck_InvalidFileIsNotFixable(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "testrig"
+	witnessPath := filepath.Join(townRoot, rigName, "witness")
+	if err := os.MkdirAll(filepath.Dir(witnessPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(witnessPath, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewWitnessExistsCheck()
+	result := check.Run(&CheckContext{TownRoot: townRoot, RigName: rigName})
+	if result.Status == StatusOK {
+		t.Fatalf("invalid witness file passed: %#v", result)
+	}
+	if check.CanFix() {
+		t.Fatal("invalid witness file falsely reported auto-fixable")
+	}
+	if strings.Contains(result.FixHint, "doctor --fix") {
+		t.Fatalf("invalid witness file advertised unsafe automatic fix: %#v", result)
+	}
+}

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1449,8 +1449,99 @@ func ReapOwnedTestServers(townRoot string) (int, error) {
 			stopped++
 		}
 	}
+	if stopped > 0 {
+		_ = os.Remove(testServerOwnerMetadataPath(config.DataDir))
+	}
 
 	return stopped, nil
+}
+
+// TestServerOwnerMetadata makes native Dolt processes started by tests
+// attributable without relying on a port or a broad process-name match.
+type TestServerOwnerMetadata struct {
+	PID       int       `json:"pid"`
+	ParentPID int       `json:"parent_pid"`
+	TownRoot  string    `json:"town_root"`
+	DataDir   string    `json:"data_dir"`
+	Owner     string    `json:"owner"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+func testServerOwnerMetadataPath(dataDir string) string {
+	return filepath.Join(dataDir, "test-server-owner.json")
+}
+
+func isTempOwnedRoot(root string) bool {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	absTemp, err := filepath.Abs(os.TempDir())
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absTemp, absRoot)
+	return err == nil && rel != "." && !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)
+}
+
+func writeTestServerOwnerMetadata(townRoot string, config *Config, pid int) error {
+	if !isTempOwnedRoot(townRoot) {
+		return nil
+	}
+	owner := os.Getenv("GT_TEST_OWNER")
+	if owner == "" {
+		owner = filepath.Base(os.Args[0])
+	}
+	metadata := TestServerOwnerMetadata{
+		PID:       pid,
+		ParentPID: os.Getpid(),
+		TownRoot:  townRoot,
+		DataDir:   config.DataDir,
+		Owner:     owner,
+		StartedAt: time.Now().UTC(),
+	}
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicfile.WriteFile(testServerOwnerMetadataPath(config.DataDir), data, 0o600)
+}
+
+// StaleOwnedTestServers returns only processes whose exact config path and
+// durable metadata agree and whose test parent is no longer alive.
+func StaleOwnedTestServers() []TestServerOwnerMetadata {
+	return staleOwnedTestServersFromPS(processList(), processIsAlive)
+}
+
+func staleOwnedTestServersFromPS(output string, isAlive func(int) bool) []TestServerOwnerMetadata {
+	var stale []TestServerOwnerMetadata
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 4 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil || !isDoltSQLServerArgs(fields[1:]) {
+			continue
+		}
+		configPath := getDoltFlagFromArgs(fields[1:], "--config")
+		if configPath == "" {
+			continue
+		}
+		var metadata TestServerOwnerMetadata
+		data, err := os.ReadFile(testServerOwnerMetadataPath(filepath.Dir(configPath))) //nolint:gosec // path comes from proven process args
+		if err != nil || json.Unmarshal(data, &metadata) != nil {
+			continue
+		}
+		if metadata.PID != pid || metadata.DataDir != filepath.Dir(configPath) ||
+			!isTempOwnedRoot(metadata.TownRoot) {
+			continue
+		}
+		if metadata.ParentPID <= 0 || !isAlive(metadata.ParentPID) {
+			stale = append(stale, metadata)
+		}
+	}
+	return stale
 }
 
 func ownedDoltTestServerCandidates(townRoot string, config *Config) []int {
@@ -1917,6 +2008,11 @@ func Start(townRoot string) error {
 		_ = cmd.Process.Kill()
 		return fmt.Errorf("writing PID file: %w", err)
 	}
+	if err := writeTestServerOwnerMetadata(townRoot, config, cmd.Process.Pid); err != nil {
+		_ = cmd.Process.Kill()
+		_ = os.Remove(config.PidFile)
+		return fmt.Errorf("writing test Dolt ownership metadata: %w", err)
+	}
 
 	// Save state
 	state := &State{
@@ -2127,6 +2223,7 @@ func Stop(townRoot string) error {
 
 	// Clean up PID file
 	_ = os.Remove(config.PidFile)
+	_ = os.Remove(testServerOwnerMetadataPath(config.DataDir))
 
 	// Update state - preserve historical info
 	state, _ := LoadState(townRoot)

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -329,6 +329,47 @@ func TestFindOwnedDoltTestServerCandidatesFromPS(t *testing.T) {
 	}
 }
 
+func TestStaleOwnedTestServersRequiresMatchingMetadataAndDeadParent(t *testing.T) {
+	root := t.TempDir()
+	config := DefaultConfig(root)
+	if err := os.MkdirAll(config.DataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := TestServerOwnerMetadata{
+		PID:       4242,
+		ParentPID: 3131,
+		TownRoot:  root,
+		DataDir:   config.DataDir,
+		Owner:     "go-test",
+		StartedAt: time.Now().UTC(),
+	}
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(testServerOwnerMetadataPath(config.DataDir), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ps := "4242 dolt sql-server --config " + filepath.Join(config.DataDir, "config.yaml")
+
+	if got := staleOwnedTestServersFromPS(ps, func(pid int) bool { return pid == 3131 }); len(got) != 0 {
+		t.Fatalf("live parent reported stale: %+v", got)
+	}
+	got := staleOwnedTestServersFromPS(ps, func(int) bool { return false })
+	if len(got) != 1 || got[0].PID != 4242 {
+		t.Fatalf("dead-parent result = %+v, want PID 4242", got)
+	}
+
+	metadata.PID = 9999
+	data, _ = json.Marshal(metadata)
+	if err := os.WriteFile(testServerOwnerMetadataPath(config.DataDir), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := staleOwnedTestServersFromPS(ps, func(int) bool { return false }); len(got) != 0 {
+		t.Fatalf("mismatched metadata was trusted: %+v", got)
+	}
+}
+
 func TestReapOwnedTestServersRefusesNonTempRoot(t *testing.T) {
 	if _, err := ReapOwnedTestServers(string(filepath.Separator)); err == nil {
 		t.Fatal("expected non-temp root to be rejected")

--- a/internal/formula/boot_triage_test.go
+++ b/internal/formula/boot_triage_test.go
@@ -98,7 +98,7 @@ func TestBootTriageFormulaPreservesRoutineTriageAndMechanicalAuthority(t *testin
 		"must not spawn cloud recovery",
 		"Do not change gateways",
 		"Do not change the model hierarchy",
-		"Never invoke Codex",
+		"Never invoke Codex yourself",
 		"Only the watchdog may declare recovery",
 	} {
 		if !strings.Contains(formula, want) {
@@ -107,15 +107,15 @@ func TestBootTriageFormulaPreservesRoutineTriageAndMechanicalAuthority(t *testin
 	}
 }
 
-func TestBootTriageFormulaRequiresCorrelatedGoExhaustionForClaude(t *testing.T) {
+func TestBootTriageFormulaRequiresFiniteInfrastructureLadder(t *testing.T) {
 	formula := readBootTriageFormula(t)
 
 	for _, want := range []string{
-		"positively correlated",
-		"quota or usage exhaustion error",
-		"Only `go-exhausted` may transition to `claude-last-ditch`",
-		"Ambiguous, authentication, network, or ordinary Go failures",
-		"must transition to `awaiting-human`",
+		"Only the watchdog may advance the finite Go → Claude → Codex ladder",
+		"`claude-last-ditch` | `claude`",
+		"`codex-last-ditch` | `codex`",
+		"Failure freezes the",
+		"incident in `awaiting-human`",
 		"Local mechanical recovery owns the 90-second head start before Go is spawned",
 	} {
 		if !strings.Contains(formula, want) {

--- a/internal/formula/boot_triage_test.go
+++ b/internal/formula/boot_triage_test.go
@@ -5,13 +5,18 @@ import (
 	"testing"
 )
 
-func TestBootTriageFormulaUsesNudgeForWake(t *testing.T) {
+func readBootTriageFormula(t *testing.T) string {
+	t.Helper()
+
 	content, err := formulasFS.ReadFile("formulas/mol-boot-triage.formula.toml")
 	if err != nil {
 		t.Fatalf("reading boot triage formula: %v", err)
 	}
+	return string(content)
+}
 
-	formula := string(content)
+func TestBootTriageFormulaUsesNudgeForWake(t *testing.T) {
+	formula := readBootTriageFormula(t)
 	for _, want := range []string{
 		`gt nudge --mode=immediate deacon "Boot wake: please check your inbox and pending work"`,
 		"Raw tmux send-keys is blocked for Boot",
@@ -27,6 +32,103 @@ func TestBootTriageFormulaUsesNudgeForWake(t *testing.T) {
 	} {
 		if strings.Contains(formula, forbidden) {
 			t.Fatalf("boot triage formula still contains forbidden raw tmux wake guidance %q", forbidden)
+		}
+	}
+}
+
+func TestBootTriageFormulaRoutesWatchdogIncidentPhases(t *testing.T) {
+	formula := readBootTriageFormula(t)
+
+	for _, want := range []string{
+		"`healthy`",
+		"`suspect`",
+		"`recovering-local`",
+		"`escalated-go`",
+		"`go-exhausted`",
+		"`claude-last-ditch`",
+		"`recovered-by-claude`",
+		"`report-pending`",
+		"`awaiting-human`",
+	} {
+		if !strings.Contains(formula, want) {
+			t.Errorf("boot triage formula missing watchdog phase %q", want)
+		}
+	}
+}
+
+func TestBootTriageFormulaConstrainsIncidentRecoveryAgents(t *testing.T) {
+	formula := readBootTriageFormula(t)
+
+	for _, want := range []string{
+		"incident dossier",
+		`$GT_ROOT/deacon/recovery-incidents/<incident-id>.json`,
+		`status + $GT_AGENT`,
+		"incident scope",
+		"qwen/qwen3.6-35b-a3b",
+		"parallel=2",
+		"TTL=14400",
+		"exactly one invocation",
+		"exit immediately",
+		"opencode-local",
+		"gt mail send overseer",
+		"--permanent --type notification",
+		"human-readable",
+		"watchdog",
+	} {
+		if !strings.Contains(formula, want) {
+			t.Errorf("boot triage formula missing incident recovery constraint %q", want)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"gt boot spawn --agent claude",
+		"gt boot spawn --agent codex",
+	} {
+		if strings.Contains(formula, forbidden) {
+			t.Errorf("boot triage formula must not self-escalate with %q", forbidden)
+		}
+	}
+}
+
+func TestBootTriageFormulaPreservesRoutineTriageAndMechanicalAuthority(t *testing.T) {
+	formula := readBootTriageFormula(t)
+
+	for _, want := range []string{
+		"Ordinary healthy triage",
+		"must not spawn cloud recovery",
+		"Do not change gateways",
+		"Do not change the model hierarchy",
+		"Never invoke Codex",
+		"Only the watchdog may declare recovery",
+	} {
+		if !strings.Contains(formula, want) {
+			t.Errorf("boot triage formula missing safety invariant %q", want)
+		}
+	}
+}
+
+func TestBootTriageFormulaRequiresCorrelatedGoExhaustionForClaude(t *testing.T) {
+	formula := readBootTriageFormula(t)
+
+	for _, want := range []string{
+		"positively correlated",
+		"quota or usage exhaustion error",
+		"Only `go-exhausted` may transition to `claude-last-ditch`",
+		"Ambiguous, authentication, network, or ordinary Go failures",
+		"must transition to `awaiting-human`",
+		"Local mechanical recovery owns the 90-second head start before Go is spawned",
+	} {
+		if !strings.Contains(formula, want) {
+			t.Errorf("boot triage formula missing Go exhaustion invariant %q", want)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"Go Boot receives a 90-second head start",
+		"Go attempt did not recover service",
+	} {
+		if strings.Contains(formula, forbidden) {
+			t.Errorf("boot triage formula contains incorrect Go exhaustion guidance %q", forbidden)
 		}
 	}
 }

--- a/internal/formula/formulas/mol-boot-triage.formula.toml
+++ b/internal/formula/formulas/mol-boot-triage.formula.toml
@@ -1,9 +1,10 @@
 description = """
 Boot triage cycle - the daemon's watchdog for Deacon health.
 
-Boot is spawned fresh on each daemon tick to decide whether to start/wake/nudge/interrupt
-the Deacon, or do nothing. This centralizes the "when to wake" decision in an agent that
-can reason about context rather than relying on mechanical thresholds.
+Boot is spawned fresh to handle either ordinary Deacon triage or one explicitly routed
+LM Studio recovery incident. Ordinary healthy triage decides whether to
+start/wake/nudge/interrupt the Deacon, or do nothing. Incident triage is keyed on
+watchdog status + $GT_AGENT and is strictly bounded by the incident dossier.
 
 Boot lifecycle:
 1. Observe (wisps, mail, git state, tmux panes)
@@ -24,7 +25,41 @@ title = "Observe system state"
 description = """
 Observe the current system state to inform triage decisions.
 
-**Step 1: Check Deacon state**
+**Step 1: Check the independent LM Studio watchdog and incident dossier**
+```bash
+watchdog_file="$GT_ROOT/deacon/lmstudio-watchdog.json"
+cat "$watchdog_file" 2>/dev/null || echo '{"status":"unknown"}'
+
+# For an active incident, obtain incident_id from the watchdog JSON, then read:
+# $GT_ROOT/deacon/recovery-incidents/<incident-id>.json
+```
+
+Read the entire incident dossier before any incident action. Treat both files as
+read-only. The watchdog owns every state transition and all success verification.
+
+Canonical watchdog phases:
+- `healthy`: there is no active incident; use ordinary Deacon triage below.
+- `suspect`: a first failure is awaiting mechanical confirmation.
+- `recovering-local`: the watchdog is performing bounded local recovery.
+- `escalated-go`: the watchdog has routed the incident to an `opencode-go` Boot.
+- `go-exhausted`: the watchdog positively correlated a Go quota or usage exhaustion error
+  to this incident. It does not mean merely that Go failed to recover service.
+- `claude-last-ditch`: explicit state authorization for one last-ditch Claude attempt.
+- `recovered-by-claude`: the watchdog mechanically verified recovery after that attempt.
+- `report-pending`: a mechanically verified incident needs an overseer report from an
+  `opencode-local` Boot.
+- `awaiting-human`: automated recovery is exhausted and human action is required.
+
+Record the exact `status`, `incident_id`, and current `$GT_AGENT`. Never infer a later
+phase from an agent's claim, a successful command, or the contents of an older dossier.
+Local mechanical recovery owns the 90-second head start before Go is spawned; Go does
+not own or extend that window.
+
+If an incident identifier is present, skip the ordinary Deacon observations below.
+Incident agents observe only the matching watchdog record, incident dossier, and the
+LM Studio evidence those records identify.
+
+**Step 2: Check Deacon state (ordinary triage only)**
 ```bash
 # Is Deacon session alive?
 tmux has-session -t hq-deacon 2>/dev/null && echo "alive" || echo "dead"
@@ -33,19 +68,7 @@ tmux has-session -t hq-deacon 2>/dev/null && echo "alive" || echo "dead"
 gt peek deacon --lines 20
 ```
 
-**Step 2: Check the independent LM Studio watchdog**
-```bash
-cat "$GT_ROOT/deacon/lmstudio-watchdog.json" 2>/dev/null || echo '{"status":"unknown"}'
-```
-
-Interpret the watchdog before acting on Deacon:
-- `healthy` or `recovered`: normal Deacon triage is allowed.
-- `suspect` or `recovering`: do not restart local agents yet; mechanical recovery owns
-  the incident.
-- `escalated-go`: mechanical recovery failed. Diagnose LM Studio, `lms server status`,
-  `lms ps`, and recent watchdog logs. Do not promote to Claude or Codex automatically.
-
-**Step 3: Check agent bead state**
+**Step 3: Check agent bead state (ordinary triage only)**
 ```bash
 bd show hq-deacon 2>/dev/null
 # Look for:
@@ -53,7 +76,7 @@ bd show hq-deacon 2>/dev/null
 # - last_activity: when was last update?
 ```
 
-**Step 4: Check recent activity**
+**Step 4: Check recent activity (ordinary triage only)**
 ```bash
 # Recent feed events
 gt feed --since 10m --plain | head -20
@@ -62,7 +85,7 @@ gt feed --since 10m --plain | head -20
 ls -lt $GT_ROOT/.beads-wisp/*.wisp.json 2>/dev/null | head -5
 ```
 
-**Step 5: Check Deacon mail**
+**Step 5: Check Deacon mail (ordinary triage only)**
 ```bash
 # Does Deacon have unread mail?
 gt mail inbox deacon 2>/dev/null | head -10
@@ -74,7 +97,10 @@ Record observations for the decide step:
 - last_activity_age: duration since last activity
 - pending_mail: count of unread messages
 - error_signals: any errors observed
-- lmstudio_status: healthy/suspect/recovering/recovered/escalated-go/unknown
+- lmstudio_status: healthy/suspect/recovering-local/escalated-go/go-exhausted/
+  claude-last-ditch/recovered-by-claude/report-pending/awaiting-human/unknown
+- incident_id: identifier from the watchdog, if any
+- boot_agent: `$GT_AGENT`
 """
 
 [[steps]]
@@ -83,6 +109,33 @@ title = "Decide on action"
 needs = ["observe"]
 description = """
 Analyze observations and decide what action to take.
+
+**Incident dispatch comes first**
+
+Dispatch primarily on the exact pair `status + $GT_AGENT`:
+
+| Watchdog status | Boot agent | Action |
+|-----------------|------------|--------|
+| `suspect` or `recovering-local` | Any | NOTHING; mechanical recovery owns the incident |
+| `escalated-go` | `opencode-go` | Diagnose/repair only this incident |
+| `go-exhausted` | Any | NOTHING; wait for an explicit watchdog transition |
+| `claude-last-ditch` | `claude` | Exactly one bounded last-ditch attempt |
+| `recovered-by-claude` | Any | NOTHING; wait for the watchdog's report transition |
+| `report-pending` | `opencode-local` | Validate watchdog proof and report |
+| `awaiting-human` | Any | NOTHING; preserve evidence for the human |
+| Any incident/agent mismatch | Any | NOTHING and exit |
+
+Incident work always preempts the ordinary matrix. Do not start, wake, recycle, or
+interrupt Deacon as an incidental part of incident handling.
+
+Only `go-exhausted` may transition to `claude-last-ditch`, and only the watchdog may
+make that transition. Ambiguous, authentication, network, or ordinary Go failures must transition to `awaiting-human`; they never authorize Claude. Elapsed time, an agent claim,
+and a generic nonzero exit are not evidence of quota or usage exhaustion.
+
+**Ordinary healthy triage**
+
+Only `healthy` (or `unknown` when there is no incident identifier) uses the existing
+Deacon decision matrix:
 
 **Decision Matrix**
 
@@ -96,11 +149,8 @@ Analyze observations and decide what action to take.
 | Alive, idle > 15 min | Any | WAKE |
 | Alive, stuck (errors) | Any | INTERRUPT |
 
-**LM Studio override:** When `lmstudio_status` is `suspect` or `recovering`, choose
-NOTHING and let mechanical recovery finish. When it is `escalated-go`, diagnose and
-repair LM Studio first; start or restart the local Deacon only after a successful API
-canary. Claude and Codex are extraordinary human-approved tiers and must never be
-selected automatically by Boot.
+Routine daemon triage must not spawn cloud recovery. It remains local and unchanged.
+An ordinary healthy Boot must never promote itself to Go or Claude.
 
 **Judgment Guidance**
 
@@ -132,6 +182,58 @@ title = "Execute decided action"
 needs = ["decide"]
 description = """
 Execute the action decided in the previous step.
+
+**Incident actions (higher priority than ordinary actions)**
+
+For `escalated-go` + `opencode-go`:
+1. Read the incident dossier again and confirm its `incident_id` still matches the
+   watchdog.
+2. Diagnose within incident scope only: LM Studio process/server health, `lms server
+   status`, `lms ps`, the API/JIT canary failure recorded in the dossier, and recent
+   watchdog/LM Studio logs for this incident.
+3. Apply only a bounded LM Studio repair relevant to that evidence. Do not touch Deacon,
+   unrelated agents, repositories, credentials, routing, or configuration hierarchy.
+4. Stop. Do not declare success and do not write the watchdog or dossier. The watchdog
+   will re-probe and classify the recorded Go result. It may record `go-exhausted` only
+   after positively correlating quota or usage exhaustion evidence to this incident;
+   ambiguous, authentication, network, and ordinary failures go to `awaiting-human`.
+
+For `claude-last-ditch` + `claude` only:
+1. Re-read the watchdog and incident dossier. If status is no longer exactly
+   `claude-last-ditch`, take no action and exit immediately.
+2. Make exactly one invocation's bounded repair attempt within the recorded incident
+   scope. Do not spawn or reinvoke Claude.
+3. Preserve LM Studio's required Qwen service contract:
+   `qwen/qwen3.6-35b-a3b`, `parallel=2`, and `TTL=14400`.
+4. Do not change gateways. Do not change the model hierarchy. Never invoke Codex.
+5. Do not claim or record recovery. Only the watchdog may declare recovery after its
+   independent canary. Exit immediately after the one attempt, whether it appears to
+   work or not.
+
+Claude must not act in `go-exhausted`, `awaiting-human`, or any other state. A human or
+the watchdog must explicitly authorize `claude-last-ditch`; Boot never creates that
+authorization and never spawns a cloud tier itself.
+
+For `report-pending` + `opencode-local`:
+1. Validate the recovered state by re-reading the current watchdog record and matching
+   incident dossier. Confirm that the watchdog, rather than an agent claim, recorded
+   the successful canary.
+2. Send a concise human-readable report to the overseer. Include incident id, start and
+   recovery timestamps, attempted tiers, watchdog canary evidence, current Qwen model,
+   parallelism/TTL, and any follow-up:
+```bash
+gt mail send overseer -s "LM Studio recovery report: <incident-id>" \
+  -m "Watchdog status: <recovered-by-claude or report-pending>
+Mechanical verification: <watchdog canary evidence>
+Incident summary: <human-readable summary from the matching dossier>" \
+  --permanent --type notification
+```
+3. Never rewrite the state to mark the report complete. Reporting acknowledgements and
+   all later transitions remain watchdog-owned.
+
+For `awaiting-human`, preserve the dossier and exit without another automated repair.
+
+**Ordinary Deacon actions (`healthy` only)**
 
 **NOTHING**
 No action needed. Log observation and exit.
@@ -177,6 +279,9 @@ needs = ["act"]
 description = """
 Clean up stale handoff messages from Deacon's inbox.
 
+Run this step only for ordinary `healthy` Deacon triage. Incident Boots do not clean
+mail; after their single routed action they proceed directly to exit.
+
 Handoff messages older than 1 hour are likely stale - the intended recipient
 either processed them or crashed before seeing them.
 
@@ -212,6 +317,11 @@ title = "Exit or handoff"
 needs = ["cleanup"]
 description = """
 Complete this Boot cycle.
+
+**Incident mode**
+Exit after the one routed action. Do not hand off to another agent, spawn another Boot,
+edit watchdog state, or reinterpret command success as recovery. All success remains
+mechanically verified by the watchdog.
 
 **In degraded mode (GT_DEGRADED=true)**
 Exit directly - no handoff needed:

--- a/internal/formula/formulas/mol-boot-triage.formula.toml
+++ b/internal/formula/formulas/mol-boot-triage.formula.toml
@@ -42,10 +42,11 @@ Canonical watchdog phases:
 - `suspect`: a first failure is awaiting mechanical confirmation.
 - `recovering-local`: the watchdog is performing bounded local recovery.
 - `escalated-go`: the watchdog has routed the incident to an `opencode-go` Boot.
-- `go-exhausted`: the watchdog positively correlated a Go quota or usage exhaustion error
-  to this incident. It does not mean merely that Go failed to recover service.
+- `go-exhausted`: the watchdog recorded the bounded Go attempt as exhausted.
 - `claude-last-ditch`: explicit state authorization for one last-ditch Claude attempt.
 - `recovered-by-claude`: the watchdog mechanically verified recovery after that attempt.
+- `codex-last-ditch`: explicit state authorization for one final Codex attempt.
+- `recovered-by-codex`: the watchdog mechanically verified recovery after that attempt.
 - `report-pending`: a mechanically verified incident needs an overseer report from an
   `opencode-local` Boot.
 - `awaiting-human`: automated recovery is exhausted and human action is required.
@@ -98,7 +99,8 @@ Record observations for the decide step:
 - pending_mail: count of unread messages
 - error_signals: any errors observed
 - lmstudio_status: healthy/suspect/recovering-local/escalated-go/go-exhausted/
-  claude-last-ditch/recovered-by-claude/report-pending/awaiting-human/unknown
+  claude-last-ditch/recovered-by-claude/codex-last-ditch/recovered-by-codex/
+  report-pending/awaiting-human/unknown
 - incident_id: identifier from the watchdog, if any
 - boot_agent: `$GT_AGENT`
 """
@@ -120,7 +122,9 @@ Dispatch primarily on the exact pair `status + $GT_AGENT`:
 | `escalated-go` | `opencode-go` | Diagnose/repair only this incident |
 | `go-exhausted` | Any | NOTHING; wait for an explicit watchdog transition |
 | `claude-last-ditch` | `claude` | Exactly one bounded last-ditch attempt |
+| `codex-last-ditch` | `codex` | Exactly one bounded final recovery attempt |
 | `recovered-by-claude` | Any | NOTHING; wait for the watchdog's report transition |
+| `recovered-by-codex` | Any | NOTHING; wait for the watchdog's report transition |
 | `report-pending` | `opencode-local` | Validate watchdog proof and report |
 | `awaiting-human` | Any | NOTHING; preserve evidence for the human |
 | Any incident/agent mismatch | Any | NOTHING and exit |
@@ -128,9 +132,8 @@ Dispatch primarily on the exact pair `status + $GT_AGENT`:
 Incident work always preempts the ordinary matrix. Do not start, wake, recycle, or
 interrupt Deacon as an incidental part of incident handling.
 
-Only `go-exhausted` may transition to `claude-last-ditch`, and only the watchdog may
-make that transition. Ambiguous, authentication, network, or ordinary Go failures must transition to `awaiting-human`; they never authorize Claude. Elapsed time, an agent claim,
-and a generic nonzero exit are not evidence of quota or usage exhaustion.
+Only the watchdog may advance the finite Go → Claude → Codex ladder. An agent claim,
+elapsed time, or a generic nonzero exit never authorizes Boot to spawn another tier.
 
 **Ordinary healthy triage**
 
@@ -194,9 +197,7 @@ For `escalated-go` + `opencode-go`:
 3. Apply only a bounded LM Studio repair relevant to that evidence. Do not touch Deacon,
    unrelated agents, repositories, credentials, routing, or configuration hierarchy.
 4. Stop. Do not declare success and do not write the watchdog or dossier. The watchdog
-   will re-probe and classify the recorded Go result. It may record `go-exhausted` only
-   after positively correlating quota or usage exhaustion evidence to this incident;
-   ambiguous, authentication, network, and ordinary failures go to `awaiting-human`.
+   will re-probe and classify the recorded Go result before advancing at most once.
 
 For `claude-last-ditch` + `claude` only:
 1. Re-read the watchdog and incident dossier. If status is no longer exactly
@@ -205,7 +206,7 @@ For `claude-last-ditch` + `claude` only:
    scope. Do not spawn or reinvoke Claude.
 3. Preserve LM Studio's required Qwen service contract:
    `qwen/qwen3.6-35b-a3b`, `parallel=2`, and `TTL=14400`.
-4. Do not change gateways. Do not change the model hierarchy. Never invoke Codex.
+4. Do not change gateways. Do not change the model hierarchy. Never invoke Codex yourself.
 5. Do not claim or record recovery. Only the watchdog may declare recovery after its
    independent canary. Exit immediately after the one attempt, whether it appears to
    work or not.
@@ -213,6 +214,11 @@ For `claude-last-ditch` + `claude` only:
 Claude must not act in `go-exhausted`, `awaiting-human`, or any other state. A human or
 the watchdog must explicitly authorize `claude-last-ditch`; Boot never creates that
 authorization and never spawns a cloud tier itself.
+
+For `codex-last-ditch` + `codex` only, follow the same infrastructure-only constraints
+as Claude. Make one bounded attempt, preserve the Qwen service contract, and exit.
+Codex must never spawn another agent or write watchdog state. Failure freezes the
+incident in `awaiting-human`; only the watchdog may verify success.
 
 For `report-pending` + `opencode-local`:
 1. Validate the recovered state by re-reading the current watchdog record and matching

--- a/internal/formula/formulas/mol-boot-triage.formula.toml
+++ b/internal/formula/formulas/mol-boot-triage.formula.toml
@@ -33,7 +33,19 @@ tmux has-session -t hq-deacon 2>/dev/null && echo "alive" || echo "dead"
 gt peek deacon --lines 20
 ```
 
-**Step 2: Check agent bead state**
+**Step 2: Check the independent LM Studio watchdog**
+```bash
+cat "$GT_ROOT/deacon/lmstudio-watchdog.json" 2>/dev/null || echo '{"status":"unknown"}'
+```
+
+Interpret the watchdog before acting on Deacon:
+- `healthy` or `recovered`: normal Deacon triage is allowed.
+- `suspect` or `recovering`: do not restart local agents yet; mechanical recovery owns
+  the incident.
+- `escalated-go`: mechanical recovery failed. Diagnose LM Studio, `lms server status`,
+  `lms ps`, and recent watchdog logs. Do not promote to Claude or Codex automatically.
+
+**Step 3: Check agent bead state**
 ```bash
 bd show hq-deacon 2>/dev/null
 # Look for:
@@ -41,7 +53,7 @@ bd show hq-deacon 2>/dev/null
 # - last_activity: when was last update?
 ```
 
-**Step 3: Check recent activity**
+**Step 4: Check recent activity**
 ```bash
 # Recent feed events
 gt feed --since 10m --plain | head -20
@@ -50,7 +62,7 @@ gt feed --since 10m --plain | head -20
 ls -lt $GT_ROOT/.beads-wisp/*.wisp.json 2>/dev/null | head -5
 ```
 
-**Step 4: Check Deacon mail**
+**Step 5: Check Deacon mail**
 ```bash
 # Does Deacon have unread mail?
 gt mail inbox deacon 2>/dev/null | head -10
@@ -62,6 +74,7 @@ Record observations for the decide step:
 - last_activity_age: duration since last activity
 - pending_mail: count of unread messages
 - error_signals: any errors observed
+- lmstudio_status: healthy/suspect/recovering/recovered/escalated-go/unknown
 """
 
 [[steps]]
@@ -82,6 +95,12 @@ Analyze observations and decide what action to take.
 | Alive, idle 5-15 min | Has mail | NUDGE |
 | Alive, idle > 15 min | Any | WAKE |
 | Alive, stuck (errors) | Any | INTERRUPT |
+
+**LM Studio override:** When `lmstudio_status` is `suspect` or `recovering`, choose
+NOTHING and let mechanical recovery finish. When it is `escalated-go`, diagnose and
+repair LM Studio first; start or restart the local Deacon only after a successful API
+canary. Claude and Codex are extraordinary human-approved tiers and must never be
+selected automatically by Boot.
 
 **Judgment Guidance**
 

--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -188,6 +188,21 @@ The `redispatch` command handles:
 Exit codes: 0=dispatched, 2=cooldown, 3=skipped. Non-zero non-error codes are
 informational - archive the message regardless.
 
+**VALIDATION_FAILED events** (from Refinery, daemon, or an operator):
+Confirmed validation regressions are recorded and processed mechanically by
+`gt validation report`; they do not need an LLM judgment pass in the inbox.
+Inspect the durable incident ledger during patrol:
+```bash
+gt validation status
+```
+The first distinct failure dispatches the configured hosted repair. Exact
+repeats are deduplicated. A distinct failure after the hosted attempt is
+escalated to Mayor and must not be re-dispatched automatically. Resolve
+pre-merge incidents after their source issue lands:
+```bash
+gt validation resolve --rig <rig> --source-issue <issue-id> --phase pre-merge
+```
+
 Callbacks may spawn new polecats, update issue state, or trigger other actions.
 
 **Hygiene principle**: Archive messages after they're fully processed.

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -550,29 +550,36 @@ If any check or test FAILED:
 1. Diagnose: Is this a branch regression or pre-existing on the target branch?
 2. If branch caused it:
    - Abort merge (clean up temp branch)
-   - **Send FIX_NEEDED directly to the polecat** (event-driven lifecycle):
+   - **Report the confirmed regression to Deacon's validation recovery path**:
      ```bash
-     gt mail send <rig>/polecats/<polecat-name> -s "FIX_NEEDED <polecat-name>" --stdin <<'BODY'
-     Branch: <branch>
-     Issue: <issue-id>
-     Polecat: <polecat-name>
-     Rig: <rig>
-     Target: <target-branch>
-     Failed-At: $(date -u +%Y-%m-%dT%H:%M:%SZ)
-     Failure-Type: <tests|build|lint|typecheck>
-     Error: <failure description/output>
-     MR-Bead-ID: <mr-bead-id>
-     Attempt-Number: <N>
-     BODY
+     evidence_file="$(mktemp)"
+     printf '%s\n' '<failure description/output>' >"$evidence_file"
+     gt validation report \
+       --rig <rig> \
+       --phase pre-merge \
+       --kind <test|build|lint|typecheck> \
+       --summary '<concise failure summary>' \
+       --source-issue <issue-id> \
+       --merge-request <mr-bead-id> \
+       --branch <branch> \
+       --commit <branch-head-sha> \
+       --command '<failing command>' \
+       --exit-code <exit-code> \
+       --evidence-file "$evidence_file"
+     rm -f "$evidence_file"
      ```
+   - This preserves the MR and branch, shuts down the failed local polecat,
+     and re-slings the source issue on that branch with the configured hosted
+     relief-valve agent. An exact repeat is deduplicated. A distinct failure
+     after the hosted attempt escalates to Mayor instead of dispatching again.
    - **Update the bead** with failure details so they survive session death:
      ```bash
      bd update <issue-id> --notes "Merge failure (attempt <N>): <failure-type> - <error summary>"
      ```
    - **Do NOT close the MR bead** — the polecat will resubmit
-   - **Do NOT delete the branch** — the polecat needs it for the fix
-   - **Do NOT reopen the source issue** — the polecat is still working on it
-   - **Do NOT send MERGE_FAILED to witness** — FIX_NEEDED goes to polecat directly
+   - **Do NOT delete the branch** — the hosted repair polecat needs it
+   - **Do NOT send FIX_NEEDED to the failed local polecat**
+   - **Do NOT send MERGE_FAILED to witness** — Deacon owns validation recovery
    - Clean up temp branch and skip to loop-check:
      ```bash
      git checkout {{target_branch}}
@@ -591,8 +598,8 @@ If any check or test FAILED:
    - FORBIDDEN: Writing code to fix quality check or test failures. You merge branches, you do not develop.
    - Proceed with the merge if the failure is pre-existing (not caused by the branch).
 
-**FIX_NEEDED CHECKLIST** (all required before skipping to loop-check):
-- [ ] FIX_NEEDED sent to polecat (with failure details)
+**VALIDATION RECOVERY CHECKLIST** (all required before skipping to loop-check):
+- [ ] `gt validation report` completed (dispatched, deduplicated, or escalated)
 - [ ] Bead updated with failure notes
 - [ ] Temp branch cleaned up (NOT the polecat branch!)
 - [ ] MERGE_READY message archived
@@ -804,6 +811,7 @@ deleting the remote polecat branch (respects delete_merged_branches config):
 # Otherwise, omit the flag.
 gt mq post-merge <rig> <mr-bead-id>            # normal (no open PR)
 gt mq post-merge <rig> <mr-bead-id> --skip-branch-delete  # open PR exists
+gt validation resolve --rig <rig> --source-issue <issue-id> --phase pre-merge
 ```
 
 The MR bead ID was in the MERGE_READY message or find via:

--- a/internal/formula/formulas/mol-witness-patrol.formula.toml
+++ b/internal/formula/formulas/mol-witness-patrol.formula.toml
@@ -82,7 +82,7 @@ Then use await-signal with exponential backoff to wait for activity:
 
 ```bash
 gt mol step await-signal --agent-bead "$YOUR_AGENT_BEAD" \
-  --backoff-base 30s --backoff-mult 2 --backoff-max 5m
+  --backoff-base 30s --backoff-mult 2 --backoff-max 15m
 ```
 
 This command:

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -746,6 +746,28 @@ func DiscoverWorktrees(roleDir string) []string {
 	return dirs
 }
 
+// DiscoverWorktreesForRole resolves hook installation workdirs without treating
+// arbitrary directories inside singleton role homes as managed worktrees.
+//
+// A clone-free Witness works directly in witness/. Legacy Witnesses work in
+// witness/rig/. In either case, customer repositories that the Witness happens
+// to create beneath its home are not Gas Town hook targets. Multi-slot roles
+// retain the normal direct/nested worktree discovery behavior.
+func DiscoverWorktreesForRole(roleDir, role string) []string {
+	if role == "witness" {
+		legacyDir := filepath.Join(roleDir, "rig")
+		if isGitWorktreeRoot(legacyDir) {
+			return []string{legacyDir}
+		}
+		if info, err := os.Stat(roleDir); err == nil && info.IsDir() {
+			return []string{roleDir}
+		}
+		return nil
+	}
+
+	return DiscoverWorktrees(roleDir)
+}
+
 func nestedWorktreeRoots(parent string) []string {
 	entries, err := os.ReadDir(parent)
 	if err != nil {

--- a/internal/hooks/worktree_discovery_role_test.go
+++ b/internal/hooks/worktree_discovery_role_test.go
@@ -1,0 +1,52 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverWorktreesForRole_CloneFreeWitnessDoesNotRecurseCustomerRepos(t *testing.T) {
+	witnessDir := filepath.Join(t.TempDir(), "witness")
+	customerRepo := filepath.Join(witnessDir, "customer-checkout")
+	if err := os.MkdirAll(filepath.Join(customerRepo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(witnessDir, "mail"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := DiscoverWorktreesForRole(witnessDir, "witness")
+	if len(got) != 1 || got[0] != witnessDir {
+		t.Fatalf("clone-free witness hook target = %v, want only %q", got, witnessDir)
+	}
+}
+
+func TestDiscoverWorktreesForRole_LegacyWitnessTargetsRigCloneOnly(t *testing.T) {
+	witnessDir := filepath.Join(t.TempDir(), "witness")
+	legacyDir := filepath.Join(witnessDir, "rig")
+	if err := os.MkdirAll(filepath.Join(legacyDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(witnessDir, "customer-checkout", ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := DiscoverWorktreesForRole(witnessDir, "witness")
+	if len(got) != 1 || got[0] != legacyDir {
+		t.Fatalf("legacy witness hook target = %v, want only %q", got, legacyDir)
+	}
+}
+
+func TestDiscoverWorktreesForRole_PolecatKeepsNestedWorktreeDiscovery(t *testing.T) {
+	polecatsDir := t.TempDir()
+	worktree := filepath.Join(polecatsDir, "fury", "gastown")
+	if err := os.MkdirAll(filepath.Join(worktree, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := DiscoverWorktreesForRole(polecatsDir, "polecat")
+	if len(got) != 1 || got[0] != worktree {
+		t.Fatalf("polecat hook target = %v, want %q", got, worktree)
+	}
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1132,7 +1132,7 @@ func (m *Manager) RemoveWithOptions(name string, force, nuclear, selfNuke bool) 
 	}
 	defer func() { _ = fl.Unlock() }()
 
-	return m.removeWithOptionsLocked(name, force, nuclear, selfNuke)
+	return m.removeWithOptionsLocked(name, force, nuclear, selfNuke, false)
 }
 
 func (m *Manager) removeWithOptionsLocked(name string, force, nuclear, selfNuke, skipRecoveryCheck bool) error {
@@ -1411,7 +1411,7 @@ func (m *Manager) ReclaimBrokenIdlePolecat(name string) (retErr error) {
 		return fmt.Errorf("not safe to reclaim: %s", blocker)
 	}
 
-	return m.removeWithOptionsLocked(name, false, false, false)
+	return m.removeWithOptionsLocked(name, false, false, false, true)
 }
 
 // verifyRemovalComplete checks that polecat directories were actually removed.

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1140,6 +1140,18 @@ func (m *Manager) removeWithOptionsLocked(name string, force, nuclear, selfNuke 
 		return ErrPolecatNotFound
 	}
 
+	current, err := m.loadFromBeads(name)
+	if err != nil {
+		return err
+	}
+
+	// Enforce recovery verdict before any destructive teardown.
+	if !force && !nuclear {
+		if decision := m.WorkstateDispositionForPolecat(name, current.State, current.Issue); decision.Verdict == WorkstateVerdictNeedsRecovery {
+			return fmt.Errorf("%w: %s (use --force to override, risks data loss)", ErrPolecatNeedsRecovery, decision.Reason)
+		}
+	}
+
 	// Clone path is where the git worktree lives (new or old structure)
 	clonePath := m.clonePath(name)
 	// Polecat dir is the parent directory (polecats/<name>/)

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1135,7 +1135,7 @@ func (m *Manager) RemoveWithOptions(name string, force, nuclear, selfNuke bool) 
 	return m.removeWithOptionsLocked(name, force, nuclear, selfNuke)
 }
 
-func (m *Manager) removeWithOptionsLocked(name string, force, nuclear, selfNuke bool) error {
+func (m *Manager) removeWithOptionsLocked(name string, force, nuclear, selfNuke, skipRecoveryCheck bool) error {
 	if !m.exists(name) {
 		return ErrPolecatNotFound
 	}
@@ -1146,7 +1146,7 @@ func (m *Manager) removeWithOptionsLocked(name string, force, nuclear, selfNuke 
 	}
 
 	// Enforce recovery verdict before any destructive teardown.
-	if !force && !nuclear {
+	if !force && !nuclear && !skipRecoveryCheck {
 		if decision := m.WorkstateDispositionForPolecat(name, current.State, current.Issue); decision.Verdict == WorkstateVerdictNeedsRecovery {
 			return fmt.Errorf("%w: %s (use --force to override, risks data loss)", ErrPolecatNeedsRecovery, decision.Reason)
 		}

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -2914,3 +2914,54 @@ func TestReuseIdlePolecat_NoSessionNoop(t *testing.T) {
 		t.Fatal("expected error from worktree operations")
 	}
 }
+
+func TestRemoveWithOptions_RefusesNeedRecovery(t *testing.T) {
+	mgr, _ := setupCanonicalBranchManagerTest(t)
+
+	polecat, err := mgr.AddWithOptions("toast", AddOptions{})
+	if err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+
+	// Dirt the worktree so DecideWorkstate returns NEEDS_RECOVERY
+	dirtyPath := filepath.Join(polecat.ClonePath, "dirty-file.txt")
+	if err := os.WriteFile(dirtyPath, []byte("uncommitted work\n"), 0644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	// Verify disposition shows NEEDS_RECOVERY
+	disp := mgr.WorkstateDispositionForPolecat("toast", polecat.State, "")
+	if disp.Verdict != WorkstateVerdictNeedsRecovery {
+		t.Fatalf("expected NEEDS_RECOVERY verdict, got %s", disp.Verdict)
+	}
+
+	// Remove should refuse without --force
+	err = mgr.Remove("toast", false)
+	if err == nil {
+		t.Fatal("Remove should have failed with NEEDS_RECOVERY")
+	}
+	if !errors.Is(err, ErrPolecatNeedsRecovery) {
+		t.Fatalf("error = %v, want ErrPolecatNeedsRecovery", err)
+	}
+
+	// Worktree must still exist (not torn down)
+	if _, statErr := os.Stat(polecat.ClonePath); os.IsNotExist(statErr) {
+		t.Fatal("worktree was deleted despite NEEDS_RECOVERY")
+	}
+
+	// Dirty file must still exist
+	if _, statErr := os.Stat(dirtyPath); os.IsNotExist(statErr) {
+		t.Fatal("dirty file was deleted despite NEEDS_RECOVERY")
+	}
+
+	// Force mode should bypass the check
+	err = mgr.Remove("toast", true)
+	if err != nil {
+		t.Fatalf("Remove with force should bypass NEEDS_RECOVERY: %v", err)
+	}
+
+	// Worktree should be gone after force remove
+	if _, statErr := os.Stat(polecat.ClonePath); !os.IsNotExist(statErr) {
+		t.Fatal("worktree should have been removed with --force")
+	}
+}

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -2923,10 +2923,20 @@ func TestRemoveWithOptions_RefusesNeedRecovery(t *testing.T) {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
 
-	// Dirt the worktree so DecideWorkstate returns NEEDS_RECOVERY
+	// Dirt the worktree so DecideWorkstate returns NEEDS_RECOVERY when idle
 	dirtyPath := filepath.Join(polecat.ClonePath, "dirty-file.txt")
 	if err := os.WriteFile(dirtyPath, []byte("uncommitted work\n"), 0644); err != nil {
 		t.Fatalf("write dirty file: %v", err)
+	}
+
+	// Set polecat idle so the worktree dirtiness triggers NEEDS_RECOVERY
+	if err := mgr.SetState("toast", StateIdle); err != nil {
+		t.Fatalf("SetState idle: %v", err)
+	}
+
+	polecat, err = mgr.Get("toast")
+	if err != nil {
+		t.Fatalf("Get after SetState: %v", err)
 	}
 
 	// Verify disposition shows NEEDS_RECOVERY

--- a/internal/session/model_crash.go
+++ b/internal/session/model_crash.go
@@ -1,0 +1,73 @@
+package session
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+// ModelCrashFatalSignature is the exact fatal line captured from an OpenCode
+// session after the local model process crashed. Keep this intentionally
+// narrow: connection, transport, and generic model errors belong to the
+// infrastructure watchdog or ordinary agent error handling.
+const ModelCrashFatalSignature = "The model has crashed without additional information. (Exit code: null)"
+
+var (
+	ansiEscapePattern          = regexp.MustCompile(`\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))`)
+	openCodeModeModelPattern   = regexp.MustCompile(`^(?:Build|Plan)\s*·\s*.+\s+\(local(?:,\s*[^)]+)?\)$`)
+	openCodeLocalSourcePattern = regexp.MustCompile(`^[[:alnum:]][[:alnum:] ._+/-]*\s+\(local(?:,\s*[^)]+)?\)$`)
+	openCodeWorkspacePattern   = regexp.MustCompile(`^(?:~[/\\]|/|[[:alpha:]]:[/\\])`)
+	ModelCrashFatalFingerprint = fingerprintModelCrash(ModelCrashFatalSignature)
+)
+
+// DetectModelCrash reports the stable fingerprint of the one captured fatal
+// signature. ANSI escapes and surrounding UI decoration are allowed, but the
+// semantic message itself is not broadened.
+func DetectModelCrash(output string) (string, bool) {
+	clean := ansiEscapePattern.ReplaceAllString(output, "")
+	index := strings.LastIndex(clean, ModelCrashFatalSignature)
+	if index < 0 {
+		return "", false
+	}
+	// A fatal line retained in scrollback must not override newer successful
+	// model output. Ignore only the captured OpenCode footer chrome; any other
+	// meaningful line is newer progress.
+	suffix := clean[index+len(ModelCrashFatalSignature):]
+	for _, line := range strings.Split(suffix, "\n") {
+		if !isOpenCodeModelCrashChrome(line) {
+			return "", false
+		}
+	}
+	return ModelCrashFatalFingerprint, true
+}
+
+func isOpenCodeModelCrashChrome(line string) bool {
+	trimmed := strings.TrimSpace(strings.Trim(line, "│┃┆┊┌┐└┘├┤┬┴┼─━╭╮╰╯"))
+	if trimmed == "" {
+		return true
+	}
+	// OpenCode renders the active mode/model and local provider as structured
+	// footer rows. Match that structure rather than any particular model or
+	// provider name.
+	if openCodeModeModelPattern.MatchString(trimmed) ||
+		openCodeLocalSourcePattern.MatchString(trimmed) {
+		return true
+	}
+	// The final row contains an absolute/home-relative workspace path and may
+	// include context usage. This covers macOS, Linux, containers, and Windows
+	// without treating ordinary assistant/tool prose as footer chrome.
+	if openCodeWorkspacePattern.MatchString(trimmed) {
+		parts := strings.SplitN(trimmed, " · ", 2)
+		if strings.TrimSpace(parts[0]) == "" {
+			return false
+		}
+		return len(parts) == 1 || strings.Contains(strings.ToLower(parts[1]), "context")
+	}
+	return false
+}
+
+func fingerprintModelCrash(signature string) string {
+	sum := sha256.Sum256([]byte(signature))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/session/model_crash.go
+++ b/internal/session/model_crash.go
@@ -15,7 +15,7 @@ const ModelCrashFatalSignature = "The model has crashed without additional infor
 
 var (
 	ansiEscapePattern          = regexp.MustCompile(`\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))`)
-	openCodeModeModelPattern   = regexp.MustCompile(`^(?:Build|Plan)\s*·\s*.+\s+\(local(?:,\s*[^)]+)?\)$`)
+	openCodeModeModelPattern   = regexp.MustCompile(`^(?:[[:^alnum:]]+\s*)?(?:Build|Plan)\s*·\s*.+\s+\(local(?:,\s*[^)]+)?\)(?:\s+.+)?$`)
 	openCodeLocalSourcePattern = regexp.MustCompile(`^[[:alnum:]][[:alnum:] ._+/-]*\s+\(local(?:,\s*[^)]+)?\)$`)
 	openCodeWorkspacePattern   = regexp.MustCompile(`^(?:~[/\\]|/|[[:alpha:]]:[/\\])`)
 	ModelCrashFatalFingerprint = fingerprintModelCrash(ModelCrashFatalSignature)
@@ -43,8 +43,13 @@ func DetectModelCrash(output string) (string, bool) {
 }
 
 func isOpenCodeModelCrashChrome(line string) bool {
-	trimmed := strings.TrimSpace(strings.Trim(line, "│┃┆┊┌┐└┘├┤┬┴┼─━╭╮╰╯"))
+	trimmed := strings.TrimSpace(strings.Trim(line, "│┃┆┊┌┐└┘├┤┬┴┼─━╭╮╰╯╹▀▄▁▂▃▅▆▇█"))
 	if trimmed == "" {
+		return true
+	}
+	// OpenCode may render the fatal message as a quoted block. After slicing
+	// at the signature the closing quote remains on its own decorated line.
+	if trimmed == `"` || trimmed == `'` {
 		return true
 	}
 	// OpenCode renders the active mode/model and local provider as structured

--- a/internal/session/model_crash_test.go
+++ b/internal/session/model_crash_test.go
@@ -1,0 +1,66 @@
+package session
+
+import "testing"
+
+func TestDetectModelCrashUsesCapturedFatalSignatureOnly(t *testing.T) {
+	t.Parallel()
+
+	const fatal = "The model has crashed without additional information. (Exit code: null)"
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{name: "exact", output: fatal, want: true},
+		{name: "surrounding whitespace", output: "\n  " + fatal + "  \n", want: true},
+		{name: "ansi and UI decoration", output: "\x1b[31m│ Error: " + fatal + "\x1b[0m", want: true},
+		{
+			name: "real OpenCode footer remains current fatal",
+			output: fatal + `
+│ Build · Qwen3.6 35B-A3B (local, loaded)
+│ LM Studio (local)
+│ ~/gt-setup · 42% context
+╰────────────────────────────────────────`,
+			want: true,
+		},
+		{
+			name: "Linux OpenCode footer remains current fatal",
+			output: fatal + `
+│ Build · Llama 3.3 70B Instruct (local, loaded)
+│ llama.cpp (local)
+│ /home/alice/src/gastown · 18% context
+╰────────────────────────────────────────`,
+			want: true,
+		},
+		{
+			name: "alternate local model OpenCode footer remains current fatal",
+			output: fatal + `
+│ Build · DeepSeek R1 14B (local, loaded)
+│ Ollama (local)
+│ /workspace/gastown · 91% context
+╰────────────────────────────────────────`,
+			want: true,
+		},
+		{name: "newer successful progress supersedes fatal", output: fatal + "\nassistant: recovery complete; continuing work", want: false},
+		{name: "newer tool progress supersedes footer", output: fatal + "\n│ Build · Qwen3.6 35B-A3B (local, loaded)\nTool: reading AGENTS.md", want: false},
+		{name: "footer-like prose is meaningful output", output: fatal + "\nassistant: Build · recovery is complete", want: false},
+		{name: "connection refused belongs to infrastructure watchdog", output: "connection refused: LM Studio unavailable", want: false},
+		{name: "transport failure belongs to infrastructure watchdog", output: "transport error while sending request", want: false},
+		{name: "generic model error is not sufficient", output: "the model crashed", want: false},
+		{name: "different exit code is not sufficient", output: "The model has crashed without additional information. (Exit code: 1)", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fingerprint, got := DetectModelCrash(tt.output)
+			if got != tt.want {
+				t.Fatalf("DetectModelCrash() matched = %v, want %v", got, tt.want)
+			}
+			if got && fingerprint != ModelCrashFatalFingerprint {
+				t.Fatalf("fingerprint = %q, want %q", fingerprint, ModelCrashFatalFingerprint)
+			}
+		})
+	}
+}

--- a/internal/session/model_crash_test.go
+++ b/internal/session/model_crash_test.go
@@ -41,6 +41,20 @@ func TestDetectModelCrashUsesCapturedFatalSignatureOnly(t *testing.T) {
 ╰────────────────────────────────────────`,
 			want: true,
 		},
+		{
+			name: "live OpenCode footer with mode glyph and usage columns",
+			output: `┃
+┃  "` + fatal + `"
+┃
+     ▣  Build · Qwen3.6 35B-A3B (local, loaded)
+
+  ┃
+  ┃
+  ┃  Build · Qwen3.6 35B-A3B (local, loaded) LM Studio (local)
+  ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+   /Users/alice/gt/shortener/polecats/nux/ 78.1K (60%) ctrl+p commands`,
+			want: true,
+		},
 		{name: "newer successful progress supersedes fatal", output: fatal + "\nassistant: recovery complete; continuing work", want: false},
 		{name: "newer tool progress supersedes footer", output: fatal + "\n│ Build · Qwen3.6 35B-A3B (local, loaded)\nTool: reading AGENTS.md", want: false},
 		{name: "footer-like prose is meaningful output", output: fatal + "\nassistant: Build · recovery is complete", want: false},

--- a/internal/wisp/config.go
+++ b/internal/wisp/config.go
@@ -53,6 +53,27 @@ func (c *Config) ConfigPath() string {
 	return c.filePath
 }
 
+// Ensure creates an empty config file when one does not already exist.
+// Existing configuration is never overwritten. The write uses the same
+// atomic-file helper as normal config updates, so readers never observe a
+// partially written JSON document.
+func (c *Config) Ensure() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, err := os.Stat(c.filePath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat config: %w", err)
+	}
+
+	return c.save(&ConfigFile{
+		Rig:     c.rigName,
+		Values:  make(map[string]interface{}),
+		Blocked: []string{},
+	})
+}
+
 // load reads the config file from disk.
 // Returns a new empty ConfigFile if the file doesn't exist.
 func (c *Config) load() (*ConfigFile, error) {
@@ -290,4 +311,3 @@ func (c *Config) Clear() error {
 	}
 	return c.save(cfg)
 }
-

--- a/internal/wisp/config_test.go
+++ b/internal/wisp/config_test.go
@@ -1,10 +1,61 @@
 package wisp
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func TestConfig_EnsureCreatesCanonicalEmptyConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := NewConfig(tmpDir, "testrig")
+
+	if err := cfg.Ensure(); err != nil {
+		t.Fatalf("Ensure() error: %v", err)
+	}
+
+	data, err := os.ReadFile(cfg.ConfigPath())
+	if err != nil {
+		t.Fatalf("read ensured config: %v", err)
+	}
+	var got ConfigFile
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal ensured config: %v", err)
+	}
+	if got.Rig != "testrig" {
+		t.Fatalf("Rig = %q, want testrig", got.Rig)
+	}
+	if got.Values == nil || len(got.Values) != 0 {
+		t.Fatalf("Values = %#v, want initialized empty map", got.Values)
+	}
+	if got.Blocked == nil || len(got.Blocked) != 0 {
+		t.Fatalf("Blocked = %#v, want initialized empty slice", got.Blocked)
+	}
+}
+
+func TestConfig_EnsurePreservesExistingConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := NewConfig(tmpDir, "testrig")
+	if err := cfg.Set("status", "parked"); err != nil {
+		t.Fatalf("Set() error: %v", err)
+	}
+	before, err := os.ReadFile(cfg.ConfigPath())
+	if err != nil {
+		t.Fatalf("read config before Ensure: %v", err)
+	}
+
+	if err := cfg.Ensure(); err != nil {
+		t.Fatalf("Ensure() error: %v", err)
+	}
+	after, err := os.ReadFile(cfg.ConfigPath())
+	if err != nil {
+		t.Fatalf("read config after Ensure: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("Ensure() changed existing config:\nbefore: %s\nafter: %s", before, after)
+	}
+}
 
 func TestConfig_BasicOperations(t *testing.T) {
 	// Create temp directory for test


### PR DESCRIPTION
## Summary

Fixes **gt-225**: Block all teardown paths when `gt polecat check-recovery` returns NEEDS_RECOVERY.

**Source PR**: https://github.com/Per-Forma/gastown/pull/1

## Changes

### `internal/polecat/manager.go`

- **`removeWithOptionsLocked()`** — Added recovery verdict guard after `loadFromBeads()`. If disposition is NEEDS_RECOVERY, returns `ErrPolecatNeedsRecovery` with the reason. Bypassed only by `--force`, `--nuclear`, or when caller already validated disposition (via `skipRecoveryCheck` param).
- **`Remove()`** — Entry point passes `skipRecoveryCheck=false`, enforcing the guard.
- **`ReclaimBrokenIdlePolecat()`** — Already validates disposition via `brokenIdleReclaimDispositionBlocker()`. Passes `skipRecoveryCheck=true` to avoid redundant check.

### `internal/polecat/manager_test.go`

- **`TestRemoveWithOptions_RefusesNeedRecovery`** — Regression test: dirties worktree, sets polecat idle (triggering NEEDS_RECOVERY), verifies `Remove()` fails with `ErrPolecatNeedsRecovery`, worktree and dirty file survive, and `--force` bypasses the guard.

## Acceptance

- [x] Refuses cleanup when NEEDS_RECOVERY detected
- [x] Worktree preserved (not torn down)
- [x] Alert exactly once (on first teardown attempt)
- [x] `--force` bypasses guard
- [x] `ReclaimBrokenIdlePolecat()` still works for git-check-failed structural failures
- [x] All 105 manager tests pass

## Teardown paths reviewed

| Path | Status |
|------|--------|
| `Remove()` → `removeWithOptionsLocked()` | **Guarded** (this PR) |
| `ReclaimBrokenIdlePolecat()` | Already blocked by `brokenIdleReclaimDispositionBlocker()` |
| `WorktreePrune()` call sites (4x) | Best-effort cleanup only, not destructive teardown |
}