### PR TITLE
feat(si-mefr): detect two live worktrees on one ref, and the armed staging a rebase leaves

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -316,6 +316,12 @@ func newDoctorForCommand(rig string) *doctor.Doctor {
 	// Worktree gitdir validity (runs across all rigs, or specific rig with --rig)
 	d.Register(doctor.NewWorktreeGitdirCheck())
 
+	// Worktree ref safety (si-mefr): two live worktrees on one branch, and the
+	// mass staged deletion a rebase under a shared ref leaves armed. Both states
+	// accumulate silently and the armed delta GROWS while unobserved.
+	d.Register(doctor.NewWorktreeSharedRefCheck())
+	d.Register(doctor.NewWorktreeArmedStagingCheck())
+
 	// Rig-specific checks (only when --rig is specified)
 	if rig != "" {
 		d.RegisterAll(doctor.RigChecks()...)

--- a/internal/cmd/doctor_test.go
+++ b/internal/cmd/doctor_test.go
@@ -2,6 +2,26 @@ package cmd
 
 import "testing"
 
+// si-mefr: a check that exists and a check that RUNS are different claims. The
+// detection for si-d6kw is worth nothing sitting unregistered, and dropping one
+// Register line is invisible to every test in internal/doctor.
+func TestDoctorRegistersWorktreeRefSafetyChecks(t *testing.T) {
+	want := map[string]bool{
+		"worktree-shared-ref":    false,
+		"worktree-armed-staging": false,
+	}
+	for _, check := range newDoctorForCommand("").Checks() {
+		if _, ok := want[check.Name()]; ok {
+			want[check.Name()] = true
+		}
+	}
+	for name, registered := range want {
+		if !registered {
+			t.Errorf("check %q is not registered with gt doctor, so it never runs", name)
+		}
+	}
+}
+
 func TestDoctorDoesNotRegisterDoltConfigCheck(t *testing.T) {
 	d := newDoctorForCommand("")
 	for _, check := range d.Checks() {

--- a/internal/doctor/worktree_ref_safety_check.go
+++ b/internal/doctor/worktree_ref_safety_check.go
@@ -1,0 +1,260 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+// si-mefr, the detection half of si-d6kw.
+//
+// Two worktrees of one repository on one branch is a state git normally refuses.
+// gt reached it anyway, and the consequences do not need an agent to act: a
+// commit in either worktree appears in the other as a delta to re-commit, and
+// the auto-save commits it. On 2026-07-28 that produced a 434-line deletion at
+// 08:01 DURING an explicit stop-write with both agents complying, and a
+// fleet-wide sweep then found keeper armed with 7767 staged line-deletions and
+// coma with 6824, each aimed at a branch a live worker was on.
+//
+// si-d6kw closed the sling route. It did not close every route:
+// WorktreeAddExistingForce still has legitimate callers, and a hand-run
+// "git worktree add --force" bypasses all of it. Nothing reported either state
+// until these checks. Both are cheap — no network, one git invocation per repo
+// for the first and one per worktree for the second.
+
+// armedStagingThreshold is the staged line-deletion count above which a worktree
+// is reported as armed. Ordinary editing stages small deletions constantly; the
+// artifacts that mattered were three and four orders of magnitude larger (434,
+// 6824, 7767). A threshold that fires on normal work is a check somebody turns
+// off, and a check that is off is worse than none because its silence still
+// reads as reassurance.
+const armedStagingThreshold = 100
+
+// sharedRef is one branch held by more than one live worktree.
+type sharedRef struct {
+	Branch string
+	Paths  []string
+}
+
+// sharedRefs returns the branches held by two or more LIVE worktrees.
+//
+// The prunable filter is load-bearing, not tidiness. Git keeps an
+// administrative record for a worktree whose directory is gone, and reports it
+// in "worktree list" exactly like a live one. Reaping a polecat is routine, so
+// without this filter every reaped worktree reads as a second holder, the check
+// cries wolf on a healthy fleet, and it gets deleted — after which there is no
+// check at all. Detached worktrees are skipped for the mirror-image reason: they
+// hold no branch, and grouping on an empty branch name would collapse them all
+// into one fictional shared ref.
+func sharedRefs(worktrees []git.Worktree) []sharedRef {
+	byBranch := make(map[string][]string)
+	for _, wt := range worktrees {
+		if wt.Prunable || wt.Branch == "" {
+			continue
+		}
+		byBranch[wt.Branch] = append(byBranch[wt.Branch], wt.Path)
+	}
+
+	var shared []sharedRef
+	for branch, paths := range byBranch {
+		if len(paths) < 2 {
+			continue
+		}
+		sort.Strings(paths)
+		shared = append(shared, sharedRef{Branch: branch, Paths: paths})
+	}
+	sort.Slice(shared, func(i, j int) bool { return shared[i].Branch < shared[j].Branch })
+	return shared
+}
+
+// rigRepoPaths returns the bare repository of every rig under the town root,
+// honouring ctx.RigName when set.
+func rigRepoPaths(ctx *CheckContext) []string {
+	entries, err := os.ReadDir(ctx.TownRoot)
+	if err != nil {
+		return nil
+	}
+
+	var repos []string
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		if ctx.RigName != "" && entry.Name() != ctx.RigName {
+			continue
+		}
+		rigPath := filepath.Join(ctx.TownRoot, entry.Name())
+		if !isRigDir(rigPath) {
+			continue
+		}
+		repoPath := filepath.Join(rigPath, ".repo.git")
+		if info, err := os.Stat(repoPath); err == nil && info.IsDir() {
+			repos = append(repos, repoPath)
+		}
+	}
+	sort.Strings(repos)
+	return repos
+}
+
+// WorktreeSharedRefCheck reports branches checked out by two or more live
+// worktrees of the same repository.
+type WorktreeSharedRefCheck struct {
+	BaseCheck
+}
+
+// NewWorktreeSharedRefCheck creates the shared-ref check.
+func NewWorktreeSharedRefCheck() *WorktreeSharedRefCheck {
+	return &WorktreeSharedRefCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "worktree-shared-ref",
+			CheckDescription: "Verify no branch is checked out by two live worktrees of one repo",
+			CheckCategory:    CategoryRig,
+		},
+	}
+}
+
+// Run enumerates every rig repository and groups its live worktrees by branch.
+func (c *WorktreeSharedRefCheck) Run(ctx *CheckContext) *CheckResult {
+	var details []string
+	examined := 0
+	var readErrs []string
+
+	for _, repoPath := range rigRepoPaths(ctx) {
+		worktrees, err := git.NewGit(repoPath).WorktreeList()
+		if err != nil {
+			readErrs = append(readErrs, fmt.Sprintf("%s: %v", repoPath, err))
+			continue
+		}
+		examined += len(worktrees)
+
+		for _, sr := range sharedRefs(worktrees) {
+			details = append(details, fmt.Sprintf("%s held by %d worktrees: %s",
+				sr.Branch, len(sr.Paths), strings.Join(sr.Paths, ", ")))
+		}
+	}
+
+	// A check that examined nothing has not found the fleet healthy — it has
+	// found nothing, and reporting OK for that is how a broken enumeration goes
+	// unnoticed indefinitely.
+	if examined == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "No worktrees examined — nothing was checked",
+			Details: readErrs,
+			FixHint: "Expected <town>/<rig>/.repo.git for at least one rig; verify the town layout",
+		}
+	}
+
+	if len(details) == 0 {
+		msg := fmt.Sprintf("No shared refs across %d worktree(s)", examined)
+		if len(readErrs) > 0 {
+			return &CheckResult{
+				Name:    c.Name(),
+				Status:  StatusWarning,
+				Message: msg + fmt.Sprintf(", but %d repo(s) could not be read", len(readErrs)),
+				Details: readErrs,
+			}
+		}
+		return &CheckResult{Name: c.Name(), Status: StatusOK, Message: msg}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusError,
+		Message: fmt.Sprintf("%d branch(es) checked out by multiple live worktrees", len(details)),
+		Details: append(details, readErrs...),
+		FixHint: "Move the LIVE worker to its own branch FIRST, then disarm the other worktree. " +
+			"Touching the shared ref while a live worker is on it is what risks real work.",
+	}
+}
+
+// WorktreeArmedStagingCheck reports worktrees whose index is staged to remove a
+// large number of lines — the state a rebase under a shared ref leaves behind,
+// and which the auto-save will commit without any agent acting.
+type WorktreeArmedStagingCheck struct {
+	BaseCheck
+}
+
+// NewWorktreeArmedStagingCheck creates the armed-staging check.
+func NewWorktreeArmedStagingCheck() *WorktreeArmedStagingCheck {
+	return &WorktreeArmedStagingCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "worktree-armed-staging",
+			CheckDescription: "Verify no worktree is staged to delete a large number of lines",
+			CheckCategory:    CategoryRig,
+		},
+	}
+}
+
+// Run measures staged line-deletions in every live worktree of every rig.
+func (c *WorktreeArmedStagingCheck) Run(ctx *CheckContext) *CheckResult {
+	var details []string
+	examined := 0
+	var readErrs []string
+
+	for _, repoPath := range rigRepoPaths(ctx) {
+		worktrees, err := git.NewGit(repoPath).WorktreeList()
+		if err != nil {
+			readErrs = append(readErrs, fmt.Sprintf("%s: %v", repoPath, err))
+			continue
+		}
+
+		for _, wt := range worktrees {
+			if wt.Prunable {
+				continue
+			}
+			if _, err := os.Stat(wt.Path); err != nil {
+				continue
+			}
+			examined++
+
+			deletions, err := git.NewGit(wt.Path).StagedLineDeletions()
+			if err != nil {
+				readErrs = append(readErrs, fmt.Sprintf("%s: %v", wt.Path, err))
+				continue
+			}
+			if deletions >= armedStagingThreshold {
+				details = append(details, fmt.Sprintf("%s (%s): %d lines staged for deletion",
+					wt.Path, wt.Branch, deletions))
+			}
+		}
+	}
+
+	if examined == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "No worktrees examined — nothing was checked",
+			Details: readErrs,
+			FixHint: "Expected <town>/<rig>/.repo.git for at least one rig; verify the town layout",
+		}
+	}
+
+	if len(details) == 0 {
+		msg := fmt.Sprintf("No armed worktrees across %d examined", examined)
+		if len(readErrs) > 0 {
+			return &CheckResult{
+				Name:    c.Name(),
+				Status:  StatusWarning,
+				Message: msg + fmt.Sprintf(", but %d could not be read", len(readErrs)),
+				Details: readErrs,
+			}
+		}
+		return &CheckResult{Name: c.Name(), Status: StatusOK, Message: msg}
+	}
+
+	sort.Strings(details)
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusError,
+		Message: fmt.Sprintf("%d worktree(s) staged to delete >=%d lines", len(details), armedStagingThreshold),
+		Details: append(details, readErrs...),
+		FixHint: "Inspect with 'git -C <path> diff --cached --shortstat'. If it is a rebase artifact, " +
+			"'git -C <path> reset --hard HEAD' drops the staging without moving the branch.",
+	}
+}

--- a/internal/doctor/worktree_ref_safety_check_test.go
+++ b/internal/doctor/worktree_ref_safety_check_test.go
@@ -1,0 +1,327 @@
+package doctor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+// si-mefr: si-d6kw's DETECTION half. Prevention closed the sling route, but
+// WorktreeAddExistingForce still has legitimate callers and a hand-run
+// "git worktree add --force" bypasses everything — so sharing can still arise,
+// and until now nothing would report it.
+//
+// The fixtures below drive REAL git worktrees rather than canned structs,
+// because both properties under test are properties of git's own output:
+// whether a stale record is distinguishable from a live holder, and whether a
+// rebase-armed index is visible to a line count. A struct literal would assert
+// my belief about git's output rather than git's output.
+
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s (in %s): %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return string(out)
+}
+
+// townWithRig builds townRoot/<rig>/.repo.git as a real repository, matching
+// the layout gt actually creates, and returns (townRoot, repoPath).
+func townWithRig(t *testing.T, rigName string) (string, string) {
+	t.Helper()
+	townRoot := t.TempDir()
+
+	src := filepath.Join(t.TempDir(), "src")
+	if err := os.MkdirAll(src, 0755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	gitRun(t, src, "init")
+	gitRun(t, src, "config", "user.email", "test@test.com")
+	gitRun(t, src, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	gitRun(t, src, "add", ".")
+	gitRun(t, src, "commit", "-m", "initial")
+
+	rigPath := filepath.Join(townRoot, rigName)
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	// config.json makes isRigDir recognise it.
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte("{}\n"), 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+	repoPath := filepath.Join(rigPath, ".repo.git")
+	gitRun(t, townRoot, "clone", "--bare", src, repoPath)
+
+	return townRoot, repoPath
+}
+
+func addWorktree(t *testing.T, repoPath, wtPath, branch string, force bool) {
+	t.Helper()
+	args := []string{"worktree", "add"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, wtPath, branch)
+	gitRun(t, repoPath, args...)
+}
+
+// A: two LIVE worktrees on one ref must be reported, naming both paths.
+func TestSharedRefsReportsTwoLiveWorktreesOnOneBranch(t *testing.T) {
+	_, repoPath := townWithRig(t, "silicon")
+	gitRun(t, repoPath, "branch", "polecat/dag/si-aka.9", "HEAD")
+
+	first := filepath.Join(t.TempDir(), "dag")
+	second := filepath.Join(t.TempDir(), "toast")
+	addWorktree(t, repoPath, first, "polecat/dag/si-aka.9", false)
+	// --force is how the real collision happened; plain add refuses here.
+	addWorktree(t, repoPath, second, "polecat/dag/si-aka.9", true)
+
+	wts, err := git.NewGit(repoPath).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+
+	shared := sharedRefs(wts)
+	if len(shared) != 1 {
+		t.Fatalf("sharedRefs found %d shared branches, want 1: %+v\n(worktrees: %+v)", len(shared), shared, wts)
+	}
+	if shared[0].Branch != "polecat/dag/si-aka.9" {
+		t.Fatalf("shared branch = %q, want polecat/dag/si-aka.9", shared[0].Branch)
+	}
+	if len(shared[0].Paths) != 2 {
+		t.Fatalf("shared paths = %v, want both holders — a report that does not NAME them "+
+			"cannot be acted on", shared[0].Paths)
+	}
+}
+
+// B: one live holder plus a PRUNABLE record on the same ref is the normal state
+// after a reap. A check that reds here gets deleted, and then there is no check.
+func TestSharedRefsIgnoresAPrunableRecord(t *testing.T) {
+	_, repoPath := townWithRig(t, "silicon")
+	gitRun(t, repoPath, "branch", "polecat/keeper/si-aka.37", "HEAD")
+
+	live := filepath.Join(t.TempDir(), "keeper-live")
+	reaped := filepath.Join(t.TempDir(), "keeper-reaped")
+	addWorktree(t, repoPath, live, "polecat/keeper/si-aka.37", false)
+	addWorktree(t, repoPath, reaped, "polecat/keeper/si-aka.37", true)
+
+	// Reap it: the directory goes, git's administrative record stays.
+	if err := os.RemoveAll(reaped); err != nil {
+		t.Fatalf("reap worktree: %v", err)
+	}
+
+	wts, err := git.NewGit(repoPath).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+
+	// Control: the reaped record must still be PRESENT in git's output, or this
+	// test proves nothing about filtering — it would just be counting one entry.
+	var sawPrunable bool
+	for _, wt := range wts {
+		if wt.Prunable {
+			sawPrunable = true
+		}
+	}
+	if !sawPrunable {
+		t.Fatalf("no prunable record in %+v — git dropped the reaped worktree from its list, so "+
+			"this fixture does not exercise the prunable filter at all", wts)
+	}
+
+	if shared := sharedRefs(wts); len(shared) != 0 {
+		t.Fatalf("sharedRefs reported %+v for one live worktree plus a reaped record; this is the "+
+			"normal post-reap state and flagging it is how the check gets deleted", shared)
+	}
+}
+
+// Two live worktrees on DIFFERENT branches is the ordinary healthy fleet.
+func TestSharedRefsIgnoresDistinctBranches(t *testing.T) {
+	_, repoPath := townWithRig(t, "silicon")
+	gitRun(t, repoPath, "branch", "polecat/dag/si-aka.9", "HEAD")
+	gitRun(t, repoPath, "branch", "polecat/toast/si-aka.9+rework", "HEAD")
+
+	addWorktree(t, repoPath, filepath.Join(t.TempDir(), "dag"), "polecat/dag/si-aka.9", false)
+	addWorktree(t, repoPath, filepath.Join(t.TempDir(), "toast"), "polecat/toast/si-aka.9+rework", false)
+
+	wts, err := git.NewGit(repoPath).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	if shared := sharedRefs(wts); len(shared) != 0 {
+		t.Fatalf("sharedRefs reported %+v for two worktrees on distinct branches", shared)
+	}
+}
+
+// A detached HEAD has no branch to share; grouping on an empty string would
+// collapse every detached worktree into one bogus "shared ref".
+func TestSharedRefsIgnoresDetachedWorktrees(t *testing.T) {
+	_, repoPath := townWithRig(t, "silicon")
+
+	first := filepath.Join(t.TempDir(), "d1")
+	second := filepath.Join(t.TempDir(), "d2")
+	gitRun(t, repoPath, "worktree", "add", "--detach", first, "HEAD")
+	gitRun(t, repoPath, "worktree", "add", "--detach", second, "HEAD")
+
+	wts, err := git.NewGit(repoPath).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	if shared := sharedRefs(wts); len(shared) != 0 {
+		t.Fatalf("sharedRefs reported %+v for two DETACHED worktrees — they hold no branch", shared)
+	}
+}
+
+// End to end through the doctor check, on the real layout.
+func TestWorktreeSharedRefCheckFailsOnASharedRef(t *testing.T) {
+	townRoot, repoPath := townWithRig(t, "silicon")
+	gitRun(t, repoPath, "branch", "polecat/dag/si-aka.9", "HEAD")
+	addWorktree(t, repoPath, filepath.Join(t.TempDir(), "dag"), "polecat/dag/si-aka.9", false)
+	addWorktree(t, repoPath, filepath.Join(t.TempDir(), "toast"), "polecat/dag/si-aka.9", true)
+
+	res := NewWorktreeSharedRefCheck().Run(&CheckContext{TownRoot: townRoot})
+	if res.Status != StatusError {
+		t.Fatalf("status = %v, want StatusError; message=%q details=%v", res.Status, res.Message, res.Details)
+	}
+	if !strings.Contains(strings.Join(res.Details, "\n"), "polecat/dag/si-aka.9") {
+		t.Fatalf("details %v do not name the shared ref", res.Details)
+	}
+}
+
+func TestWorktreeSharedRefCheckPassesOnAHealthyRig(t *testing.T) {
+	townRoot, repoPath := townWithRig(t, "silicon")
+	gitRun(t, repoPath, "branch", "polecat/dag/si-aka.9", "HEAD")
+	addWorktree(t, repoPath, filepath.Join(t.TempDir(), "dag"), "polecat/dag/si-aka.9", false)
+
+	res := NewWorktreeSharedRefCheck().Run(&CheckContext{TownRoot: townRoot})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %v on a healthy rig, want StatusOK; message=%q details=%v",
+			res.Status, res.Message, res.Details)
+	}
+}
+
+// D, the denominator: examining nothing must NOT read as a clean bill of health.
+// This is the failure mode that makes a check worthless — it reports OK forever
+// once its enumeration breaks, and nobody notices because OK is what they expect.
+func TestWorktreeSharedRefCheckFailsWhenItExaminesNothing(t *testing.T) {
+	res := NewWorktreeSharedRefCheck().Run(&CheckContext{TownRoot: t.TempDir()})
+	if res.Status == StatusOK {
+		t.Fatalf("status = StatusOK having examined zero worktrees (message=%q); an empty "+
+			"enumeration must not report healthy", res.Message)
+	}
+}
+
+// A repo that cannot be READ must not reduce to a clean bill of health. This is
+// the same failure as the empty enumeration one layer down: git failing and git
+// finding nothing look identical in a bare status, and the reassuring one is
+// the wrong default.
+func TestWorktreeSharedRefCheckDoesNotReportOKWhenARepoCannotBeRead(t *testing.T) {
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "silicon")
+	if err := os.MkdirAll(filepath.Join(rigPath, ".repo.git"), 0755); err != nil {
+		t.Fatalf("mkdir bogus repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte("{}\n"), 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+
+	res := NewWorktreeSharedRefCheck().Run(&CheckContext{TownRoot: townRoot})
+	if res.Status == StatusOK {
+		t.Fatalf("status = StatusOK for a .repo.git that is not a git repository (message=%q); "+
+			"an unreadable repo is not a healthy one", res.Message)
+	}
+}
+
+// C, through the doctor check: an armed worktree is reported. The line-based
+// vs file-status proof lives in internal/git's staged_line_stat_test.go, which
+// carries the negative control asserting --diff-filter=D is blind to it.
+func TestWorktreeArmedStagingCheckFailsOnAnArmedWorktree(t *testing.T) {
+	townRoot, repoPath := townWithRig(t, "silicon")
+	wt := filepath.Join(t.TempDir(), "keeper")
+	gitRun(t, repoPath, "branch", "polecat/keeper/si-aka.37", "HEAD")
+	addWorktree(t, repoPath, wt, "polecat/keeper/si-aka.37", false)
+
+	// Arm it the way a rebase does: contents removed, file still present.
+	body := strings.Repeat("a line of merged work\n", 500)
+	if err := os.WriteFile(filepath.Join(wt, "delta.txt"), []byte(body), 0644); err != nil {
+		t.Fatalf("write delta: %v", err)
+	}
+	gitRun(t, wt, "config", "user.email", "test@test.com")
+	gitRun(t, wt, "config", "user.name", "Test User")
+	gitRun(t, wt, "add", "delta.txt")
+	gitRun(t, wt, "commit", "-m", "merged work")
+	if err := os.WriteFile(filepath.Join(wt, "delta.txt"), []byte("a line of merged work\n"), 0644); err != nil {
+		t.Fatalf("rewrite delta: %v", err)
+	}
+	gitRun(t, wt, "add", "delta.txt")
+
+	// Control: file-status is blind to this, which is why the check counts lines.
+	if out := strings.TrimSpace(gitRun(t, wt, "diff", "--cached", "--name-status", "--diff-filter=D")); out != "" {
+		t.Fatalf("fixture stages FILE deletions (%q); it is not the rebase-armed state", out)
+	}
+
+	res := NewWorktreeArmedStagingCheck().Run(&CheckContext{TownRoot: townRoot})
+	if res.Status != StatusError {
+		t.Fatalf("status = %v, want StatusError; message=%q details=%v", res.Status, res.Message, res.Details)
+	}
+	if !strings.Contains(strings.Join(res.Details, "\n"), "499") {
+		t.Fatalf("details %v do not report the staged line count", res.Details)
+	}
+}
+
+func TestWorktreeArmedStagingCheckPassesOnACleanWorktree(t *testing.T) {
+	townRoot, repoPath := townWithRig(t, "silicon")
+	wt := filepath.Join(t.TempDir(), "keeper")
+	gitRun(t, repoPath, "branch", "polecat/keeper/si-aka.37", "HEAD")
+	addWorktree(t, repoPath, wt, "polecat/keeper/si-aka.37", false)
+
+	res := NewWorktreeArmedStagingCheck().Run(&CheckContext{TownRoot: townRoot})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %v on a clean worktree, want StatusOK; message=%q details=%v",
+			res.Status, res.Message, res.Details)
+	}
+}
+
+// A small staged deletion is ordinary editing, not an armed rebase artifact.
+// Without this the check fires on normal work and gets turned off.
+func TestWorktreeArmedStagingCheckIgnoresSmallStagedDeletions(t *testing.T) {
+	townRoot, repoPath := townWithRig(t, "silicon")
+	wt := filepath.Join(t.TempDir(), "keeper")
+	gitRun(t, repoPath, "branch", "polecat/keeper/si-aka.37", "HEAD")
+	addWorktree(t, repoPath, wt, "polecat/keeper/si-aka.37", false)
+
+	gitRun(t, wt, "config", "user.email", "test@test.com")
+	gitRun(t, wt, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(wt, "small.txt"), []byte(strings.Repeat("x\n", 10)), 0644); err != nil {
+		t.Fatalf("write small: %v", err)
+	}
+	gitRun(t, wt, "add", "small.txt")
+	gitRun(t, wt, "commit", "-m", "small file")
+	if err := os.WriteFile(filepath.Join(wt, "small.txt"), []byte("x\n"), 0644); err != nil {
+		t.Fatalf("rewrite small: %v", err)
+	}
+	gitRun(t, wt, "add", "small.txt")
+
+	res := NewWorktreeArmedStagingCheck().Run(&CheckContext{TownRoot: townRoot})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %v for 9 staged line-deletions (threshold %d), want StatusOK; details=%v",
+			res.Status, armedStagingThreshold, res.Details)
+	}
+}
+
+// D for the armed check too.
+func TestWorktreeArmedStagingCheckFailsWhenItExaminesNothing(t *testing.T) {
+	res := NewWorktreeArmedStagingCheck().Run(&CheckContext{TownRoot: t.TempDir()})
+	if res.Status == StatusOK {
+		t.Fatalf("status = StatusOK having examined zero worktrees (message=%q)", res.Message)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1145,6 +1146,49 @@ func (g *Git) StagedDeletions() ([]string, error) {
 		return nil, nil
 	}
 	return strings.Split(trimmed, "\n"), nil
+}
+
+// StagedLineDeletions returns the number of LINES staged for removal.
+//
+// This exists because StagedDeletions above cannot see the state that matters.
+// When a branch is rebased under a second worktree, the other worktree's index
+// is left staged to remove the entire rebase delta — as MODIFICATIONS to files
+// that still exist, not as file deletions. --diff-filter=D therefore reports
+// nothing while thousands of lines are staged to disappear, and the auto-save
+// commits them with no agent acting (si-d6kw: keeper armed with 7767, coma with
+// 6824, both found only because the Mayor's sweep counted lines).
+//
+// Counting lines is the whole point. A caller that wants "is this worktree
+// armed" must use this and not a file-status check.
+func (g *Git) StagedLineDeletions() (int, error) {
+	out, err := g.run("diff", "--cached", "--shortstat")
+	if err != nil {
+		return 0, err
+	}
+	return parseShortstatDeletions(out), nil
+}
+
+// parseShortstatDeletions reads the deletions field out of a --shortstat line:
+//
+//	" 5 files changed, 26 insertions(+), 434 deletions(-)"
+//	" 3 files changed, 7767 deletions(-)"        <- no insertions clause at all
+//
+// Keyed off the label rather than the field position, because the insertions
+// clause is omitted entirely when there are none and a positional parser then
+// reads the insertions count as deletions.
+func parseShortstatDeletions(shortstat string) int {
+	for _, field := range strings.Split(shortstat, ",") {
+		field = strings.TrimSpace(field)
+		if !strings.Contains(field, "deletion") {
+			continue
+		}
+		n, err := strconv.Atoi(strings.Fields(field)[0])
+		if err != nil {
+			return 0
+		}
+		return n
+	}
+	return 0
 }
 
 // ShowFile returns the contents of a file at a given ref (e.g., "origin/main:CLAUDE.md").

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2314,11 +2314,85 @@ func (g *Git) WorktreeAddExisting(path, branch string) error {
 
 // WorktreeAddExistingForce creates a new worktree even if the branch is already checked out elsewhere.
 // This is useful for cross-rig worktrees where multiple clones need to be on main.
+//
+// DO NOT use this to attach a worker to a branch another worker may be on. It
+// forces past git's "already used by worktree at ..." check without asking
+// whether the holder is live, which puts two worktrees on one ref; a commit in
+// either then shows up in the other as a delta to re-commit, and an auto-saver
+// will commit that delta with no agent acting. That is si-d6kw, which cost a
+// fleet-wide sweep and three armed worktrees (7767 / 6824 / 434 staged
+// deletions). Use WorktreeAddExistingSafe for anything worker-facing.
 func (g *Git) WorktreeAddExistingForce(path, branch string) error {
 	if _, err := g.run("worktree", "add", "--force", path, branch); err != nil {
 		return err
 	}
 	return InitSubmodules(path, g.submoduleReferencePath())
+}
+
+// BranchHeldError reports that a branch is checked out by a live worktree, so
+// attaching a second one would put two workers on a single ref.
+type BranchHeldError struct {
+	Branch string
+	Path   string
+}
+
+func (e *BranchHeldError) Error() string {
+	return fmt.Sprintf("branch %s is already checked out by a live worktree at %s", e.Branch, e.Path)
+}
+
+// LiveWorktreeForBranch returns the worktree that currently has branch checked
+// out, or nil if none does. Worktrees git reports as prunable — the record
+// survives but the directory does not — are NOT live and are not returned.
+func (g *Git) LiveWorktreeForBranch(branch string) (*Worktree, error) {
+	branch = strings.TrimPrefix(branch, "refs/heads/")
+	worktrees, err := g.WorktreeList()
+	if err != nil {
+		return nil, err
+	}
+	for i := range worktrees {
+		wt := worktrees[i]
+		if wt.Branch != branch || wt.Prunable {
+			continue
+		}
+		// Belt and braces: a record can be current-looking and still point at a
+		// directory that is gone, if the list ran before something removed it.
+		if _, statErr := os.Stat(wt.Path); statErr != nil {
+			continue
+		}
+		return &wt, nil
+	}
+	return nil, nil
+}
+
+// WorktreeAddExistingSafe attaches a worktree to an existing branch, refusing
+// when a LIVE worktree already holds that branch and clearing the way when the
+// only thing holding it is a stale record.
+//
+// This is the distinction plain git does not make for you. "git worktree add"
+// refuses both cases with the same message, which is why callers reached for
+// --force; but --force cannot tell "the previous worker was reaped" (safe, and
+// the case the resume workflow is built on) from "another worker is on this ref
+// right now" (si-d6kw: mutual reversion, and an auto-saver that commits a mass
+// deletion nobody authored).
+//
+// Live holder  -> *BranchHeldError, nothing created.
+// Stale holder -> prune the dead record, then attach normally.
+// No holder    -> attach normally.
+func (g *Git) WorktreeAddExistingSafe(path, branch string) error {
+	holder, err := g.LiveWorktreeForBranch(branch)
+	if err != nil {
+		return fmt.Errorf("checking whether %s is already checked out: %w", branch, err)
+	}
+	if holder != nil {
+		return &BranchHeldError{Branch: branch, Path: holder.Path}
+	}
+	// No live holder. A stale record may still make git refuse, so drop dead
+	// records first. Prune only removes worktrees whose directory is already
+	// gone; it cannot touch a live one.
+	if err := g.WorktreePrune(); err != nil {
+		return fmt.Errorf("pruning stale worktree records before attaching %s: %w", branch, err)
+	}
+	return g.WorktreeAddExisting(path, branch)
 }
 
 // submoduleReferencePath returns the mayor/rig path to use as --reference
@@ -2430,10 +2504,19 @@ func (g *Git) WorktreePrune() error {
 }
 
 // Worktree represents a git worktree.
+//
+// Prunable distinguishes a worktree git still has an administrative record for
+// but whose directory is gone (reaped, moved, deleted) from one that is live on
+// disk. Git refuses "worktree add" for a branch held by EITHER kind with the
+// same "already used by worktree at ..." message, so callers that want to
+// tolerate the first without tolerating the second must read this field —
+// see WorktreeAddExistingSafe.
 type Worktree struct {
-	Path   string
-	Branch string
-	Commit string
+	Path           string
+	Branch         string
+	Commit         string
+	Prunable       bool
+	PrunableReason string
 }
 
 // WorktreeList returns all worktrees for this repository.
@@ -2462,6 +2545,9 @@ func (g *Git) WorktreeList() ([]Worktree, error) {
 			current.Commit = strings.TrimPrefix(line, "HEAD ")
 		case strings.HasPrefix(line, "branch "):
 			current.Branch = strings.TrimPrefix(line, "branch refs/heads/")
+		case line == "prunable" || strings.HasPrefix(line, "prunable "):
+			current.Prunable = true
+			current.PrunableReason = strings.TrimSpace(strings.TrimPrefix(line, "prunable"))
 		}
 	}
 

--- a/internal/git/staged_line_stat_test.go
+++ b/internal/git/staged_line_stat_test.go
@@ -1,0 +1,185 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// si-mefr: detection for the armed state si-d6kw left behind.
+//
+// When a branch is rebased under a second worktree, that worktree's index ends
+// up staged to remove the entire rebase delta. The Mayor's fleet sweep found
+// keeper armed with 7767 staged line-deletions and coma with 6824 — and the
+// auto-save commits that with no agent acting (proven 2026-07-28 at 08:01,
+// during an explicit stop-write, with both agents complying).
+//
+// THE LOAD-BEARING DETAIL: the delta is staged as MODIFICATIONS to files that
+// still exist, not as file deletions. Every file-status check — --diff-filter=D,
+// --name-status — reports NOTHING while thousands of lines are staged to
+// disappear. Only a LINE-based count sees it. Each test below therefore carries
+// its own negative control asserting the file-status view is blind to the very
+// state being measured; without that control these tests would pass just as
+// happily against a fixture that was never armed in the first place.
+
+// armFixture stages a mass line-deletion the way a rebase does: the file stays,
+// its contents mostly go.
+func armFixture(t *testing.T, repo string, lines int) {
+	t.Helper()
+	body := strings.Repeat("a line of merged work\n", lines)
+	path := filepath.Join(repo, "delta.txt")
+	writeAndCommit(t, repo, path, body, "seed the delta")
+
+	// Rewrite to a single line and stage it — file still present, contents gone.
+	writeAndStage(t, repo, path, "a line of merged work\n")
+}
+
+func writeAndCommit(t *testing.T, repo, path, body, msg string) {
+	t.Helper()
+	writeAndStage(t, repo, path, body)
+	run(t, repo, "commit", "-m", msg)
+}
+
+func writeAndStage(t *testing.T, repo, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	run(t, repo, "add", filepath.Base(path))
+}
+
+func run(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+// assertFileStatusIsBlind is the negative control. If this ever fails, the
+// fixture is staging real file deletions and the line-based test below is
+// passing for a reason that has nothing to do with the defect.
+func assertFileStatusIsBlind(t *testing.T, g *Git, repo string) {
+	t.Helper()
+	deleted, err := g.StagedDeletions()
+	if err != nil {
+		t.Fatalf("StagedDeletions: %v", err)
+	}
+	if len(deleted) != 0 {
+		t.Fatalf("negative control failed: StagedDeletions saw %v. The fixture is staging FILE "+
+			"deletions, so it is not the rebase-armed state and the line-based assertion below "+
+			"proves nothing about it", deleted)
+	}
+	nameStatus := strings.TrimSpace(run(t, repo, "diff", "--cached", "--name-status", "--diff-filter=D"))
+	if nameStatus != "" {
+		t.Fatalf("negative control failed: --diff-filter=D reported %q; the armed state must be "+
+			"invisible to file-status checks", nameStatus)
+	}
+}
+
+func TestStagedLineDeletionsSeesWhatFileStatusChecksCannot(t *testing.T) {
+	repo := initTestRepo(t)
+	g := NewGit(repo)
+	armFixture(t, repo, 200)
+
+	// The control first: prove the state really is invisible to file-status.
+	assertFileStatusIsBlind(t, g, repo)
+
+	got, err := g.StagedLineDeletions()
+	if err != nil {
+		t.Fatalf("StagedLineDeletions: %v", err)
+	}
+	if got != 199 {
+		t.Fatalf("StagedLineDeletions = %d, want 199 — this is the count that made keeper's 7767 "+
+			"visible when every file-status check read clean", got)
+	}
+}
+
+// Denominator: a clean index must read zero, or "armed" would fire on every
+// worktree and the check would be deleted for crying wolf.
+func TestStagedLineDeletionsIsZeroOnACleanIndex(t *testing.T) {
+	repo := initTestRepo(t)
+	g := NewGit(repo)
+
+	got, err := g.StagedLineDeletions()
+	if err != nil {
+		t.Fatalf("StagedLineDeletions: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("StagedLineDeletions = %d on a clean index, want 0", got)
+	}
+}
+
+// A pure addition is not an armed state. shortstat reports insertions in the
+// same line, so a parser that grabs the wrong number reads 200 deletions here.
+func TestStagedLineDeletionsIgnoresInsertions(t *testing.T) {
+	repo := initTestRepo(t)
+	g := NewGit(repo)
+
+	writeAndStage(t, repo, filepath.Join(repo, "new.txt"), strings.Repeat("added\n", 200))
+
+	got, err := g.StagedLineDeletions()
+	if err != nil {
+		t.Fatalf("StagedLineDeletions: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("StagedLineDeletions = %d for a 200-line pure insertion, want 0 — the parser is "+
+			"reading the insertions field", got)
+	}
+}
+
+// shortstat omits the insertions clause entirely when there are none, so the
+// deletions field moves position. A positional parser passes the test above and
+// fails here.
+func TestStagedLineDeletionsHandlesDeletionsOnlyShortstat(t *testing.T) {
+	repo := initTestRepo(t)
+	g := NewGit(repo)
+
+	path := filepath.Join(repo, "delta.txt")
+	writeAndCommit(t, repo, path, strings.Repeat("x\n", 50), "seed")
+	writeAndStage(t, repo, path, "")
+
+	raw := run(t, repo, "diff", "--cached", "--shortstat")
+	if strings.Contains(raw, "insertion") {
+		t.Skipf("git emitted an insertions clause (%q); this git does not exercise the "+
+			"deletions-only shortstat form", strings.TrimSpace(raw))
+	}
+
+	got, err := g.StagedLineDeletions()
+	if err != nil {
+		t.Fatalf("StagedLineDeletions: %v", err)
+	}
+	if got != 50 {
+		t.Fatalf("StagedLineDeletions = %d for shortstat %q, want 50", got, strings.TrimSpace(raw))
+	}
+}
+
+// Guard the parser against a shortstat whose numbers it must not transpose.
+func TestParseShortstatDeletions(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{" 5 files changed, 26 insertions(+), 434 deletions(-)", 434},
+		{" 1 file changed, 1 insertion(+), 1 deletion(-)", 1},
+		{" 3 files changed, 7767 deletions(-)", 7767},
+		{" 2 files changed, 12 insertions(+)", 0},
+		{"", 0},
+		{"garbage", 0},
+	}
+	for _, tc := range cases {
+		if got := parseShortstatDeletions(tc.in); got != tc.want {
+			t.Errorf("parseShortstatDeletions(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+	// The transposition this guards against: 26 insertions must never be read
+	// as the deletion count for the line that recorded 434.
+	if got := parseShortstatDeletions(" 5 files changed, 26 insertions(+), 434 deletions(-)"); got == 26 {
+		t.Fatal("parser returned the insertions count as deletions")
+	}
+}

--- a/internal/git/worktree_holder_test.go
+++ b/internal/git/worktree_holder_test.go
@@ -1,0 +1,362 @@
+package git
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// si-d6kw: gt put two polecat worktrees on one branch. A commit in either then
+// appeared in the other as a delta to re-commit, and the auto-save committed
+// that delta with no agent acting — 7767 / 6824 / 434 staged deletions found
+// armed across the fleet.
+//
+// The subtlety these tests exist to pin down: git refuses BOTH a live holder
+// and a stale record with the same "already used by worktree at ..." message,
+// which is why callers reached for --force in the first place. Dropping --force
+// would fix the collision and break the reap-and-resume workflow it was added
+// for. So the guard is not "refuse when git refuses" — it is "refuse a LIVE
+// holder, clear a dead one" — and the tests have to show both halves, plus that
+// the refusal is the guard's and not git's.
+
+func worktreeHolderRepo(t *testing.T) (*Git, string) {
+	t.Helper()
+	dir := initTestRepo(t)
+	return NewGit(dir), dir
+}
+
+// addWorktreeOnNewBranch creates a real worktree holding a real branch.
+func addWorktreeOnNewBranch(t *testing.T, repo string, path, branch string) {
+	t.Helper()
+	cmd := exec.Command("git", "worktree", "add", "-b", branch, path)
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("seed worktree %s on %s: %v\n%s", path, branch, err, out)
+	}
+}
+
+func TestWorktreeAddExistingSafeRefusesBranchHeldByLiveWorktree(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	holder := filepath.Join(t.TempDir(), "holder")
+	addWorktreeOnNewBranch(t, repo, holder, "polecat/dag/si-aka.9")
+
+	second := filepath.Join(t.TempDir(), "second")
+	err := g.WorktreeAddExistingSafe(second, "polecat/dag/si-aka.9")
+	if err == nil {
+		t.Fatal("WorktreeAddExistingSafe attached a second worktree to a live-held branch; " +
+			"that is the si-d6kw defect")
+	}
+
+	var held *BranchHeldError
+	if !errors.As(err, &held) {
+		t.Fatalf("error = %v (%T), want *BranchHeldError — callers switch on this type to "+
+			"produce the actionable refusal", err, err)
+	}
+	if !sameResolvedPath(t, held.Path, holder) {
+		t.Fatalf("BranchHeldError.Path = %q, want %q — the message must NAME the holder, "+
+			"or the operator cannot act on it", held.Path, holder)
+	}
+
+	// The refusal must be total. A partially-created worktree is the hazard.
+	if _, statErr := os.Stat(second); !os.IsNotExist(statErr) {
+		t.Fatalf("refused, but %s exists anyway — nothing may be created on the refusal path", second)
+	}
+	for _, wt := range mustList(t, g) {
+		if wt.Path == second {
+			t.Fatalf("refused, but git registered a worktree at %s", second)
+		}
+	}
+}
+
+// NEGATIVE CONTROL. Without this, the test above passes even if the guard does
+// nothing, because plain git would refuse too — and the whole point is that the
+// old code got PAST git's refusal. This asserts the setup really is one --force
+// away from the two-worktrees-on-one-ref state, so the refusal above is
+// attributable to the guard rather than to git.
+func TestWorktreeAddExistingForceStillReachesTheStateTheGuardRefuses(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	holder := filepath.Join(t.TempDir(), "holder")
+	addWorktreeOnNewBranch(t, repo, holder, "polecat/dag/si-aka.9")
+
+	second := filepath.Join(t.TempDir(), "second")
+	if err := g.WorktreeAddExistingForce(second, "polecat/dag/si-aka.9"); err != nil {
+		t.Fatalf("WorktreeAddExistingForce: %v — if this now fails, the negative control is "+
+			"stale and the refusal test above may be measuring git rather than the guard", err)
+	}
+
+	var holders int
+	for _, wt := range mustList(t, g) {
+		if wt.Branch == "polecat/dag/si-aka.9" {
+			holders++
+		}
+	}
+	if holders != 2 {
+		t.Fatalf("worktrees on polecat/dag/si-aka.9 = %d, want 2 — the reproduction of si-d6kw "+
+			"did not reproduce, so the guard test proves nothing", holders)
+	}
+}
+
+// The workflow that must NOT break. Alice's recovery slings were 4-of-5 clean
+// precisely because the original worktree had been reaped; a guard that refuses
+// this case removes the only working recovery route and pushes operators to a
+// worse one.
+func TestWorktreeAddExistingSafeResumesBranchAfterHolderWasReaped(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	holder := filepath.Join(t.TempDir(), "holder")
+	addWorktreeOnNewBranch(t, repo, holder, "polecat/keeper/si-aka.37")
+
+	// Reap it the way the fleet does: the directory goes, the record remains.
+	if err := os.RemoveAll(holder); err != nil {
+		t.Fatalf("reap holder: %v", err)
+	}
+
+	// Denominator: the stale record must actually still be there, otherwise this
+	// test proves only that attaching to an unheld branch works.
+	if !recordExistsFor(t, g, "polecat/keeper/si-aka.37") {
+		t.Fatal("no worktree record for the branch after reaping — test setup no longer " +
+			"reproduces the stale-holder case it is named for")
+	}
+
+	resumed := filepath.Join(t.TempDir(), "resumed")
+	if err := g.WorktreeAddExistingSafe(resumed, "polecat/keeper/si-aka.37"); err != nil {
+		t.Fatalf("WorktreeAddExistingSafe refused a reaped holder: %v\n"+
+			"This is the resume workflow --force existed for; refusing it is the regression "+
+			"si-d6kw's own fix order warned about", err)
+	}
+	assertOnBranch(t, resumed, "polecat/keeper/si-aka.37")
+}
+
+// The case a directory-existence check alone gets WRONG, and the reason
+// LiveWorktreeForBranch reads git's prunable flag rather than just stat()ing
+// the path. A worktree whose .git file is broken still has its DIRECTORY on
+// disk, and git still reports the branch as taken — but it is not a live
+// worker, it is the broken worktree that "gt polecat repair" exists for.
+// Treating it as a live holder makes such a polecat permanently unresumable.
+//
+// This test was added because a mutation that deleted the Prunable check went
+// GREEN: the stat() fallback covered the reaped-directory case and hid it.
+func TestWorktreeAddExistingSafeResumesWorktreeWhoseGitFileIsBroken(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	broken := filepath.Join(t.TempDir(), "broken")
+	addWorktreeOnNewBranch(t, repo, broken, "polecat/coma/si-aka.14.2")
+
+	// Break the link without removing the directory.
+	if err := os.Remove(filepath.Join(broken, ".git")); err != nil {
+		t.Fatalf("break worktree .git: %v", err)
+	}
+
+	// Denominator: the state under test must actually hold — directory present,
+	// git reporting prunable. If either drifts, this test silently becomes a
+	// duplicate of the reaped-holder one.
+	if _, err := os.Stat(broken); err != nil {
+		t.Fatalf("broken worktree directory should still exist: %v", err)
+	}
+	var sawBrokenAsPrunable bool
+	for _, wt := range mustList(t, g) {
+		if wt.Branch == "polecat/coma/si-aka.14.2" && wt.Prunable {
+			sawBrokenAsPrunable = true
+		}
+	}
+	if !sawBrokenAsPrunable {
+		t.Fatal("git no longer reports the broken worktree as prunable — this test is not " +
+			"exercising the directory-exists-but-dead case it is named for")
+	}
+
+	resumed := filepath.Join(t.TempDir(), "resumed")
+	if err := g.WorktreeAddExistingSafe(resumed, "polecat/coma/si-aka.14.2"); err != nil {
+		t.Fatalf("WorktreeAddExistingSafe refused a broken (not live) worktree: %v\n"+
+			"A directory-existence check alone gives this wrong answer; the prunable flag "+
+			"is what distinguishes 'someone is working here' from 'this worktree is dead'", err)
+	}
+	assertOnBranch(t, resumed, "polecat/coma/si-aka.14.2")
+}
+
+func TestWorktreeAddExistingSafeAttachesWhenNoWorktreeHoldsBranch(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	cmd := exec.Command("git", "branch", "polecat/toast/si-aka.9+rework")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create branch: %v\n%s", err, out)
+	}
+
+	path := filepath.Join(t.TempDir(), "fresh")
+	if err := g.WorktreeAddExistingSafe(path, "polecat/toast/si-aka.9+rework"); err != nil {
+		t.Fatalf("WorktreeAddExistingSafe on an unheld branch: %v", err)
+	}
+	assertOnBranch(t, path, "polecat/toast/si-aka.9+rework")
+}
+
+// LiveWorktreeForBranch is the predicate the whole guard rests on. Test it
+// directly so a failure points at the discrimination rather than at the caller.
+func TestLiveWorktreeForBranchIgnoresPrunableRecords(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	live := filepath.Join(t.TempDir(), "live")
+	stale := filepath.Join(t.TempDir(), "stale")
+	addWorktreeOnNewBranch(t, repo, live, "branch/live")
+	addWorktreeOnNewBranch(t, repo, stale, "branch/stale")
+	if err := os.RemoveAll(stale); err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+
+	// Denominator on the parse itself: if WorktreeList stopped reporting
+	// prunable at all, every record would look live and the "stale" assertion
+	// below would still pass by accident on a differently-broken parser.
+	list := mustList(t, g)
+	var sawPrunable bool
+	for _, wt := range list {
+		if wt.Branch == "branch/stale" {
+			if !wt.Prunable {
+				t.Fatalf("record for branch/stale parsed with Prunable=false; "+
+					"reason=%q — git reports it as prunable", wt.PrunableReason)
+			}
+			sawPrunable = true
+		}
+	}
+	if !sawPrunable {
+		t.Fatal("no record found for branch/stale — cannot distinguish 'correctly ignored' " +
+			"from 'never examined'")
+	}
+
+	got, err := g.LiveWorktreeForBranch("branch/stale")
+	if err != nil {
+		t.Fatalf("LiveWorktreeForBranch(stale): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("LiveWorktreeForBranch(branch/stale) = %s, want nil — a reaped worktree is "+
+			"not a live holder", got.Path)
+	}
+
+	got, err = g.LiveWorktreeForBranch("branch/live")
+	if err != nil {
+		t.Fatalf("LiveWorktreeForBranch(live): %v", err)
+	}
+	if got == nil || !sameResolvedPath(t, got.Path, live) {
+		t.Fatalf("LiveWorktreeForBranch(branch/live) = %v, want %s", got, live)
+	}
+
+	// refs/heads/ prefix must resolve the same way; callers pass both forms.
+	got, err = g.LiveWorktreeForBranch("refs/heads/branch/live")
+	if err != nil {
+		t.Fatalf("LiveWorktreeForBranch(refs/heads/...): %v", err)
+	}
+	if got == nil || !sameResolvedPath(t, got.Path, live) {
+		t.Fatalf("LiveWorktreeForBranch with refs/heads/ prefix = %v, want %s", got, live)
+	}
+}
+
+// samePath compares paths after resolving symlinks. On macOS t.TempDir() hands
+// back /var/... while git reports the resolved /private/var/..., so a raw
+// string compare fails on a correct result.
+func sameResolvedPath(t *testing.T, a, b string) bool {
+	t.Helper()
+	ra, err := filepath.EvalSymlinks(a)
+	if err != nil {
+		ra = a
+	}
+	rb, err := filepath.EvalSymlinks(b)
+	if err != nil {
+		rb = b
+	}
+	return ra == rb
+}
+
+// PRODUCTION ARCHITECTURE. Rigs use a bare .repo.git as the repo base and hang
+// every polecat worktree off it (si-d6kw measured dag's git-dir as
+// .repo.git/worktrees/silicon7). The manager-level tests run on the LEGACY
+// mayor/rig base because that is what the scaffolding builds, so without this
+// test nothing exercises the guard on the shape it actually ships against.
+//
+// Two properties matter, and the first is the one that would bite: a bare repo
+// appears in "worktree list --porcelain" with a "bare" line and NO "branch"
+// line. If that parsed as a worktree holding something, the base itself could
+// read as a live holder and refuse every resume.
+func TestWorktreeGuardOnBareRepoBase(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	if err := os.MkdirAll(src, 0755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	runGit(t, src, "init", "-b", "main", ".")
+	runGit(t, src, "config", "user.email", "test@test.com")
+	runGit(t, src, "config", "user.name", "Test User")
+	runGit(t, src, "commit", "--allow-empty", "-m", "init")
+
+	bare := filepath.Join(root, "repo.git")
+	runGit(t, root, "clone", "--bare", src, bare)
+	g := NewGitWithDir(bare, "")
+
+	// The bare base holds no branch.
+	for _, wt := range mustList(t, g) {
+		if wt.Branch != "" && wt.Path == bare {
+			t.Fatalf("bare repo base parsed as holding branch %q; it has no working tree "+
+				"and must never read as a live holder", wt.Branch)
+		}
+	}
+	held, err := g.LiveWorktreeForBranch("main")
+	if err != nil {
+		t.Fatalf("LiveWorktreeForBranch(main) on bare base: %v", err)
+	}
+	if held != nil {
+		t.Fatalf("bare base reported as live holder of main at %s — every resume would refuse", held.Path)
+	}
+
+	// A polecat worktree off the bare base IS a live holder.
+	runGit(t, bare, "branch", "polecat/dag/si-aka.9", "main")
+	holder := filepath.Join(root, "dag")
+	runGit(t, bare, "worktree", "add", holder, "polecat/dag/si-aka.9")
+
+	second := filepath.Join(root, "toast")
+	err = g.WorktreeAddExistingSafe(second, "polecat/dag/si-aka.9")
+	var branchHeld *BranchHeldError
+	if !errors.As(err, &branchHeld) {
+		t.Fatalf("WorktreeAddExistingSafe on bare base = %v, want *BranchHeldError — "+
+			"this is the exact dag/toast collision, on the exact architecture it happened on", err)
+	}
+
+	// And the reaped case still resumes on a bare base.
+	if err := os.RemoveAll(holder); err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+	if err := g.WorktreeAddExistingSafe(second, "polecat/dag/si-aka.9"); err != nil {
+		t.Fatalf("resume after reap on bare base: %v", err)
+	}
+	assertOnBranch(t, second, "polecat/dag/si-aka.9")
+}
+
+func mustList(t *testing.T, g *Git) []Worktree {
+	t.Helper()
+	list, err := g.WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatal("WorktreeList returned nothing — an empty list satisfies every loop below")
+	}
+	return list
+}
+
+func recordExistsFor(t *testing.T, g *Git, branch string) bool {
+	t.Helper()
+	for _, wt := range mustList(t, g) {
+		if wt.Branch == branch {
+			return true
+		}
+	}
+	return false
+}
+
+func assertOnBranch(t *testing.T, path, branch string) {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = path
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse in %s: %v", path, err)
+	}
+	if got := strings.TrimSpace(string(out)); got != branch {
+		t.Fatalf("worktree %s is on %q, want %q", path, got, branch)
+	}
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -32,6 +32,29 @@ import (
 	"github.com/steveyegge/gastown/internal/util"
 )
 
+// resumeBranchError wraps a failure to attach a worktree to a resume branch.
+//
+// The refusal case gets an actionable message on purpose. si-d6kw's own
+// post-mortem found that the operator reached for the unsafe option because the
+// safe one failed with a bare "exit status 1" — a defect that manufactures
+// pressure toward the dangerous path. A refusal that does not say what to do
+// instead recreates exactly that.
+func resumeBranchError(resumeBranch string, err error) error {
+	var held *git.BranchHeldError
+	if errors.As(err, &held) {
+		return fmt.Errorf("refusing to resume %s: it is checked out by a live worktree at %s\n\n"+
+			"Two worktrees on one branch is not a warning, it is data loss: a commit in either\n"+
+			"appears in the other as a delta to re-commit, and the auto-save commits that delta\n"+
+			"with no agent acting (si-d6kw).\n\n"+
+			"Instead:\n"+
+			"  - sling to the worker that already holds the branch, or\n"+
+			"  - let a fresh polecat branch be minted (drop --branch) and rebase, or\n"+
+			"  - if that worktree is genuinely finished, retire it first, then retry",
+			resumeBranch, held.Path)
+	}
+	return fmt.Errorf("creating worktree on existing branch %s: %w", resumeBranch, err)
+}
+
 // Retry constants for Dolt operations (matching hook update pattern in sling.go).
 // Configurable via operational.polecat in settings/config.json.
 const (
@@ -766,14 +789,15 @@ func (m *Manager) addWithOptionsLocked(name string, opts AddOptions, polecatDir 
 
 	if opts.ResumeBranch != "" {
 		// Resume an existing branch (gh#3602). Make sure we have the latest tip
-		// for the named branch, then attach the worktree directly. WorktreeAddExistingForce
-		// handles the case where another worktree previously had this branch checked out.
+		// for the named branch, then attach the worktree directly. Safe, not
+		// Force: a worktree PREVIOUSLY on this branch is pruned and resumed, but
+		// one that still holds it is refused (si-d6kw).
 		if err := repoGit.FetchBranch("origin", opts.ResumeBranch); err != nil {
 			style.PrintWarning("could not fetch resume branch %s: %v", opts.ResumeBranch, err)
 		}
-		if err := repoGit.WorktreeAddExistingForce(clonePath, opts.ResumeBranch); err != nil {
+		if err := repoGit.WorktreeAddExistingSafe(clonePath, opts.ResumeBranch); err != nil {
 			cleanupOnError()
-			return nil, fmt.Errorf("creating worktree on existing branch %s: %w", opts.ResumeBranch, err)
+			return nil, resumeBranchError(opts.ResumeBranch, err)
 		}
 		worktreeCreated = true
 	} else {
@@ -964,15 +988,17 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (_ *Polecat, retE
 
 	if opts.ResumeBranch != "" {
 		// Resume an existing branch (gh#3602): attach the worktree directly to the
-		// named branch. WorktreeAddExistingForce tolerates the branch being checked
-		// out elsewhere (stale worktree), and the explicit fetch ensures we have
-		// the latest tip before checkout.
+		// named branch. WorktreeAddExistingSafe tolerates a STALE worktree record
+		// for the branch — which is what "tolerates the branch being checked out
+		// elsewhere" was always meant to cover — and refuses a live holder, which
+		// --force could not tell apart (si-d6kw). The explicit fetch ensures we
+		// have the latest tip before checkout.
 		if err := repoGit.FetchBranch("origin", opts.ResumeBranch); err != nil {
 			style.PrintWarning("could not fetch resume branch %s: %v", opts.ResumeBranch, err)
 		}
-		if err := repoGit.WorktreeAddExistingForce(clonePath, opts.ResumeBranch); err != nil {
+		if err := repoGit.WorktreeAddExistingSafe(clonePath, opts.ResumeBranch); err != nil {
 			cleanupOnError()
-			return nil, fmt.Errorf("creating worktree on existing branch %s: %w", opts.ResumeBranch, err)
+			return nil, resumeBranchError(opts.ResumeBranch, err)
 		}
 		worktreeCreated = true
 	} else {
@@ -1596,6 +1622,15 @@ func (m *Manager) RepairWorktreeWithOptions(name string, force bool, opts AddOpt
 	if opts.ResumeBranch != "" {
 		// Resume an existing branch: fetch and attach the temp worktree directly
 		// to the named branch instead of creating a fresh polecat/<name>/<bead>+<ts>.
+		//
+		// Deliberately still Force, unlike the two sling resume paths (si-d6kw).
+		// Repair rebuilds ONE polecat's own worktree and does not remove the old
+		// registration first, so the record most likely holding this branch is
+		// the very one being replaced — WorktreeAddExistingSafe would refuse and
+		// repair could never run. Note also that no production caller sets
+		// ResumeBranch here: RepairWorktree passes AddOptions{}. A future caller
+		// that does must remove the old worktree registration before this point,
+		// otherwise it inherits the two-worktrees-one-ref hazard.
 		if err := repoGit.FetchBranch("origin", opts.ResumeBranch); err != nil {
 			style.PrintWarning("could not fetch resume branch %s: %v", opts.ResumeBranch, err)
 		}

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1688,6 +1688,25 @@ func TestAddWithOptions_ResumeBranch(t *testing.T) {
 		t.Fatalf("update-ref origin/%s: %v\n%s", prBranch, err, out)
 	}
 
+	// Return the repo base to main. createStalePolecatCommit builds the marker
+	// commit by CHECKING OUT the branch here and never switching back, which
+	// parks the repo base itself on the branch we are about to resume.
+	//
+	// That state does not exist in production: repoBase() prefers the bare
+	// .repo.git, which has no working tree and therefore holds no branch (the
+	// live rig confirms it — si-d6kw measured polecat git-dirs as
+	// .repo.git/worktrees/silicon7). mayor/rig is the legacy fallback this
+	// scaffolding happens to use.
+	//
+	// Leaving it parked would make this test assert that a polecat may attach to
+	// a branch a live working tree already has checked out — which is exactly
+	// the si-d6kw defect, and the si-d6kw guard now correctly refuses it.
+	cmd = exec.Command("git", "checkout", "main")
+	cmd.Dir = mayorRig
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("return repo base to main: %v\n%s", err, out)
+	}
+
 	polecat, err := mgr.AddWithOptions("toast", AddOptions{ResumeBranch: prBranch})
 	if err != nil {
 		t.Fatalf("AddWithOptions with ResumeBranch: %v", err)

--- a/internal/polecat/resume_branch_holder_test.go
+++ b/internal/polecat/resume_branch_holder_test.go
@@ -1,0 +1,180 @@
+package polecat
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+// si-d6kw. "gt sling <bead> <rig> --branch <held-branch>" spawned a SECOND
+// polecat onto a branch another polecat's worktree still had checked out. The
+// two auto-checkpointed over each other; a fleet sweep then found three more
+// worktrees armed with 7767 / 6824 / 434 staged deletions, and one of those
+// deletions was committed at 08:01 during an explicit stop-write with both
+// agents complying — because the auto-save needs no agent to act.
+//
+// The guard lives in internal/git; these tests exist because a guard the sling
+// resume path does not CALL protects nothing. Both spawn entry points are
+// covered: AddWithOptions (named polecat) and addWithOptionsLocked, reached via
+// AllocateAndAdd (pool allocation), which is the one --branch actually used.
+
+// seedLiveWorktreeOnBranch creates a real branch in the repo and a real, live
+// worktree holding it — the "dag still has it checked out" precondition.
+func seedLiveWorktreeOnBranch(t *testing.T, repo, branch string) string {
+	t.Helper()
+	cmd := exec.Command("git", "branch", branch, "HEAD")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create branch %s: %v\n%s", branch, err, out)
+	}
+	holder := filepath.Join(t.TempDir(), "holder")
+	cmd = exec.Command("git", "worktree", "add", holder, branch)
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("seed live worktree on %s: %v\n%s", branch, err, out)
+	}
+	return holder
+}
+
+func assertRefusalIsActionable(t *testing.T, err error, branch, holder string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("resume onto a live-held branch SUCCEEDED — this is si-d6kw: two worktrees " +
+			"on one ref, which the auto-save turns into committed data loss")
+	}
+	msg := err.Error()
+	// Naming the holder is the difference between a refusal an operator can act
+	// on and one they route around. si-d6kw's post-mortem traced the original
+	// incident to a safe path that failed with a bare "exit status 1".
+	if !strings.Contains(msg, holder) {
+		resolved, evalErr := filepath.EvalSymlinks(holder)
+		if evalErr != nil || !strings.Contains(msg, resolved) {
+			t.Fatalf("refusal does not name the holding worktree %s.\nGot: %s", holder, msg)
+		}
+	}
+	if !strings.Contains(msg, branch) {
+		t.Fatalf("refusal does not name the branch %s.\nGot: %s", branch, msg)
+	}
+	// It must tell the operator what to do instead, or it manufactures pressure
+	// toward the dangerous option exactly as the original defect did.
+	if !strings.Contains(msg, "Instead:") {
+		t.Fatalf("refusal offers no alternative; an operator who is blocked will find a "+
+			"worse route.\nGot: %s", msg)
+	}
+}
+
+func TestAddWithOptionsRefusesResumeBranchHeldByLiveWorktree(t *testing.T) {
+	mgr, mayorRig := setupCanonicalBranchManagerTest(t)
+	const branch = "polecat/dag/si-aka.9+ms43eli5"
+	holder := seedLiveWorktreeOnBranch(t, mayorRig, branch)
+
+	_, err := mgr.AddWithOptions("toast", AddOptions{ResumeBranch: branch})
+	assertRefusalIsActionable(t, err, branch, holder)
+
+	// The refusal must leave nothing behind. A half-built polecat directory is
+	// its own failure mode — reconcile treats it as an allocation.
+	polecatDir := filepath.Join(mgr.rig.Path, "polecats", "toast")
+	if _, statErr := os.Stat(polecatDir); !os.IsNotExist(statErr) {
+		t.Fatalf("polecat dir %s survived the refusal; rollback did not run", polecatDir)
+	}
+
+	// And the original holder must be untouched: still the only worktree on the
+	// branch, still on it. Refusing loudly while having already forced would be
+	// the worst of both.
+	holders := worktreesOnBranch(t, mayorRig, branch)
+	if len(holders) != 1 {
+		t.Fatalf("worktrees on %s = %d (%v), want exactly 1 — the original holder", branch, len(holders), holders)
+	}
+}
+
+func TestAllocateAndAddRefusesResumeBranchHeldByLiveWorktree(t *testing.T) {
+	mgr, mayorRig := setupCanonicalBranchManagerTest(t)
+	const branch = "polecat/keeper/si-aka.37+ms43gm2z"
+	holder := seedLiveWorktreeOnBranch(t, mayorRig, branch)
+
+	_, _, err := mgr.AllocateAndAdd(AddOptions{ResumeBranch: branch})
+	assertRefusalIsActionable(t, err, branch, holder)
+
+	holders := worktreesOnBranch(t, mayorRig, branch)
+	if len(holders) != 1 {
+		t.Fatalf("worktrees on %s = %d (%v), want exactly 1", branch, len(holders), holders)
+	}
+}
+
+// The recovery workflow --branch exists for, which the guard must NOT break.
+// Four of Alice's five recovery slings were exactly this case.
+func TestAddWithOptionsResumesBranchWhoseHolderWasReaped(t *testing.T) {
+	mgr, mayorRig := setupCanonicalBranchManagerTest(t)
+	const branch = "polecat/cheedo/si-aka.10+ms43f8l0"
+	holder := seedLiveWorktreeOnBranch(t, mayorRig, branch)
+
+	// Reap the original worker the way the fleet does.
+	if err := os.RemoveAll(holder); err != nil {
+		t.Fatalf("reap holder: %v", err)
+	}
+	// Denominator: the stale record must survive the reap, or this test is just
+	// the unheld-branch case wearing a different name. Note this deliberately
+	// counts records INCLUDING prunable ones — worktreesOnBranch excludes them,
+	// which is the whole point of the reap.
+	if !anyWorktreeRecordFor(t, mayorRig, branch) {
+		t.Fatal("no worktree record for the branch after reaping — setup no longer " +
+			"reproduces the stale-holder case")
+	}
+
+	polecat, err := mgr.AddWithOptions("toast", AddOptions{ResumeBranch: branch})
+	if err != nil {
+		t.Fatalf("resume after reap was refused: %v\n"+
+			"This is the workflow --force was added for. A guard that blocks it removes the "+
+			"only working recovery route, which is what si-d6kw's fix order warned about", err)
+	}
+	if polecat.Branch != branch {
+		t.Fatalf("resumed polecat is on %q, want %q", polecat.Branch, branch)
+	}
+	head, err := git.NewGit(polecat.ClonePath).CurrentBranch()
+	if err != nil {
+		t.Fatalf("read resumed worktree branch: %v", err)
+	}
+	if head != branch {
+		t.Fatalf("resumed worktree HEAD is on %q, want %q", head, branch)
+	}
+}
+
+// anyWorktreeRecordFor reports whether git still has ANY record for the branch,
+// live or prunable. Used for setup denominators, where the point is that a dead
+// record survives.
+func anyWorktreeRecordFor(t *testing.T, repo, branch string) bool {
+	t.Helper()
+	list, err := git.NewGit(repo).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	for _, wt := range list {
+		if wt.Branch == branch {
+			return true
+		}
+	}
+	return false
+}
+
+// worktreesOnBranch returns the LIVE worktrees holding branch.
+func worktreesOnBranch(t *testing.T, repo, branch string) []string {
+	t.Helper()
+	list, err := git.NewGit(repo).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatal("WorktreeList returned nothing — an empty list satisfies any count assertion")
+	}
+	var paths []string
+	for _, wt := range list {
+		if wt.Branch == branch && !wt.Prunable {
+			paths = append(paths, wt.Path)
+		}
+	}
+	return paths
+}


### PR DESCRIPTION
> **Stacked on #4619.** This branch is cut from `fix/si-d6kw-sling-worktree-collision`, so the
> diff below includes that PR's commit. It needs `git.Worktree.Prunable`, which #4619 adds and
> `main` does not have. Merge #4619 first and this narrows to its own commit.

si-mefr, the **detection** half of si-d6kw. #4619 closed the sling route and #4620 built the safe
recovery path. Neither makes the state observable, and it can still arise:
`WorktreeAddExistingForce` has two legitimate callers (`worktree.go:157`, `mq_integration.go:163`)
and a hand-run `git worktree add --force` bypasses everything. The armed delta also **grows while
unobserved** — keeper went 7748 → 7767 during the conversation about it.

Two checks, registered with `gt doctor`:

| check | reports |
|---|---|
| `worktree-shared-ref` | branches held by two or more **live** worktrees of one repo |
| `worktree-armed-staging` | worktrees staged to delete ≥100 lines |

## Counting LINES is the whole point

A rebase under a shared ref leaves the delta staged as **modifications to files that still exist**,
not as file deletions. `--diff-filter=D` and `--name-status` report *nothing* while thousands of
lines are staged to disappear. The Mayor's sweep found keeper's 7767 and coma's 6824 only because it
counted lines.

`git.StagedDeletions` — already in this repo — is exactly that blind file-status check. The new
`git.StagedLineDeletions` sits beside it with a doc comment saying which one a caller wants and why.

## Two filters that are load-bearing, not tidiness

- **Prunable.** Git reports the administrative record of a *reaped* worktree identically to a live
  one, and reaping a polecat is routine. Without the filter the check reds on a healthy fleet, gets
  turned off, and then there is no check.
- **Detached HEAD.** Grouping on an empty branch name would collapse every detached worktree into
  one fictional shared ref.

Both checks also refuse to report OK when they examined **zero** worktrees, or when a repo could not
be read. An enumeration that silently breaks otherwise reports health forever — and health is what
the reader already expects, so nobody looks.

## Verification

Nine mutations, nine kills. The one worth naming:

| mutation | killed by |
|---|---|
| **measure with `--diff-filter=D` instead of `--shortstat`** — the actual defect this exists to beat | `StagedLineDeletionsSeesWhatFileStatusChecksCannot` |
| drop the prunable filter | `SharedRefsIgnoresAPrunableRecord` |
| drop the detached-HEAD filter | `SharedRefsIgnoresDetachedWorktrees` |
| report a single holder as shared | 3 tests |
| drop either zero-examined denominator | `...FailsWhenItExaminesNothing` |
| never report an armed worktree | `ArmedStagingCheckFailsOnAnArmedWorktree` |
| threshold fires on ordinary edits | `IgnoresSmallStagedDeletions` |
| label match loose enough to read insertions as deletions | `IgnoresInsertions` + parser table |
| forget to register the checks | `TestDoctorRegistersWorktreeRefSafetyChecks` |

Every armed-state test carries a **negative control** asserting the file-status view is blind to its
own fixture, so it cannot pass against a fixture that was never armed. The prunable test likewise
asserts the reaped record is genuinely *present* in git's output first — otherwise it would be
counting one entry and proving nothing about filtering.

Fixtures drive **real git worktrees**, not struct literals: both properties under test are
properties of git's own output, and a struct literal would assert my belief about that output
instead of the output.

`CGO_ENABLED=0 go test ./internal/git/ ./internal/doctor/ ./internal/cmd/` — four failures, all four
reproducing identically on the unmodified base `5670826e` (three macOS `/private/var` symlink,
one `TestGetServerAddr_UsesConfigYAMLPort`). Baseline run before attributing, not after.

## Scope note

There is no `internal/patrol` package — patrol is an agent workflow, not a Go check registry — so
registering with `gt doctor` is the integration point that exists. The bead asked for "doctor plus
the patrol cycle"; I did not build a patrol surface that isn't there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)