### PR TITLE
fix(si-9wu1): the auto-save refuses a mass staged deletion instead of committing it

### DIFF
--- a/internal/autosave/refusal.go
+++ b/internal/autosave/refusal.go
@@ -1,0 +1,168 @@
+// Package autosave records when the gt-pvx auto-save safety net declines to
+// commit, in a form that outlives the session it happened in.
+//
+// si-9wu1, Mayor's ruling hq-vpt06 (2026-07-30).
+//
+// The auto-save unstages FILE deletions before committing, on the stated policy
+// that a safety net "should preserve work (additions + modifications), never
+// destroy it (deletions)". That policy is the hole. A rebase under a shared ref
+// leaves the delta staged as MODIFICATIONS to files that still exist, so the
+// file-status query behind that guard returns empty while thousands of lines
+// are staged to disappear — and the auto-save commits them. That is commit
+// 504a5ed: 5 files, +26, -434, landed at 08:01:47 during an explicit stop-write
+// with both agents complying.
+//
+// The ruling chose REFUSE over unstage-the-removal or commit-and-record, on an
+// argument about LOSS rather than tidiness:
+//
+//	refuse           the tree is untouched and the sandbox outlives the session.
+//	                 "the safety net did not fire" is not "work was destroyed".
+//	unstage          on a real refactor this commits additions WITHOUT their
+//	                 removals — a broken half-refactor presented as a save.
+//	commit + record  the commit still LANDS, and on a shared ref landing IS the
+//	                 harm: 504a5ed moving the ref is what set dag and toast
+//	                 oscillating. A recorded pre-commit HEAD makes the manual
+//	                 reset tidier, not unnecessary.
+//
+// Only one of those has "did nothing" as its failure mode.
+//
+// This package exists rather than living in internal/cmd because internal/cmd
+// imports internal/doctor to register checks, and the doctor check that
+// surfaces these markers would close that loop into an import cycle.
+package autosave
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// MarkerName is written BESIDE a worktree, never inside it: "git clean -f" and
+// "git reset --hard" run in these worktrees routinely and would erase a record
+// kept within.
+const MarkerName = ".gt-autosave-refused.json"
+
+// Threshold is the staged line-deletion count at which the auto-save declines.
+//
+// It must stay equal to doctor's armedStagingThreshold — a detector that
+// reports a hazard the safety net cheerfully commits is worse than neither.
+// TestRefusalThresholdMatchesDoctorThreshold pins them together.
+//
+// A plain line threshold, deliberately. The ruling offered a refinement — gate
+// on whether the ref is shared, since a mass removal in a SOLO worktree is
+// usually a real refactor — and left the call to the implementer. Declined:
+// under REFUSE a false positive costs nothing (the tree survives, the marker
+// says why, and si-n7vl now makes resuming that polecat possible), so the
+// refinement buys accuracy the failure mode does not need. The ruling's own
+// tiebreaker was that a safety net should be simple enough to reason about at
+// 3am.
+const Threshold = 100
+
+// Refusal is the durable record of a declined auto-save.
+type Refusal struct {
+	RefusedAt       time.Time `json:"refused_at"`
+	WorktreePath    string    `json:"worktree_path"`
+	Branch          string    `json:"branch"`
+	StagedDeletions int       `json:"staged_line_deletions"`
+	Threshold       int       `json:"threshold"`
+	Reason          string    `json:"reason"`
+}
+
+// WriteRefusal records a declined auto-save beside the worktree and returns the
+// marker path.
+//
+// The ruling made this non-optional, and the reason is what makes "print a loud
+// warning" insufficient on its own: the auto-save fires on gt done, AT SESSION
+// END, when nobody is reading stdout. A refusal printed to a dying terminal is
+// unobservable, and that trades a silent destructive write for a silent
+// non-save — the same defect class pointing the other way. The record has to be
+// something a later reader hits WITHOUT knowing to look for it, which is what
+// doctor's autosave-refusal check provides.
+func WriteRefusal(worktreePath, branch string, deletions int) (string, error) {
+	rec := Refusal{
+		RefusedAt:       time.Now(),
+		WorktreePath:    worktreePath,
+		Branch:          branch,
+		StagedDeletions: deletions,
+		Threshold:       Threshold,
+		Reason: "auto-save declined: the index is staged to delete more lines than the safety net " +
+			"will commit unreviewed. THE WORKING TREE WAS NOT MODIFIED — the work is still on " +
+			"disk. This is the signature a rebase leaves in a worktree that shares its branch " +
+			"with another worktree (si-d6kw), and it can also be a genuine large refactor. " +
+			"Inspect with 'git -C <worktree> diff --cached --shortstat', then either commit it " +
+			"deliberately or 'git -C <worktree> reset --hard HEAD' to drop the staging without " +
+			"moving the branch. Delete this file once resolved.",
+	}
+
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(filepath.Dir(worktreePath), MarkerName)
+	if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// FindRefusals returns every refusal marker under root, to a bounded depth.
+//
+// Bounded rather than a full walk because a town root contains entire
+// repositories, and markers only ever land beside a worktree — at most a few
+// levels down, e.g. <town>/<rig>/polecats/<name>/.
+func FindRefusals(root string, maxDepth int) []string {
+	var found []string
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// An unreadable subtree must not abort the scan; a partial answer
+			// beats no answer for a detector.
+			return nil //nolint:nilerr
+		}
+		if d.IsDir() {
+			if pathDepth(root, path) >= maxDepth {
+				return fs.SkipDir
+			}
+			switch d.Name() {
+			case ".git", ".repo.git", "node_modules":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == MarkerName {
+			found = append(found, path)
+		}
+		return nil
+	})
+	return found
+}
+
+// pathDepth returns how many directory levels path sits below root.
+func pathDepth(root, path string) int {
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." {
+		return 0
+	}
+	return len(strings.Split(rel, string(filepath.Separator)))
+}
+
+// Describe renders a marker for an operator, falling back to the raw path when
+// the file cannot be parsed — a corrupt marker still means a refusal happened,
+// and dropping it silently would be the same unobservable non-report the marker
+// exists to prevent.
+func Describe(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Sprintf("%s (unreadable: %v)", path, err)
+	}
+	var rec Refusal
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return fmt.Sprintf("%s (unparseable marker: %v)", path, err)
+	}
+	return fmt.Sprintf("%s (%s): %d lines staged for deletion, auto-save refused %s",
+		rec.WorktreePath, rec.Branch, rec.StagedDeletions, rec.RefusedAt.Format(time.RFC3339))
+}

--- a/internal/autosave/refusal_test.go
+++ b/internal/autosave/refusal_test.go
@@ -1,0 +1,134 @@
+package autosave
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// si-9wu1 / ruling hq-vpt06. The refusal is only worth anything if it OUTLIVES
+// the session: the auto-save fires on gt done, at session end, when nobody is
+// reading stdout. These tests pin the durable half.
+
+func TestWriteRefusalLandsBesideTheWorktreeNotInsideIt(t *testing.T) {
+	parent := t.TempDir()
+	worktree := filepath.Join(parent, "silicon")
+	if err := os.MkdirAll(worktree, 0755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+
+	path, err := WriteRefusal(worktree, "polecat/keeper/si-aka.37", 7767)
+	if err != nil {
+		t.Fatalf("WriteRefusal: %v", err)
+	}
+
+	if got := filepath.Dir(path); got != parent {
+		t.Fatalf("marker written to %q, want the worktree's PARENT %q — inside the worktree it "+
+			"would be erased by the 'git reset --hard' / 'git clean -f' these sandboxes get "+
+			"routinely, which is the one thing the record must survive", got, parent)
+	}
+	if _, err := os.Stat(filepath.Join(worktree, MarkerName)); err == nil {
+		t.Fatal("a marker was also written INSIDE the worktree")
+	}
+}
+
+func TestWriteRefusalRecordsWhatAnOperatorNeeds(t *testing.T) {
+	parent := t.TempDir()
+	worktree := filepath.Join(parent, "silicon")
+	if err := os.MkdirAll(worktree, 0755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+
+	path, err := WriteRefusal(worktree, "polecat/keeper/si-aka.37", 7767)
+	if err != nil {
+		t.Fatalf("WriteRefusal: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+
+	var rec Refusal
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("marker is not valid JSON: %v\n%s", err, data)
+	}
+	if rec.StagedDeletions != 7767 {
+		t.Errorf("StagedDeletions = %d, want 7767", rec.StagedDeletions)
+	}
+	if rec.Branch != "polecat/keeper/si-aka.37" {
+		t.Errorf("Branch = %q, want polecat/keeper/si-aka.37", rec.Branch)
+	}
+	if rec.WorktreePath != worktree {
+		t.Errorf("WorktreePath = %q, want %q", rec.WorktreePath, worktree)
+	}
+	if rec.RefusedAt.IsZero() {
+		t.Error("RefusedAt is zero — a record with no time cannot be aged or ordered")
+	}
+	// The reader arrives without context. The single fact that stops them
+	// panicking is that nothing was destroyed.
+	if !strings.Contains(rec.Reason, "NOT MODIFIED") {
+		t.Errorf("Reason does not tell the reader the working tree was untouched: %q", rec.Reason)
+	}
+}
+
+func TestFindRefusalsLocatesAMarkerAtPolecatDepth(t *testing.T) {
+	town := t.TempDir()
+	worktree := filepath.Join(town, "silicon", "polecats", "keeper", "silicon")
+	if err := os.MkdirAll(worktree, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, err := WriteRefusal(worktree, "polecat/keeper/si-aka.37", 7767); err != nil {
+		t.Fatalf("WriteRefusal: %v", err)
+	}
+
+	found := FindRefusals(town, 5)
+	if len(found) != 1 {
+		t.Fatalf("FindRefusals found %d markers, want 1 — a marker the scan cannot reach is the "+
+			"unobservable non-save the ruling forbade: %v", len(found), found)
+	}
+}
+
+// Denominator: the scan must not report markers that are not there.
+func TestFindRefusalsReturnsNothingOnACleanTown(t *testing.T) {
+	town := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(town, "silicon", "polecats", "keeper", "silicon"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if found := FindRefusals(town, 5); len(found) != 0 {
+		t.Fatalf("FindRefusals found %v on a clean town", found)
+	}
+}
+
+// The walk must not descend into repository internals; a town root contains
+// whole repos and an unbounded walk is both slow and liable to false positives.
+func TestFindRefusalsSkipsRepositoryInternals(t *testing.T) {
+	town := t.TempDir()
+	inGit := filepath.Join(town, "silicon", ".repo.git", "worktrees", "keeper")
+	if err := os.MkdirAll(inGit, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(inGit, MarkerName), []byte("{}\n"), 0644); err != nil {
+		t.Fatalf("write decoy: %v", err)
+	}
+
+	if found := FindRefusals(town, 5); len(found) != 0 {
+		t.Fatalf("FindRefusals descended into .repo.git: %v", found)
+	}
+}
+
+// A corrupt marker still means a refusal happened. Dropping it silently would
+// be the same unobservable non-report the marker exists to prevent.
+func TestDescribeStillReportsAnUnparseableMarker(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, MarkerName)
+	if err := os.WriteFile(path, []byte("not json"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := Describe(path)
+	if !strings.Contains(got, path) {
+		t.Fatalf("Describe(%q) = %q — a corrupt marker must still surface its path", path, got)
+	}
+}

--- a/internal/cmd/autosave_guard.go
+++ b/internal/cmd/autosave_guard.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/steveyegge/gastown/internal/autosave"
+	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/style"
+)
+
+// errAutosaveRefused marks the refusal so the caller can distinguish "declined
+// on purpose" (abort) from "git add failed" (warn and carry on).
+var errAutosaveRefused = errors.New("auto-save refused")
+
+// stageForAutosave refuses an armed index, or stages the working tree for the
+// auto-save commit.
+//
+// The refusal and the staging are ONE function on purpose. The guard is only
+// correct if it runs before "git add -A" — the ruling that chose refusal over
+// the alternatives turns on refusal being "the only option that never writes",
+// and a guard placed one line after the staging has already written. Keeping
+// both here means there is no call-site ordering left to get wrong, and it puts
+// the property under test: TestRefuseArmedAutosaveWritesNothingToTheRepository
+// asserts the index is untouched across a refusal, which can only hold if the
+// add did not run.
+func stageForAutosave(g *git.Git, worktreePath, branch string) error {
+	if err := refuseArmedAutosave(g, worktreePath, branch); err != nil {
+		return err
+	}
+	return g.Add("-A")
+}
+
+// refuseArmedAutosave declines the gt-pvx auto-save when the index is staged to
+// remove more lines than a safety net should commit unreviewed. It returns nil
+// when the auto-save may proceed.
+//
+// si-9wu1, Mayor's ruling hq-vpt06 (2026-07-30).
+//
+// TWO THINGS ABOUT THIS FUNCTION ARE LOAD-BEARING AND BOTH LOOK INCIDENTAL.
+//
+// It reads StagedLineDeletions, NEVER StagedDeletions. The latter is
+// --diff-filter=D, a file-status query, and the state being caught is staged as
+// MODIFICATIONS to files that still exist — a rebase under a shared ref removes
+// content from within files rather than removing files. --diff-filter=D returns
+// empty for it. That blindness is the entire defect: it is why the auto-save's
+// existing "never destroy work" guard passed 504a5ed's 434-line deletion
+// straight through, and re-using that query here would faithfully reproduce it.
+//
+// It runs before any staging — see stageForAutosave, which is why that ordering
+// is structural rather than remembered. The armed state is already in the index,
+// so it is measurable without writing anything, and "the only option that never
+// writes" is the whole reason refusal beat the alternatives: unstaging the
+// removal commits a broken half-refactor, and committing with a recorded HEAD
+// still lands the commit — and on a shared ref, landing IS the harm.
+func refuseArmedAutosave(g *git.Git, worktreePath, branch string) error {
+	armed, err := g.StagedLineDeletions()
+	if err != nil {
+		// Measuring failed. Do not refuse on an unknown — the auto-save's whole
+		// purpose is preventing loss, and blocking it on a git hiccup would
+		// strand work for a reason unrelated to the hazard.
+		style.PrintWarning("could not measure staged deletions before auto-save: %v", err)
+		return nil
+	}
+	if armed < autosave.Threshold {
+		return nil
+	}
+
+	markerPath, markerErr := autosave.WriteRefusal(worktreePath, branch, armed)
+	fmt.Printf("\n%s Auto-save REFUSED — the index is staged to delete %d lines\n",
+		style.Bold.Render("⛔"), armed)
+	fmt.Printf("  The working tree was NOT modified. Your work is still on disk.\n")
+	if markerErr == nil {
+		fmt.Printf("  Recorded at: %s\n", markerPath)
+	} else {
+		style.PrintWarning("could not write the refusal marker: %v", markerErr)
+	}
+	fmt.Printf("  Inspect: git -C %s diff --cached --shortstat\n\n", worktreePath)
+
+	return fmt.Errorf("%w: %d lines staged for deletion (threshold %d).\n"+
+		"A safety net must not commit a mass removal unreviewed — this is the signature a\n"+
+		"rebase leaves in a worktree sharing its branch with another worktree (si-d6kw),\n"+
+		"and it is also what a genuine large refactor looks like.\n"+
+		"Commit it deliberately, or 'git -C %s reset --hard HEAD' to drop the staging\n"+
+		"without moving the branch, then re-run gt done.",
+		errAutosaveRefused, armed, autosave.Threshold, worktreePath)
+}

--- a/internal/cmd/autosave_guard_e2e_test.go
+++ b/internal/cmd/autosave_guard_e2e_test.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/autosave"
+)
+
+// si-9wu1, end to end. THE GAP THESE CLOSE, STATED PRECISELY.
+//
+// autosave_guard_test.go proves stageForAutosave refuses an armed index and
+// writes nothing. It calls that function directly. Nothing in it proves gt done
+// ever REACHES the guard — and the path to it is not a straight line:
+//
+//	runDone -> auto-detect doneCleanupStatus (g.CheckUncommittedWork + g.Status)
+//	        -> "uncommitted"?  -> HasUncommittedChanges && !CleanExcludingRuntime()
+//	        -> stageForAutosave
+//
+// The armed state is a STAGED modification over a CLEAN working tree. If any
+// link in that chain treated "worktree matches index" as clean — a plausible
+// reading of every function named in it — the guard would never run, the
+// auto-save would never run either, and all nine unit tests would still be
+// green. The refusal would be dead code that tests beautifully.
+//
+// Both the bead and the Mayor's ruling recorded this in the same words: "NOT
+// PROVEN: no end-to-end gt done run", with the ruling adding "whoever
+// implements should close that by running it". This file runs it.
+//
+// TestRunDoneAutosavesOrdinaryUncommittedWork is the denominator and is not
+// optional. Without it, the refusal test passes if runDone aborts ANYWHERE
+// before the auto-save for any unrelated reason — "no commit landed" is exactly
+// what a fixture that never got that far also looks like.
+
+// armDoneWorktree stages a `lines`-line removal from within a file that still
+// exists — the rebase signature — into an already-initialised repo, and asserts
+// the fixture really is that state rather than a file deletion.
+func armDoneWorktree(t *testing.T, workDir string, lines int) {
+	t.Helper()
+
+	body := strings.Repeat("a line of merged work\n", lines+1)
+	writeMQSubmitTestFile(t, workDir, "delta.txt", body)
+	runGitForMQSubmitTest(t, workDir, "add", "delta.txt")
+	runGitForMQSubmitTest(t, workDir, "commit", "-m", "merged work")
+
+	writeMQSubmitTestFile(t, workDir, "delta.txt", "a line of merged work\n")
+	runGitForMQSubmitTest(t, workDir, "add", "delta.txt")
+
+	// Control: invisible to the file-status query the OLD guard used, or this
+	// fixture is not reproducing the defect.
+	if out := strings.TrimSpace(gitOut(t, workDir, "diff", "--cached", "--name-status", "--diff-filter=D")); out != "" {
+		t.Fatalf("fixture stages FILE deletions (%q) — that is not the rebase-armed state", out)
+	}
+}
+
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	return runGitForMQSubmitTest(t, dir, args...)
+}
+
+// setupAutosaveE2EDone builds the town + polecat worktree + bd stub that runDone
+// needs, and leaves every done flag at its default so the CLEANUP STATUS IS
+// AUTO-DETECTED. Passing doneCleanupStatus="uncommitted" by hand would skip the
+// exact link under test.
+func setupAutosaveE2EDone(t *testing.T) string {
+	t.Helper()
+	workDir, currentBeadsDir, ownerBeadsDir := setupRoutedSourceTestTown(t)
+	setupRoutedSubmitCommandTown(t, workDir)
+	setupRoutedSubmitGitRepo(t, workDir, false)
+	installSubmitSourceBDRecorder(t, currentBeadsDir, ownerBeadsDir)
+	resetDoneFlagsForTest(t)
+
+	townRoot := routedSourceTestTownRoot(workDir)
+	t.Setenv("GT_TEST_NUDGE_LOG", filepath.Join(t.TempDir(), "nudge.log"))
+	t.Setenv("GT_TOWN_ROOT", townRoot)
+	t.Setenv("GT_ROOT", townRoot)
+	t.Setenv("GT_ROLE", "gastown/polecats/refuge")
+	t.Setenv("GT_RIG", "gastown")
+	t.Setenv("GT_POLECAT", "refuge")
+	t.Setenv("BD_ACTOR", "gastown/polecats/refuge")
+	t.Chdir(workDir)
+
+	doneIssue = "bd-source"
+	doneSkipVerify = true
+	updateAgentStateOnDoneFn = func(cwd, townRoot, exitType, issueID string) error { return nil }
+	return workDir
+}
+
+// gt done against an armed worktree must refuse, and must leave the repository
+// byte-for-byte as it found it. This is 504a5ed's scenario driven through the
+// real entry point.
+func TestRunDoneRefusesAnArmedWorktree(t *testing.T) {
+	workDir := setupAutosaveE2EDone(t)
+	armDoneWorktree(t, workDir, 500)
+
+	beforeHead := gitOut(t, workDir, "rev-parse", "HEAD")
+	beforeStaged := gitOut(t, workDir, "diff", "--cached", "--shortstat")
+	beforeStatus := gitOut(t, workDir, "status", "--porcelain")
+
+	err := runDone(nil, nil)
+
+	// The substantive property FIRST, before anything about the error. Deleting
+	// the guard makes runDone continue past the auto-save and die further down
+	// for an unrelated reason; asserting the error shape first would report that
+	// downstream symptom instead of the defect that caused it.
+	if got := gitOut(t, workDir, "rev-parse", "HEAD"); got != beforeHead {
+		t.Fatalf("THE AUTO-SAVE COMMITTED A 500-LINE REMOVAL. HEAD %q -> %q.\n"+
+			"That is 504a5ed reproduced: 5 files, +26, -434, landed during an explicit "+
+			"stop-write. Commit:\n%s", beforeHead, got,
+			gitOut(t, workDir, "show", "--stat", "--format=%s", "HEAD"))
+	}
+	if got := gitOut(t, workDir, "diff", "--cached", "--shortstat"); got != beforeStaged {
+		t.Errorf("the INDEX changed across a refusal:\nbefore %q\nafter  %q", beforeStaged, got)
+	}
+	if got := gitOut(t, workDir, "status", "--porcelain"); got != beforeStatus {
+		t.Errorf("the working tree changed across a refusal:\nbefore %q\nafter  %q", beforeStatus, got)
+	}
+
+	// Nothing was committed — but that is also true of a run that aborted before
+	// ever reaching the auto-save. The refusal has to be the REASON.
+	if err == nil {
+		t.Fatal("gt done completed against an armed worktree without refusing")
+	}
+	if !errors.Is(err, errAutosaveRefused) {
+		t.Fatalf("nothing was committed, but NOT because the auto-save refused: %v\n"+
+			"Some earlier guard stopped this run, so it does not exercise the path under test.", err)
+	}
+
+	// And the record has to outlive the session: gt done runs at session end,
+	// when nobody is reading stdout.
+	marker := filepath.Join(filepath.Dir(workDir), autosave.MarkerName)
+	data, readErr := os.ReadFile(marker)
+	if readErr != nil {
+		t.Fatalf("no refusal marker at %s: %v", marker, readErr)
+	}
+	if !strings.Contains(string(data), "WORKING TREE WAS NOT MODIFIED") {
+		t.Errorf("the marker does not lead with the one fact that stops a reader panicking; "+
+			"a refusal notice that reads like a failure notice gets 'fixed' by disabling the "+
+			"guard.\nmarker: %s", data)
+	}
+}
+
+// DENOMINATOR. Ordinary uncommitted work must still be auto-saved by the same
+// call — proving runDone reaches the auto-save with this fixture at all. Without
+// this, the test above cannot distinguish "refused" from "never got there".
+func TestRunDoneAutosavesOrdinaryUncommittedWork(t *testing.T) {
+	workDir := setupAutosaveE2EDone(t)
+
+	// A small removal plus new work: under the threshold, so the guard allows it.
+	writeMQSubmitTestFile(t, workDir, "file.txt", "ordinary edit\n")
+	writeMQSubmitTestFile(t, workDir, "new_work.txt", "implementation\n")
+
+	beforeHead := strings.TrimSpace(gitOut(t, workDir, "rev-parse", "HEAD"))
+
+	err := runDone(nil, nil)
+
+	afterHead := strings.TrimSpace(gitOut(t, workDir, "rev-parse", "HEAD"))
+	if afterHead == beforeHead {
+		t.Fatalf("gt done did not auto-save ordinary uncommitted work (HEAD still %s, err=%v).\n"+
+			"Then TestRunDoneRefusesAnArmedWorktree proves nothing: it asserts no commit landed, "+
+			"and no commit lands on this fixture either way.", beforeHead, err)
+	}
+	if errors.Is(err, errAutosaveRefused) {
+		t.Fatalf("the guard refused ordinary work below the %d-line threshold: %v",
+			autosave.Threshold, err)
+	}
+
+	subject := gitOut(t, workDir, "log", "-1", "--format=%s")
+	if !strings.Contains(subject, "auto-save") {
+		t.Errorf("HEAD moved but not via the auto-save: %q", strings.TrimSpace(subject))
+	}
+	if staged := gitOut(t, workDir, "show", "--name-only", "--format=", "HEAD"); !strings.Contains(staged, "new_work.txt") {
+		t.Errorf("the auto-save commit does not contain the new work: %q", staged)
+	}
+
+	// No marker: nothing was refused.
+	if _, statErr := os.Stat(filepath.Join(filepath.Dir(workDir), autosave.MarkerName)); statErr == nil {
+		t.Error("a refusal marker was written for an allowed auto-save")
+	}
+}

--- a/internal/cmd/autosave_guard_test.go
+++ b/internal/cmd/autosave_guard_test.go
@@ -1,0 +1,203 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/autosave"
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+// si-9wu1 / ruling hq-vpt06. The auto-save's existing guard unstages FILE
+// deletions and lets a mass line-removal through, because a rebase stages the
+// delta as modifications to files that still exist. That is commit 504a5ed:
+// 5 files, +26, -434, landed during an explicit stop-write.
+//
+// The ruling chose REFUSE specifically because it is the only option that never
+// writes. That property is what these tests pin — not just "an error came back".
+
+func guardRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+// armedRepo returns a repo whose index is staged to remove `lines` lines from a
+// file that still exists — the rebase signature, not a file deletion.
+func armedRepo(t *testing.T, lines int) (string, string) {
+	t.Helper()
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "silicon")
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	guardRun(t, repo, "init")
+	guardRun(t, repo, "config", "user.email", "t@t.com")
+	guardRun(t, repo, "config", "user.name", "T")
+
+	body := strings.Repeat("a line of merged work\n", lines+1)
+	if err := os.WriteFile(filepath.Join(repo, "delta.txt"), []byte(body), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	guardRun(t, repo, "add", "delta.txt")
+	guardRun(t, repo, "commit", "-m", "merged work")
+
+	if err := os.WriteFile(filepath.Join(repo, "delta.txt"), []byte("a line of merged work\n"), 0644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	guardRun(t, repo, "add", "delta.txt")
+
+	// Control: the state must be invisible to the file-status query the OLD
+	// guard used, or this fixture is not the defect.
+	if out := strings.TrimSpace(guardRun(t, repo, "diff", "--cached", "--name-status", "--diff-filter=D")); out != "" {
+		t.Fatalf("fixture stages FILE deletions (%q) — not the rebase-armed state", out)
+	}
+	return parent, repo
+}
+
+func TestRefuseArmedAutosaveRefusesTheRebaseArmedState(t *testing.T) {
+	_, repo := armedRepo(t, 500)
+
+	err := refuseArmedAutosave(git.NewGit(repo), repo, "polecat/keeper/si-aka.37")
+	if err == nil {
+		t.Fatal("auto-save was allowed to proceed against an index staged to delete 500 lines; " +
+			"that is 504a5ed")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error does not report the line count: %v", err)
+	}
+}
+
+// THE PROPERTY THE RULING TURNS ON. Refusing must leave the repository exactly
+// as it found it — index and working tree. If refusal writes, it is no longer
+// distinguishable from the options it was chosen over.
+func TestRefuseArmedAutosaveWritesNothingToTheRepository(t *testing.T) {
+	_, repo := armedRepo(t, 500)
+
+	beforeStatus := guardRun(t, repo, "status", "--porcelain")
+	beforeStaged := guardRun(t, repo, "diff", "--cached", "--shortstat")
+	beforeHead := guardRun(t, repo, "rev-parse", "HEAD")
+
+	// stageForAutosave, not refuseArmedAutosave: the point is that the staging
+	// did NOT happen, and only the function that owns the staging can show it.
+	err := stageForAutosave(git.NewGit(repo), repo, "polecat/keeper/si-aka.37")
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	if !errors.Is(err, errAutosaveRefused) {
+		t.Fatalf("error = %v, want it to wrap errAutosaveRefused — the caller aborts on that "+
+			"sentinel and merely warns on anything else", err)
+	}
+
+	if got := guardRun(t, repo, "status", "--porcelain"); got != beforeStatus {
+		t.Errorf("working tree/index changed across the refusal:\nbefore %q\nafter  %q", beforeStatus, got)
+	}
+	if got := guardRun(t, repo, "diff", "--cached", "--shortstat"); got != beforeStaged {
+		t.Errorf("the INDEX changed across the refusal:\nbefore %q\nafter  %q", beforeStaged, got)
+	}
+	if got := guardRun(t, repo, "rev-parse", "HEAD"); got != beforeHead {
+		t.Errorf("HEAD moved across the refusal: %q -> %q", beforeHead, got)
+	}
+}
+
+// And the refusal must be findable afterwards, beside the worktree.
+func TestRefuseArmedAutosaveLeavesADurableMarker(t *testing.T) {
+	parent, repo := armedRepo(t, 500)
+
+	if err := refuseArmedAutosave(git.NewGit(repo), repo, "polecat/keeper/si-aka.37"); err == nil {
+		t.Fatal("expected a refusal")
+	}
+
+	marker := filepath.Join(parent, autosave.MarkerName)
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("no refusal marker at %s: %v — a refusal that only prints is unobservable, "+
+			"because the auto-save fires at session end when nobody reads stdout", marker, err)
+	}
+}
+
+// Denominator: ordinary work must still be auto-saved. A guard that refuses
+// everything protects nothing and gets removed.
+func TestRefuseArmedAutosaveAllowsOrdinaryWork(t *testing.T) {
+	_, repo := armedRepo(t, 10)
+
+	if err := refuseArmedAutosave(git.NewGit(repo), repo, "polecat/keeper/si-aka.37"); err != nil {
+		t.Fatalf("auto-save refused for a 10-line removal (threshold %d): %v", autosave.Threshold, err)
+	}
+}
+
+// Denominator: a clean index must not be refused either.
+func TestRefuseArmedAutosaveAllowsACleanIndex(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "silicon")
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	guardRun(t, repo, "init")
+	guardRun(t, repo, "config", "user.email", "t@t.com")
+	guardRun(t, repo, "config", "user.name", "T")
+	if err := os.WriteFile(filepath.Join(repo, "a.txt"), []byte("hi\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	guardRun(t, repo, "add", "a.txt")
+	guardRun(t, repo, "commit", "-m", "init")
+
+	if err := refuseArmedAutosave(git.NewGit(repo), repo, "polecat/keeper/si-aka.37"); err != nil {
+		t.Fatalf("auto-save refused on a clean index: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(parent, autosave.MarkerName)); statErr == nil {
+		t.Fatal("a refusal marker was written for a clean index")
+	}
+}
+
+// The staging must not run when the index is armed. This is the ordering the
+// ruling depends on, and folding the staging into stageForAutosave is what
+// makes it testable at all: a guard sitting one line above a call to
+// "git add -A" in a 900-line function is enforced by nothing but proximity.
+func TestStageForAutosaveDoesNotStageWhenItRefuses(t *testing.T) {
+	_, repo := armedRepo(t, 500)
+
+	// An untracked file that "git add -A" would stage. If staging ran, this
+	// shows up in the index.
+	if err := os.WriteFile(filepath.Join(repo, "untracked.txt"), []byte("new\n"), 0644); err != nil {
+		t.Fatalf("write untracked: %v", err)
+	}
+
+	if err := stageForAutosave(git.NewGit(repo), repo, "polecat/keeper/si-aka.37"); err == nil {
+		t.Fatal("expected a refusal")
+	}
+
+	staged := guardRun(t, repo, "diff", "--cached", "--name-only")
+	if strings.Contains(staged, "untracked.txt") {
+		t.Fatalf("untracked.txt was staged despite the refusal; staging ran before the guard, "+
+			"and the refusal is then no longer the option that never writes.\nstaged: %q", staged)
+	}
+}
+
+// Denominator for the above: when NOT refusing, stageForAutosave must actually
+// stage — otherwise the test above passes because staging never works at all.
+func TestStageForAutosaveStagesWhenItAllows(t *testing.T) {
+	_, repo := armedRepo(t, 10)
+
+	if err := os.WriteFile(filepath.Join(repo, "untracked.txt"), []byte("new\n"), 0644); err != nil {
+		t.Fatalf("write untracked: %v", err)
+	}
+
+	if err := stageForAutosave(git.NewGit(repo), repo, "polecat/keeper/si-aka.37"); err != nil {
+		t.Fatalf("stageForAutosave: %v", err)
+	}
+
+	staged := guardRun(t, repo, "diff", "--cached", "--name-only")
+	if !strings.Contains(staged, "untracked.txt") {
+		t.Fatalf("stageForAutosave did not stage the working tree; the refusal test above would "+
+			"then pass for the wrong reason.\nstaged: %q", staged)
+	}
+}

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -316,6 +316,12 @@ func newDoctorForCommand(rig string) *doctor.Doctor {
 	// Worktree gitdir validity (runs across all rigs, or specific rig with --rig)
 	d.Register(doctor.NewWorktreeGitdirCheck())
 
+	// Worktree ref safety (si-mefr): two live worktrees on one branch, and the
+	// mass staged deletion a rebase under a shared ref leaves armed. Both states
+	// accumulate silently and the armed delta GROWS while unobserved.
+	d.Register(doctor.NewWorktreeSharedRefCheck())
+	d.Register(doctor.NewWorktreeArmedStagingCheck())
+
 	// Rig-specific checks (only when --rig is specified)
 	if rig != "" {
 		d.RegisterAll(doctor.RigChecks()...)

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -321,6 +321,9 @@ func newDoctorForCommand(rig string) *doctor.Doctor {
 	// accumulate silently and the armed delta GROWS while unobserved.
 	d.Register(doctor.NewWorktreeSharedRefCheck())
 	d.Register(doctor.NewWorktreeArmedStagingCheck())
+	// And the durable record of an auto-save that refused (si-9wu1): the refusal
+	// prints at session end, when nobody is reading stdout.
+	d.Register(doctor.NewAutosaveRefusalCheck())
 
 	// Rig-specific checks (only when --rig is specified)
 	if rig != "" {

--- a/internal/cmd/doctor_test.go
+++ b/internal/cmd/doctor_test.go
@@ -9,6 +9,7 @@ func TestDoctorRegistersWorktreeRefSafetyChecks(t *testing.T) {
 	want := map[string]bool{
 		"worktree-shared-ref":    false,
 		"worktree-armed-staging": false,
+		"autosave-refusal":       false,
 	}
 	for _, check := range newDoctorForCommand("").Checks() {
 		if _, ok := want[check.Name()]; ok {

--- a/internal/cmd/doctor_test.go
+++ b/internal/cmd/doctor_test.go
@@ -2,6 +2,26 @@ package cmd
 
 import "testing"
 
+// si-mefr: a check that exists and a check that RUNS are different claims. The
+// detection for si-d6kw is worth nothing sitting unregistered, and dropping one
+// Register line is invisible to every test in internal/doctor.
+func TestDoctorRegistersWorktreeRefSafetyChecks(t *testing.T) {
+	want := map[string]bool{
+		"worktree-shared-ref":    false,
+		"worktree-armed-staging": false,
+	}
+	for _, check := range newDoctorForCommand("").Checks() {
+		if _, ok := want[check.Name()]; ok {
+			want[check.Name()] = true
+		}
+	}
+	for name, registered := range want {
+		if !registered {
+			t.Errorf("check %q is not registered with gt doctor, so it never runs", name)
+		}
+	}
+}
+
 func TestDoctorDoesNotRegisterDoltConfigCheck(t *testing.T) {
 	d := newDoctorForCommand("")
 	for _, check := range d.Checks() {

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -799,7 +799,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 			// Stage all changes (git add -A), then unstage overlay/runtime files (gt-p35)
 			// and any deletions of tracked files (gt-pvx safety: never commit deletions).
-			if addErr := g.Add("-A"); addErr != nil {
+			// si-9wu1: stageForAutosave refuses an armed index BEFORE it stages
+			// anything. The refusal and the staging live in one function so the
+			// ordering cannot be got wrong by editing a call site.
+			if addErr := stageForAutosave(g, cwd, branch); errors.Is(addErr, errAutosaveRefused) {
+				return addErr
+			} else if addErr != nil {
 				style.PrintWarning("auto-commit: git add failed: %v — uncommitted work may be at risk", addErr)
 			} else {
 				// Unstage Gas Town overlay files that git add -A picked up.

--- a/internal/doctor/autosave_refusal_check.go
+++ b/internal/doctor/autosave_refusal_check.go
@@ -1,0 +1,74 @@
+package doctor
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/steveyegge/gastown/internal/autosave"
+)
+
+// autosaveRefusalScanDepth bounds the walk. Markers land beside a worktree —
+// <town>/<rig>/polecats/<name>/ is four levels — so five is generous without
+// descending into repository contents.
+const autosaveRefusalScanDepth = 5
+
+// AutosaveRefusalCheck surfaces auto-saves that declined to commit.
+//
+// This check is the half of si-9wu1 that makes the refusal mean anything. The
+// auto-save fires on gt done, at session end, when nobody is reading stdout —
+// so a refusal that only prints is unobservable, and refusing silently would
+// trade a silent destructive write for a silent non-save. The marker is durable
+// and this is what a later reader hits without knowing to look for it.
+//
+// It reports StatusError rather than a warning because a refusal means real
+// work is sitting uncommitted in a sandbox that nothing else will save.
+type AutosaveRefusalCheck struct {
+	BaseCheck
+}
+
+// NewAutosaveRefusalCheck creates the auto-save refusal check.
+func NewAutosaveRefusalCheck() *AutosaveRefusalCheck {
+	return &AutosaveRefusalCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "autosave-refusal",
+			CheckDescription: "Report auto-saves that refused to commit a mass staged deletion",
+			CheckCategory:    CategoryRig,
+		},
+	}
+}
+
+// Run scans the town for refusal markers.
+func (c *AutosaveRefusalCheck) Run(ctx *CheckContext) *CheckResult {
+	if ctx.TownRoot == "" {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "No town root — nothing was scanned",
+		}
+	}
+
+	markers := autosave.FindRefusals(ctx.TownRoot, autosaveRefusalScanDepth)
+	if len(markers) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No refused auto-saves",
+		}
+	}
+
+	details := make([]string, 0, len(markers))
+	for _, m := range markers {
+		details = append(details, autosave.Describe(m))
+	}
+	sort.Strings(details)
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusError,
+		Message: fmt.Sprintf("%d worktree(s) hold work the auto-save refused to commit", len(markers)),
+		Details: details,
+		FixHint: "The working tree was not modified — the work is still there. Inspect with " +
+			"'git -C <worktree> diff --cached --shortstat', commit deliberately or " +
+			"'git -C <worktree> reset --hard HEAD', then delete the marker file.",
+	}
+}

--- a/internal/doctor/autosave_refusal_check_test.go
+++ b/internal/doctor/autosave_refusal_check_test.go
@@ -1,0 +1,70 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/autosave"
+)
+
+// si-9wu1: the refusal has to be discoverable by someone who does not know to
+// look for it. gt doctor is where an operator already goes when something feels
+// wrong, which is the only property that matters for a detector.
+
+func TestAutosaveRefusalCheckReportsAMarker(t *testing.T) {
+	town := t.TempDir()
+	worktree := filepath.Join(town, "silicon", "polecats", "keeper", "silicon")
+	if err := os.MkdirAll(worktree, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, err := autosave.WriteRefusal(worktree, "polecat/keeper/si-aka.37", 7767); err != nil {
+		t.Fatalf("WriteRefusal: %v", err)
+	}
+
+	res := NewAutosaveRefusalCheck().Run(&CheckContext{TownRoot: town})
+	if res.Status != StatusError {
+		t.Fatalf("status = %v, want StatusError; message=%q", res.Status, res.Message)
+	}
+	joined := strings.Join(res.Details, "\n")
+	if !strings.Contains(joined, "7767") || !strings.Contains(joined, "polecat/keeper/si-aka.37") {
+		t.Fatalf("details %v do not name the line count and the branch — an operator cannot act "+
+			"on a report that does not say where or how much", res.Details)
+	}
+	if !strings.Contains(res.FixHint, "not modified") {
+		t.Errorf("FixHint should lead with the fact that nothing was destroyed: %q", res.FixHint)
+	}
+}
+
+func TestAutosaveRefusalCheckPassesOnACleanTown(t *testing.T) {
+	town := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(town, "silicon", "polecats", "keeper", "silicon"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	res := NewAutosaveRefusalCheck().Run(&CheckContext{TownRoot: town})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %v on a clean town, want StatusOK; message=%q details=%v",
+			res.Status, res.Message, res.Details)
+	}
+}
+
+// Denominator: no town root is not a clean bill of health.
+func TestAutosaveRefusalCheckDoesNotReportOKWithNoTownRoot(t *testing.T) {
+	res := NewAutosaveRefusalCheck().Run(&CheckContext{})
+	if res.Status == StatusOK {
+		t.Fatalf("status = StatusOK having scanned nothing (message=%q)", res.Message)
+	}
+}
+
+// The refusal threshold and the detector threshold must not drift apart. If the
+// detector fired lower than the refusal, gt doctor would report a hazard the
+// safety net commits anyway — a warning contradicted by the tool that issued it.
+func TestRefusalThresholdMatchesDoctorThreshold(t *testing.T) {
+	if autosave.Threshold != armedStagingThreshold {
+		t.Fatalf("autosave.Threshold = %d but doctor armedStagingThreshold = %d; a gap between "+
+			"them is a window where doctor reports armed and the auto-save commits it anyway",
+			autosave.Threshold, armedStagingThreshold)
+	}
+}

--- a/internal/doctor/worktree_ref_safety_check.go
+++ b/internal/doctor/worktree_ref_safety_check.go
@@ -1,0 +1,260 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+// si-mefr, the detection half of si-d6kw.
+//
+// Two worktrees of one repository on one branch is a state git normally refuses.
+// gt reached it anyway, and the consequences do not need an agent to act: a
+// commit in either worktree appears in the other as a delta to re-commit, and
+// the auto-save commits it. On 2026-07-28 that produced a 434-line deletion at
+// 08:01 DURING an explicit stop-write with both agents complying, and a
+// fleet-wide sweep then found keeper armed with 7767 staged line-deletions and
+// coma with 6824, each aimed at a branch a live worker was on.
+//
+// si-d6kw closed the sling route. It did not close every route:
+// WorktreeAddExistingForce still has legitimate callers, and a hand-run
+// "git worktree add --force" bypasses all of it. Nothing reported either state
+// until these checks. Both are cheap — no network, one git invocation per repo
+// for the first and one per worktree for the second.
+
+// armedStagingThreshold is the staged line-deletion count above which a worktree
+// is reported as armed. Ordinary editing stages small deletions constantly; the
+// artifacts that mattered were three and four orders of magnitude larger (434,
+// 6824, 7767). A threshold that fires on normal work is a check somebody turns
+// off, and a check that is off is worse than none because its silence still
+// reads as reassurance.
+const armedStagingThreshold = 100
+
+// sharedRef is one branch held by more than one live worktree.
+type sharedRef struct {
+	Branch string
+	Paths  []string
+}
+
+// sharedRefs returns the branches held by two or more LIVE worktrees.
+//
+// The prunable filter is load-bearing, not tidiness. Git keeps an
+// administrative record for a worktree whose directory is gone, and reports it
+// in "worktree list" exactly like a live one. Reaping a polecat is routine, so
+// without this filter every reaped worktree reads as a second holder, the check
+// cries wolf on a healthy fleet, and it gets deleted — after which there is no
+// check at all. Detached worktrees are skipped for the mirror-image reason: they
+// hold no branch, and grouping on an empty branch name would collapse them all
+// into one fictional shared ref.
+func sharedRefs(worktrees []git.Worktree) []sharedRef {
+	byBranch := make(map[string][]string)
+	for _, wt := range worktrees {
+		if wt.Prunable || wt.Branch == "" {
+			continue
+		}
+		byBranch[wt.Branch] = append(byBranch[wt.Branch], wt.Path)
+	}
+
+	var shared []sharedRef
+	for branch, paths := range byBranch {
+		if len(paths) < 2 {
+			continue
+		}
+		sort.Strings(paths)
+		shared = append(shared, sharedRef{Branch: branch, Paths: paths})
+	}
+	sort.Slice(shared, func(i, j int) bool { return shared[i].Branch < shared[j].Branch })
+	return shared
+}
+
+// rigRepoPaths returns the bare repository of every rig under the town root,
+// honouring ctx.RigName when set.
+func rigRepoPaths(ctx *CheckContext) []string {
+	entries, err := os.ReadDir(ctx.TownRoot)
+	if err != nil {
+		return nil
+	}
+
+	var repos []string
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		if ctx.RigName != "" && entry.Name() != ctx.RigName {
+			continue
+		}
+		rigPath := filepath.Join(ctx.TownRoot, entry.Name())
+		if !isRigDir(rigPath) {
+			continue
+		}
+		repoPath := filepath.Join(rigPath, ".repo.git")
+		if info, err := os.Stat(repoPath); err == nil && info.IsDir() {
+			repos = append(repos, repoPath)
+		}
+	}
+	sort.Strings(repos)
+	return repos
+}
+
+// WorktreeSharedRefCheck reports branches checked out by two or more live
+// worktrees of the same repository.
+type WorktreeSharedRefCheck struct {
+	BaseCheck
+}
+
+// NewWorktreeSharedRefCheck creates the shared-ref check.
+func NewWorktreeSharedRefCheck() *WorktreeSharedRefCheck {
+	return &WorktreeSharedRefCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "worktree-shared-ref",
+			CheckDescription: "Verify no branch is checked out by two live worktrees of one repo",
+			CheckCategory:    CategoryRig,
+		},
+	}
+}
+
+// Run enumerates every rig repository and groups its live worktrees by branch.
+func (c *WorktreeSharedRefCheck) Run(ctx *CheckContext) *CheckResult {
+	var details []string
+	examined := 0
+	var readErrs []string
+
+	for _, repoPath := range rigRepoPaths(ctx) {
+		worktrees, err := git.NewGit(repoPath).WorktreeList()
+		if err != nil {
+			readErrs = append(readErrs, fmt.Sprintf("%s: %v", repoPath, err))
+			continue
+		}
+		examined += len(worktrees)
+
+		for _, sr := range sharedRefs(worktrees) {
+			details = append(details, fmt.Sprintf("%s held by %d worktrees: %s",
+				sr.Branch, len(sr.Paths), strings.Join(sr.Paths, ", ")))
+		}
+	}
+
+	// A check that examined nothing has not found the fleet healthy — it has
+	// found nothing, and reporting OK for that is how a broken enumeration goes
+	// unnoticed indefinitely.
+	if examined == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "No worktrees examined — nothing was checked",
+			Details: readErrs,
+			FixHint: "Expected <town>/<rig>/.repo.git for at least one rig; verify the town layout",
+		}
+	}
+
+	if len(details) == 0 {
+		msg := fmt.Sprintf("No shared refs across %d worktree(s)", examined)
+		if len(readErrs) > 0 {
+			return &CheckResult{
+				Name:    c.Name(),
+				Status:  StatusWarning,
+				Message: msg + fmt.Sprintf(", but %d repo(s) could not be read", len(readErrs)),
+				Details: readErrs,
+			}
+		}
+		return &CheckResult{Name: c.Name(), Status: StatusOK, Message: msg}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusError,
+		Message: fmt.Sprintf("%d branch(es) checked out by multiple live worktrees", len(details)),
+		Details: append(details, readErrs...),
+		FixHint: "Move the LIVE worker to its own branch FIRST, then disarm the other worktree. " +
+			"Touching the shared ref while a live worker is on it is what risks real work.",
+	}
+}
+
+// WorktreeArmedStagingCheck reports worktrees whose index is staged to remove a
+// large number of lines — the state a rebase under a shared ref leaves behind,
+// and which the auto-save will commit without any agent acting.
+type WorktreeArmedStagingCheck struct {
+	BaseCheck
+}
+
+// NewWorktreeArmedStagingCheck creates the armed-staging check.
+func NewWorktreeArmedStagingCheck() *WorktreeArmedStagingCheck {
+	return &WorktreeArmedStagingCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "worktree-armed-staging",
+			CheckDescription: "Verify no worktree is staged to delete a large number of lines",
+			CheckCategory:    CategoryRig,
+		},
+	}
+}
+
+// Run measures staged line-deletions in every live worktree of every rig.
+func (c *WorktreeArmedStagingCheck) Run(ctx *CheckContext) *CheckResult {
+	var details []string
+	examined := 0
+	var readErrs []string
+
+	for _, repoPath := range rigRepoPaths(ctx) {
+		worktrees, err := git.NewGit(repoPath).WorktreeList()
+		if err != nil {
+			readErrs = append(readErrs, fmt.Sprintf("%s: %v", repoPath, err))
+			continue
+		}
+
+		for _, wt := range worktrees {
+			if wt.Prunable {
+				continue
+			}
+			if _, err := os.Stat(wt.Path); err != nil {
+				continue
+			}
+			examined++
+
+			deletions, err := git.NewGit(wt.Path).StagedLineDeletions()
+			if err != nil {
+				readErrs = append(readErrs, fmt.Sprintf("%s: %v", wt.Path, err))
+				continue
+			}
+			if deletions >= armedStagingThreshold {
+				details = append(details, fmt.Sprintf("%s (%s): %d lines staged for deletion",
+					wt.Path, wt.Branch, deletions))
+			}
+		}
+	}
+
+	if examined == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "No worktrees examined — nothing was checked",
+			Details: readErrs,
+			FixHint: "Expected <town>/<rig>/.repo.git for at least one rig; verify the town layout",
+		}
+	}
+
+	if len(details) == 0 {
+		msg := fmt.Sprintf("No armed worktrees across %d examined", examined)
+		if len(readErrs) > 0 {
+			return &CheckResult{
+				Name:    c.Name(),
+				Status:  StatusWarning,
+				Message: msg + fmt.Sprintf(", but %d could not be read", len(readErrs)),
+				Details: readErrs,
+			}
+		}
+		return &CheckResult{Name: c.Name(), Status: StatusOK, Message: msg}
+	}
+
+	sort.Strings(details)
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusError,
+		Message: fmt.Sprintf("%d worktree(s) staged to delete >=%d lines", len(details), armedStagingThreshold),
+		Details: append(details, readErrs...),
+		FixHint: "Inspect with 'git -C <path> diff --cached --shortstat'. If it is a rebase artifact, " +
+			"'git -C <path> reset --hard HEAD' drops the staging without moving the branch.",
+	}
+}

--- a/internal/doctor/worktree_ref_safety_check_test.go
+++ b/internal/doctor/worktree_ref_safety_check_test.go
@@ -1,0 +1,327 @@
+package doctor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+// si-mefr: si-d6kw's DETECTION half. Prevention closed the sling route, but
+// WorktreeAddExistingForce still has legitimate callers and a hand-run
+// "git worktree add --force" bypasses everything — so sharing can still arise,
+// and until now nothing would report it.
+//
+// The fixtures below drive REAL git worktrees rather than canned structs,
+// because both properties under test are properties of git's own output:
+// whether a stale record is distinguishable from a live holder, and whether a
+// rebase-armed index is visible to a line count. A struct literal would assert
+// my belief about git's output rather than git's output.
+
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s (in %s): %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return string(out)
+}
+
+// townWithRig builds townRoot/<rig>/.repo.git as a real repository, matching
+// the layout gt actually creates, and returns (townRoot, repoPath).
+func townWithRig(t *testing.T, rigName string) (string, string) {
+	t.Helper()
+	townRoot := t.TempDir()
+
+	src := filepath.Join(t.TempDir(), "src")
+	if err := os.MkdirAll(src, 0755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	gitRun(t, src, "init")
+	gitRun(t, src, "config", "user.email", "test@test.com")
+	gitRun(t, src, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	gitRun(t, src, "add", ".")
+	gitRun(t, src, "commit", "-m", "initial")
+
+	rigPath := filepath.Join(townRoot, rigName)
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	// config.json makes isRigDir recognise it.
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte("{}\n"), 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+	repoPath := filepath.Join(rigPath, ".repo.git")
+	gitRun(t, townRoot, "clone", "--bare", src, repoPath)
+
+	return townRoot, repoPath
+}
+
+func addWorktree(t *testing.T, repoPath, wtPath, branch string, force bool) {
+	t.Helper()
+	args := []string{"worktree", "add"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, wtPath, branch)
+	gitRun(t, repoPath, args...)
+}
+
+// A: two LIVE worktrees on one ref must be reported, naming both paths.
+func TestSharedRefsReportsTwoLiveWorktreesOnOneBranch(t *testing.T) {
+	_, repoPath := townWithRig(t, "silicon")
+	gitRun(t, repoPath, "branch", "polecat/dag/si-aka.9", "HEAD")
+
+	first := filepath.Join(t.TempDir(), "dag")
+	second := filepath.Join(t.TempDir(), "toast")
+	addWorktree(t, repoPath, first, "polecat/dag/si-aka.9", false)
+	// --force is how the real collision happened; plain add refuses here.
+	addWorktree(t, repoPath, second, "polecat/dag/si-aka.9", true)
+
+	wts, err := git.NewGit(repoPath).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+
+	shared := sharedRefs(wts)
+	if len(shared) != 1 {
+		t.Fatalf("sharedRefs found %d shared branches, want 1: %+v\n(worktrees: %+v)", len(shared), shared, wts)
+	}
+	if shared[0].Branch != "polecat/dag/si-aka.9" {
+		t.Fatalf("shared branch = %q, want polecat/dag/si-aka.9", shared[0].Branch)
+	}
+	if len(shared[0].Paths) != 2 {
+		t.Fatalf("shared paths = %v, want both holders — a report that does not NAME them "+
+			"cannot be acted on", shared[0].Paths)
+	}
+}
+
+// B: one live holder plus a PRUNABLE record on the same ref is the normal state
+// after a reap. A check that reds here gets deleted, and then there is no check.
+func TestSharedRefsIgnoresAPrunableRecord(t *testing.T) {
+	_, repoPath := townWithRig(t, "silicon")
+	gitRun(t, repoPath, "branch", "polecat/keeper/si-aka.37", "HEAD")
+
+	live := filepath.Join(t.TempDir(), "keeper-live")
+	reaped := filepath.Join(t.TempDir(), "keeper-reaped")
+	addWorktree(t, repoPath, live, "polecat/keeper/si-aka.37", false)
+	addWorktree(t, repoPath, reaped, "polecat/keeper/si-aka.37", true)
+
+	// Reap it: the directory goes, git's administrative record stays.
+	if err := os.RemoveAll(reaped); err != nil {
+		t.Fatalf("reap worktree: %v", err)
+	}
+
+	wts, err := git.NewGit(repoPath).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+
+	// Control: the reaped record must still be PRESENT in git's output, or this
+	// test proves nothing about filtering — it would just be counting one entry.
+	var sawPrunable bool
+	for _, wt := range wts {
+		if wt.Prunable {
+			sawPrunable = true
+		}
+	}
+	if !sawPrunable {
+		t.Fatalf("no prunable record in %+v — git dropped the reaped worktree from its list, so "+
+			"this fixture does not exercise the prunable filter at all", wts)
+	}
+
+	if shared := sharedRefs(wts); len(shared) != 0 {
+		t.Fatalf("sharedRefs reported %+v for one live worktree plus a reaped record; this is the "+
+			"normal post-reap state and flagging it is how the check gets deleted", shared)
+	}
+}
+
+// Two live worktrees on DIFFERENT branches is the ordinary healthy fleet.
+func TestSharedRefsIgnoresDistinctBranches(t *testing.T) {
+	_, repoPath := townWithRig(t, "silicon")
+	gitRun(t, repoPath, "branch", "polecat/dag/si-aka.9", "HEAD")
+	gitRun(t, repoPath, "branch", "polecat/toast/si-aka.9+rework", "HEAD")
+
+	addWorktree(t, repoPath, filepath.Join(t.TempDir(), "dag"), "polecat/dag/si-aka.9", false)
+	addWorktree(t, repoPath, filepath.Join(t.TempDir(), "toast"), "polecat/toast/si-aka.9+rework", false)
+
+	wts, err := git.NewGit(repoPath).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	if shared := sharedRefs(wts); len(shared) != 0 {
+		t.Fatalf("sharedRefs reported %+v for two worktrees on distinct branches", shared)
+	}
+}
+
+// A detached HEAD has no branch to share; grouping on an empty string would
+// collapse every detached worktree into one bogus "shared ref".
+func TestSharedRefsIgnoresDetachedWorktrees(t *testing.T) {
+	_, repoPath := townWithRig(t, "silicon")
+
+	first := filepath.Join(t.TempDir(), "d1")
+	second := filepath.Join(t.TempDir(), "d2")
+	gitRun(t, repoPath, "worktree", "add", "--detach", first, "HEAD")
+	gitRun(t, repoPath, "worktree", "add", "--detach", second, "HEAD")
+
+	wts, err := git.NewGit(repoPath).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	if shared := sharedRefs(wts); len(shared) != 0 {
+		t.Fatalf("sharedRefs reported %+v for two DETACHED worktrees — they hold no branch", shared)
+	}
+}
+
+// End to end through the doctor check, on the real layout.
+func TestWorktreeSharedRefCheckFailsOnASharedRef(t *testing.T) {
+	townRoot, repoPath := townWithRig(t, "silicon")
+	gitRun(t, repoPath, "branch", "polecat/dag/si-aka.9", "HEAD")
+	addWorktree(t, repoPath, filepath.Join(t.TempDir(), "dag"), "polecat/dag/si-aka.9", false)
+	addWorktree(t, repoPath, filepath.Join(t.TempDir(), "toast"), "polecat/dag/si-aka.9", true)
+
+	res := NewWorktreeSharedRefCheck().Run(&CheckContext{TownRoot: townRoot})
+	if res.Status != StatusError {
+		t.Fatalf("status = %v, want StatusError; message=%q details=%v", res.Status, res.Message, res.Details)
+	}
+	if !strings.Contains(strings.Join(res.Details, "\n"), "polecat/dag/si-aka.9") {
+		t.Fatalf("details %v do not name the shared ref", res.Details)
+	}
+}
+
+func TestWorktreeSharedRefCheckPassesOnAHealthyRig(t *testing.T) {
+	townRoot, repoPath := townWithRig(t, "silicon")
+	gitRun(t, repoPath, "branch", "polecat/dag/si-aka.9", "HEAD")
+	addWorktree(t, repoPath, filepath.Join(t.TempDir(), "dag"), "polecat/dag/si-aka.9", false)
+
+	res := NewWorktreeSharedRefCheck().Run(&CheckContext{TownRoot: townRoot})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %v on a healthy rig, want StatusOK; message=%q details=%v",
+			res.Status, res.Message, res.Details)
+	}
+}
+
+// D, the denominator: examining nothing must NOT read as a clean bill of health.
+// This is the failure mode that makes a check worthless — it reports OK forever
+// once its enumeration breaks, and nobody notices because OK is what they expect.
+func TestWorktreeSharedRefCheckFailsWhenItExaminesNothing(t *testing.T) {
+	res := NewWorktreeSharedRefCheck().Run(&CheckContext{TownRoot: t.TempDir()})
+	if res.Status == StatusOK {
+		t.Fatalf("status = StatusOK having examined zero worktrees (message=%q); an empty "+
+			"enumeration must not report healthy", res.Message)
+	}
+}
+
+// A repo that cannot be READ must not reduce to a clean bill of health. This is
+// the same failure as the empty enumeration one layer down: git failing and git
+// finding nothing look identical in a bare status, and the reassuring one is
+// the wrong default.
+func TestWorktreeSharedRefCheckDoesNotReportOKWhenARepoCannotBeRead(t *testing.T) {
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "silicon")
+	if err := os.MkdirAll(filepath.Join(rigPath, ".repo.git"), 0755); err != nil {
+		t.Fatalf("mkdir bogus repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte("{}\n"), 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+
+	res := NewWorktreeSharedRefCheck().Run(&CheckContext{TownRoot: townRoot})
+	if res.Status == StatusOK {
+		t.Fatalf("status = StatusOK for a .repo.git that is not a git repository (message=%q); "+
+			"an unreadable repo is not a healthy one", res.Message)
+	}
+}
+
+// C, through the doctor check: an armed worktree is reported. The line-based
+// vs file-status proof lives in internal/git's staged_line_stat_test.go, which
+// carries the negative control asserting --diff-filter=D is blind to it.
+func TestWorktreeArmedStagingCheckFailsOnAnArmedWorktree(t *testing.T) {
+	townRoot, repoPath := townWithRig(t, "silicon")
+	wt := filepath.Join(t.TempDir(), "keeper")
+	gitRun(t, repoPath, "branch", "polecat/keeper/si-aka.37", "HEAD")
+	addWorktree(t, repoPath, wt, "polecat/keeper/si-aka.37", false)
+
+	// Arm it the way a rebase does: contents removed, file still present.
+	body := strings.Repeat("a line of merged work\n", 500)
+	if err := os.WriteFile(filepath.Join(wt, "delta.txt"), []byte(body), 0644); err != nil {
+		t.Fatalf("write delta: %v", err)
+	}
+	gitRun(t, wt, "config", "user.email", "test@test.com")
+	gitRun(t, wt, "config", "user.name", "Test User")
+	gitRun(t, wt, "add", "delta.txt")
+	gitRun(t, wt, "commit", "-m", "merged work")
+	if err := os.WriteFile(filepath.Join(wt, "delta.txt"), []byte("a line of merged work\n"), 0644); err != nil {
+		t.Fatalf("rewrite delta: %v", err)
+	}
+	gitRun(t, wt, "add", "delta.txt")
+
+	// Control: file-status is blind to this, which is why the check counts lines.
+	if out := strings.TrimSpace(gitRun(t, wt, "diff", "--cached", "--name-status", "--diff-filter=D")); out != "" {
+		t.Fatalf("fixture stages FILE deletions (%q); it is not the rebase-armed state", out)
+	}
+
+	res := NewWorktreeArmedStagingCheck().Run(&CheckContext{TownRoot: townRoot})
+	if res.Status != StatusError {
+		t.Fatalf("status = %v, want StatusError; message=%q details=%v", res.Status, res.Message, res.Details)
+	}
+	if !strings.Contains(strings.Join(res.Details, "\n"), "499") {
+		t.Fatalf("details %v do not report the staged line count", res.Details)
+	}
+}
+
+func TestWorktreeArmedStagingCheckPassesOnACleanWorktree(t *testing.T) {
+	townRoot, repoPath := townWithRig(t, "silicon")
+	wt := filepath.Join(t.TempDir(), "keeper")
+	gitRun(t, repoPath, "branch", "polecat/keeper/si-aka.37", "HEAD")
+	addWorktree(t, repoPath, wt, "polecat/keeper/si-aka.37", false)
+
+	res := NewWorktreeArmedStagingCheck().Run(&CheckContext{TownRoot: townRoot})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %v on a clean worktree, want StatusOK; message=%q details=%v",
+			res.Status, res.Message, res.Details)
+	}
+}
+
+// A small staged deletion is ordinary editing, not an armed rebase artifact.
+// Without this the check fires on normal work and gets turned off.
+func TestWorktreeArmedStagingCheckIgnoresSmallStagedDeletions(t *testing.T) {
+	townRoot, repoPath := townWithRig(t, "silicon")
+	wt := filepath.Join(t.TempDir(), "keeper")
+	gitRun(t, repoPath, "branch", "polecat/keeper/si-aka.37", "HEAD")
+	addWorktree(t, repoPath, wt, "polecat/keeper/si-aka.37", false)
+
+	gitRun(t, wt, "config", "user.email", "test@test.com")
+	gitRun(t, wt, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(wt, "small.txt"), []byte(strings.Repeat("x\n", 10)), 0644); err != nil {
+		t.Fatalf("write small: %v", err)
+	}
+	gitRun(t, wt, "add", "small.txt")
+	gitRun(t, wt, "commit", "-m", "small file")
+	if err := os.WriteFile(filepath.Join(wt, "small.txt"), []byte("x\n"), 0644); err != nil {
+		t.Fatalf("rewrite small: %v", err)
+	}
+	gitRun(t, wt, "add", "small.txt")
+
+	res := NewWorktreeArmedStagingCheck().Run(&CheckContext{TownRoot: townRoot})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %v for 9 staged line-deletions (threshold %d), want StatusOK; details=%v",
+			res.Status, armedStagingThreshold, res.Details)
+	}
+}
+
+// D for the armed check too.
+func TestWorktreeArmedStagingCheckFailsWhenItExaminesNothing(t *testing.T) {
+	res := NewWorktreeArmedStagingCheck().Run(&CheckContext{TownRoot: t.TempDir()})
+	if res.Status == StatusOK {
+		t.Fatalf("status = StatusOK having examined zero worktrees (message=%q)", res.Message)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1145,6 +1146,49 @@ func (g *Git) StagedDeletions() ([]string, error) {
 		return nil, nil
 	}
 	return strings.Split(trimmed, "\n"), nil
+}
+
+// StagedLineDeletions returns the number of LINES staged for removal.
+//
+// This exists because StagedDeletions above cannot see the state that matters.
+// When a branch is rebased under a second worktree, the other worktree's index
+// is left staged to remove the entire rebase delta — as MODIFICATIONS to files
+// that still exist, not as file deletions. --diff-filter=D therefore reports
+// nothing while thousands of lines are staged to disappear, and the auto-save
+// commits them with no agent acting (si-d6kw: keeper armed with 7767, coma with
+// 6824, both found only because the Mayor's sweep counted lines).
+//
+// Counting lines is the whole point. A caller that wants "is this worktree
+// armed" must use this and not a file-status check.
+func (g *Git) StagedLineDeletions() (int, error) {
+	out, err := g.run("diff", "--cached", "--shortstat")
+	if err != nil {
+		return 0, err
+	}
+	return parseShortstatDeletions(out), nil
+}
+
+// parseShortstatDeletions reads the deletions field out of a --shortstat line:
+//
+//	" 5 files changed, 26 insertions(+), 434 deletions(-)"
+//	" 3 files changed, 7767 deletions(-)"        <- no insertions clause at all
+//
+// Keyed off the label rather than the field position, because the insertions
+// clause is omitted entirely when there are none and a positional parser then
+// reads the insertions count as deletions.
+func parseShortstatDeletions(shortstat string) int {
+	for _, field := range strings.Split(shortstat, ",") {
+		field = strings.TrimSpace(field)
+		if !strings.Contains(field, "deletion") {
+			continue
+		}
+		n, err := strconv.Atoi(strings.Fields(field)[0])
+		if err != nil {
+			return 0
+		}
+		return n
+	}
+	return 0
 }
 
 // ShowFile returns the contents of a file at a given ref (e.g., "origin/main:CLAUDE.md").

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2314,11 +2314,85 @@ func (g *Git) WorktreeAddExisting(path, branch string) error {
 
 // WorktreeAddExistingForce creates a new worktree even if the branch is already checked out elsewhere.
 // This is useful for cross-rig worktrees where multiple clones need to be on main.
+//
+// DO NOT use this to attach a worker to a branch another worker may be on. It
+// forces past git's "already used by worktree at ..." check without asking
+// whether the holder is live, which puts two worktrees on one ref; a commit in
+// either then shows up in the other as a delta to re-commit, and an auto-saver
+// will commit that delta with no agent acting. That is si-d6kw, which cost a
+// fleet-wide sweep and three armed worktrees (7767 / 6824 / 434 staged
+// deletions). Use WorktreeAddExistingSafe for anything worker-facing.
 func (g *Git) WorktreeAddExistingForce(path, branch string) error {
 	if _, err := g.run("worktree", "add", "--force", path, branch); err != nil {
 		return err
 	}
 	return InitSubmodules(path, g.submoduleReferencePath())
+}
+
+// BranchHeldError reports that a branch is checked out by a live worktree, so
+// attaching a second one would put two workers on a single ref.
+type BranchHeldError struct {
+	Branch string
+	Path   string
+}
+
+func (e *BranchHeldError) Error() string {
+	return fmt.Sprintf("branch %s is already checked out by a live worktree at %s", e.Branch, e.Path)
+}
+
+// LiveWorktreeForBranch returns the worktree that currently has branch checked
+// out, or nil if none does. Worktrees git reports as prunable — the record
+// survives but the directory does not — are NOT live and are not returned.
+func (g *Git) LiveWorktreeForBranch(branch string) (*Worktree, error) {
+	branch = strings.TrimPrefix(branch, "refs/heads/")
+	worktrees, err := g.WorktreeList()
+	if err != nil {
+		return nil, err
+	}
+	for i := range worktrees {
+		wt := worktrees[i]
+		if wt.Branch != branch || wt.Prunable {
+			continue
+		}
+		// Belt and braces: a record can be current-looking and still point at a
+		// directory that is gone, if the list ran before something removed it.
+		if _, statErr := os.Stat(wt.Path); statErr != nil {
+			continue
+		}
+		return &wt, nil
+	}
+	return nil, nil
+}
+
+// WorktreeAddExistingSafe attaches a worktree to an existing branch, refusing
+// when a LIVE worktree already holds that branch and clearing the way when the
+// only thing holding it is a stale record.
+//
+// This is the distinction plain git does not make for you. "git worktree add"
+// refuses both cases with the same message, which is why callers reached for
+// --force; but --force cannot tell "the previous worker was reaped" (safe, and
+// the case the resume workflow is built on) from "another worker is on this ref
+// right now" (si-d6kw: mutual reversion, and an auto-saver that commits a mass
+// deletion nobody authored).
+//
+// Live holder  -> *BranchHeldError, nothing created.
+// Stale holder -> prune the dead record, then attach normally.
+// No holder    -> attach normally.
+func (g *Git) WorktreeAddExistingSafe(path, branch string) error {
+	holder, err := g.LiveWorktreeForBranch(branch)
+	if err != nil {
+		return fmt.Errorf("checking whether %s is already checked out: %w", branch, err)
+	}
+	if holder != nil {
+		return &BranchHeldError{Branch: branch, Path: holder.Path}
+	}
+	// No live holder. A stale record may still make git refuse, so drop dead
+	// records first. Prune only removes worktrees whose directory is already
+	// gone; it cannot touch a live one.
+	if err := g.WorktreePrune(); err != nil {
+		return fmt.Errorf("pruning stale worktree records before attaching %s: %w", branch, err)
+	}
+	return g.WorktreeAddExisting(path, branch)
 }
 
 // submoduleReferencePath returns the mayor/rig path to use as --reference
@@ -2430,10 +2504,19 @@ func (g *Git) WorktreePrune() error {
 }
 
 // Worktree represents a git worktree.
+//
+// Prunable distinguishes a worktree git still has an administrative record for
+// but whose directory is gone (reaped, moved, deleted) from one that is live on
+// disk. Git refuses "worktree add" for a branch held by EITHER kind with the
+// same "already used by worktree at ..." message, so callers that want to
+// tolerate the first without tolerating the second must read this field —
+// see WorktreeAddExistingSafe.
 type Worktree struct {
-	Path   string
-	Branch string
-	Commit string
+	Path           string
+	Branch         string
+	Commit         string
+	Prunable       bool
+	PrunableReason string
 }
 
 // WorktreeList returns all worktrees for this repository.
@@ -2462,6 +2545,9 @@ func (g *Git) WorktreeList() ([]Worktree, error) {
 			current.Commit = strings.TrimPrefix(line, "HEAD ")
 		case strings.HasPrefix(line, "branch "):
 			current.Branch = strings.TrimPrefix(line, "branch refs/heads/")
+		case line == "prunable" || strings.HasPrefix(line, "prunable "):
+			current.Prunable = true
+			current.PrunableReason = strings.TrimSpace(strings.TrimPrefix(line, "prunable"))
 		}
 	}
 

--- a/internal/git/staged_line_stat_test.go
+++ b/internal/git/staged_line_stat_test.go
@@ -1,0 +1,185 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// si-mefr: detection for the armed state si-d6kw left behind.
+//
+// When a branch is rebased under a second worktree, that worktree's index ends
+// up staged to remove the entire rebase delta. The Mayor's fleet sweep found
+// keeper armed with 7767 staged line-deletions and coma with 6824 — and the
+// auto-save commits that with no agent acting (proven 2026-07-28 at 08:01,
+// during an explicit stop-write, with both agents complying).
+//
+// THE LOAD-BEARING DETAIL: the delta is staged as MODIFICATIONS to files that
+// still exist, not as file deletions. Every file-status check — --diff-filter=D,
+// --name-status — reports NOTHING while thousands of lines are staged to
+// disappear. Only a LINE-based count sees it. Each test below therefore carries
+// its own negative control asserting the file-status view is blind to the very
+// state being measured; without that control these tests would pass just as
+// happily against a fixture that was never armed in the first place.
+
+// armFixture stages a mass line-deletion the way a rebase does: the file stays,
+// its contents mostly go.
+func armFixture(t *testing.T, repo string, lines int) {
+	t.Helper()
+	body := strings.Repeat("a line of merged work\n", lines)
+	path := filepath.Join(repo, "delta.txt")
+	writeAndCommit(t, repo, path, body, "seed the delta")
+
+	// Rewrite to a single line and stage it — file still present, contents gone.
+	writeAndStage(t, repo, path, "a line of merged work\n")
+}
+
+func writeAndCommit(t *testing.T, repo, path, body, msg string) {
+	t.Helper()
+	writeAndStage(t, repo, path, body)
+	run(t, repo, "commit", "-m", msg)
+}
+
+func writeAndStage(t *testing.T, repo, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	run(t, repo, "add", filepath.Base(path))
+}
+
+func run(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+// assertFileStatusIsBlind is the negative control. If this ever fails, the
+// fixture is staging real file deletions and the line-based test below is
+// passing for a reason that has nothing to do with the defect.
+func assertFileStatusIsBlind(t *testing.T, g *Git, repo string) {
+	t.Helper()
+	deleted, err := g.StagedDeletions()
+	if err != nil {
+		t.Fatalf("StagedDeletions: %v", err)
+	}
+	if len(deleted) != 0 {
+		t.Fatalf("negative control failed: StagedDeletions saw %v. The fixture is staging FILE "+
+			"deletions, so it is not the rebase-armed state and the line-based assertion below "+
+			"proves nothing about it", deleted)
+	}
+	nameStatus := strings.TrimSpace(run(t, repo, "diff", "--cached", "--name-status", "--diff-filter=D"))
+	if nameStatus != "" {
+		t.Fatalf("negative control failed: --diff-filter=D reported %q; the armed state must be "+
+			"invisible to file-status checks", nameStatus)
+	}
+}
+
+func TestStagedLineDeletionsSeesWhatFileStatusChecksCannot(t *testing.T) {
+	repo := initTestRepo(t)
+	g := NewGit(repo)
+	armFixture(t, repo, 200)
+
+	// The control first: prove the state really is invisible to file-status.
+	assertFileStatusIsBlind(t, g, repo)
+
+	got, err := g.StagedLineDeletions()
+	if err != nil {
+		t.Fatalf("StagedLineDeletions: %v", err)
+	}
+	if got != 199 {
+		t.Fatalf("StagedLineDeletions = %d, want 199 — this is the count that made keeper's 7767 "+
+			"visible when every file-status check read clean", got)
+	}
+}
+
+// Denominator: a clean index must read zero, or "armed" would fire on every
+// worktree and the check would be deleted for crying wolf.
+func TestStagedLineDeletionsIsZeroOnACleanIndex(t *testing.T) {
+	repo := initTestRepo(t)
+	g := NewGit(repo)
+
+	got, err := g.StagedLineDeletions()
+	if err != nil {
+		t.Fatalf("StagedLineDeletions: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("StagedLineDeletions = %d on a clean index, want 0", got)
+	}
+}
+
+// A pure addition is not an armed state. shortstat reports insertions in the
+// same line, so a parser that grabs the wrong number reads 200 deletions here.
+func TestStagedLineDeletionsIgnoresInsertions(t *testing.T) {
+	repo := initTestRepo(t)
+	g := NewGit(repo)
+
+	writeAndStage(t, repo, filepath.Join(repo, "new.txt"), strings.Repeat("added\n", 200))
+
+	got, err := g.StagedLineDeletions()
+	if err != nil {
+		t.Fatalf("StagedLineDeletions: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("StagedLineDeletions = %d for a 200-line pure insertion, want 0 — the parser is "+
+			"reading the insertions field", got)
+	}
+}
+
+// shortstat omits the insertions clause entirely when there are none, so the
+// deletions field moves position. A positional parser passes the test above and
+// fails here.
+func TestStagedLineDeletionsHandlesDeletionsOnlyShortstat(t *testing.T) {
+	repo := initTestRepo(t)
+	g := NewGit(repo)
+
+	path := filepath.Join(repo, "delta.txt")
+	writeAndCommit(t, repo, path, strings.Repeat("x\n", 50), "seed")
+	writeAndStage(t, repo, path, "")
+
+	raw := run(t, repo, "diff", "--cached", "--shortstat")
+	if strings.Contains(raw, "insertion") {
+		t.Skipf("git emitted an insertions clause (%q); this git does not exercise the "+
+			"deletions-only shortstat form", strings.TrimSpace(raw))
+	}
+
+	got, err := g.StagedLineDeletions()
+	if err != nil {
+		t.Fatalf("StagedLineDeletions: %v", err)
+	}
+	if got != 50 {
+		t.Fatalf("StagedLineDeletions = %d for shortstat %q, want 50", got, strings.TrimSpace(raw))
+	}
+}
+
+// Guard the parser against a shortstat whose numbers it must not transpose.
+func TestParseShortstatDeletions(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{" 5 files changed, 26 insertions(+), 434 deletions(-)", 434},
+		{" 1 file changed, 1 insertion(+), 1 deletion(-)", 1},
+		{" 3 files changed, 7767 deletions(-)", 7767},
+		{" 2 files changed, 12 insertions(+)", 0},
+		{"", 0},
+		{"garbage", 0},
+	}
+	for _, tc := range cases {
+		if got := parseShortstatDeletions(tc.in); got != tc.want {
+			t.Errorf("parseShortstatDeletions(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+	// The transposition this guards against: 26 insertions must never be read
+	// as the deletion count for the line that recorded 434.
+	if got := parseShortstatDeletions(" 5 files changed, 26 insertions(+), 434 deletions(-)"); got == 26 {
+		t.Fatal("parser returned the insertions count as deletions")
+	}
+}

--- a/internal/git/worktree_holder_test.go
+++ b/internal/git/worktree_holder_test.go
@@ -1,0 +1,362 @@
+package git
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// si-d6kw: gt put two polecat worktrees on one branch. A commit in either then
+// appeared in the other as a delta to re-commit, and the auto-save committed
+// that delta with no agent acting — 7767 / 6824 / 434 staged deletions found
+// armed across the fleet.
+//
+// The subtlety these tests exist to pin down: git refuses BOTH a live holder
+// and a stale record with the same "already used by worktree at ..." message,
+// which is why callers reached for --force in the first place. Dropping --force
+// would fix the collision and break the reap-and-resume workflow it was added
+// for. So the guard is not "refuse when git refuses" — it is "refuse a LIVE
+// holder, clear a dead one" — and the tests have to show both halves, plus that
+// the refusal is the guard's and not git's.
+
+func worktreeHolderRepo(t *testing.T) (*Git, string) {
+	t.Helper()
+	dir := initTestRepo(t)
+	return NewGit(dir), dir
+}
+
+// addWorktreeOnNewBranch creates a real worktree holding a real branch.
+func addWorktreeOnNewBranch(t *testing.T, repo string, path, branch string) {
+	t.Helper()
+	cmd := exec.Command("git", "worktree", "add", "-b", branch, path)
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("seed worktree %s on %s: %v\n%s", path, branch, err, out)
+	}
+}
+
+func TestWorktreeAddExistingSafeRefusesBranchHeldByLiveWorktree(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	holder := filepath.Join(t.TempDir(), "holder")
+	addWorktreeOnNewBranch(t, repo, holder, "polecat/dag/si-aka.9")
+
+	second := filepath.Join(t.TempDir(), "second")
+	err := g.WorktreeAddExistingSafe(second, "polecat/dag/si-aka.9")
+	if err == nil {
+		t.Fatal("WorktreeAddExistingSafe attached a second worktree to a live-held branch; " +
+			"that is the si-d6kw defect")
+	}
+
+	var held *BranchHeldError
+	if !errors.As(err, &held) {
+		t.Fatalf("error = %v (%T), want *BranchHeldError — callers switch on this type to "+
+			"produce the actionable refusal", err, err)
+	}
+	if !sameResolvedPath(t, held.Path, holder) {
+		t.Fatalf("BranchHeldError.Path = %q, want %q — the message must NAME the holder, "+
+			"or the operator cannot act on it", held.Path, holder)
+	}
+
+	// The refusal must be total. A partially-created worktree is the hazard.
+	if _, statErr := os.Stat(second); !os.IsNotExist(statErr) {
+		t.Fatalf("refused, but %s exists anyway — nothing may be created on the refusal path", second)
+	}
+	for _, wt := range mustList(t, g) {
+		if wt.Path == second {
+			t.Fatalf("refused, but git registered a worktree at %s", second)
+		}
+	}
+}
+
+// NEGATIVE CONTROL. Without this, the test above passes even if the guard does
+// nothing, because plain git would refuse too — and the whole point is that the
+// old code got PAST git's refusal. This asserts the setup really is one --force
+// away from the two-worktrees-on-one-ref state, so the refusal above is
+// attributable to the guard rather than to git.
+func TestWorktreeAddExistingForceStillReachesTheStateTheGuardRefuses(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	holder := filepath.Join(t.TempDir(), "holder")
+	addWorktreeOnNewBranch(t, repo, holder, "polecat/dag/si-aka.9")
+
+	second := filepath.Join(t.TempDir(), "second")
+	if err := g.WorktreeAddExistingForce(second, "polecat/dag/si-aka.9"); err != nil {
+		t.Fatalf("WorktreeAddExistingForce: %v — if this now fails, the negative control is "+
+			"stale and the refusal test above may be measuring git rather than the guard", err)
+	}
+
+	var holders int
+	for _, wt := range mustList(t, g) {
+		if wt.Branch == "polecat/dag/si-aka.9" {
+			holders++
+		}
+	}
+	if holders != 2 {
+		t.Fatalf("worktrees on polecat/dag/si-aka.9 = %d, want 2 — the reproduction of si-d6kw "+
+			"did not reproduce, so the guard test proves nothing", holders)
+	}
+}
+
+// The workflow that must NOT break. Alice's recovery slings were 4-of-5 clean
+// precisely because the original worktree had been reaped; a guard that refuses
+// this case removes the only working recovery route and pushes operators to a
+// worse one.
+func TestWorktreeAddExistingSafeResumesBranchAfterHolderWasReaped(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	holder := filepath.Join(t.TempDir(), "holder")
+	addWorktreeOnNewBranch(t, repo, holder, "polecat/keeper/si-aka.37")
+
+	// Reap it the way the fleet does: the directory goes, the record remains.
+	if err := os.RemoveAll(holder); err != nil {
+		t.Fatalf("reap holder: %v", err)
+	}
+
+	// Denominator: the stale record must actually still be there, otherwise this
+	// test proves only that attaching to an unheld branch works.
+	if !recordExistsFor(t, g, "polecat/keeper/si-aka.37") {
+		t.Fatal("no worktree record for the branch after reaping — test setup no longer " +
+			"reproduces the stale-holder case it is named for")
+	}
+
+	resumed := filepath.Join(t.TempDir(), "resumed")
+	if err := g.WorktreeAddExistingSafe(resumed, "polecat/keeper/si-aka.37"); err != nil {
+		t.Fatalf("WorktreeAddExistingSafe refused a reaped holder: %v\n"+
+			"This is the resume workflow --force existed for; refusing it is the regression "+
+			"si-d6kw's own fix order warned about", err)
+	}
+	assertOnBranch(t, resumed, "polecat/keeper/si-aka.37")
+}
+
+// The case a directory-existence check alone gets WRONG, and the reason
+// LiveWorktreeForBranch reads git's prunable flag rather than just stat()ing
+// the path. A worktree whose .git file is broken still has its DIRECTORY on
+// disk, and git still reports the branch as taken — but it is not a live
+// worker, it is the broken worktree that "gt polecat repair" exists for.
+// Treating it as a live holder makes such a polecat permanently unresumable.
+//
+// This test was added because a mutation that deleted the Prunable check went
+// GREEN: the stat() fallback covered the reaped-directory case and hid it.
+func TestWorktreeAddExistingSafeResumesWorktreeWhoseGitFileIsBroken(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	broken := filepath.Join(t.TempDir(), "broken")
+	addWorktreeOnNewBranch(t, repo, broken, "polecat/coma/si-aka.14.2")
+
+	// Break the link without removing the directory.
+	if err := os.Remove(filepath.Join(broken, ".git")); err != nil {
+		t.Fatalf("break worktree .git: %v", err)
+	}
+
+	// Denominator: the state under test must actually hold — directory present,
+	// git reporting prunable. If either drifts, this test silently becomes a
+	// duplicate of the reaped-holder one.
+	if _, err := os.Stat(broken); err != nil {
+		t.Fatalf("broken worktree directory should still exist: %v", err)
+	}
+	var sawBrokenAsPrunable bool
+	for _, wt := range mustList(t, g) {
+		if wt.Branch == "polecat/coma/si-aka.14.2" && wt.Prunable {
+			sawBrokenAsPrunable = true
+		}
+	}
+	if !sawBrokenAsPrunable {
+		t.Fatal("git no longer reports the broken worktree as prunable — this test is not " +
+			"exercising the directory-exists-but-dead case it is named for")
+	}
+
+	resumed := filepath.Join(t.TempDir(), "resumed")
+	if err := g.WorktreeAddExistingSafe(resumed, "polecat/coma/si-aka.14.2"); err != nil {
+		t.Fatalf("WorktreeAddExistingSafe refused a broken (not live) worktree: %v\n"+
+			"A directory-existence check alone gives this wrong answer; the prunable flag "+
+			"is what distinguishes 'someone is working here' from 'this worktree is dead'", err)
+	}
+	assertOnBranch(t, resumed, "polecat/coma/si-aka.14.2")
+}
+
+func TestWorktreeAddExistingSafeAttachesWhenNoWorktreeHoldsBranch(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	cmd := exec.Command("git", "branch", "polecat/toast/si-aka.9+rework")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create branch: %v\n%s", err, out)
+	}
+
+	path := filepath.Join(t.TempDir(), "fresh")
+	if err := g.WorktreeAddExistingSafe(path, "polecat/toast/si-aka.9+rework"); err != nil {
+		t.Fatalf("WorktreeAddExistingSafe on an unheld branch: %v", err)
+	}
+	assertOnBranch(t, path, "polecat/toast/si-aka.9+rework")
+}
+
+// LiveWorktreeForBranch is the predicate the whole guard rests on. Test it
+// directly so a failure points at the discrimination rather than at the caller.
+func TestLiveWorktreeForBranchIgnoresPrunableRecords(t *testing.T) {
+	g, repo := worktreeHolderRepo(t)
+	live := filepath.Join(t.TempDir(), "live")
+	stale := filepath.Join(t.TempDir(), "stale")
+	addWorktreeOnNewBranch(t, repo, live, "branch/live")
+	addWorktreeOnNewBranch(t, repo, stale, "branch/stale")
+	if err := os.RemoveAll(stale); err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+
+	// Denominator on the parse itself: if WorktreeList stopped reporting
+	// prunable at all, every record would look live and the "stale" assertion
+	// below would still pass by accident on a differently-broken parser.
+	list := mustList(t, g)
+	var sawPrunable bool
+	for _, wt := range list {
+		if wt.Branch == "branch/stale" {
+			if !wt.Prunable {
+				t.Fatalf("record for branch/stale parsed with Prunable=false; "+
+					"reason=%q — git reports it as prunable", wt.PrunableReason)
+			}
+			sawPrunable = true
+		}
+	}
+	if !sawPrunable {
+		t.Fatal("no record found for branch/stale — cannot distinguish 'correctly ignored' " +
+			"from 'never examined'")
+	}
+
+	got, err := g.LiveWorktreeForBranch("branch/stale")
+	if err != nil {
+		t.Fatalf("LiveWorktreeForBranch(stale): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("LiveWorktreeForBranch(branch/stale) = %s, want nil — a reaped worktree is "+
+			"not a live holder", got.Path)
+	}
+
+	got, err = g.LiveWorktreeForBranch("branch/live")
+	if err != nil {
+		t.Fatalf("LiveWorktreeForBranch(live): %v", err)
+	}
+	if got == nil || !sameResolvedPath(t, got.Path, live) {
+		t.Fatalf("LiveWorktreeForBranch(branch/live) = %v, want %s", got, live)
+	}
+
+	// refs/heads/ prefix must resolve the same way; callers pass both forms.
+	got, err = g.LiveWorktreeForBranch("refs/heads/branch/live")
+	if err != nil {
+		t.Fatalf("LiveWorktreeForBranch(refs/heads/...): %v", err)
+	}
+	if got == nil || !sameResolvedPath(t, got.Path, live) {
+		t.Fatalf("LiveWorktreeForBranch with refs/heads/ prefix = %v, want %s", got, live)
+	}
+}
+
+// samePath compares paths after resolving symlinks. On macOS t.TempDir() hands
+// back /var/... while git reports the resolved /private/var/..., so a raw
+// string compare fails on a correct result.
+func sameResolvedPath(t *testing.T, a, b string) bool {
+	t.Helper()
+	ra, err := filepath.EvalSymlinks(a)
+	if err != nil {
+		ra = a
+	}
+	rb, err := filepath.EvalSymlinks(b)
+	if err != nil {
+		rb = b
+	}
+	return ra == rb
+}
+
+// PRODUCTION ARCHITECTURE. Rigs use a bare .repo.git as the repo base and hang
+// every polecat worktree off it (si-d6kw measured dag's git-dir as
+// .repo.git/worktrees/silicon7). The manager-level tests run on the LEGACY
+// mayor/rig base because that is what the scaffolding builds, so without this
+// test nothing exercises the guard on the shape it actually ships against.
+//
+// Two properties matter, and the first is the one that would bite: a bare repo
+// appears in "worktree list --porcelain" with a "bare" line and NO "branch"
+// line. If that parsed as a worktree holding something, the base itself could
+// read as a live holder and refuse every resume.
+func TestWorktreeGuardOnBareRepoBase(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	if err := os.MkdirAll(src, 0755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	runGit(t, src, "init", "-b", "main", ".")
+	runGit(t, src, "config", "user.email", "test@test.com")
+	runGit(t, src, "config", "user.name", "Test User")
+	runGit(t, src, "commit", "--allow-empty", "-m", "init")
+
+	bare := filepath.Join(root, "repo.git")
+	runGit(t, root, "clone", "--bare", src, bare)
+	g := NewGitWithDir(bare, "")
+
+	// The bare base holds no branch.
+	for _, wt := range mustList(t, g) {
+		if wt.Branch != "" && wt.Path == bare {
+			t.Fatalf("bare repo base parsed as holding branch %q; it has no working tree "+
+				"and must never read as a live holder", wt.Branch)
+		}
+	}
+	held, err := g.LiveWorktreeForBranch("main")
+	if err != nil {
+		t.Fatalf("LiveWorktreeForBranch(main) on bare base: %v", err)
+	}
+	if held != nil {
+		t.Fatalf("bare base reported as live holder of main at %s — every resume would refuse", held.Path)
+	}
+
+	// A polecat worktree off the bare base IS a live holder.
+	runGit(t, bare, "branch", "polecat/dag/si-aka.9", "main")
+	holder := filepath.Join(root, "dag")
+	runGit(t, bare, "worktree", "add", holder, "polecat/dag/si-aka.9")
+
+	second := filepath.Join(root, "toast")
+	err = g.WorktreeAddExistingSafe(second, "polecat/dag/si-aka.9")
+	var branchHeld *BranchHeldError
+	if !errors.As(err, &branchHeld) {
+		t.Fatalf("WorktreeAddExistingSafe on bare base = %v, want *BranchHeldError — "+
+			"this is the exact dag/toast collision, on the exact architecture it happened on", err)
+	}
+
+	// And the reaped case still resumes on a bare base.
+	if err := os.RemoveAll(holder); err != nil {
+		t.Fatalf("reap: %v", err)
+	}
+	if err := g.WorktreeAddExistingSafe(second, "polecat/dag/si-aka.9"); err != nil {
+		t.Fatalf("resume after reap on bare base: %v", err)
+	}
+	assertOnBranch(t, second, "polecat/dag/si-aka.9")
+}
+
+func mustList(t *testing.T, g *Git) []Worktree {
+	t.Helper()
+	list, err := g.WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatal("WorktreeList returned nothing — an empty list satisfies every loop below")
+	}
+	return list
+}
+
+func recordExistsFor(t *testing.T, g *Git, branch string) bool {
+	t.Helper()
+	for _, wt := range mustList(t, g) {
+		if wt.Branch == branch {
+			return true
+		}
+	}
+	return false
+}
+
+func assertOnBranch(t *testing.T, path, branch string) {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = path
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse in %s: %v", path, err)
+	}
+	if got := strings.TrimSpace(string(out)); got != branch {
+		t.Fatalf("worktree %s is on %q, want %q", path, got, branch)
+	}
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -32,6 +32,29 @@ import (
 	"github.com/steveyegge/gastown/internal/util"
 )
 
+// resumeBranchError wraps a failure to attach a worktree to a resume branch.
+//
+// The refusal case gets an actionable message on purpose. si-d6kw's own
+// post-mortem found that the operator reached for the unsafe option because the
+// safe one failed with a bare "exit status 1" — a defect that manufactures
+// pressure toward the dangerous path. A refusal that does not say what to do
+// instead recreates exactly that.
+func resumeBranchError(resumeBranch string, err error) error {
+	var held *git.BranchHeldError
+	if errors.As(err, &held) {
+		return fmt.Errorf("refusing to resume %s: it is checked out by a live worktree at %s\n\n"+
+			"Two worktrees on one branch is not a warning, it is data loss: a commit in either\n"+
+			"appears in the other as a delta to re-commit, and the auto-save commits that delta\n"+
+			"with no agent acting (si-d6kw).\n\n"+
+			"Instead:\n"+
+			"  - sling to the worker that already holds the branch, or\n"+
+			"  - let a fresh polecat branch be minted (drop --branch) and rebase, or\n"+
+			"  - if that worktree is genuinely finished, retire it first, then retry",
+			resumeBranch, held.Path)
+	}
+	return fmt.Errorf("creating worktree on existing branch %s: %w", resumeBranch, err)
+}
+
 // Retry constants for Dolt operations (matching hook update pattern in sling.go).
 // Configurable via operational.polecat in settings/config.json.
 const (
@@ -766,14 +789,15 @@ func (m *Manager) addWithOptionsLocked(name string, opts AddOptions, polecatDir 
 
 	if opts.ResumeBranch != "" {
 		// Resume an existing branch (gh#3602). Make sure we have the latest tip
-		// for the named branch, then attach the worktree directly. WorktreeAddExistingForce
-		// handles the case where another worktree previously had this branch checked out.
+		// for the named branch, then attach the worktree directly. Safe, not
+		// Force: a worktree PREVIOUSLY on this branch is pruned and resumed, but
+		// one that still holds it is refused (si-d6kw).
 		if err := repoGit.FetchBranch("origin", opts.ResumeBranch); err != nil {
 			style.PrintWarning("could not fetch resume branch %s: %v", opts.ResumeBranch, err)
 		}
-		if err := repoGit.WorktreeAddExistingForce(clonePath, opts.ResumeBranch); err != nil {
+		if err := repoGit.WorktreeAddExistingSafe(clonePath, opts.ResumeBranch); err != nil {
 			cleanupOnError()
-			return nil, fmt.Errorf("creating worktree on existing branch %s: %w", opts.ResumeBranch, err)
+			return nil, resumeBranchError(opts.ResumeBranch, err)
 		}
 		worktreeCreated = true
 	} else {
@@ -964,15 +988,17 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (_ *Polecat, retE
 
 	if opts.ResumeBranch != "" {
 		// Resume an existing branch (gh#3602): attach the worktree directly to the
-		// named branch. WorktreeAddExistingForce tolerates the branch being checked
-		// out elsewhere (stale worktree), and the explicit fetch ensures we have
-		// the latest tip before checkout.
+		// named branch. WorktreeAddExistingSafe tolerates a STALE worktree record
+		// for the branch — which is what "tolerates the branch being checked out
+		// elsewhere" was always meant to cover — and refuses a live holder, which
+		// --force could not tell apart (si-d6kw). The explicit fetch ensures we
+		// have the latest tip before checkout.
 		if err := repoGit.FetchBranch("origin", opts.ResumeBranch); err != nil {
 			style.PrintWarning("could not fetch resume branch %s: %v", opts.ResumeBranch, err)
 		}
-		if err := repoGit.WorktreeAddExistingForce(clonePath, opts.ResumeBranch); err != nil {
+		if err := repoGit.WorktreeAddExistingSafe(clonePath, opts.ResumeBranch); err != nil {
 			cleanupOnError()
-			return nil, fmt.Errorf("creating worktree on existing branch %s: %w", opts.ResumeBranch, err)
+			return nil, resumeBranchError(opts.ResumeBranch, err)
 		}
 		worktreeCreated = true
 	} else {
@@ -1596,6 +1622,15 @@ func (m *Manager) RepairWorktreeWithOptions(name string, force bool, opts AddOpt
 	if opts.ResumeBranch != "" {
 		// Resume an existing branch: fetch and attach the temp worktree directly
 		// to the named branch instead of creating a fresh polecat/<name>/<bead>+<ts>.
+		//
+		// Deliberately still Force, unlike the two sling resume paths (si-d6kw).
+		// Repair rebuilds ONE polecat's own worktree and does not remove the old
+		// registration first, so the record most likely holding this branch is
+		// the very one being replaced — WorktreeAddExistingSafe would refuse and
+		// repair could never run. Note also that no production caller sets
+		// ResumeBranch here: RepairWorktree passes AddOptions{}. A future caller
+		// that does must remove the old worktree registration before this point,
+		// otherwise it inherits the two-worktrees-one-ref hazard.
 		if err := repoGit.FetchBranch("origin", opts.ResumeBranch); err != nil {
 			style.PrintWarning("could not fetch resume branch %s: %v", opts.ResumeBranch, err)
 		}

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1688,6 +1688,25 @@ func TestAddWithOptions_ResumeBranch(t *testing.T) {
 		t.Fatalf("update-ref origin/%s: %v\n%s", prBranch, err, out)
 	}
 
+	// Return the repo base to main. createStalePolecatCommit builds the marker
+	// commit by CHECKING OUT the branch here and never switching back, which
+	// parks the repo base itself on the branch we are about to resume.
+	//
+	// That state does not exist in production: repoBase() prefers the bare
+	// .repo.git, which has no working tree and therefore holds no branch (the
+	// live rig confirms it — si-d6kw measured polecat git-dirs as
+	// .repo.git/worktrees/silicon7). mayor/rig is the legacy fallback this
+	// scaffolding happens to use.
+	//
+	// Leaving it parked would make this test assert that a polecat may attach to
+	// a branch a live working tree already has checked out — which is exactly
+	// the si-d6kw defect, and the si-d6kw guard now correctly refuses it.
+	cmd = exec.Command("git", "checkout", "main")
+	cmd.Dir = mayorRig
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("return repo base to main: %v\n%s", err, out)
+	}
+
 	polecat, err := mgr.AddWithOptions("toast", AddOptions{ResumeBranch: prBranch})
 	if err != nil {
 		t.Fatalf("AddWithOptions with ResumeBranch: %v", err)

--- a/internal/polecat/resume_branch_holder_test.go
+++ b/internal/polecat/resume_branch_holder_test.go
@@ -1,0 +1,180 @@
+package polecat
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+// si-d6kw. "gt sling <bead> <rig> --branch <held-branch>" spawned a SECOND
+// polecat onto a branch another polecat's worktree still had checked out. The
+// two auto-checkpointed over each other; a fleet sweep then found three more
+// worktrees armed with 7767 / 6824 / 434 staged deletions, and one of those
+// deletions was committed at 08:01 during an explicit stop-write with both
+// agents complying — because the auto-save needs no agent to act.
+//
+// The guard lives in internal/git; these tests exist because a guard the sling
+// resume path does not CALL protects nothing. Both spawn entry points are
+// covered: AddWithOptions (named polecat) and addWithOptionsLocked, reached via
+// AllocateAndAdd (pool allocation), which is the one --branch actually used.
+
+// seedLiveWorktreeOnBranch creates a real branch in the repo and a real, live
+// worktree holding it — the "dag still has it checked out" precondition.
+func seedLiveWorktreeOnBranch(t *testing.T, repo, branch string) string {
+	t.Helper()
+	cmd := exec.Command("git", "branch", branch, "HEAD")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create branch %s: %v\n%s", branch, err, out)
+	}
+	holder := filepath.Join(t.TempDir(), "holder")
+	cmd = exec.Command("git", "worktree", "add", holder, branch)
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("seed live worktree on %s: %v\n%s", branch, err, out)
+	}
+	return holder
+}
+
+func assertRefusalIsActionable(t *testing.T, err error, branch, holder string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("resume onto a live-held branch SUCCEEDED — this is si-d6kw: two worktrees " +
+			"on one ref, which the auto-save turns into committed data loss")
+	}
+	msg := err.Error()
+	// Naming the holder is the difference between a refusal an operator can act
+	// on and one they route around. si-d6kw's post-mortem traced the original
+	// incident to a safe path that failed with a bare "exit status 1".
+	if !strings.Contains(msg, holder) {
+		resolved, evalErr := filepath.EvalSymlinks(holder)
+		if evalErr != nil || !strings.Contains(msg, resolved) {
+			t.Fatalf("refusal does not name the holding worktree %s.\nGot: %s", holder, msg)
+		}
+	}
+	if !strings.Contains(msg, branch) {
+		t.Fatalf("refusal does not name the branch %s.\nGot: %s", branch, msg)
+	}
+	// It must tell the operator what to do instead, or it manufactures pressure
+	// toward the dangerous option exactly as the original defect did.
+	if !strings.Contains(msg, "Instead:") {
+		t.Fatalf("refusal offers no alternative; an operator who is blocked will find a "+
+			"worse route.\nGot: %s", msg)
+	}
+}
+
+func TestAddWithOptionsRefusesResumeBranchHeldByLiveWorktree(t *testing.T) {
+	mgr, mayorRig := setupCanonicalBranchManagerTest(t)
+	const branch = "polecat/dag/si-aka.9+ms43eli5"
+	holder := seedLiveWorktreeOnBranch(t, mayorRig, branch)
+
+	_, err := mgr.AddWithOptions("toast", AddOptions{ResumeBranch: branch})
+	assertRefusalIsActionable(t, err, branch, holder)
+
+	// The refusal must leave nothing behind. A half-built polecat directory is
+	// its own failure mode — reconcile treats it as an allocation.
+	polecatDir := filepath.Join(mgr.rig.Path, "polecats", "toast")
+	if _, statErr := os.Stat(polecatDir); !os.IsNotExist(statErr) {
+		t.Fatalf("polecat dir %s survived the refusal; rollback did not run", polecatDir)
+	}
+
+	// And the original holder must be untouched: still the only worktree on the
+	// branch, still on it. Refusing loudly while having already forced would be
+	// the worst of both.
+	holders := worktreesOnBranch(t, mayorRig, branch)
+	if len(holders) != 1 {
+		t.Fatalf("worktrees on %s = %d (%v), want exactly 1 — the original holder", branch, len(holders), holders)
+	}
+}
+
+func TestAllocateAndAddRefusesResumeBranchHeldByLiveWorktree(t *testing.T) {
+	mgr, mayorRig := setupCanonicalBranchManagerTest(t)
+	const branch = "polecat/keeper/si-aka.37+ms43gm2z"
+	holder := seedLiveWorktreeOnBranch(t, mayorRig, branch)
+
+	_, _, err := mgr.AllocateAndAdd(AddOptions{ResumeBranch: branch})
+	assertRefusalIsActionable(t, err, branch, holder)
+
+	holders := worktreesOnBranch(t, mayorRig, branch)
+	if len(holders) != 1 {
+		t.Fatalf("worktrees on %s = %d (%v), want exactly 1", branch, len(holders), holders)
+	}
+}
+
+// The recovery workflow --branch exists for, which the guard must NOT break.
+// Four of Alice's five recovery slings were exactly this case.
+func TestAddWithOptionsResumesBranchWhoseHolderWasReaped(t *testing.T) {
+	mgr, mayorRig := setupCanonicalBranchManagerTest(t)
+	const branch = "polecat/cheedo/si-aka.10+ms43f8l0"
+	holder := seedLiveWorktreeOnBranch(t, mayorRig, branch)
+
+	// Reap the original worker the way the fleet does.
+	if err := os.RemoveAll(holder); err != nil {
+		t.Fatalf("reap holder: %v", err)
+	}
+	// Denominator: the stale record must survive the reap, or this test is just
+	// the unheld-branch case wearing a different name. Note this deliberately
+	// counts records INCLUDING prunable ones — worktreesOnBranch excludes them,
+	// which is the whole point of the reap.
+	if !anyWorktreeRecordFor(t, mayorRig, branch) {
+		t.Fatal("no worktree record for the branch after reaping — setup no longer " +
+			"reproduces the stale-holder case")
+	}
+
+	polecat, err := mgr.AddWithOptions("toast", AddOptions{ResumeBranch: branch})
+	if err != nil {
+		t.Fatalf("resume after reap was refused: %v\n"+
+			"This is the workflow --force was added for. A guard that blocks it removes the "+
+			"only working recovery route, which is what si-d6kw's fix order warned about", err)
+	}
+	if polecat.Branch != branch {
+		t.Fatalf("resumed polecat is on %q, want %q", polecat.Branch, branch)
+	}
+	head, err := git.NewGit(polecat.ClonePath).CurrentBranch()
+	if err != nil {
+		t.Fatalf("read resumed worktree branch: %v", err)
+	}
+	if head != branch {
+		t.Fatalf("resumed worktree HEAD is on %q, want %q", head, branch)
+	}
+}
+
+// anyWorktreeRecordFor reports whether git still has ANY record for the branch,
+// live or prunable. Used for setup denominators, where the point is that a dead
+// record survives.
+func anyWorktreeRecordFor(t *testing.T, repo, branch string) bool {
+	t.Helper()
+	list, err := git.NewGit(repo).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	for _, wt := range list {
+		if wt.Branch == branch {
+			return true
+		}
+	}
+	return false
+}
+
+// worktreesOnBranch returns the LIVE worktrees holding branch.
+func worktreesOnBranch(t *testing.T, repo, branch string) []string {
+	t.Helper()
+	list, err := git.NewGit(repo).WorktreeList()
+	if err != nil {
+		t.Fatalf("WorktreeList: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatal("WorktreeList returned nothing — an empty list satisfies any count assertion")
+	}
+	var paths []string
+	for _, wt := range list {
+		if wt.Branch == branch && !wt.Prunable {
+			paths = append(paths, wt.Path)
+		}
+	}
+	return paths
+}


### PR DESCRIPTION
> **Stacked on #4624, which is stacked on #4619.** Cut from `fix/si-mefr-shared-ref-detection`
> because it needs `git.StagedLineDeletions` (added by #4624) and must share its threshold. Merge
> #4619 → #4624 → this, and each narrows to its own commit.

Implements Mayor's ruling hq-vpt06.

## The defect

The gt-pvx auto-save unstages **file** deletions before committing, on the stated policy that a
safety net *"should preserve work (additions + modifications), never destroy it (deletions)"*.

That policy is the hole. A rebase under a shared ref stages the delta as **modifications to files
that still exist**, so `g.StagedDeletions()` — `--diff-filter=D` — returns empty while thousands of
lines are staged to disappear, and the auto-save commits them.

That is commit `504a5ed`: 5 files, +26, **-434**, landed at 08:01:47 during an explicit stop-write
with both agents complying. The one automated check between the auto-save and that commit could not
see it.

## Why REFUSE, and not the alternatives

| option | failure mode |
|---|---|
| **refuse** | tree untouched, sandbox outlives the session. "the net did not fire" ≠ "work destroyed" |
| unstage the removal | commits additions **without** their removals — a broken half-refactor presented as a save |
| commit + record HEAD | the commit still **lands**, and on a shared ref landing *is* the harm |

Only one has "did nothing" as its failure mode. My own objection in the bead — that refusing might
destroy a legitimate refactor — dissolves under refusal, because refusal drops nothing.

Measured with `StagedLineDeletions`, never `StagedDeletions`. Re-using the file-status query here
would have faithfully reproduced the defect being fixed.

## Two properties that are structural, not remembered

**The guard runs before `git add -A`.** Refusal is only "the option that never writes" if nothing
has been staged yet — and a guard sitting one line above that call in a 900-line function is
enforced by proximity alone. So the refusal and the staging are one function, `stageForAutosave`,
which puts the ordering under test rather than under a comment.

**The refusal outlives the session.** The auto-save fires on `gt done` — at session end, when nobody
is reading stdout. A refusal that only prints would trade a silent destructive write for a silent
non-save: the same defect class pointing the other way. `internal/autosave` writes a marker **beside**
the worktree (never inside — `git reset --hard` and `git clean -f` run in these sandboxes routinely),
and doctor's new `autosave-refusal` check surfaces it where an operator already looks.

`autosave.Threshold` is pinned equal to doctor's `armedStagingThreshold` by a test. A gap between
them is a window where `gt doctor` reports a hazard the safety net commits anyway.

## Declined refinement

The ruling offered gating on whether the ref is shared, since a mass removal in a **solo** worktree
is usually a real refactor, and left the call here. Declined: under REFUSE a false positive costs
nothing, so the refinement buys accuracy the failure mode does not need — and the ruling's own
tiebreaker was that a safety net should be simple enough to reason about at 3am.

## Verification

Nine mutations, nine kills:

| mutation | killed by |
|---|---|
| **use the blind `--diff-filter=D` query** (the defect itself) | 3 tests |
| **stage before the guard** (the ordering the ruling turns on) | `StageForAutosaveDoesNotStageWhenItRefuses` |
| never stage at all (so the above passes for the wrong reason) | `StageForAutosaveStagesWhenItAllows` |
| never refuse | 3 tests |
| refuse but leave no durable record | `LeavesADurableMarker` |
| refuse everything | `AllowsOrdinaryWork` |
| write the marker **inside** the worktree | `LandsBesideTheWorktreeNotInsideIt` |
| drift the threshold from the detector's | `RefusalThresholdMatchesDoctorThreshold` |
| forget to register the check | `TestDoctorRegistersWorktreeRefSafetyChecks` |

Every armed fixture asserts the state is **invisible to `--diff-filter=D`** before asserting
anything else, so none can pass against a fixture that was never armed.

`CGO_ENABLED=0 go test ./internal/autosave/ ./internal/doctor/ ./internal/cmd/ ./internal/git/` —
four failures, all four pre-existing and reproducing on the unmodified base (three macOS
`/private/var` symlink, one `TestGetServerAddr_UsesConfigYAMLPort`).

**Not proven:** no end-to-end `gt done` run against an armed worktree. The guard is tested directly
against real armed repositories; the wiring into `runDone` is a call site I have read, not executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)