### PR TITLE
fix(polecat): render WORKING verdict without a green "Safe to nuke"

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1192,46 +1193,76 @@ func runPolecatCheckRecovery(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println()
 
+	renderRecoveryVerdict(os.Stdout, status)
+
+	return nil
+}
+
+// renderRecoveryVerdict writes the verdict-specific portion of the human-readable
+// check-recovery output. It is split out of runPolecatCheckRecovery so that every
+// verdict — including WORKING and any verdict added to workstate.go later — has an
+// explicit, test-covered arm. The default arm must fail loud (never render a green
+// "Safe to nuke"), so a verdict with no case surfaces as unrecognised instead of
+// being mistaken for safe-to-destroy. See #4631.
+func renderRecoveryVerdict(w io.Writer, status RecoveryStatus) {
 	switch status.Verdict {
-	case "NEEDS_MQ_SUBMIT":
-		fmt.Printf("  Verdict:         %s\n", style.Warning.Render("NEEDS_MQ_SUBMIT"))
-		fmt.Printf("  MQ Status:       %s\n", status.MQStatus)
-		fmt.Println()
-		fmt.Printf("  %s Work is pushed but was never submitted to the merge queue.\n", style.Warning.Render("⚠"))
-		fmt.Println("  Submit to MQ before cleanup, or the branch will be orphaned.")
-	case "PENDING_MR":
-		fmt.Printf("  Verdict:         %s\n", style.Warning.Render("PENDING_MR"))
-		fmt.Println()
-		fmt.Println("  Work is waiting on an active merge request; preserve this polecat until it lands.")
-	case "NEEDS_RECOVERY":
-		fmt.Printf("  Verdict:         %s\n", style.Error.Render("NEEDS_RECOVERY"))
-		fmt.Println()
+	case polecat.WorkstateVerdictNeedsMQSubmit:
+		fmt.Fprintf(w, "  Verdict:         %s\n", style.Warning.Render(polecat.WorkstateVerdictNeedsMQSubmit))
+		fmt.Fprintf(w, "  MQ Status:       %s\n", status.MQStatus)
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "  %s Work is pushed but was never submitted to the merge queue.\n", style.Warning.Render("⚠"))
+		fmt.Fprintln(w, "  Submit to MQ before cleanup, or the branch will be orphaned.")
+	case polecat.WorkstateVerdictPendingMR:
+		fmt.Fprintf(w, "  Verdict:         %s\n", style.Warning.Render(polecat.WorkstateVerdictPendingMR))
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "  Work is waiting on an active merge request; preserve this polecat until it lands.")
+	case polecat.WorkstateVerdictNeedsRecovery:
+		fmt.Fprintf(w, "  Verdict:         %s\n", style.Error.Render(polecat.WorkstateVerdictNeedsRecovery))
+		fmt.Fprintln(w)
 		if len(status.Blockers) > 0 {
-			fmt.Printf("  %s Cleanup refused by these predicate(s):\n", style.Warning.Render("⚠"))
+			fmt.Fprintf(w, "  %s Cleanup refused by these predicate(s):\n", style.Warning.Render("⚠"))
 			for _, blocker := range status.Blockers {
-				fmt.Printf("    - %s\n", blocker)
+				fmt.Fprintf(w, "    - %s\n", blocker)
 			}
 			if len(status.RecoveryActions) > 0 {
-				fmt.Println()
-				fmt.Println("  Recovery action(s):")
+				fmt.Fprintln(w)
+				fmt.Fprintln(w, "  Recovery action(s):")
 				for _, action := range status.RecoveryActions {
-					fmt.Printf("    - %s\n", action)
+					fmt.Fprintf(w, "    - %s\n", action)
 				}
 			}
 		} else {
-			fmt.Printf("  %s Cleanup refused by an unknown recovery predicate.\n", style.Warning.Render("⚠"))
+			fmt.Fprintf(w, "  %s Cleanup refused by an unknown recovery predicate.\n", style.Warning.Render("⚠"))
 		}
-		fmt.Println("  Escalate to Mayor for recovery before cleanup.")
-	default:
-		fmt.Printf("  Verdict:         %s\n", style.Success.Render("SAFE_TO_NUKE"))
+		fmt.Fprintln(w, "  Escalate to Mayor for recovery before cleanup.")
+	case polecat.WorkstateVerdictWorking:
+		fmt.Fprintf(w, "  Verdict:         %s\n", style.Warning.Render(polecat.WorkstateVerdictWorking))
+		fmt.Fprintln(w)
+		if len(status.Blockers) > 0 {
+			fmt.Fprintf(w, "  %s Work is in progress on this polecat:\n", style.Warning.Render("⚠"))
+			for _, blocker := range status.Blockers {
+				fmt.Fprintf(w, "    - %s\n", blocker)
+			}
+		}
+		fmt.Fprintln(w, "  Work is in progress; do not nuke until it reaches a terminal state.")
+	case polecat.WorkstateVerdictSafeToNuke:
+		fmt.Fprintf(w, "  Verdict:         %s\n", style.Success.Render(polecat.WorkstateVerdictSafeToNuke))
 		if status.MQStatus != "" {
-			fmt.Printf("  MQ Status:       %s\n", status.MQStatus)
+			fmt.Fprintf(w, "  MQ Status:       %s\n", status.MQStatus)
 		}
-		fmt.Println()
-		fmt.Printf("  %s Safe to nuke - no work at risk.\n", style.Success.Render("✓"))
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "  %s Safe to nuke - no work at risk.\n", style.Success.Render("✓"))
+	default:
+		fmt.Fprintf(w, "  Verdict:         %s\n", style.Error.Render(status.Verdict))
+		if status.MQStatus != "" {
+			fmt.Fprintf(w, "  MQ Status:       %s\n", status.MQStatus)
+		}
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "  %s Unrecognised verdict %q - refusing to report safe. Read --json and investigate.\n", style.Error.Render("✗"), status.Verdict)
+		for _, blocker := range status.Blockers {
+			fmt.Fprintf(w, "    - %s\n", blocker)
+		}
 	}
-
-	return nil
 }
 
 func applyGitStateToWorkstateInput(input *polecat.WorkstateInput, worktreePath string, gitState *GitState, gitErr error) {

--- a/internal/cmd/polecat_check_recovery_test.go
+++ b/internal/cmd/polecat_check_recovery_test.go
@@ -863,3 +863,45 @@ func runCmd(t *testing.T, dir, name string, args ...string) {
 		t.Fatalf("%s %v: %v\n%s", name, args, err, out)
 	}
 }
+
+// safeToNukeMarker is the human-readable line the operator reads before deciding
+// to destroy a polecat. It must appear only for a genuine SAFE_TO_NUKE verdict.
+const safeToNukeMarker = "Safe to nuke"
+
+// TestRenderRecoveryVerdict pins #4631: the text renderer must not present any
+// non-SAFE_TO_NUKE verdict — WORKING in particular — as a green "Safe to nuke",
+// and an unrecognised verdict must fail loud rather than inherit that arm.
+func TestRenderRecoveryVerdict(t *testing.T) {
+	// Range over the exported constant list so a verdict added to workstate.go is
+	// exercised here automatically instead of silently inheriting a default arm.
+	for _, verdict := range polecat.WorkstateVerdicts {
+		t.Run(verdict, func(t *testing.T) {
+			var buf bytes.Buffer
+			renderRecoveryVerdict(&buf, RecoveryStatus{Verdict: verdict})
+			out := buf.String()
+
+			if !strings.Contains(out, verdict) {
+				t.Errorf("output does not name verdict %q:\n%s", verdict, out)
+			}
+			gotSafe := strings.Contains(out, safeToNukeMarker)
+			wantSafe := verdict == polecat.WorkstateVerdictSafeToNuke
+			if gotSafe != wantSafe {
+				t.Errorf("verdict %q: %q present = %v, want %v:\n%s",
+					verdict, safeToNukeMarker, gotSafe, wantSafe, out)
+			}
+		})
+	}
+
+	// An unrecognised verdict must never render as safe-to-nuke.
+	t.Run("unknown", func(t *testing.T) {
+		var buf bytes.Buffer
+		renderRecoveryVerdict(&buf, RecoveryStatus{Verdict: "MADE_UP_VERDICT"})
+		out := buf.String()
+		if strings.Contains(out, safeToNukeMarker) {
+			t.Errorf("unrecognised verdict rendered as safe-to-nuke:\n%s", out)
+		}
+		if !strings.Contains(out, "Unrecognised") {
+			t.Errorf("unrecognised verdict not flagged as unrecognised:\n%s", out)
+		}
+	})
+}

--- a/internal/polecat/workstate.go
+++ b/internal/polecat/workstate.go
@@ -10,6 +10,18 @@ const (
 	WorkstateVerdictNeedsMQSubmit = "NEEDS_MQ_SUBMIT"
 )
 
+// WorkstateVerdicts enumerates every verdict a WorkstateDisposition can carry.
+// Any consumer that renders or branches on a verdict must handle each entry;
+// ranging over this slice in tests catches a new verdict that a switch forgot
+// to cover, instead of letting it inherit a default arm (see #4631).
+var WorkstateVerdicts = []string{
+	WorkstateVerdictWorking,
+	WorkstateVerdictSafeToNuke,
+	WorkstateVerdictPendingMR,
+	WorkstateVerdictNeedsRecovery,
+	WorkstateVerdictNeedsMQSubmit,
+}
+
 // WorkstateInput contains the lifecycle, git, and merge-queue facts needed to
 // classify a polecat consistently across list, recovery, witness, and capacity.
 type WorkstateInput struct {


### PR DESCRIPTION
## Summary

`gt polecat check-recovery`'s **text** output rendered a green `SAFE_TO_NUKE` /
`✓ Safe to nuke - no work at risk.` for the `WORKING` verdict. The renderer's
switch had explicit cases only for `NEEDS_MQ_SUBMIT`, `PENDING_MR` and
`NEEDS_RECOVERY`; both `WORKING` and any future verdict fell through to a
`default:` arm that unconditionally printed the safe-to-nuke line.

It's display-only (JSON output and programmatic consumers were already correct),
but it fails open toward *"safe to destroy"* — on the exact surface a human reads
before deciding to nuke a polecat.

## Related Issue

Fixes #4631

## Changes

- Extract `renderRecoveryVerdict(io.Writer, RecoveryStatus)` out of
  `runPolecatCheckRecovery` so every verdict arm is unit-test-covered (no cobra
  runtime needed).
- Add explicit `WORKING` and `SAFE_TO_NUKE` cases.
- Make `default:` **fail loud** — it now renders the verdict in error style and
  `Unrecognised verdict %q - refusing to report safe`, so an unhandled verdict is
  never mistaken for safe-to-nuke.
- Add `polecat.WorkstateVerdicts` enumerating every verdict, so a verdict added
  to `workstate.go` later is exercised by the table test instead of silently
  inheriting `default:`.

Pure rendering/transport change — no thresholds or heuristics added (ZFC-safe).

## Testing

- [x] Unit tests pass (affected packages: `./internal/cmd/`, `./internal/polecat/`)
- [x] `gofmt` clean, `go vet` clean on touched packages

### Test verification (RED → GREEN)

New table test `TestRenderRecoveryVerdict` ranges over `WorkstateVerdicts` and
asserts `"Safe to nuke"` appears **only** for `SAFE_TO_NUKE`, plus an `unknown`
verdict must fail loud.

**RED** — switch reverted to pre-fix semantics (`WORKING`/unknown fall through to
green default), test only:

```
--- FAIL: TestRenderRecoveryVerdict/WORKING
    polecat_check_recovery_test.go:889: verdict "WORKING": "Safe to nuke" present = true, want false:
          Verdict:         SAFE_TO_NUKE
          ✓ Safe to nuke - no work at risk.
--- FAIL: TestRenderRecoveryVerdict/unknown
    polecat_check_recovery_test.go:901: unrecognised verdict rendered as safe-to-nuke
--- FAIL: TestRenderRecoveryVerdict
```

**GREEN** — with the fix:

```
--- PASS: TestRenderRecoveryVerdict/WORKING
--- PASS: TestRenderRecoveryVerdict/SAFE_TO_NUKE
--- PASS: TestRenderRecoveryVerdict/PENDING_MR
--- PASS: TestRenderRecoveryVerdict/NEEDS_RECOVERY
--- PASS: TestRenderRecoveryVerdict/NEEDS_MQ_SUBMIT
--- PASS: TestRenderRecoveryVerdict/unknown
--- PASS: TestRenderRecoveryVerdict
ok  github.com/steveyegge/gastown/internal/cmd
```

`./internal/polecat/` also passes. Pre-existing failures in `./internal/cmd/`
(`TestExecuteWarrants_*`, `TestCapacitySnapshot*`, `TestAcquirePolecatAdmission*`)
are unrelated — they need a `tmux` binary / warrants boot fixture absent in the
build container and fail identically on unmodified `main`.

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable) — n/a, no user-facing docs enumerate this output
- [x] No breaking changes
