### PR TITLE
fix(sling): default base_branch to the rig's configured branch, not literal "main"

### DIFF
--- a/internal/cmd/sling_288_test.go
+++ b/internal/cmd/sling_288_test.go
@@ -663,7 +663,7 @@ exit /b 1
 			t.Setenv("BEADS_DB", "stale")
 			t.Setenv("BD_DB", "stale")
 
-			rootID, err := bondFormulaDirect("mol-polecat-work", "mol-polecat-work", tc.beadID, formulaWorkDir, townRoot, formulaVarsForBead("mol-polecat-work", tc.beadID, "Test", nil))
+			rootID, err := bondFormulaDirect("mol-polecat-work", "mol-polecat-work", tc.beadID, formulaWorkDir, townRoot, formulaVarsForBead("mol-polecat-work", tc.beadID, "Test", nil, townRoot))
 			if err != nil {
 				t.Fatalf("bondFormulaDirect: %v", err)
 			}

--- a/internal/cmd/sling_basebranch_test.go
+++ b/internal/cmd/sling_basebranch_test.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/constants"
+)
+
+// writeRigRoute wires a bead prefix to a rig directory and writes that rig's
+// config.json, so beads.GetRigPathForPrefix + rig.LoadRigConfig can resolve the
+// rig's default branch from a bead ID during the test.
+func writeRigRoute(t *testing.T, townRoot, prefix, rigDir, configJSON string) {
+	t.Helper()
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0700); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	route := `{"prefix":"` + prefix + `","path":"` + rigDir + `"}` + "\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(route), 0600); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	rigPath := filepath.Join(townRoot, rigDir)
+	if err := os.MkdirAll(rigPath, 0700); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	if configJSON != "" {
+		if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte(configJSON), 0600); err != nil {
+			t.Fatalf("write config.json: %v", err)
+		}
+	}
+}
+
+func TestResolveFormulaBaseBranch(t *testing.T) {
+	t.Run("uses rig config default_branch when it is not main", func(t *testing.T) {
+		townRoot := t.TempDir()
+		writeRigRoute(t, townRoot, "feat-", "featrig", `{"default_branch":"develop"}`)
+
+		if got := resolveFormulaBaseBranch(townRoot, "feat-123"); got != "develop" {
+			t.Fatalf("resolveFormulaBaseBranch = %q, want %q", got, "develop")
+		}
+	})
+
+	t.Run("falls back to main when the bead has no rig route", func(t *testing.T) {
+		townRoot := t.TempDir()
+		if got := resolveFormulaBaseBranch(townRoot, "unknown-1"); got != constants.BranchMain {
+			t.Fatalf("resolveFormulaBaseBranch = %q, want %q", got, constants.BranchMain)
+		}
+	})
+
+	t.Run("falls back to main when rig config omits default_branch", func(t *testing.T) {
+		townRoot := t.TempDir()
+		writeRigRoute(t, townRoot, "bare-", "barerig", `{}`)
+		if got := resolveFormulaBaseBranch(townRoot, "bare-9"); got != constants.BranchMain {
+			t.Fatalf("resolveFormulaBaseBranch = %q, want %q", got, constants.BranchMain)
+		}
+	})
+}
+
+func TestEnsureFormulaRequiredVars_UsesResolvedDefaultBranch(t *testing.T) {
+	t.Run("applies the resolved default branch when base_branch is absent", func(t *testing.T) {
+		vars := ensureFormulaRequiredVars("mol-polecat-work", nil, "develop")
+		if !containsVar(vars, "base_branch=develop") {
+			t.Fatalf("vars = %v, want base_branch=develop", vars)
+		}
+		if containsVar(vars, "base_branch=main") {
+			t.Fatalf("vars = %v, must not default base_branch to main on a non-main rig", vars)
+		}
+	})
+
+	t.Run("does not override an explicit base_branch", func(t *testing.T) {
+		vars := ensureFormulaRequiredVars("mol-polecat-work", []string{"base_branch=release-2"}, "develop")
+		if !containsVar(vars, "base_branch=release-2") {
+			t.Fatalf("vars = %v, want explicit base_branch=release-2 preserved", vars)
+		}
+		if containsVar(vars, "base_branch=develop") {
+			t.Fatalf("vars = %v, resolved default must not override an explicit base_branch", vars)
+		}
+	})
+
+	t.Run("falls back to main when no default branch is resolved", func(t *testing.T) {
+		vars := ensureFormulaRequiredVars("mol-polecat-work", nil, "")
+		if !containsVar(vars, "base_branch="+constants.BranchMain) {
+			t.Fatalf("vars = %v, want base_branch=%s", vars, constants.BranchMain)
+		}
+	})
+}
+
+func TestFormulaVarsForBead_ResolvesBaseBranchFromRig(t *testing.T) {
+	townRoot := t.TempDir()
+	writeRigRoute(t, townRoot, "feat-", "featrig", `{"default_branch":"develop"}`)
+
+	vars := formulaVarsForBead("mol-polecat-work", "feat-1", "Title", nil, townRoot)
+
+	if !containsVar(vars, "base_branch=develop") {
+		t.Fatalf("vars = %v, want base_branch resolved from rig config (develop), not the literal main", vars)
+	}
+	if !containsVar(vars, "feature=Title") || !containsVar(vars, "issue=feat-1") {
+		t.Fatalf("vars = %v, missing feature/issue vars", vars)
+	}
+}
+
+func containsVar(vars []string, want string) bool {
+	for _, v := range vars {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -1060,7 +1060,7 @@ func InstantiateFormulaOnBead(ctx context.Context, formulaName, beadID, title, h
 		telemetry.RecordMolCook(ctx, formulaName, nil)
 	}
 
-	formulaVars := formulaVarsForBead(formulaName, beadID, title, extraVars)
+	formulaVars := formulaVarsForBead(formulaName, beadID, title, extraVars, townRoot)
 	wispRootID, err := bondFormulaDirect(resolvedFormula, formulaName, beadID, formulaWorkDir, townRoot, formulaVars)
 	if err != nil {
 		return nil, fmt.Errorf("bonding formula %s to bead %s: %w", formulaName, beadID, err)
@@ -1074,13 +1074,30 @@ func InstantiateFormulaOnBead(ctx context.Context, formulaName, beadID, title, h
 	}, nil
 }
 
-func formulaVarsForBead(formulaName, beadID, title string, extraVars []string) []string {
+func formulaVarsForBead(formulaName, beadID, title string, extraVars []string, townRoot string) []string {
 	formulaVars := []string{
 		fmt.Sprintf("feature=%s", title),
 		fmt.Sprintf("issue=%s", beadID),
 	}
 	formulaVars = append(formulaVars, extraVars...)
-	return ensureFormulaRequiredVars(formulaName, formulaVars)
+	return ensureFormulaRequiredVars(formulaName, formulaVars, resolveFormulaBaseBranch(townRoot, beadID))
+}
+
+// resolveFormulaBaseBranch returns the configured default branch of the rig that
+// owns beadID, falling back to constants.BranchMain when no rig config is
+// available. It mirrors the default-branch resolution already used by
+// polecat/manager.go, cmd/rig.go, and cmd/prime_molecule.go, so a formula var
+// default never points a rig whose default branch is not "main" at a
+// nonexistent branch (issue #4586).
+func resolveFormulaBaseBranch(townRoot, beadID string) string {
+	rigPath := beads.GetRigPathForPrefix(townRoot, beads.ExtractPrefix(beadID))
+	if rigPath == "" {
+		return constants.BranchMain
+	}
+	if rigCfg, err := rigpkg.LoadRigConfig(rigPath); err == nil && rigCfg.DefaultBranch != "" {
+		return rigCfg.DefaultBranch
+	}
+	return constants.BranchMain
 }
 
 // bondFormulaDirect attaches a formula to a bead through bd's canonical bond path.
@@ -1156,10 +1173,14 @@ func parseBondSpawnRootIDWithStatus(bondOut []byte, formulaName, beadID, fallbac
 
 // ensureFormulaRequiredVars appends missing required vars for formulas that enforce
 // strict var presence on direct bond paths.
-func ensureFormulaRequiredVars(formulaName string, vars []string) []string {
+func ensureFormulaRequiredVars(formulaName string, vars []string, defaultBranch string) []string {
 	// Currently only mol-polecat-work has strict required vars on bond.
 	if formulaName != "mol-polecat-work" && formulaName != "polecat-work" {
 		return vars
+	}
+
+	if defaultBranch == "" {
+		defaultBranch = constants.BranchMain
 	}
 
 	seen := make(map[string]bool, len(vars))
@@ -1173,7 +1194,7 @@ func ensureFormulaRequiredVars(formulaName string, vars []string) []string {
 		Key   string
 		Value string
 	}{
-		{"base_branch", "main"},
+		{"base_branch", defaultBranch},
 		{"setup_command", ""},
 		{"typecheck_command", ""},
 		{"lint_command", ""},


### PR DESCRIPTION
## Summary

`ensureFormulaRequiredVars` supplied the formula var `base_branch=main` as a flat literal whenever a `mol-polecat-work` bond omitted it, ignoring the rig's configured `default_branch`. On a rig whose default branch is not `main`, such a bond is pointed at a branch that does not exist.

This resolves the default from rig config the same way every comparable call site already does — `internal/polecat/manager.go`, `internal/cmd/rig.go`, and `internal/cmd/prime_molecule.go` all `LoadRigConfig` first and fall back to `main` only as a last resort. `ensureFormulaRequiredVars` was the sole outlier.

## Related Issue

Fixes #4586

## Changes

- Add `resolveFormulaBaseBranch(townRoot, beadID)` — resolves the owning rig's `default_branch` via `beads.GetRigPathForPrefix` + `rig.LoadRigConfig`, falling back to `constants.BranchMain` when no rig config is available. It mirrors the established default-branch idiom rather than inventing a new one.
- `ensureFormulaRequiredVars` now takes the resolved default branch instead of the hardcoded `"main"`. An explicit `base_branch` var still wins (unchanged `seen` guard).
- Thread `townRoot` through `formulaVarsForBead` so the resolution has town context. All call sites updated.
- Scope is limited to the single `base_branch` default site called out in the issue. The empty-string command-var defaults (#4585) and the optional `RefExists` validation are intentionally left out.

## Testing

- [x] Unit tests pass (`go test ./internal/cmd/`)
- [x] Manual testing performed (Docker `golang:1.26` + `libicu-dev`)

### Test verification (RED → GREEN)

New tests in `internal/cmd/sling_basebranch_test.go` write a rig with `default_branch: develop` and assert the resulting `base_branch` var.

**RED** — revert only the `base_branch` value to the literal `"main"` and run the new tests:

```
--- FAIL: TestEnsureFormulaRequiredVars_UsesResolvedDefaultBranch/applies_the_resolved_default_branch_when_base_branch_is_absent
    sling_basebranch_test.go:65: vars = [base_branch=main setup_command= ...], want base_branch=develop
--- FAIL: TestFormulaVarsForBead_ResolvesBaseBranchFromRig
    sling_basebranch_test.go:97: vars = [feature=Title issue=feat-1 base_branch=main ...], want base_branch resolved from rig config (develop), not the literal main
FAIL	github.com/steveyegge/gastown/internal/cmd
```

**GREEN** — on this branch:

```
--- PASS: TestResolveFormulaBaseBranch (3 subtests)
--- PASS: TestEnsureFormulaRequiredVars_UsesResolvedDefaultBranch (3 subtests)
--- PASS: TestFormulaVarsForBead_ResolvesBaseBranchFromRig
ok  	github.com/steveyegge/gastown/internal/cmd	0.093s
```

**No regression** — full `go test -short ./internal/cmd/`: 1309 → 1311 passing (the two new top-level tests), with the same 8 pre-existing environment-dependent failures (missing `tmux`/`bd`/Dolt) on both `main` and this branch. Changed production lines are covered 100% by the new tests. `gofmt` and `go vet` clean on the changed files.

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable) — n/a, no user-facing docs enumerate this default
- [x] No breaking changes
