### PR TITLE
fix(git): refuse pushing reserved refs; refuse gt done on detached HEAD

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -77,6 +77,22 @@ const (
 	ExitDeferred  = "DEFERRED"
 )
 
+// gitDetachedHeadName is the literal branch name CurrentBranch reports on a
+// detached HEAD (git rev-parse --abbrev-ref HEAD prints "HEAD", exit 0). The
+// git package uses the same sentinel in StashListForBranch / UnpushedCommits.
+const gitDetachedHeadName = "HEAD"
+
+// errIfDetachedHead refuses gt done when the current branch resolves to the
+// detached-HEAD sentinel. Recording it as branch: and pushing it would create
+// refs/heads/HEAD on the remote, corrupting origin/HEAD in every clone that
+// fetches it. See #4629.
+func errIfDetachedHead(branch string) error {
+	if branch == gitDetachedHeadName {
+		return fmt.Errorf("cannot run gt done from a detached HEAD (HEAD is not on a branch); check out a branch first")
+	}
+	return nil
+}
+
 func doneContaminationBaseRef(defaultBranch, explicitTarget string) string {
 	targetBranch := defaultBranch
 	if explicitTarget != "" {
@@ -700,6 +716,10 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	branch, err := g.CurrentBranch()
 	if err != nil {
 		return fmt.Errorf("getting current branch: %w", err)
+	}
+	// Refuse a detached HEAD before any wisp/push side effects (see #4629).
+	if err := errIfDetachedHead(branch); err != nil {
+		return err
 	}
 
 	// Auto-detect cleanup status if not explicitly provided

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -2234,3 +2234,16 @@ func testRunGit(t *testing.T, dir string, args ...string) {
 		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
 	}
 }
+
+func TestErrIfDetachedHead(t *testing.T) {
+	// The detached-HEAD sentinel that CurrentBranch reports must be refused.
+	if err := errIfDetachedHead(gitDetachedHeadName); err == nil {
+		t.Fatalf("errIfDetachedHead(%q) = nil, want error", gitDetachedHeadName)
+	}
+	// Real branch names must pass through.
+	for _, branch := range []string{"main", "fix/issue-4629", "polecat/slit/hy-f1vw"} {
+		if err := errIfDetachedHead(branch); err != nil {
+			t.Errorf("errIfDetachedHead(%q) = %v, want nil", branch, err)
+		}
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1077,10 +1077,35 @@ func normalizeGitRemoteURL(raw string) string {
 	return strings.ToLower(strings.TrimSuffix(s, "/"))
 }
 
+// reservedRefNames are git pseudo-refs that must never be pushed as a branch:
+// creating e.g. refs/heads/HEAD on the remote de-symbolifies refs/remotes/origin/HEAD
+// in every clone on its next fetch, silently repointing the "default branch" idiom
+// (diff/merge-base/CI) at whatever commit was pushed — with no error. See #4629.
+var reservedRefNames = map[string]bool{
+	"HEAD":       true,
+	"FETCH_HEAD": true,
+	"ORIG_HEAD":  true,
+	"MERGE_HEAD": true,
+}
+
+// refuseReservedRefPush rejects a push whose destination ref is a git pseudo-ref.
+// It is a backstop: a detached-HEAD "gt done" resolves the branch to the literal
+// "HEAD" and would otherwise push refs/heads/HEAD. See #4629.
+func refuseReservedRefPush(refspec string) error {
+	destination := pushDestinationBranch(refspec)
+	if reservedRefNames[destination] {
+		return fmt.Errorf("refusing to push to reserved ref %q: this is almost always a detached-HEAD accident and would corrupt origin/HEAD in every clone that fetches it (no refs were pushed)", destination)
+	}
+	return nil
+}
+
 // Push pushes to the remote branch with a timeout to prevent indefinite hangs
 // when the remote is unreachable.
 func (g *Git) Push(remote, branch string, force bool) error {
 	if err := g.RefuseForkBackedDefaultPush(remote, branch, g.RemoteDefaultBranch()); err != nil {
+		return err
+	}
+	if err := refuseReservedRefPush(branch); err != nil {
 		return err
 	}
 	args := []string{"push", remote, branch}
@@ -1096,6 +1121,9 @@ func (g *Git) Push(remote, branch string, force bool) error {
 // pre-push hook checks to allow integration branch content landing on main.
 func (g *Git) PushWithEnv(remote, branch string, force bool, env []string) error {
 	if err := g.RefuseForkBackedDefaultPush(remote, branch, g.RemoteDefaultBranch()); err != nil {
+		return err
+	}
+	if err := refuseReservedRefPush(branch); err != nil {
 		return err
 	}
 	args := []string{"push", remote, branch}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3820,3 +3820,67 @@ func TestBranchPushedToRemote_NoPushURL(t *testing.T) {
 		t.Errorf("BranchPushedToRemote unpushed = %d, want >= 1", unpushed)
 	}
 }
+
+func TestRefuseReservedRefPush(t *testing.T) {
+	// Reserved destination refs must be refused regardless of refspec spelling.
+	refused := []string{
+		"HEAD",
+		"HEAD:HEAD",
+		"refs/heads/HEAD",
+		"feature:HEAD",
+		"feature:refs/heads/HEAD",
+		"+HEAD:HEAD",
+		"FETCH_HEAD",
+		"ORIG_HEAD",
+		"src:MERGE_HEAD",
+	}
+	for _, refspec := range refused {
+		if err := refuseReservedRefPush(refspec); err == nil {
+			t.Errorf("refuseReservedRefPush(%q) = nil, want refusal", refspec)
+		}
+	}
+
+	// Ordinary branches (including ones that merely contain a reserved name) are allowed.
+	allowed := []string{
+		"main",
+		"feature/HEAD-fix",
+		"polecat/slit/hy-f1vw",
+		"feature:main",
+		"refs/heads/develop",
+	}
+	for _, refspec := range allowed {
+		if err := refuseReservedRefPush(refspec); err != nil {
+			t.Errorf("refuseReservedRefPush(%q) = %v, want nil", refspec, err)
+		}
+	}
+}
+
+// TestPushRefusesDetachedHeadRefspec pins #4629: a detached-HEAD push resolves
+// the branch to the literal "HEAD" and pushes it. The fully-qualified refspec
+// "HEAD:refs/heads/HEAD" is accepted by git (unlike the ambiguous "HEAD:HEAD"),
+// so without the guard it would create refs/heads/HEAD on the remote and
+// de-symbolify origin/HEAD in every clone that fetches it. Push must refuse.
+func TestPushRefusesDetachedHeadRefspec(t *testing.T) {
+	localDir, remoteDir, _ := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+
+	// Detach HEAD onto the current commit.
+	detach := exec.Command("git", "checkout", "--detach", "HEAD")
+	detach.Dir = localDir
+	if out, err := detach.CombinedOutput(); err != nil {
+		t.Fatalf("git checkout --detach: %v\n%s", err, out)
+	}
+
+	if err := g.Push("origin", "HEAD:refs/heads/HEAD", false); err == nil {
+		t.Fatal("Push(origin, HEAD:refs/heads/HEAD) returned nil, want refusal")
+	}
+
+	ls := exec.Command("git", "ls-remote", "--heads", remoteDir)
+	out, err := ls.Output()
+	if err != nil {
+		t.Fatalf("git ls-remote: %v", err)
+	}
+	if strings.Contains(string(out), "refs/heads/HEAD") {
+		t.Fatalf("remote gained refs/heads/HEAD after refused push:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

`gt done` from a **detached HEAD** silently corrupts `origin/HEAD` in every clone.

`CurrentBranch()` returns the literal string `"HEAD"` on a detached HEAD (`git
rev-parse --abbrev-ref HEAD` prints `HEAD` and exits `0`, so a naive capture reads
as success). `gt done` then records `branch: HEAD` and pushes it, creating a real
`refs/heads/HEAD` on the forge. The **next `git fetch` in any clone
de-symbolifies** that clone's `refs/remotes/origin/HEAD`:

```
origin/HEAD -> 4f7c726e...   (an unmerged polecat commit)
origin/main -> 21f5deb4...
```

`origin/HEAD` is the idiom for "the default branch" (diff, merge-base, CI, review
tooling), so every such use now silently reads an unmerged commit in place of
`main` — `git fetch` returns `rc=0`, no warning. It is per-clone: deleting the
remote branch does not repair clones that already fetched it.

## Related Issue

Fixes #4629

## Changes

Both guards are exactly what the issue suggests:

- **Push boundary (root backstop).** `git.Push` / `git.PushWithEnv` now refuse a
  push whose **destination** ref is a git pseudo-ref (`HEAD`, `FETCH_HEAD`,
  `ORIG_HEAD`, `MERGE_HEAD`), reusing the existing `pushDestinationBranch` refspec
  parser (so `HEAD:HEAD`, `HEAD:refs/heads/HEAD`, `+feature:HEAD`, … are all
  caught). This protects every push path, present and future. Mirrors the sibling
  `RefuseForkBackedDefaultPush` guard already invoked there.
- **`gt done` up front.** Refuses a detached HEAD before any wisp/push side
  effects, with a message naming the state, via `errIfDetachedHead`. It uses the
  same `"HEAD"` sentinel the git package already relies on in
  `StashListForBranch` / `UnpushedCommits`.

No thresholds/heuristics added (ZFC-safe). `CurrentBranch`'s existing contract
(and `TestCurrentBranch`) is left untouched.

## Testing

- [x] `go test ./internal/git/` — all pass
- [x] `go test ./internal/cmd/` — all pass (with `tmux` present)
- [x] `gofmt` clean, `go vet` clean on both packages

### Test verification (RED → GREEN)

Note: modern git refuses the *ambiguous* `HEAD:HEAD`, but accepts the
fully-qualified `HEAD:refs/heads/HEAD` — which is what actually creates
`refs/heads/HEAD` (reproduced below). The tests use that form.

**RED** (guards reverted to pre-fix behavior, new tests only):

```
--- FAIL: TestPushRefusesDetachedHeadRefspec
    git_test.go:3875: Push(origin, HEAD:refs/heads/HEAD) returned nil, want refusal
--- FAIL: TestRefuseReservedRefPush
    git_test.go:3839: refuseReservedRefPush("feature:HEAD") = nil, want refusal
    git_test.go:3839: refuseReservedRefPush("FETCH_HEAD") = nil, want refusal
    ... (ORIG_HEAD, src:MERGE_HEAD, refs/heads/HEAD, +HEAD:HEAD)
--- FAIL: TestErrIfDetachedHead
    done_test.go:2241: errIfDetachedHead("HEAD") = nil, want error
```

Reproduction that RED is real (unmodified git creating the bad ref):

```
$ git checkout --detach HEAD && git push origin HEAD:refs/heads/HEAD
 * [new branch]      HEAD -> HEAD
$ git ls-remote --heads origin
7bce02f4...   refs/heads/HEAD
```

**GREEN** (with the fix):

```
--- PASS: TestRefuseReservedRefPush
--- PASS: TestPushRefusesDetachedHeadRefspec
--- PASS: TestErrIfDetachedHead
--- PASS: TestCurrentBranch        (existing sentinel contract unchanged)
ok  github.com/steveyegge/gastown/internal/git
ok  github.com/steveyegge/gastown/internal/cmd
```

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable) — n/a
- [x] No breaking changes
