### PR TITLE
fix(patrol): refuse to cook a patrol wisp that cannot name its own rig (dbt-as8)

### DIFF
--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -36,6 +36,12 @@ type PatrolConfig struct {
 // Remaining stale beads are cleaned by burnPreviousPatrolWisps at cycle end.
 const maxStalePurgePerRun = 5
 
+// errPatrolRigUnsubstituted marks a patrol description that still carries the
+// UNSET_RIG sentinel. It is a distinct sentinel error so that autoSpawnPatrol can
+// treat it as fatal while leaving every other render failure as non-fatal as
+// before (dbt-as8).
+var errPatrolRigUnsubstituted = errors.New("patrol rig var was never substituted")
+
 // findActivePatrol finds an active patrol molecule for the role.
 // Returns the patrol ID, display line, and whether one was found.
 // Returns an error if discovery fails (e.g. transient bd failure),
@@ -198,6 +204,18 @@ func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
 		return "", refinery.NewSafetyStoppedError(stop)
 	}
 
+	// Render the description BEFORE mutating anything, so a patrol that cannot
+	// name its own rig burns nothing and creates nothing (dbt-as8).
+	//
+	// A render FAILURE stays non-fatal, as it was: it is warned about where the
+	// description is written, below. An UNSUBSTITUTED RIG is fatal, because that
+	// wisp is not merely bare — it is ~25KB of instructions naming a rig that
+	// does not exist, and every command inside it fails in a way nothing checks.
+	desc, descErr := renderPatrolWispDescription(cfg)
+	if descErr != nil && errors.Is(descErr, errPatrolRigUnsubstituted) {
+		return "", descErr
+	}
+
 	// Resolve the beads directory following redirects.
 	// This ensures bd targets the correct database (e.g., rig database
 	// instead of HQ) regardless of inherited BEADS_DIR. See gt-ctir.
@@ -244,8 +262,11 @@ func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
 	// Create the patrol wisp (root only — steps are read inline at prime time,
 	// not tracked as individual DB rows). Child wisps are reserved for pour=true
 	// formulas like releases where checkpoint recovery matters.
+	// The wisp is created with the SAME var set the description is rendered from
+	// (patrolFormulaVars), so the stored vars and the instructions the agent
+	// reads can never disagree about which rig this patrol belongs to (dbt-as8).
 	spawnArgs := []string{"mol", "wisp", "create", protoID, "--root-only", "--actor", cfg.RoleName}
-	for _, v := range cfg.ExtraVars {
+	for _, v := range patrolFormulaVars(cfg) {
 		spawnArgs = append(spawnArgs, "--var", v)
 	}
 	cmdSpawn := BdCmd(spawnArgs...).
@@ -300,9 +321,8 @@ func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
 		return patrolID, fmt.Errorf("created wisp %s but failed to hook", patrolID)
 	}
 
-	desc, err := renderPatrolWispDescription(cfg)
-	if err != nil {
-		style.PrintWarning("could not render patrol description for %s: %v", patrolID, err)
+	if descErr != nil {
+		style.PrintWarning("could not render patrol description for %s: %v", patrolID, descErr)
 	} else if err := updatePatrolWispDescription(cfg, resolvedBeadsDir, patrolID, desc); err != nil {
 		style.PrintWarning("could not write patrol description for %s: %v", patrolID, err)
 	}
@@ -310,9 +330,16 @@ func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
 	return patrolID, nil
 }
 
-func renderPatrolWispDescription(cfg PatrolConfig) (string, error) {
-	rigName := patrolRigName(cfg)
-	ctx := RoleContext{TownRoot: cfg.BeadsDir, Rig: rigName}
+// patrolFormulaVars returns the full --var set a patrol wisp must be minted
+// with: the role's own derived vars first, then any caller-supplied ExtraVars,
+// which win on conflict (later entries override earlier ones in
+// buildFormulaVarMap).
+//
+// This must be the single source of the var set. When the description was
+// rendered from one set and the wisp created from another, a caller that forgot
+// to pass rig produced a wisp whose commands named UNSET_RIG (dbt-as8).
+func patrolFormulaVars(cfg PatrolConfig) []string {
+	ctx := RoleContext{TownRoot: cfg.BeadsDir, Rig: patrolRigName(cfg)}
 	var vars []string
 	switch cfg.PatrolMolName {
 	case constants.MolWitnessPatrol:
@@ -320,8 +347,67 @@ func renderPatrolWispDescription(cfg PatrolConfig) (string, error) {
 	case constants.MolRefineryPatrol:
 		vars = buildRefineryPatrolVars(ctx)
 	}
-	vars = append(vars, cfg.ExtraVars...)
-	return renderFormulaRootAndStepsFull(cfg.PatrolMolName, cfg.BeadsDir, rigName, vars)
+	return dedupeFormulaVars(append(vars, cfg.ExtraVars...))
+}
+
+// dedupeFormulaVars keeps the LAST assignment of each key, at the position of
+// that last assignment. Callers that pass the role's own vars through ExtraVars
+// would otherwise emit every --var twice, and last-wins is the precedence
+// buildFormulaVarMap already applies — so this changes the arg list, never the
+// resolved value.
+func dedupeFormulaVars(vars []string) []string {
+	lastIdx := make(map[string]int, len(vars))
+	for i, kv := range vars {
+		lastIdx[formulaVarKey(kv)] = i
+	}
+	out := make([]string, 0, len(vars))
+	for i, kv := range vars {
+		if lastIdx[formulaVarKey(kv)] == i {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+func formulaVarKey(kv string) string {
+	if idx := strings.IndexByte(kv, '='); idx > 0 {
+		return kv[:idx]
+	}
+	return kv
+}
+
+func renderPatrolWispDescription(cfg PatrolConfig) (string, error) {
+	desc, err := renderFormulaRootAndStepsFull(cfg.PatrolMolName, cfg.BeadsDir, patrolRigName(cfg), patrolFormulaVars(cfg))
+	if err != nil {
+		return "", err
+	}
+	if err := assertPatrolRigSubstituted(cfg, desc); err != nil {
+		return "", err
+	}
+	return desc, nil
+}
+
+// assertPatrolRigSubstituted refuses a patrol description that still carries the
+// UNSET_RIG sentinel.
+//
+// A rig-scoped patrol formula declares `rig` with an UNSET_RIG default, so a
+// caller that never supplies it does not fail — it renders ~25KB of shell
+// instructions addressed to a rig that does not exist, and the commands inside
+// then fail one at a time in ways nothing checks: `gt agents resolve --rig
+// UNSET_RIG` returns no bead, so idle/backoff/heartbeat tracking silently
+// no-ops and the patrol never backs off (dbt-as8).
+//
+// The check is on the RENDERED TEXT rather than on the formula name, so it says
+// SAFE for formulas that have no rig var at all (the deacon patrol) and speaks
+// only when a substitution that was supposed to happen did not.
+func assertPatrolRigSubstituted(cfg PatrolConfig, desc string) error {
+	if !strings.Contains(desc, constants.UnsetRigSentinel) {
+		return nil
+	}
+	return fmt.Errorf("%w: %s still carries %s after rendering (assignee %q yielded rig %q) — "+
+		"refusing to cook a patrol wisp that cannot name its own rig",
+		errPatrolRigUnsubstituted, cfg.PatrolMolName, constants.UnsetRigSentinel,
+		cfg.Assignee, patrolRigName(cfg))
 }
 
 func patrolRigName(cfg PatrolConfig) string {

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -1396,3 +1396,103 @@ func TestDedupeFormulaVars_LastWinsAtLastPosition(t *testing.T) {
 		}
 	}
 }
+
+// TestAutoSpawnPatrol_RigLessRefusalCreatesNothing pins the safety claim the
+// dbt-as8 fix actually rests on: when the rig cannot be named, autoSpawnPatrol
+// must refuse BEFORE it burns the previous cycle's wisp or creates a new one, so
+// nothing is left behind. Code ordering alone does not demonstrate that — a later
+// edit could move the render below the burn and every existing test would still
+// pass — so this asserts it against the bd command log.
+//
+// The CONTROL arm is load-bearing and runs in the same test: a properly-rigged
+// config on the identical town and mocks must reach `mol wisp create`. Without it,
+// an empty log is indistinguishable from a mock that was never invoked, and the
+// refusing arm would pass for the wrong reason.
+func TestAutoSpawnPatrol_RigLessRefusalCreatesNothing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock bd/gt scripts use POSIX shell")
+	}
+
+	run := func(t *testing.T, assignee string) (string, error, string) {
+		t.Helper()
+		townRoot := setupRefinerySafetyStopTown(t)
+		logPath := installPatrolSpawnMockBD(t)
+		id, err := autoSpawnPatrol(PatrolConfig{
+			RoleName:      "witness",
+			PatrolMolName: constants.MolWitnessPatrol,
+			BeadsDir:      townRoot,
+			Assignee:      assignee,
+		})
+		data, readErr := os.ReadFile(logPath)
+		if readErr != nil && !os.IsNotExist(readErr) {
+			t.Fatalf("read bd log: %v", readErr)
+		}
+		return id, err, string(data)
+	}
+
+	t.Run("rig-less refuses and mutates nothing", func(t *testing.T) {
+		id, err, log := run(t, "orphaned-agent")
+		if !errors.Is(err, errPatrolRigUnsubstituted) {
+			t.Fatalf("autoSpawnPatrol error = %v, want errPatrolRigUnsubstituted", err)
+		}
+		if id != "" {
+			t.Errorf("returned patrol id %q, want empty — nothing should have been created", id)
+		}
+		for _, forbidden := range []string{"mol wisp create", "--status=hooked", "--body-file"} {
+			if strings.Contains(log, forbidden) {
+				t.Errorf("bd log contains %q; autoSpawnPatrol mutated state before refusing:\n%s", forbidden, log)
+			}
+		}
+	})
+
+	t.Run("CONTROL rigged config reaches wisp create", func(t *testing.T) {
+		_, _, log := run(t, "testrig/witness")
+		// Not asserting success end-to-end — the mocks do not model the whole
+		// flow. Only that creation was ATTEMPTED, which is what makes the
+		// refusing arm's absence meaningful.
+		if !strings.Contains(log, "mol wisp create") {
+			t.Fatalf("CONTROL: bd log lacks \"mol wisp create\", so the log probe is blind and the refusing arm proves nothing:\n%s", log)
+		}
+	})
+}
+
+// installPatrolSpawnMockBD installs a bd whose agent bead carries NO safety_stop
+// (so autoSpawnPatrol proceeds to the render) plus a gt that reports the witness
+// patrol formula, and logs every bd invocation.
+func installPatrolSpawnMockBD(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "bd.log")
+	bd := `#!/bin/sh
+printf '%s\n' "$*" >> "` + logPath + `"
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+case "$cmd" in
+  version) echo "bd test" ;;
+  show)
+    printf '%s\n' '[{"id":"gt-testrig-witness","title":"Witness","issue_type":"task","labels":["gt:agent"],"status":"open","description":"role_type: witness\nrig: testrig\nagent_state: idle"}]'
+    ;;
+  mol) echo "Root issue: testrig-wisp-ctl" ;;
+  *) exit 0 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bd), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	gt := `#!/bin/sh
+case "$1 $2" in
+  "formula list") echo "mol-witness-patrol    Witness patrol" ;;
+  *) exit 0 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "gt"), []byte(gt), 0o755); err != nil {
+		t.Fatalf("write fake gt: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -1234,3 +1234,165 @@ func TestBurnPreviousPatrolWisps_IgnoresOtherBeads(t *testing.T) {
 		t.Errorf("non-patrol bead status = %q, want %q (should not be burned)", otherIssue.Status, beads.StatusHooked)
 	}
 }
+
+// --- dbt-as8: the rig var must reach every patrol wisp, and a wisp that cannot
+// name its own rig must be refused rather than cooked. ---
+
+// TestRenderPatrolWispDescription_WitnessSubstitutesRig is the witness twin of
+// TestRenderPatrolWispDescription_RefinerySubstitutesRigAndEmptyDefaults. The
+// witness arm is the one dbt-as8 was filed against and had no test of its own,
+// which is how three callers came to disagree about whether to pass rig.
+func TestRenderPatrolWispDescription_WitnessSubstitutesRig(t *testing.T) {
+	desc, err := renderPatrolWispDescription(PatrolConfig{
+		PatrolMolName: constants.MolWitnessPatrol,
+		BeadsDir:      t.TempDir(),
+		Assignee:      "gastown/witness",
+	})
+	if err != nil {
+		t.Fatalf("renderPatrolWispDescription: %v", err)
+	}
+	if !strings.Contains(desc, "gt agents resolve --role witness --rig gastown") {
+		t.Fatalf("description did not substitute witness rig:\n%s", desc)
+	}
+	if strings.Contains(desc, constants.UnsetRigSentinel) {
+		t.Fatalf("description still carries %s:\n%s", constants.UnsetRigSentinel, desc)
+	}
+}
+
+// TestAssertPatrolRigSubstituted_BothVerdictsInOneRun exercises the guard in
+// both directions in a single run. A guard that can only refuse is not a guard —
+// it is the absence of the step printing a reassuring sentence — so the SAFE arm
+// is as load-bearing as the refusing one.
+func TestAssertPatrolRigSubstituted_BothVerdictsInOneRun(t *testing.T) {
+	cfg := PatrolConfig{PatrolMolName: constants.MolWitnessPatrol, Assignee: "gastown/witness"}
+
+	safe := "gt agents resolve --role witness --rig gastown --json"
+	if err := assertPatrolRigSubstituted(cfg, safe); err != nil {
+		t.Fatalf("SAFE arm: guard refused a substituted description: %v", err)
+	}
+
+	poisoned := "gt agents resolve --role witness --rig " + constants.UnsetRigSentinel + " --json"
+	err := assertPatrolRigSubstituted(cfg, poisoned)
+	if err == nil {
+		t.Fatal("UNSAFE arm: guard accepted a description carrying the sentinel")
+	}
+	if !errors.Is(err, errPatrolRigUnsubstituted) {
+		t.Fatalf("UNSAFE arm: error does not wrap errPatrolRigUnsubstituted: %v", err)
+	}
+	// The message must name the inputs that produced the failure, not just the
+	// fact of it: the caller who forgot the var reads this line, not the code.
+	for _, want := range []string{constants.MolWitnessPatrol, constants.UnsetRigSentinel, "gastown/witness"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message missing %q: %v", want, err)
+		}
+	}
+}
+
+// TestRenderPatrolWispDescription_RefusesRigScopedPatrolWithNoRig covers the
+// failure this bead is about: a caller that supplies no rig at all. Both a
+// refusing arm and a permitted arm run here, and the permitted arm is the
+// deacon patrol — a formula with no rig var — which proves the guard keys on
+// the rendered text rather than on "is this a patrol".
+func TestRenderPatrolWispDescription_RefusesRigScopedPatrolWithNoRig(t *testing.T) {
+	townRoot := t.TempDir()
+
+	for _, molName := range []string{constants.MolWitnessPatrol, constants.MolRefineryPatrol} {
+		// Assignee with no "/" yields an empty rig, so no rig var is derived and
+		// the formula default (the sentinel) survives rendering.
+		_, err := renderPatrolWispDescription(PatrolConfig{
+			PatrolMolName: molName,
+			BeadsDir:      townRoot,
+			Assignee:      "orphaned-agent",
+		})
+		if err == nil {
+			t.Fatalf("%s: rendered a description with no rig instead of refusing", molName)
+		}
+		if !errors.Is(err, errPatrolRigUnsubstituted) {
+			t.Fatalf("%s: error does not wrap errPatrolRigUnsubstituted: %v", molName, err)
+		}
+	}
+
+	// In-run control: the same rig-less assignee on a formula that has no rig
+	// var must still render. Without this arm an always-refusing guard passes.
+	if _, err := renderPatrolWispDescription(PatrolConfig{
+		PatrolMolName: constants.MolDeaconPatrol,
+		BeadsDir:      townRoot,
+		Assignee:      "deacon",
+	}); err != nil {
+		t.Fatalf("CONTROL: deacon patrol has no rig var and must still render: %v", err)
+	}
+}
+
+// TestPatrolFormulaVars_SingleSourceForSpawnAndDescription pins the invariant
+// that broke: the wisp used to be CREATED from cfg.ExtraVars while its
+// description was RENDERED from a different set, so a caller that forgot rig
+// produced a wisp whose stored vars and instructions disagreed.
+func TestPatrolFormulaVars_SingleSourceForSpawnAndDescription(t *testing.T) {
+	townRoot := t.TempDir()
+
+	witness := patrolFormulaVars(PatrolConfig{
+		PatrolMolName: constants.MolWitnessPatrol,
+		BeadsDir:      townRoot,
+		Assignee:      "testrig/witness",
+	})
+	if !slicesContains(witness, "rig=testrig") {
+		t.Errorf("witness vars missing rig=testrig: %v", witness)
+	}
+
+	refineryVars := patrolFormulaVars(PatrolConfig{
+		PatrolMolName: constants.MolRefineryPatrol,
+		BeadsDir:      townRoot,
+		Assignee:      "testrig/refinery",
+	})
+	if !slicesContains(refineryVars, "rig=testrig") {
+		t.Errorf("refinery vars missing rig=testrig: %v", refineryVars)
+	}
+
+	// ExtraVars come last so an explicit caller override still wins.
+	overridden := patrolFormulaVars(PatrolConfig{
+		PatrolMolName: constants.MolWitnessPatrol,
+		BeadsDir:      townRoot,
+		Assignee:      "testrig/witness",
+		ExtraVars:     []string{"rig=explicit"},
+	})
+	if got := overridden[len(overridden)-1]; got != "rig=explicit" {
+		t.Errorf("ExtraVars must be appended last so they win, got last=%q in %v", got, overridden)
+	}
+
+	// Control: a formula with no rig var derives nothing, so the guard above has
+	// nothing to refuse and deacon patrols are unaffected.
+	deacon := patrolFormulaVars(PatrolConfig{
+		PatrolMolName: constants.MolDeaconPatrol,
+		BeadsDir:      townRoot,
+		Assignee:      "deacon",
+		ExtraVars:     []string{"idle_effort_threshold=7"},
+	})
+	if len(deacon) != 1 || deacon[0] != "idle_effort_threshold=7" {
+		t.Errorf("deacon vars = %v, want only the caller's ExtraVars", deacon)
+	}
+}
+
+func slicesContains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDedupeFormulaVars_LastWinsAtLastPosition pins the precedence that
+// buildFormulaVarMap already applies, so collapsing duplicate --var args can
+// never change a resolved value.
+func TestDedupeFormulaVars_LastWinsAtLastPosition(t *testing.T) {
+	got := dedupeFormulaVars([]string{"rig=a", "prefix=gt", "rig=b", "bare"})
+	want := []string{"prefix=gt", "rig=b", "bare"}
+	if len(got) != len(want) {
+		t.Fatalf("dedupeFormulaVars = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dedupeFormulaVars = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/cmd/patrol_new.go
+++ b/internal/cmd/patrol_new.go
@@ -62,6 +62,10 @@ func runPatrolNew(cmd *cobra.Command, args []string) error {
 			PatrolMolName: constants.MolWitnessPatrol,
 			BeadsDir:      roleInfo.TownRoot,
 			Assignee:      roleInfo.Rig + "/witness",
+			// Without rig/prefix the formula's {{rig}} falls back to its
+			// UNSET_RIG default and the minted wisp instructs the witness to
+			// resolve its agent bead in a rig that does not exist (dbt-as8).
+			ExtraVars: buildWitnessPatrolVars(roleInfo),
 		}
 	case RoleRefinery:
 		cfg = PatrolConfig{

--- a/internal/cmd/patrol_report.go
+++ b/internal/cmd/patrol_report.go
@@ -69,6 +69,10 @@ func runPatrolReport(cmd *cobra.Command, args []string) error {
 			PatrolMolName: constants.MolWitnessPatrol,
 			BeadsDir:      roleInfo.TownRoot,
 			Assignee:      roleInfo.Rig + "/witness",
+			// `gt patrol report` mints the NEXT cycle's wisp, so omitting these
+			// left every cycle after session start carrying UNSET_RIG while the
+			// one hooked by `gt prime` looked clean (dbt-as8).
+			ExtraVars: buildWitnessPatrolVars(roleInfo),
 		}
 	case RoleRefinery:
 		cfg = PatrolConfig{

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -306,6 +306,13 @@ const (
 	// MolRefineryPatrol is the refinery patrol formula name.
 	MolRefineryPatrol = "mol-refinery-patrol"
 
+	// UnsetRigSentinel is the default value of the `rig` var in every rig-scoped
+	// patrol formula. It exists so that a formula parses standalone, but it is
+	// never a usable rig name: a rendered patrol description still containing it
+	// proves the minting caller never supplied the rig, and the wisp must be
+	// refused rather than cooked (dbt-as8).
+	UnsetRigSentinel = "UNSET_RIG"
+
 	// MolDogReaper is the wisp reaper dog formula name.
 	MolDogReaper = "mol-dog-reaper"
 


### PR DESCRIPTION
Closes dbt-as8.

Every rig-scoped patrol formula declares `rig` with a default of `UNSET_RIG` so it parses standalone. A minting caller that never supplies the var therefore does not fail — it renders ~25KB of shell instructions addressed to a rig that does not exist:

```
YOUR_AGENT_BEAD=$(gt agents resolve --role witness --rig UNSET_RIG --json | jq -r .id)
```

`gt agents resolve` exits 1, but the pipe means `$?` is jq's, so the assignment succeeds with the literal string `"null"`. The formula's next line — *"This must resolve exactly one bead ID. If it fails, STOP and report the error"* — is prose addressed to the agent, not a shell test, and `"null"` is non-empty so even a `[ -z ]` guard would pass it. `await-signal` then warns three times and carries on with idle tracking, backoff persistence and the agent heartbeat all silently no-op'd, so the patrol never reaches abbreviated effort. The formula states its own intent 20 lines above the defect ("idle cycles should burn ~10% of the tokens a full patrol uses"), so an idle patrol on an affected build burns roughly ten times that, indefinitely. **It does not fail safe.**

## What this changes

1. `gt patrol new` and `gt patrol report` build the witness `PatrolConfig` with no `ExtraVars` at all, while `gt prime` passes `buildWitnessPatrolVars`. The wisp is *created* from those vars, so on those two paths the stored var set carries neither `rig` nor `prefix`.
2. The wisp was CREATED from `cfg.ExtraVars` but its description was RENDERED from a different, role-derived set. `patrolFormulaVars` is now the single source for both, so stored vars and the instructions the agent actually reads cannot disagree about which rig the patrol belongs to. Duplicate keys collapse last-wins — the precedence `buildFormulaVarMap` already applied.
3. The fail-safe, and **on current `main` this is the only part that changes rendered output**: `assertPatrolRigSubstituted` refuses a rendered patrol description still carrying the sentinel, and `autoSpawnPatrol` now renders *before* it burns the previous cycle's wisp or creates a new one, so a patrol that cannot name its rig leaves nothing behind. Other render failures stay non-fatal exactly as before; only the unsubstituted rig is fatal, via a distinct sentinel error.

The guard keys on the **rendered text**, not on the formula name, so it says SAFE for formulas with no rig var at all — the deacon patrol renders unchanged, and the tests assert that arm in the same run as the refusing arm.

## Scope — narrower than the bug report, and worth stating plainly

Measured rather than inherited from the report:

- **Against this PR's base (`649b832b`), the four real role/rig arms already render correctly.** `2bd80946 fix(patrol): rebuild heartbeat and root-wisp flow (#4496)` added `rig=` to `buildRefineryPatrolVars` and moved the render path to derive role vars from the assignee. So this PR does **not** repair a broken rendering on `main`. What it repairs is the residual **fail-open**: a config from which no rig can be derived at all renders 25,886 bytes carrying the sentinel with `err=nil`, plus the create/render var-set split in (2).
- **The reported symptom is nonetheless live in a running town, because the deployed build predates `2bd80946`.** One probe run against the real formulas on three trees: on the deployed commit all four arms carry `UNSET_RIG`; on this PR's base none do. That half is a rebuild, not a code change, and nothing here can clear already-minted wisps.
- **It is neither rig-specific nor witness-specific.** On the deployed tree the witness arm fails because two of three callers pass no vars; the refinery arm fails for an unrelated reason — `buildRefineryPatrolVars` never emitted `rig=` there at all — so refinery was broken on every path in every rig. A fix that only corrected the caller list would have left every refinery patrol broken.

## Verification

Both verdicts in one run, against the live 25KB/42KB formulas rather than fixtures:

| arm | base `649b832b` | this branch |
|---|---|---|
| witness + refinery × 3 real rigs | renders `--rig <rig>`, 0 sentinel | same |
| rig-less assignee | **25,886 B, `err=nil`, sentinel present** | **refused with a named error** |
| rig-less **deacon** (control) | 50,158 B, `err=nil` | 50,158 B, `err=nil` |

The deacon control is load-bearing: a guard that could only refuse would fail that arm. Also checked against the live town's 47 formula files — `UNSET_RIG` occurs exactly twice, both as `default = "UNSET_RIG"` in the two rig-scoped patrol formulas — so no legitimate description can trip the refusal.

`go build ./...` and `go vet ./...` clean; `internal/cmd` and `internal/constants` pass. `internal/doctor` and `internal/doltserver` fail **identically on this branch and on an unmodified base checkout** (`TestGetServerAddr_UsesConfigYAMLPort`, `TestWaitForCatalog_NoServer`, `TestFindBrokenWorkspaces_MultipleRigs`) — pre-existing and environment-dependent, untouched here.

New tests only; no pre-existing test was modified. Code authored by `nitro`, whose session was terminated by account quota before it could open this PR; re-verified end to end and the commit message corrected where it described the deployed tree rather than this base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
