### PR TITLE
fix(plugin): skip town-disabled plugins during sync

### DIFF
--- a/internal/cmd/plugin.go
+++ b/internal/cmd/plugin.go
@@ -542,7 +542,7 @@ func runPluginSync(cmd *cobra.Command, args []string) error {
 	targetDir := filepath.Join(townRoot, "plugins")
 
 	if pluginSyncDryRun {
-		report, err := plugin.DetectDrift(sourceDir, targetDir)
+		report, err := plugin.DetectDrift(townRoot, sourceDir, targetDir)
 		if err != nil {
 			return fmt.Errorf("detecting drift: %w", err)
 		}
@@ -550,6 +550,8 @@ func runPluginSync(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s Plugin sync dry run\n", style.Bold.Render("Plugin sync:"))
 		fmt.Printf("  Source: %s\n", sourceDir)
 		fmt.Printf("  Target: %s\n\n", targetDir)
+
+		printDisabledPlugins(report.Disabled)
 
 		if !report.HasDrift() && len(report.Extra) == 0 {
 			fmt.Printf("  %s All plugins up to date\n", style.Success.Render("✓"))
@@ -570,10 +572,12 @@ func runPluginSync(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	result, err := plugin.SyncPlugins(sourceDir, targetDir, pluginSyncClean)
+	result, err := plugin.SyncPlugins(townRoot, sourceDir, targetDir, pluginSyncClean)
 	if err != nil {
 		return fmt.Errorf("syncing plugins: %w", err)
 	}
+
+	printDisabledPlugins(result.Disabled)
 
 	if len(result.Copied) == 0 && len(result.Removed) == 0 {
 		fmt.Printf("%s Plugins already up to date (%d checked)\n",
@@ -597,6 +601,25 @@ func runPluginSync(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// printDisabledPlugins names every plugin sync refused to install and the
+// marker directory that vetoed it, so an operator never has to guess why a
+// plugin present in the source did not appear in the runtime.
+//
+// A marker for a plugin that is currently installed gets a louder line: the
+// skip-list is append-only and nobody prunes it, so that combination usually
+// means the marker is stale and the plugin is being frozen by accident.
+func printDisabledPlugins(disabled []plugin.DisabledPlugin) {
+	for _, d := range disabled {
+		if d.Installed {
+			fmt.Printf("  %s %s (skipped, but currently INSTALLED — marker %s/%s may be stale; %s will not receive source updates)\n",
+				style.Warning.Render("⚠"), d.Name, plugin.DisabledPluginsDir, d.Marker, d.Name)
+			continue
+		}
+		fmt.Printf("  %s %s (skipped: disabled town-wide by %s/%s)\n",
+			style.Warning.Render("⊘"), d.Name, plugin.DisabledPluginsDir, d.Marker)
+	}
 }
 
 func runPluginHistory(cmd *cobra.Command, args []string) error {

--- a/internal/doctor/patrol_check.go
+++ b/internal/doctor/patrol_check.go
@@ -425,8 +425,10 @@ func (c *PatrolPluginsAccessibleCheck) Fix(ctx *CheckContext) error {
 // PatrolPluginDriftCheck detects when runtime plugins are out of sync with source.
 type PatrolPluginDriftCheck struct {
 	FixableCheck
+	townRoot  string
 	sourceDir string
 	targetDir string
+	disabled  []plugin.DisabledPlugin
 }
 
 // NewPatrolPluginDriftCheck creates a new plugin drift check.
@@ -444,6 +446,7 @@ func NewPatrolPluginDriftCheck() *PatrolPluginDriftCheck {
 
 // Run checks for plugin drift between source and runtime.
 func (c *PatrolPluginDriftCheck) Run(ctx *CheckContext) *CheckResult {
+	c.townRoot = ctx.TownRoot
 	c.targetDir = filepath.Join(ctx.TownRoot, "plugins")
 
 	sourceDir, err := plugin.FindGastownSource(ctx.TownRoot)
@@ -467,7 +470,7 @@ func (c *PatrolPluginDriftCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	report, err := plugin.DetectDrift(sourceDir, c.targetDir)
+	report, err := plugin.DetectDrift(ctx.TownRoot, sourceDir, c.targetDir)
 	if err != nil {
 		return &CheckResult{
 			Name:    c.Name(),
@@ -476,16 +479,30 @@ func (c *PatrolPluginDriftCheck) Run(ctx *CheckContext) *CheckResult {
 			Details: []string{err.Error()},
 		}
 	}
+	c.disabled = report.Disabled
+
+	var disabledDetails []string
+	for _, d := range report.Disabled {
+		if d.Installed {
+			disabledDetails = append(disabledDetails,
+				fmt.Sprintf("%s: installed but on the skip-list; marker %s/%s may be stale, %s is frozen at its installed version",
+					d.Name, plugin.DisabledPluginsDir, d.Marker, d.Name))
+			continue
+		}
+		disabledDetails = append(disabledDetails,
+			fmt.Sprintf("%s: not synced, disabled town-wide by %s/%s", d.Name, plugin.DisabledPluginsDir, d.Marker))
+	}
 
 	if !report.HasDrift() {
 		return &CheckResult{
 			Name:    c.Name(),
 			Status:  StatusOK,
 			Message: "Runtime plugins match source",
+			Details: disabledDetails,
 		}
 	}
 
-	var details []string
+	details := disabledDetails
 	for _, d := range report.Drifted {
 		details = append(details, fmt.Sprintf("%s: content differs", d.Name))
 	}
@@ -507,7 +524,20 @@ func (c *PatrolPluginDriftCheck) Fix(ctx *CheckContext) error {
 	if c.sourceDir == "" || c.targetDir == "" {
 		return fmt.Errorf("drift check did not run; cannot fix")
 	}
-	_, err := plugin.SyncPlugins(c.sourceDir, c.targetDir, false)
+	result, err := plugin.SyncPlugins(c.townRoot, c.sourceDir, c.targetDir, false)
+	if result != nil {
+		// This fix runs unattended (patrol formulas reach it via
+		// 'gt doctor --fix'), so name every veto in the transcript.
+		for _, d := range result.Disabled {
+			if d.Installed {
+				fmt.Fprintf(os.Stderr, "patrol-plugin-drift: WARNING: %s is on the skip-list but is currently installed; marker %s/%s may be stale and %s is frozen at its installed version\n",
+					d.Name, plugin.DisabledPluginsDir, d.Marker, d.Name)
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "patrol-plugin-drift: skipped %s (disabled town-wide by %s/%s)\n",
+				d.Name, plugin.DisabledPluginsDir, d.Marker)
+		}
+	}
 	return err
 }
 

--- a/internal/doctor/patrol_plugin_drift_test.go
+++ b/internal/doctor/patrol_plugin_drift_test.go
@@ -1,0 +1,79 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestPlugin(t *testing.T, dir, name string) {
+	t.Helper()
+	pluginDir := filepath.Join(dir, name)
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := "+++\nname = \"" + name + "\"\n+++\ninstructions"
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.md"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestPatrolPluginDriftCheck_DisabledPluginNotResurrected covers the path that
+// actually re-armed disabled plugins in production: a patrol formula reaching
+// 'gt doctor --fix', which runs this check's Fix without a human present.
+func TestPatrolPluginDriftCheck_DisabledPluginNotResurrected(t *testing.T) {
+	townRoot := t.TempDir()
+	sourceDir := filepath.Join(townRoot, "gastown", "plugins")
+	targetDir := filepath.Join(townRoot, "plugins")
+
+	writeTestPlugin(t, sourceDir, "rebuild-gt")
+	writeTestPlugin(t, sourceDir, "github-sheriff")
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Chdir away from the gastown checkout so source resolution falls through
+	// to the town candidates instead of this repo's own plugins/ directory.
+	t.Chdir(t.TempDir())
+
+	marker := filepath.Join(townRoot, ".disabled-plugins", "rebuild-gt.town.redisabled-20260806")
+	if err := os.MkdirAll(marker, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &CheckContext{TownRoot: townRoot}
+	check := NewPatrolPluginDriftCheck()
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected drift warning for github-sheriff, got %s: %s", result.Status, result.Message)
+	}
+	if len(check.disabled) != 1 || check.disabled[0].Name != "rebuild-gt" {
+		t.Errorf("expected rebuild-gt recorded as disabled, got %+v", check.disabled)
+	}
+
+	if err := check.Fix(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "github-sheriff", "plugin.md")); err != nil {
+		t.Errorf("github-sheriff should have been synced: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "rebuild-gt")); !os.IsNotExist(err) {
+		t.Fatalf("doctor --fix resurrected a disabled plugin: %v", err)
+	}
+
+	// Marker gone: the same check must install it again, or "skipped" was
+	// proving nothing.
+	if err := os.RemoveAll(marker); err != nil {
+		t.Fatal(err)
+	}
+	if result := check.Run(ctx); result.Status != StatusWarning {
+		t.Fatalf("expected rebuild-gt to register as drift again, got %s: %s", result.Status, result.Message)
+	}
+	if err := check.Fix(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "rebuild-gt", "plugin.md")); err != nil {
+		t.Errorf("rebuild-gt should sync once the marker is removed: %v", err)
+	}
+}

--- a/internal/plugin/disabled.go
+++ b/internal/plugin/disabled.go
@@ -1,0 +1,77 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DisabledPluginsDir is the town-level directory where operators park plugins
+// that must not be reinstalled. Entries are archived plugin directories whose
+// names carry provenance and a date, e.g.
+//
+//	rebuild-gt.town.redisabled-20260806
+//	dolt-archive.DEN-SOURCE.removed-20260806
+//	tool-updater.rig.redisabled-20260714
+//
+// so the plugin name is the prefix up to the first dot, never the whole
+// directory name.
+const DisabledPluginsDir = ".disabled-plugins"
+
+// DisabledPlugin records a plugin name that is blocked from sync, and the
+// marker directory that blocks it.
+type DisabledPlugin struct {
+	Name   string // plugin name, e.g. "rebuild-gt"
+	Marker string // directory under .disabled-plugins/ that blocked it
+
+	// Installed reports that the runtime already has this plugin, which makes
+	// the marker suspect: something disabled it, yet it is running. Set by
+	// SyncPlugins and DetectDrift, which know the target; always false from
+	// LoadDisabledPlugins, which does not.
+	Installed bool
+}
+
+// LoadDisabledPlugins reads <townRoot>/.disabled-plugins and returns the plugin
+// names an operator has deliberately disabled town-wide, keyed by plugin name.
+//
+// This is a positive record of operator intent, so it holds regardless of which
+// source directory sync resolves to, who invokes sync, or from which working
+// directory. A missing or unreadable directory yields an empty set: the guard
+// only ever removes names from a sync, it never blocks one from running.
+func LoadDisabledPlugins(townRoot string) map[string]DisabledPlugin {
+	disabled := make(map[string]DisabledPlugin)
+	if townRoot == "" {
+		return disabled
+	}
+
+	entries, err := os.ReadDir(filepath.Join(townRoot, DisabledPluginsDir))
+	if err != nil {
+		return disabled
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		name := disabledPluginName(entry.Name())
+		if name == "" {
+			continue
+		}
+		// ReadDir is sorted, so the first marker for a name wins
+		// deterministically. Any single marker is sufficient evidence.
+		if _, ok := disabled[name]; !ok {
+			disabled[name] = DisabledPlugin{Name: name, Marker: entry.Name()}
+		}
+	}
+	return disabled
+}
+
+// disabledPluginName extracts the plugin name from a marker directory name.
+// Markers are "<plugin>.<provenance>.<when>"; the name is everything before the
+// first dot. A marker with no dot is already a bare plugin name.
+func disabledPluginName(dirName string) string {
+	if i := strings.IndexByte(dirName, '.'); i >= 0 {
+		return dirName[:i]
+	}
+	return dirName
+}

--- a/internal/plugin/disabled_test.go
+++ b/internal/plugin/disabled_test.go
@@ -1,0 +1,285 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// markDisabled creates a marker directory under <townRoot>/.disabled-plugins/.
+// dirName is the full archive name, suffixes and all — markers in a real town
+// are never bare plugin names.
+func markDisabled(t *testing.T, townRoot, dirName string) string {
+	t.Helper()
+	path := filepath.Join(townRoot, DisabledPluginsDir, dirName)
+	if err := os.MkdirAll(path, 0755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestDisabledPluginName(t *testing.T) {
+	// Names taken from a live town's .disabled-plugins/ — matching the whole
+	// directory name instead of the prefix is the failure this guards against.
+	tests := []struct {
+		dirName string
+		want    string
+	}{
+		{"dolt-archive.DEN-SOURCE.removed-20260806", "dolt-archive"},
+		{"rebuild-gt.town.redisabled-20260806", "rebuild-gt"},
+		{"tool-updater.rig.redisabled-20260714", "tool-updater"},
+		{"compactor-dog.plugins.re-disabled-20260604-103030", "compactor-dog"},
+		{"rate-limit-watchdog.town", "rate-limit-watchdog"},
+		{"rebuild-gt", "rebuild-gt"}, // bare name, no suffix
+	}
+	for _, tt := range tests {
+		if got := disabledPluginName(tt.dirName); got != tt.want {
+			t.Errorf("disabledPluginName(%q) = %q, want %q", tt.dirName, got, tt.want)
+		}
+	}
+}
+
+func TestLoadDisabledPlugins(t *testing.T) {
+	townRoot := t.TempDir()
+	markDisabled(t, townRoot, "rebuild-gt.town.redisabled-20260806")
+	markDisabled(t, townRoot, "dolt-archive.DEN-SOURCE.removed-20260806")
+	markDisabled(t, townRoot, "dolt-archive.plugins.redisabled-20260714") // second marker, same plugin
+
+	disabled := LoadDisabledPlugins(townRoot)
+	if len(disabled) != 2 {
+		t.Fatalf("expected 2 disabled plugin names, got %d: %v", len(disabled), disabled)
+	}
+	if d, ok := disabled["rebuild-gt"]; !ok || d.Marker != "rebuild-gt.town.redisabled-20260806" {
+		t.Errorf("rebuild-gt not blocked correctly: %+v (ok=%v)", d, ok)
+	}
+	// ReadDir is sorted, so the marker reported is deterministic.
+	if d, ok := disabled["dolt-archive"]; !ok || d.Marker != "dolt-archive.DEN-SOURCE.removed-20260806" {
+		t.Errorf("dolt-archive not blocked correctly: %+v (ok=%v)", d, ok)
+	}
+}
+
+func TestLoadDisabledPlugins_NoDirectory(t *testing.T) {
+	if disabled := LoadDisabledPlugins(t.TempDir()); len(disabled) != 0 {
+		t.Errorf("expected empty set with no .disabled-plugins dir, got %v", disabled)
+	}
+	if disabled := LoadDisabledPlugins(""); len(disabled) != 0 {
+		t.Errorf("expected empty set for empty townRoot, got %v", disabled)
+	}
+}
+
+func TestLoadDisabledPlugins_IgnoresFilesAndDotEntries(t *testing.T) {
+	townRoot := t.TempDir()
+	disabledDir := filepath.Join(townRoot, DisabledPluginsDir)
+	if err := os.MkdirAll(disabledDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(disabledDir, "notes.md"), []byte("why we disabled these"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	markDisabled(t, townRoot, ".hidden-archive")
+
+	if disabled := LoadDisabledPlugins(townRoot); len(disabled) != 0 {
+		t.Errorf("expected files and dot entries to be ignored, got %v", disabled)
+	}
+}
+
+// TestSyncPlugins_DisabledBothDirections is the load-bearing test: the same
+// source and town, synced twice, differing only in whether the marker exists.
+// A guard verified in one direction only is not known to work.
+func TestSyncPlugins_DisabledBothDirections(t *testing.T) {
+	townRoot := t.TempDir()
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(townRoot, "plugins")
+
+	createTestPlugin(t, srcDir, "rebuild-gt", "+++\nname = \"rebuild-gt\"\n+++\nrebuild the binary", nil)
+	createTestPlugin(t, srcDir, "github-sheriff", "+++\nname = \"github-sheriff\"\n+++\nsheriff", nil)
+
+	// Direction 1: marker present -> rebuild-gt must not be installed.
+	marker := markDisabled(t, townRoot, "rebuild-gt.town.redisabled-20260806")
+
+	result, err := SyncPlugins(townRoot, srcDir, dstDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Copied) != 1 || result.Copied[0] != "github-sheriff" {
+		t.Errorf("expected only github-sheriff copied, got %v", result.Copied)
+	}
+	if len(result.Disabled) != 1 || result.Disabled[0].Name != "rebuild-gt" {
+		t.Fatalf("expected rebuild-gt reported as disabled, got %+v", result.Disabled)
+	}
+	// Not installed, so the marker is doing exactly its job — no stale warning.
+	if result.Disabled[0].Installed {
+		t.Errorf("rebuild-gt is not installed; it must not be flagged as a stale marker")
+	}
+	if result.Disabled[0].Marker != "rebuild-gt.town.redisabled-20260806" {
+		t.Errorf("expected the marker dirname in the result, got %q", result.Disabled[0].Marker)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "rebuild-gt")); !os.IsNotExist(err) {
+		t.Fatalf("rebuild-gt was resurrected into the runtime: %v", err)
+	}
+
+	// Direction 2: same source, marker removed -> rebuild-gt must be installed.
+	// Without this the "skip" could be an artifact of anything at all.
+	if err := os.RemoveAll(marker); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err = SyncPlugins(townRoot, srcDir, dstDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Copied) != 1 || result.Copied[0] != "rebuild-gt" {
+		t.Errorf("expected rebuild-gt copied after marker removal, got %v", result.Copied)
+	}
+	if len(result.Disabled) != 0 {
+		t.Errorf("expected nothing disabled after marker removal, got %+v", result.Disabled)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "rebuild-gt", "plugin.md")); err != nil {
+		t.Errorf("rebuild-gt not installed after marker removal: %v", err)
+	}
+}
+
+// TestSyncPlugins_DisabledMatchesPrefixNotWholeName pins the name-matching rule:
+// markers carry provenance suffixes, so a whole-name comparison would match
+// nothing and the guard would silently pass while copying the plugin.
+func TestSyncPlugins_DisabledMatchesPrefixNotWholeName(t *testing.T) {
+	townRoot := t.TempDir()
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(townRoot, "plugins")
+
+	createTestPlugin(t, srcDir, "dolt-archive", "+++\nname = \"dolt-archive\"\n+++\narchive", nil)
+	markDisabled(t, townRoot, "dolt-archive.DEN-SOURCE.removed-20260806")
+
+	result, err := SyncPlugins(townRoot, srcDir, dstDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Copied) != 0 {
+		t.Errorf("suffixed marker failed to block the plugin, copied %v", result.Copied)
+	}
+	if len(result.Disabled) != 1 {
+		t.Errorf("expected dolt-archive reported as disabled, got %+v", result.Disabled)
+	}
+}
+
+// TestSyncPlugins_DisabledDoesNotOverMatch guards the other side of prefix
+// matching: a marker must block exactly its own plugin, not neighbours that
+// merely share a leading substring.
+func TestSyncPlugins_DisabledDoesNotOverMatch(t *testing.T) {
+	townRoot := t.TempDir()
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(townRoot, "plugins")
+
+	createTestPlugin(t, srcDir, "rebuild-gt-docs", "+++\nname = \"rebuild-gt-docs\"\n+++\ndocs", nil)
+	markDisabled(t, townRoot, "rebuild-gt.town.redisabled-20260806")
+
+	result, err := SyncPlugins(townRoot, srcDir, dstDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Copied) != 1 || result.Copied[0] != "rebuild-gt-docs" {
+		t.Errorf("expected rebuild-gt-docs to sync normally, copied %v disabled %+v", result.Copied, result.Disabled)
+	}
+}
+
+// TestSyncPlugins_DisabledNotRemovedByClean pins the blast radius of a stale
+// marker. Markers accumulate over months and a re-enabled plugin can still have
+// old ones (compactor-dog did, in the town this bead came from), so a marker
+// must only withhold updates — never escalate into deleting a live plugin.
+func TestSyncPlugins_DisabledNotRemovedByClean(t *testing.T) {
+	townRoot := t.TempDir()
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(townRoot, "plugins")
+
+	createTestPlugin(t, srcDir, "compactor-dog", "+++\nname = \"compactor-dog\"\n+++\nnew version", nil)
+	createTestPlugin(t, dstDir, "compactor-dog", "+++\nname = \"compactor-dog\"\n+++\ninstalled version", nil)
+	markDisabled(t, townRoot, "compactor-dog.disabled-20260604-072900")
+
+	result, err := SyncPlugins(townRoot, srcDir, dstDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Removed) != 0 {
+		t.Errorf("clean mode removed a disabled plugin, got %v", result.Removed)
+	}
+	if len(result.Copied) != 0 {
+		t.Errorf("disabled plugin was updated from source, got %v", result.Copied)
+	}
+	// The contradiction — marked disabled, yet running — must be flagged, not
+	// absorbed silently.
+	if len(result.Disabled) != 1 || !result.Disabled[0].Installed {
+		t.Errorf("expected the skipped plugin flagged as installed, got %+v", result.Disabled)
+	}
+	installed, err := os.ReadFile(filepath.Join(dstDir, "compactor-dog", "plugin.md"))
+	if err != nil {
+		t.Fatalf("disabled plugin did not survive clean sync: %v", err)
+	}
+	if !strings.Contains(string(installed), "installed version") {
+		t.Errorf("installed copy was overwritten from source: %q", installed)
+	}
+}
+
+func TestDetectDrift_DisabledIsNotDrift(t *testing.T) {
+	townRoot := t.TempDir()
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(townRoot, "plugins")
+	if err := os.MkdirAll(dstDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	createTestPlugin(t, srcDir, "rebuild-gt", "+++\nname = \"rebuild-gt\"\n+++\nrebuild", nil)
+	marker := markDisabled(t, townRoot, "rebuild-gt.town.redisabled-20260806")
+
+	report, err := DetectDrift(townRoot, srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.HasDrift() {
+		t.Errorf("disabled plugin reported as drift: missing=%v drifted=%v", report.Missing, report.Drifted)
+	}
+	if len(report.Disabled) != 1 || report.Disabled[0].Name != "rebuild-gt" {
+		t.Errorf("expected rebuild-gt reported as disabled, got %+v", report.Disabled)
+	}
+
+	// Other direction: without the marker it is ordinary drift again.
+	if err := os.RemoveAll(marker); err != nil {
+		t.Fatal(err)
+	}
+	report, err = DetectDrift(townRoot, srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.HasDrift() || len(report.Missing) != 1 || report.Missing[0] != "rebuild-gt" {
+		t.Errorf("expected rebuild-gt as drift after marker removal, got missing=%v", report.Missing)
+	}
+}
+
+func TestDetectDrift_InstalledDisabledPluginIsNotExtra(t *testing.T) {
+	townRoot := t.TempDir()
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(townRoot, "plugins")
+
+	createTestPlugin(t, srcDir, "dolt-archive", "+++\nname = \"dolt-archive\"\n+++\narchive", nil)
+	createTestPlugin(t, dstDir, "dolt-archive", "+++\nname = \"dolt-archive\"\n+++\narchive", nil)
+	markDisabled(t, townRoot, "dolt-archive.town.redisabled-20260806")
+
+	report, err := DetectDrift(townRoot, srcDir, dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.HasDrift() {
+		t.Errorf("disabled plugin reported as drift: missing=%v drifted=%v", report.Missing, report.Drifted)
+	}
+	// Not Extra either: --clean must not read this report as license to
+	// delete a plugin that is merely frozen.
+	if len(report.Extra) != 0 {
+		t.Errorf("expected the installed disabled plugin not to be listed as extra, got %v", report.Extra)
+	}
+	if len(report.Disabled) != 1 || report.Disabled[0].Name != "dolt-archive" {
+		t.Fatalf("expected dolt-archive reported as disabled, got %+v", report.Disabled)
+	}
+	if !report.Disabled[0].Installed {
+		t.Errorf("expected the installed disabled plugin flagged so the marker can be questioned")
+	}
+}

--- a/internal/plugin/sync.go
+++ b/internal/plugin/sync.go
@@ -12,16 +12,25 @@ import (
 
 // SyncResult records the outcome of a plugin sync operation.
 type SyncResult struct {
-	Copied  []string // plugin names that were copied/updated
-	Removed []string // plugin names that were removed (clean mode)
-	Skipped []string // plugin names that were already up-to-date
-	Errors  []string // errors encountered
+	Copied   []string         // plugin names that were copied/updated
+	Removed  []string         // plugin names that were removed (clean mode)
+	Skipped  []string         // plugin names that were already up-to-date
+	Disabled []DisabledPlugin // plugins skipped because they are disabled town-wide
+	Errors   []string         // errors encountered
 }
 
 // SyncPlugins copies plugin directories from source to target.
 // If clean is true, removes plugins from target that don't exist in source.
-func SyncPlugins(sourceDir, targetDir string, clean bool) (*SyncResult, error) {
+//
+// Plugins named in <townRoot>/.disabled-plugins/ are never copied. A stale
+// marker (one left behind for a plugin that was later re-enabled) must not
+// escalate into deleting a live plugin, so a disabled plugin already present in
+// the target is left alone, including in clean mode: the guard withholds
+// updates, it never removes. Pass an empty townRoot to sync without the
+// skip-list (tests only; every production caller has a town root).
+func SyncPlugins(townRoot, sourceDir, targetDir string, clean bool) (*SyncResult, error) {
 	result := &SyncResult{}
+	disabled := LoadDisabledPlugins(townRoot)
 
 	srcInfo, err := os.Stat(sourceDir)
 	if err != nil {
@@ -48,6 +57,15 @@ func SyncPlugins(sourceDir, targetDir string, clean bool) (*SyncResult, error) {
 		pluginMD := filepath.Join(sourceDir, entry.Name(), "plugin.md")
 		if _, err := os.Stat(pluginMD); err != nil {
 			continue // Not a plugin directory
+		}
+		if d, ok := disabled[entry.Name()]; ok {
+			// Disabled town-wide: do not copy. Still count it as present in
+			// the source so clean mode below leaves any existing copy in
+			// place rather than deleting it.
+			d.Installed = isInstalled(targetDir, entry.Name())
+			result.Disabled = append(result.Disabled, d)
+			srcPlugins[entry.Name()] = true
+			continue
 		}
 		srcPlugins[entry.Name()] = true
 
@@ -86,6 +104,14 @@ func SyncPlugins(sourceDir, targetDir string, clean bool) (*SyncResult, error) {
 	}
 
 	return result, nil
+}
+
+// isInstalled reports whether the runtime already has a plugin by this name.
+// A skip-list entry for an installed plugin is a contradiction worth surfacing:
+// the marker says the town disabled it, the runtime says it is running.
+func isInstalled(targetDir, name string) bool {
+	info, err := os.Stat(filepath.Join(targetDir, name))
+	return err == nil && info.IsDir()
 }
 
 // dirsMatch checks if two plugin directories have identical contents.
@@ -256,11 +282,12 @@ func hasPlugins(dir string) bool {
 
 // DriftReport describes differences between source and runtime plugins.
 type DriftReport struct {
-	Source  string       `json:"source"`
-	Target string       `json:"target"`
-	Drifted []DriftEntry `json:"drifted,omitempty"`
-	Missing []string     `json:"missing,omitempty"` // in source but not target
-	Extra   []string     `json:"extra,omitempty"`   // in target but not source
+	Source   string           `json:"source"`
+	Target   string           `json:"target"`
+	Drifted  []DriftEntry     `json:"drifted,omitempty"`
+	Missing  []string         `json:"missing,omitempty"`  // in source but not target
+	Extra    []string         `json:"extra,omitempty"`    // in target but not source
+	Disabled []DisabledPlugin `json:"disabled,omitempty"` // in source but disabled town-wide
 }
 
 // DriftEntry describes a single plugin that differs between source and runtime.
@@ -271,11 +298,16 @@ type DriftEntry struct {
 }
 
 // DetectDrift compares plugin directories between source and target.
-func DetectDrift(sourceDir, targetDir string) (*DriftReport, error) {
+//
+// Plugins disabled in <townRoot>/.disabled-plugins/ are reported under Disabled
+// rather than as drift, so a drift check does not demand a fix that SyncPlugins
+// deliberately refuses to perform.
+func DetectDrift(townRoot, sourceDir, targetDir string) (*DriftReport, error) {
 	report := &DriftReport{
 		Source: sourceDir,
 		Target: targetDir,
 	}
+	disabled := LoadDisabledPlugins(townRoot)
 
 	srcEntries, err := os.ReadDir(sourceDir)
 	if err != nil {
@@ -296,6 +328,15 @@ func DetectDrift(sourceDir, targetDir string) (*DriftReport, error) {
 			continue
 		}
 		if _, err := os.Stat(filepath.Join(sourceDir, entry.Name(), "plugin.md")); err != nil {
+			continue
+		}
+		if d, ok := disabled[entry.Name()]; ok {
+			// Not drift: sync will refuse to copy this. Drop it from
+			// tgtPlugins so an already-installed copy is not reported as
+			// Extra either — clean mode leaves it alone.
+			d.Installed = tgtPlugins[entry.Name()]
+			report.Disabled = append(report.Disabled, d)
+			delete(tgtPlugins, entry.Name())
 			continue
 		}
 

--- a/internal/plugin/sync_test.go
+++ b/internal/plugin/sync_test.go
@@ -30,7 +30,7 @@ func TestSyncPlugins_CopiesNew(t *testing.T) {
 
 	createTestPlugin(t, srcDir, "my-plugin", "+++\nname = \"my-plugin\"\n+++\ndo stuff", nil)
 
-	result, err := SyncPlugins(srcDir, dstDir, false)
+	result, err := SyncPlugins("", srcDir, dstDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestSyncPlugins_SkipsUpToDate(t *testing.T) {
 	createTestPlugin(t, srcDir, "my-plugin", content, nil)
 	createTestPlugin(t, dstDir, "my-plugin", content, nil)
 
-	result, err := SyncPlugins(srcDir, dstDir, false)
+	result, err := SyncPlugins("", srcDir, dstDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestSyncPlugins_UpdatesChanged(t *testing.T) {
 	createTestPlugin(t, srcDir, "my-plugin", "+++\nname = \"my-plugin\"\n+++\nv2 instructions", nil)
 	createTestPlugin(t, dstDir, "my-plugin", "+++\nname = \"my-plugin\"\n+++\nv1 instructions", nil)
 
-	result, err := SyncPlugins(srcDir, dstDir, false)
+	result, err := SyncPlugins("", srcDir, dstDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestSyncPlugins_CopiesExtraFiles(t *testing.T) {
 	createTestPlugin(t, srcDir, "my-plugin", "+++\nname = \"my-plugin\"\n+++\nstuff",
 		map[string]string{"run.sh": "#!/bin/bash\necho hi"})
 
-	result, err := SyncPlugins(srcDir, dstDir, false)
+	result, err := SyncPlugins("", srcDir, dstDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func TestSyncPlugins_CleanRemovesExtra(t *testing.T) {
 	createTestPlugin(t, dstDir, "keep-me", "+++\nname = \"keep-me\"\n+++\nkeep", nil)
 	createTestPlugin(t, dstDir, "old-plugin", "+++\nname = \"old-plugin\"\n+++\nold", nil)
 
-	result, err := SyncPlugins(srcDir, dstDir, true)
+	result, err := SyncPlugins("", srcDir, dstDir, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func TestSyncPlugins_NoCleanKeepsExtra(t *testing.T) {
 	createTestPlugin(t, srcDir, "new-plugin", "+++\nname = \"new-plugin\"\n+++\nnew", nil)
 	createTestPlugin(t, dstDir, "old-plugin", "+++\nname = \"old-plugin\"\n+++\nold", nil)
 
-	result, err := SyncPlugins(srcDir, dstDir, false)
+	result, err := SyncPlugins("", srcDir, dstDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +178,7 @@ func TestSyncPlugins_IgnoresNonPluginDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := SyncPlugins(srcDir, dstDir, false)
+	result, err := SyncPlugins("", srcDir, dstDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestDetectDrift_NoDrift(t *testing.T) {
 	createTestPlugin(t, srcDir, "stable", content, nil)
 	createTestPlugin(t, dstDir, "stable", content, nil)
 
-	report, err := DetectDrift(srcDir, dstDir)
+	report, err := DetectDrift("", srcDir, dstDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func TestDetectDrift_ContentDiffers(t *testing.T) {
 	createTestPlugin(t, srcDir, "changed", "+++\nname = \"changed\"\n+++\nv2", nil)
 	createTestPlugin(t, dstDir, "changed", "+++\nname = \"changed\"\n+++\nv1", nil)
 
-	report, err := DetectDrift(srcDir, dstDir)
+	report, err := DetectDrift("", srcDir, dstDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +229,7 @@ func TestDetectDrift_MissingFromTarget(t *testing.T) {
 
 	createTestPlugin(t, srcDir, "new-one", "+++\nname = \"new-one\"\n+++\nnew", nil)
 
-	report, err := DetectDrift(srcDir, dstDir)
+	report, err := DetectDrift("", srcDir, dstDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,7 +247,7 @@ func TestDetectDrift_ExtraInTarget(t *testing.T) {
 
 	createTestPlugin(t, dstDir, "orphan", "+++\nname = \"orphan\"\n+++\nold", nil)
 
-	report, err := DetectDrift(srcDir, dstDir)
+	report, err := DetectDrift("", srcDir, dstDir)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Problem

`gt plugin sync` resolves its source via `FindGastownSource` (`internal/plugin/sync.go`), which walks up from the **current working directory** before falling back to hardcoded candidates — and the first hardcoded candidate is `<townRoot>/gastown/crew/den/plugins`, an ordinary crew member's worktree.

Two consequences:

- The same command syncs from a different directory depending on where it is invoked (`cd ~/gt` vs `make install` vs `cd gastown/` all resolve differently).
- Town-wide runtime state gets seeded from one crew seat's checkout, which can contain plugins that were removed town-wide.

In the town this was found in, two deliberately-disabled plugins have been resurrected six times (2026-06-09, 06-11, 06-17, 07-14, 07-22, 08-06). Each was "fixed" by cleaning a directory; most of those cleanups targeted a directory that was not even the active source, because the active source legitimately differed per invocation. The most recent resurrection had no human involved at all: a patrol formula reached `gt doctor --fix`, which runs the plugin drift fix.

## Fix

Make the skip declarative rather than chasing source directories. Sync now reads `<townRoot>/.disabled-plugins/` and refuses to copy any plugin named there, regardless of which source was resolved, who invoked sync, or from which cwd.

Marker directories carry provenance suffixes, so the plugin name is the prefix up to the first dot — matching whole directory names would silently match nothing:

```
dolt-archive.DEN-SOURCE.removed-20260806   -> dolt-archive
rebuild-gt.town.redisabled-20260806        -> rebuild-gt
tool-updater.rig.redisabled-20260714       -> tool-updater
```

## The premise is only as good as the directory

This approach assumes `.disabled-plugins/` records **current** operator intent. It does not, and this is worth stating plainly rather than burying.

It is an append-only graveyard of historical moves that nobody prunes. Testing this change against a live town surfaced exactly that: an actively-running plugin (`compactor-dog`, present in both the runtime and the sync source) still had three markers from 2026-06-04, so the directory had been wrong about it for two months. Reconciling the directory makes the premise true now; nothing keeps it true later.

So the guard is built to make a stale marker cheap and loud rather than silent and expensive:

- **It withholds updates; it never removes.** A disabled plugin already present in the runtime is left in place, including under `--clean`, and is not reported as `Extra`. A stale marker costs a frozen plugin, never a deleted one.
- **A marker for an installed plugin warns by name.** That combination is a contradiction — the marker says the town disabled it, the runtime says it is running — so it is surfaced instead of absorbed:

```
⚠ compactor-dog (skipped, but currently INSTALLED — marker .disabled-plugins/compactor-dog.disabled-20260604-072900 may be stale; compactor-dog will not receive source updates)
⊘ rebuild-gt (skipped: disabled town-wide by .disabled-plugins/rebuild-gt.town.redisabled-20260806)
```

Without that warning the consequence is concrete and confirmed by test: with the plugin present in the sync source and a stale marker present, the runtime copy is frozen at its installed version **indefinitely and silently** — an e2e run with source at `VERSION 2` left the runtime at `VERSION 1`, reporting only "already up to date".

Every skip is also named in the unattended `gt doctor --fix` path, which had been silently reinstalling plugins with no record at all. `DetectDrift` reports disabled plugins separately instead of as `Missing`, so the drift check no longer warns forever about a fix that sync deliberately refuses to perform.

This does not change source resolution or `gt doctor --fix` argument handling — both are real problems, both are separate changes.

## Test plan

Guards are negative-tested in both directions; a check that has only ever passed is not known to work.

- `internal/plugin/disabled_test.go` — name extraction against real marker names; marker present → plugin not copied; **same source, marker removed → plugin copied**; suffixed markers match (whole-name matching would not); markers do not over-match neighbours sharing a prefix (`rebuild-gt` must not block `rebuild-gt-docs`); `--clean` leaves an installed disabled plugin alone and does not overwrite it; installed-vs-not is flagged in both directions so the stale-marker warning cannot fire spuriously or fail to fire.
- `internal/doctor/patrol_plugin_drift_test.go` — covers the path that actually caused the production incident: `PatrolPluginDriftCheck.Fix`, as reached by a patrol formula, installs the other plugin but not the disabled one, then installs it once the marker is removed.
- **Mutation-checked**: reverting the guard to whole-name matching fails 7 tests; removing the skip entirely fails 3. The tests fail when the fix is absent.
- **End-to-end** with a real `gt` binary against a scratch town: markers present → both plugins skipped with named markers, third plugin synced; markers removed → both plugins install; installed-plus-marker → warning fires and the runtime copy stays at its old version. A `--dry-run` against a live town confirmed the skip fires on that town's actual marker names.

Pre-existing unrelated failure in `internal/doctor`: `TestGetServerAddr_UsesConfigYAMLPort` (fails on the base commit too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)