### PR TITLE
fix(memory): route memory writes through bd remember/forget

### DIFF
--- a/internal/cmd/forget.go
+++ b/internal/cmd/forget.go
@@ -45,7 +45,7 @@ func runForget(cmd *cobra.Command, args []string) error {
 			if err != nil || existing == "" {
 				return fmt.Errorf("memory %q not found", key)
 			}
-			if err := bdKvClear(fullKey); err != nil {
+			if err := bdForget(fullKey); err != nil {
 				return fmt.Errorf("removing memory: %w", err)
 			}
 			fmt.Printf("%s Forgot memory: %s\n", style.Success.Render("✓"), style.Bold.Render(key))
@@ -58,7 +58,7 @@ func runForget(cmd *cobra.Command, args []string) error {
 		fullKey := memoryKeyPrefix + t + "." + key
 		existing, _ := bdKvGet(fullKey)
 		if existing != "" {
-			if err := bdKvClear(fullKey); err != nil {
+			if err := bdForget(fullKey); err != nil {
 				return fmt.Errorf("removing memory: %w", err)
 			}
 			displayKey := key
@@ -77,7 +77,7 @@ func runForget(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("memory %q not found", key)
 	}
 
-	if err := bdKvClear(fullKey); err != nil {
+	if err := bdForget(fullKey); err != nil {
 		return fmt.Errorf("removing memory: %w", err)
 	}
 

--- a/internal/cmd/remember.go
+++ b/internal/cmd/remember.go
@@ -101,7 +101,7 @@ func runRemember(cmd *cobra.Command, args []string) error {
 		verb = "Updated"
 	}
 
-	if err := bdKvSet(fullKey, content); err != nil {
+	if err := bdRemember(fullKey, content); err != nil {
 		return fmt.Errorf("storing memory: %w", err)
 	}
 
@@ -192,9 +192,31 @@ func sanitizeKey(key string) string {
 	return key
 }
 
-// bdKvSet calls bd kv set <key> <value>.
-func bdKvSet(key, value string) error {
-	cmd := exec.Command("bd", "kv", "set", key, value)
+// memoryWriteArgs builds the bd argv storing content under fullKey.
+//
+// bd owns the "memory." kv namespace: it rejects `bd kv set memory.*` and
+// prepends the prefix itself, so fullKey (memory.<type>.<key>) must have it
+// stripped before it goes to --key, or the memory lands at memory.memory.*
+// — accepted by bd and invisible to every reader.
+func memoryWriteArgs(fullKey, content string) []string {
+	return []string{"remember", "--key", strings.TrimPrefix(fullKey, memoryKeyPrefix), content}
+}
+
+// memoryClearArgs builds the bd argv removing the memory under fullKey.
+func memoryClearArgs(fullKey string) []string {
+	return []string{"forget", strings.TrimPrefix(fullKey, memoryKeyPrefix)}
+}
+
+// bdRemember stores a memory via the sanctioned `bd remember` path.
+func bdRemember(fullKey, content string) error {
+	cmd := exec.Command("bd", memoryWriteArgs(fullKey, content)...)
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// bdForget removes a memory via the sanctioned `bd forget` path.
+func bdForget(fullKey string) error {
+	cmd := exec.Command("bd", memoryClearArgs(fullKey)...)
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
@@ -207,13 +229,6 @@ func bdKvGet(key string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
-}
-
-// bdKvClear calls bd kv clear <key>.
-func bdKvClear(key string) error {
-	cmd := exec.Command("bd", "kv", "clear", key)
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
 }
 
 // parseBdKvListJSON parses bd kv list --json output into displayable string values.

--- a/internal/cmd/remember_bd_route_test.go
+++ b/internal/cmd/remember_bd_route_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The memory write/clear argv is checked against the REAL bd on PATH, not a
+// mock: the defect being guarded is a disagreement with bd about who owns the
+// "memory." kv namespace, and a mock would only restate our own side of it.
+//
+// Every probe runs against a throwaway --db under t.TempDir(). The fixed argv
+// is ACCEPTED by bd, so it does store -- isolating the database is what keeps
+// the probe from writing into whatever store the test's working directory
+// happens to resolve to.
+
+func bdOnPath(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("bd")
+	if err != nil {
+		t.Skipf("bd not on PATH: %v", err)
+	}
+	return path
+}
+
+// runBdIsolated runs bd against a scratch database private to this test.
+func runBdIsolated(t *testing.T, args ...string) string {
+	t.Helper()
+	full := append([]string{"--db", filepath.Join(t.TempDir(), "probe.db")}, args...)
+	out, _ := exec.Command(bdOnPath(t), full...).CombinedOutput()
+	return string(out)
+}
+
+const reservedPrefixRejection = "reserved for persistent memories"
+
+// TestMemoryWriteArgsNotRejectedAsReservedPrefix fails while gt builds
+// `bd kv set memory.<type>.<key>`, which bd refuses outright.
+func TestMemoryWriteArgsNotRejectedAsReservedPrefix(t *testing.T) {
+	args := memoryWriteArgs(memoryKeyPrefix+"general.route-probe", "probe content")
+
+	if out := runBdIsolated(t, args...); strings.Contains(out, reservedPrefixRejection) {
+		t.Errorf("bd refuses the memory-write argv as a reserved-prefix key.\nargv: bd %s\nbd said: %s",
+			strings.Join(args, " "), strings.TrimSpace(out))
+	}
+}
+
+// TestMemoryClearArgsNotRejectedAsReservedPrefix covers gt forget, which hits
+// the same reserved namespace.
+func TestMemoryClearArgsNotRejectedAsReservedPrefix(t *testing.T) {
+	args := memoryClearArgs(memoryKeyPrefix + "general.route-probe")
+
+	if out := runBdIsolated(t, args...); strings.Contains(out, reservedPrefixRejection) {
+		t.Errorf("bd refuses the memory-clear argv as a reserved-prefix key.\nargv: bd %s\nbd said: %s",
+			strings.Join(args, " "), strings.TrimSpace(out))
+	}
+}
+
+// TestMemoryArgsStripPrefixBdManages pins the half of the contract the
+// rejection probes cannot see: bd prepends "memory." itself, so a key that
+// still carries the prefix stores memory.memory.<type>.<key> -- accepted by
+// bd, invisible to gt memories, and silent.
+func TestMemoryArgsStripPrefixBdManages(t *testing.T) {
+	fullKey := memoryKeyPrefix + "feedback.some-key"
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"write", memoryWriteArgs(fullKey, "content")},
+		{"clear", memoryClearArgs(fullKey)},
+	} {
+		for _, arg := range tc.args {
+			if strings.HasPrefix(arg, memoryKeyPrefix) {
+				t.Errorf("%s argv passes a key bd would double-prefix: %q in bd %s",
+					tc.name, arg, strings.Join(tc.args, " "))
+			}
+		}
+		if !containsArg(tc.args, "feedback.some-key") {
+			t.Errorf("%s argv does not carry the de-prefixed key %q: bd %s",
+				tc.name, "feedback.some-key", strings.Join(tc.args, " "))
+		}
+	}
+}
+
+// TestMemoryRoundTripsThroughBd is the end-to-end check: a memory written with
+// memoryWriteArgs must come back from `bd recall` under the de-prefixed key,
+// and memoryClearArgs must remove it. This is what actually fails if bd's
+// prefix ownership changes again.
+func TestMemoryRoundTripsThroughBd(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "probe.db")
+	bd := bdOnPath(t)
+	run := func(args ...string) string {
+		out, _ := exec.Command(bd, append([]string{"--db", db}, args...)...).CombinedOutput()
+		return string(out)
+	}
+
+	const content = "route probe content"
+	fullKey := memoryKeyPrefix + "general.route-probe"
+
+	run(memoryWriteArgs(fullKey, content)...)
+
+	stored := run("kv", "list")
+	if !strings.Contains(stored, fullKey+" = "+content) {
+		t.Errorf("memory did not land at %q.\nbd kv list said: %s", fullKey, strings.TrimSpace(stored))
+	}
+
+	run(memoryClearArgs(fullKey)...)
+
+	if after := run("kv", "list"); strings.Contains(after, fullKey) {
+		t.Errorf("memory survived the clear argv.\nbd kv list said: %s", strings.TrimSpace(after))
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

`gt remember` fails on every invocation, and `gt forget` fails on every memory that exists.

```
$ gt remember --type feedback --key some-key "content"
Error: invalid key: key cannot start with "memory."
  (reserved for persistent memories; use 'bd remember' / 'bd forget')
Error: storing memory: exit status 1
```

Both commands shell out to `bd kv set` / `bd kv clear` with a key under the `memory.` namespace, which bd reserves and refuses. The failure is unconditional — it does not depend on `--key`, `--type`, or store contents.

## Why bd is right to refuse

bd owns that namespace and exposes it through `bd remember` / `bd forget`, which prepend the prefix themselves. A generic kv value stored under `memory.*` is indistinguishable from a memory, and the merge resolver auto-resolves those keys `--theirs` — so it can be silently overridden by a remote on pull. The validator is correct; gt is the stale caller.

## Fix

The write path moves to the sanctioned subcommands, and the prefix bd manages is stripped before the key reaches `--key`.

Stripping is not cosmetic. Passing the full key stores `memory.memory.<type>.<key>`, which bd **accepts** and no reader ever looks for — trading a loud failure for a silent one. That half is the reason the tests check the stored location and not just the exit status.

The read path is untouched: `bd kv get` and `bd kv list` do not validate the prefix, so reads of existing memories were never affected.

## Tests

Four tests, all failing before this change and passing after.

They exercise the real `bd` on `PATH` rather than a mock — the defect is a disagreement with bd about namespace ownership, and a mock would only restate our own side of it. Each probe runs against a throwaway `--db` under `t.TempDir()` so it cannot write into the invoking directory's store, and the suite skips when bd is absent.

```
--- PASS: TestMemoryWriteArgsNotRejectedAsReservedPrefix
--- PASS: TestMemoryClearArgsNotRejectedAsReservedPrefix
--- PASS: TestMemoryArgsStripPrefixBdManages
--- PASS: TestMemoryRoundTripsThroughBd
```

Verified by reverting the argv to its pre-fix form and re-running: 4 FAIL before, 4 PASS after, same test binary layout.

## Pre-existing failures

`internal/cmd` has four failures unrelated to this change, in `agent_tracking_beads_test.go`, `compact_test.go`, and `convoy_empty_test.go`. The failing set is identical on unmodified `main` and with this commit applied — verified by building and running both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)