### PR TITLE
fix(plugins): repair github-sheriff repo detection and dedupe key

### DIFF
--- a/plugins/github-sheriff/plugin.md
+++ b/plugins/github-sheriff/plugin.md
@@ -1,7 +1,7 @@
 +++
 name = "github-sheriff"
-description = "Monitor GitHub CI checks on open PRs and create beads for failures"
-version = 1
+description = "Monitor GitHub CI checks on open PRs across all rigs and create beads for failures"
+version = 2
 
 [gate]
 type = "cooldown"
@@ -12,15 +12,16 @@ labels = ["plugin:github-sheriff", "category:ci-monitoring"]
 digest = true
 
 [execution]
-timeout = "2m"
+timeout = "10m"
 notify_on_failure = true
 severity = "low"
 +++
 
 # GitHub Sheriff
 
-Polls GitHub for open pull requests, categorizes them by readiness, and creates
-`ci-failure` beads for new failures. Implements the PR Sheriff pattern from the
+Sweeps every rig's GitHub repo for open pull requests, categorizes them by
+readiness, and files one `ci-failure` bead per PR with failing CI. Implements
+the PR Sheriff pattern from the
 [Gas Town User Manual](https://steve-yegge.medium.com/gas-town-emergency-user-manual-cf0e4556d74b)
 as a Deacon plugin.
 
@@ -29,6 +30,13 @@ Categorizes each PR as:
 - **Needs review**: CI failing, large, or has conflicts
 
 Requires: `gh` CLI installed and authenticated (`gh auth status`).
+
+> **This plugin has no `run.sh`. The commands below are the implementation, not
+> illustration.** Run them as written. If a step fails, report the failure —
+> do NOT substitute your own method of finding repos, composing bead titles, or
+> deciding what counts as a failure. Every field marked MANDATORY below is
+> machine-matched by later runs; improvising any of them creates duplicate beads
+> that no query can reconcile.
 
 ## Detection
 
@@ -42,97 +50,356 @@ if [ $? -ne 0 ]; then
 fi
 ```
 
-Detect the repo from the rig's git remote. Fall back to explicit config if
-detection fails:
+This plugin is dispatched town-level, so it sweeps **every rig**, not one repo.
+Enumerate rigs from `mayor/rigs.json` — the authoritative rig list — and resolve
+each rig's GitHub repo from its real git directory.
+
+Rigs come in two layouts and they genuinely differ, so both must be tried:
+
+- **Worktree rigs** (laser, teleport, payment_portal, gleam, …) keep their
+  remote in `<rig>/.repo.git`. A plain `git -C <rig>` finds no repository at
+  all — these are exactly the rigs that have CI failures.
+- **Plain-clone rigs** (beads, gastown) answer to `git -C <rig>`.
 
 ```bash
-REPO=$(git -C "$GT_RIG_ROOT" remote get-url origin 2>/dev/null \
-  | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+TOWN_ROOT="${GT_TOWN_ROOT:-${GT_ROOT:-$HOME/gt}}"
+RIGS_JSON="$TOWN_ROOT/mayor/rigs.json"
 
-if [ -z "$REPO" ]; then
-  echo "SKIP: could not detect GitHub repo from rig remote"
-  exit 0
+if [ ! -f "$RIGS_JSON" ]; then
+  echo "FAIL: rigs.json not found at $RIGS_JSON — cannot enumerate rigs"
+  exit 1
+fi
+
+REPOS=()
+UNRESOLVED=()
+
+while IFS= read -r RIG; do
+  [ -z "$RIG" ] && continue
+  RIG_PATH="$TOWN_ROOT/$RIG"
+
+  # Worktree layout first, then plain clone, then rigs.json as last resort.
+  URL=$(git --git-dir="$RIG_PATH/.repo.git" remote get-url origin 2>/dev/null)
+  [ -z "$URL" ] && URL=$(git -C "$RIG_PATH" remote get-url origin 2>/dev/null)
+  [ -z "$URL" ] && URL=$(jq -r --arg r "$RIG" '.rigs[$r].git_url // empty' "$RIGS_JSON")
+
+  REPO=$(printf '%s' "$URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+
+  if [ -z "$REPO" ]; then
+    UNRESOLVED+=("$RIG")
+    continue
+  fi
+
+  # The workspace root repo is not a project repo — it has no PRs and never
+  # will. Sweeping it yields a confident "0 open PRs" that means nothing.
+  case "$REPO" in
+    */gas-town-workspace|gas-town-workspace)
+      echo "REJECT: rig $RIG resolved to $REPO (workspace root, not a project repo)"
+      continue
+      ;;
+  esac
+
+  REPOS+=("$RIG|$REPO")
+done < <(jq -r '.rigs | keys[]' "$RIGS_JSON")
+
+echo "Detected ${#REPOS[@]} repo(s) to sweep"
+[ ${#UNRESOLVED[@]} -gt 0 ] && echo "Unresolved rigs (no git remote): ${UNRESOLVED[*]}"
+```
+
+**Never use `$GT_RIG_ROOT`.** It is not set in agent sessions, and `git -C ""`
+silently operates on the current directory instead of erroring — which is how
+this plugin spent weeks reporting success while sweeping the workspace root.
+
+Detecting nothing is a failure, not an all-clear:
+
+```bash
+if [ ${#REPOS[@]} -eq 0 ]; then
+  echo "FAIL: detected 0 repos to sweep — nothing was checked"
+  gt plugin record-run --plugin github-sheriff --result failure \
+    --title "github-sheriff: FAILED — detected 0 repos" \
+    --description "Rig enumeration produced no GitHub repos. Unresolved: ${UNRESOLVED[*]:-none}" \
+    >/dev/null 2>&1 || true
+  gt escalate "Plugin FAILED: github-sheriff detected 0 repos" \
+    --severity low \
+    --reason "Sweep found no repos to check; CI is unmonitored until this is fixed"
+  exit 1
 fi
 ```
 
 ## Action
 
-### Step 1: List open PRs with full details
+### Step 1: Sweep every repo and categorize its PRs
 
-Fetch all open PRs in a single GraphQL call via `gh`. This returns additions,
-deletions, mergeable status, and CI check results without per-PR API overhead:
+Track swept repos and errors separately. A repo that failed to enumerate was
+**not** checked, and must never be counted as clean.
+
+This is one block on purpose — the repo loop and the PR loop nest, so run it
+whole. Process substitution (not a pipe) keeps array modifications after the
+loop.
 
 ```bash
 SINCE=$(date -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -v-7d +%Y-%m-%dT%H:%M:%SZ)
-PRS=$(gh pr list --repo "$REPO" --state open \
-  --json number,title,author,additions,deletions,mergeable,statusCheckRollup,url,updatedAt \
-  --limit 100 | jq --arg since "$SINCE" '[.[] | select(.updatedAt >= $since)]')
 
-PR_COUNT=$(echo "$PRS" | jq length)
-if [ "$PR_COUNT" -eq 0 ]; then
-  echo "No open PRs found for $REPO"
-  exit 0
-fi
-```
-
-### Step 2: Categorize each PR
-
-Process each PR using process substitution (not a pipe) so array modifications
-persist after the loop:
-
-```bash
+SWEPT=0
+SWEEP_ERRORS=()
+TOTAL_PRS=0
+# Space-delimited sets, consulted by Step 4 so it needs no extra API calls.
+OPEN_KEYS=" "
+EXPIRABLE_REPOS=" "
 EASY_WINS=()
 NEEDS_REVIEW=()
 FAILURES=()
+NON_FAILURES=()
 
-while IFS= read -r PR_JSON; do
-  [ -z "$PR_JSON" ] && continue
+for ENTRY in "${REPOS[@]}"; do
+  IFS='|' read -r RIG REPO <<< "$ENTRY"
 
-  PR_NUM=$(echo "$PR_JSON" | jq -r '.number')
-  PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
-  AUTHOR=$(echo "$PR_JSON" | jq -r '.author.login')
-  ADDITIONS=$(echo "$PR_JSON" | jq -r '.additions // 0')
-  DELETIONS=$(echo "$PR_JSON" | jq -r '.deletions // 0')
-  MERGEABLE=$(echo "$PR_JSON" | jq -r '.mergeable')
-  TOTAL_CHANGES=$((ADDITIONS + DELETIONS))
+  ALL_PRS=$(gh pr list --repo "$REPO" --state open \
+    --json number,title,author,additions,deletions,mergeable,statusCheckRollup,url,updatedAt \
+    --limit 100 2>/dev/null)
 
-  # Determine CI status from statusCheckRollup
-  TOTAL_CHECKS=$(echo "$PR_JSON" | jq '.statusCheckRollup | length')
-  PASSING_CHECKS=$(echo "$PR_JSON" | jq '[.statusCheckRollup[] | select(
-    .conclusion == "SUCCESS" or .conclusion == "NEUTRAL" or
-    .conclusion == "SKIPPED" or .state == "SUCCESS"
-  )] | length')
-
-  if [ "$TOTAL_CHECKS" -gt 0 ] && [ "$TOTAL_CHECKS" -eq "$PASSING_CHECKS" ]; then
-    CI_PASS=true
-  else
-    CI_PASS=false
+  # An empty result is an API failure. A repo with no PRs returns "[]".
+  if [ -z "$ALL_PRS" ]; then
+    SWEEP_ERRORS+=("$REPO")
+    continue
   fi
 
-  # Collect individual check failures for bead creation
-  while IFS= read -r CHECK; do
-    [ -z "$CHECK" ] && continue
-    CHECK_NAME=$(echo "$CHECK" | jq -r '.name')
-    CHECK_URL=$(echo "$CHECK" | jq -r '.detailsUrl // .targetUrl // empty')
-    FAILURES+=("$PR_NUM|$PR_TITLE|$CHECK_NAME|$CHECK_URL")
-  done < <(echo "$PR_JSON" | jq -c '.statusCheckRollup[] | select(
-    .conclusion == "FAILURE" or .conclusion == "CANCELLED" or
-    .conclusion == "TIMED_OUT" or .state == "FAILURE" or .state == "ERROR"
-  )')
+  SWEPT=$((SWEPT + 1))
+  ALL_COUNT=$(echo "$ALL_PRS" | jq length)
 
-  # Categorize PR
-  if [ "$MERGEABLE" = "MERGEABLE" ] && [ "$CI_PASS" = true ] && [ "$TOTAL_CHANGES" -lt 200 ]; then
-    EASY_WINS+=("PR #$PR_NUM: $PR_TITLE (by $AUTHOR, +$ADDITIONS/-$DELETIONS)")
-  else
-    REASONS=""
-    [ "$MERGEABLE" != "MERGEABLE" ] && REASONS+="conflicts "
-    [ "$CI_PASS" != true ] && REASONS+="ci-failing "
-    [ "$TOTAL_CHANGES" -ge 200 ] && REASONS+="large(${TOTAL_CHANGES}loc) "
-    NEEDS_REVIEW+=("PR #$PR_NUM: $PR_TITLE (by $AUTHOR, ${REASONS% })")
+  # Record every open PR so Step 4 can expire beads without re-querying
+  # GitHub. At the --limit ceiling the list may be truncated, and a PR missing
+  # from a truncated list is not evidence that it closed — so this repo is not
+  # safe to expire against.
+  if [ "$ALL_COUNT" -lt 100 ]; then
+    EXPIRABLE_REPOS+="$REPO "
+    while IFS= read -r N; do
+      [ -n "$N" ] && OPEN_KEYS+="$REPO/$N "
+    done < <(echo "$ALL_PRS" | jq -r '.[].number')
   fi
-done < <(echo "$PRS" | jq -c '.[]')
 
-# Report categorized PRs
+  # Only recently-touched PRs are worth categorizing.
+  PRS=$(echo "$ALL_PRS" | jq --arg since "$SINCE" '[.[] | select(.updatedAt >= $since)]')
+  PR_COUNT=$(echo "$PRS" | jq length)
+  TOTAL_PRS=$((TOTAL_PRS + PR_COUNT))
+  [ "$PR_COUNT" -eq 0 ] && continue
+
+  while IFS= read -r PR_JSON; do
+    [ -z "$PR_JSON" ] && continue
+
+    PR_NUM=$(echo "$PR_JSON" | jq -r '.number')
+    PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+    AUTHOR=$(echo "$PR_JSON" | jq -r '.author.login')
+    ADDITIONS=$(echo "$PR_JSON" | jq -r '.additions // 0')
+    DELETIONS=$(echo "$PR_JSON" | jq -r '.deletions // 0')
+    MERGEABLE=$(echo "$PR_JSON" | jq -r '.mergeable')
+    TOTAL_CHANGES=$((ADDITIONS + DELETIONS))
+
+    TOTAL_CHECKS=$(echo "$PR_JSON" | jq '.statusCheckRollup | length')
+    PASSING_CHECKS=$(echo "$PR_JSON" | jq '[.statusCheckRollup[] | select(
+      .conclusion == "SUCCESS" or .conclusion == "NEUTRAL" or
+      .conclusion == "SKIPPED" or .state == "SUCCESS"
+    )] | length')
+
+    if [ "$TOTAL_CHECKS" -gt 0 ] && [ "$TOTAL_CHECKS" -eq "$PASSING_CHECKS" ]; then
+      CI_PASS=true
+    else
+      CI_PASS=false
+    fi
+
+    # A real failure only. CANCELLED and TIMED_OUT are infrastructure noise,
+    # not code defects — see "What counts as a failure" below.
+    FAILED_CHECKS=$(echo "$PR_JSON" | jq -r '[.statusCheckRollup[] | select(
+      .conclusion == "FAILURE" or .state == "FAILURE" or .state == "ERROR"
+    ) | .name // .context] | join(", ")')
+
+    # Counted for the summary so cancellations stay visible without filing beads.
+    NOISE=$(echo "$PR_JSON" | jq '[.statusCheckRollup[] | select(
+      .conclusion == "CANCELLED" or .conclusion == "TIMED_OUT"
+    )] | length')
+    [ "$NOISE" -gt 0 ] && NON_FAILURES+=("$REPO#$PR_NUM: $NOISE cancelled/timed-out")
+
+    if [ -n "$FAILED_CHECKS" ]; then
+      FAILURES+=("$REPO|$PR_NUM|$PR_TITLE|$FAILED_CHECKS")
+    fi
+
+    if [ "$MERGEABLE" = "MERGEABLE" ] && [ "$CI_PASS" = true ] && [ "$TOTAL_CHANGES" -lt 200 ]; then
+      EASY_WINS+=("$REPO#$PR_NUM: $PR_TITLE (by $AUTHOR, +$ADDITIONS/-$DELETIONS)")
+    else
+      REASONS=""
+      [ "$MERGEABLE" != "MERGEABLE" ] && REASONS+="conflicts "
+      [ -n "$FAILED_CHECKS" ] && REASONS+="ci-failing "
+      [ "$TOTAL_CHANGES" -ge 200 ] && REASONS+="large(${TOTAL_CHANGES}loc) "
+      [ -n "$REASONS" ] && NEEDS_REVIEW+=("$REPO#$PR_NUM: $PR_TITLE (by $AUTHOR, ${REASONS% })")
+    fi
+  done < <(echo "$PRS" | jq -c '.[]')
+done
+```
+
+#### What counts as a failure
+
+| Conclusion | File a bead? | Why |
+|---|---|---|
+| `FAILURE`, state `FAILURE`/`ERROR` | **Yes** | A real check failure |
+| `CANCELLED` | **No** | Runner/timeout noise. Cancelled jobs have zero failed steps — filing them manufactures work that does not exist |
+| `TIMED_OUT` | **No** | A CI-health signal, not a code defect. Report in the summary; do not file a bead a worker will try to debug |
+| `SUCCESS`, `NEUTRAL`, `SKIPPED` | No | Passing |
+
+### Step 2: Adopt legacy beads (self-retiring migration)
+
+Beads filed before the structural key exists carry no `ci:` label, so Step 2
+cannot see them — it would file a second bead beside every one of them. Adopt
+them instead: parse the PR reference out of the old title once, attach the key,
+and collapse duplicates onto a single survivor.
+
+This is the **only** place a bead title is ever parsed, and it is one-way: once
+a bead carries the key it takes the normal path above and this step skips it.
+Beads whose title does not resolve are left untouched and reported.
+
+```bash
+ADOPTED=0
+COLLAPSED=0
+UNADOPTED=0
+
+resolve_repo() {
+  TOK="${1##*/}"
+  for E in "${REPOS[@]}"; do
+    RIG="${E%%|*}"; RREPO="${E##*|}"
+    if [ "$TOK" = "${RREPO##*/}" ] || [ "$TOK" = "$RIG" ]; then echo "$RREPO"; return 0; fi
+  done
+  return 1
+}
+
+while IFS= read -r B; do
+  [ -z "$B" ] && continue
+  BEAD_ID=$(echo "$B" | jq -r '.id')
+
+  # Already keyed — Step 2 owns it.
+  echo "$B" | jq -e '.labels[]? | select(startswith("ci:"))' >/dev/null 2>&1 && continue
+
+  TITLE=$(echo "$B" | jq -r '.title')
+  # Two passes: "<repo> PR #N" first, then "<repo>#N" / "<repo> #N".
+  PARSED=$(printf '%s' "$TITLE" | sed -nE 's|^.*[[:space:]:]([A-Za-z0-9._/-]+)[[:space:]]+PR[[:space:]]*#([0-9]+).*$|\1 \2|p')
+  [ -z "$PARSED" ] && PARSED=$(printf '%s' "$TITLE" | sed -nE 's|^.*[[:space:]:]([A-Za-z0-9._/-]+)[[:space:]]*#([0-9]+).*$|\1 \2|p')
+  if [ -z "$PARSED" ]; then UNADOPTED=$((UNADOPTED + 1)); continue; fi
+
+  TOK=${PARSED%% *}; PR_NUM=${PARSED##* }
+  REPO=$(resolve_repo "$TOK") || { UNADOPTED=$((UNADOPTED + 1)); continue; }
+  KEY="ci:$REPO/$PR_NUM"
+
+  # Ask who already owns this key. That covers a bead this plugin filed, and a
+  # legacy bead adopted earlier in this same pass — the label is live
+  # immediately, so the query is the whole bookkeeping. One bead survives per
+  # key; the rest are the duplicates the broken digest produced.
+  OWNER=$(bd list --label "$KEY" --status open --limit 0 --json 2>/dev/null | jq -r '.[0].id // empty')
+
+  if [ -n "$OWNER" ] && [ "$OWNER" != "$BEAD_ID" ]; then
+    bd close "$BEAD_ID" --reason "Duplicate of $OWNER ($KEY) — github-sheriff dedupe was title-derived and never matched" \
+      >/dev/null 2>&1 && COLLAPSED=$((COLLAPSED + 1))
+  else
+    bd update "$BEAD_ID" --add-label "$KEY" >/dev/null 2>&1 && ADOPTED=$((ADOPTED + 1))
+  fi
+done < <(bd list --label ci-failure --status open --limit 0 --json 2>/dev/null | jq -c '.[]')
+```
+
+### Step 3: File one bead per failing PR
+
+**One bead per PR, not per check.** Per-check beads are what produced 34 beads
+for a single PR. Failing check names go in the description, which is updated in
+place on later runs.
+
+Every bead MUST carry these exact fields. They are machine-matched, not prose:
+
+- **Title, exactly**: `ci-failure: <owner>/<repo>#<pr>`
+  Nothing appended, no `[bug]` prefix, no check name, no `PR` before the number.
+- **Labels, all three MANDATORY**: `ci-failure`, `plugin:github-sheriff`, and
+  the structural dedupe key `ci:<owner>/<repo>/<pr>`.
+
+Dedupe on the **structural label**, never on the title. Titles are prose and
+prose drifts; a title-derived digest is what let this plugin re-file the same
+failure in seven different formats.
+
+```bash
+CREATED=0
+UPDATED=0
+
+for F in "${FAILURES[@]}"; do
+  IFS='|' read -r REPO PR_NUM PR_TITLE FAILED_CHECKS <<< "$F"
+
+  KEY="ci:$REPO/$PR_NUM"
+  BEAD_TITLE="ci-failure: $REPO#$PR_NUM"
+  DESCRIPTION="Failing checks: $FAILED_CHECKS
+
+PR: https://github.com/$REPO/pull/$PR_NUM
+PR title: $PR_TITLE
+Last seen failing: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  EXISTING=$(bd list --label "$KEY" --status open --json 2>/dev/null | jq -r '.[0].id // empty')
+
+  if [ -n "$EXISTING" ]; then
+    bd update "$EXISTING" -d "$DESCRIPTION" >/dev/null 2>&1 && UPDATED=$((UPDATED + 1))
+    continue
+  fi
+
+  BEAD_ID=$(bd create "$BEAD_TITLE" -t task -p 2 \
+    -d "$DESCRIPTION" \
+    -l "ci-failure,plugin:github-sheriff,$KEY" \
+    --json 2>/dev/null | jq -r '.id // empty')
+
+  if [ -n "$BEAD_ID" ]; then
+    CREATED=$((CREATED + 1))
+    gt activity emit github_check_failed \
+      --message "CI failing on $REPO#$PR_NUM ($FAILED_CHECKS), bead $BEAD_ID" \
+      2>/dev/null || true
+  fi
+done
+```
+
+### Step 4: Expire beads whose PR is no longer open
+
+A bead for a closed or merged PR is dead weight. Closing it is safe: no future
+run re-files it, because the PR is no longer in the open-PR sweep.
+
+Decide this from the sweep in Step 1, not from fresh API calls. A `gh pr view`
+per bead is an extra request per open bead per run, which at this plugin's
+dispatch rate is what exhausts the GitHub quota — and a rate-limited expiry
+step would start closing beads on failed lookups.
+
+Only repos that swept cleanly are eligible. If a repo errored, its beads are
+simply unknown this run, and unknown is never a reason to close:
+
+```bash
+EXPIRED=0
+
+while IFS= read -r B; do
+  [ -z "$B" ] && continue
+  BEAD_ID=$(echo "$B" | jq -r '.id')
+  KEY=$(echo "$B" | jq -r '.labels[]? | select(startswith("ci:"))' | head -1)
+  [ -z "$KEY" ] && continue
+
+  TARGET=${KEY#ci:}
+  REPO=${TARGET%/*}
+  PR_NUM=${TARGET##*/}
+
+  # Not swept cleanly this run -> no opinion.
+  case "$EXPIRABLE_REPOS" in *" $REPO "*) ;; *) continue ;; esac
+
+  # Swept, and the PR was not among its open PRs -> it closed or merged.
+  case "$OPEN_KEYS" in
+    *" $REPO/$PR_NUM "*) ;;
+    *)
+      bd close "$BEAD_ID" --reason "PR $REPO#$PR_NUM is no longer open" >/dev/null 2>&1 \
+        && EXPIRED=$((EXPIRED + 1))
+      ;;
+  esac
+done < <(bd list --label ci-failure --status open --limit 0 --json 2>/dev/null | jq -c '.[]')
+```
+
+## Record Result
+
+"0 failures" and "nothing was swept" are different outcomes and must never
+render the same. Report what was actually checked:
+
+```bash
 if [ ${#EASY_WINS[@]} -gt 0 ]; then
   echo "Easy wins (${#EASY_WINS[@]}):"
   printf '  %s\n' "${EASY_WINS[@]}"
@@ -141,22 +408,34 @@ if [ ${#NEEDS_REVIEW[@]} -gt 0 ]; then
   echo "Needs review (${#NEEDS_REVIEW[@]}):"
   printf '  %s\n' "${NEEDS_REVIEW[@]}"
 fi
-```
+if [ ${#NON_FAILURES[@]} -gt 0 ]; then
+  echo "Not filed — cancelled/timed-out (${#NON_FAILURES[@]}):"
+  printf '  %s\n' "${NON_FAILURES[@]}"
+fi
 
-## Record Result
-
-```bash
-SUMMARY="$REPO: $PR_COUNT PRs — ${#EASY_WINS[@]} easy win(s), ${#NEEDS_REVIEW[@]} need review, ${#FAILURES[@]} CI failure(s) detected"
+SUMMARY="swept $SWEPT/${#REPOS[@]} repos, $TOTAL_PRS open PRs — ${#EASY_WINS[@]} easy win(s), ${#NEEDS_REVIEW[@]} need review, ${#FAILURES[@]} PR(s) with CI failures ($CREATED bead(s) created, $UPDATED updated, $EXPIRED expired)"
+[ "$ADOPTED" -gt 0 ] || [ "$COLLAPSED" -gt 0 ] && SUMMARY="$SUMMARY; legacy: $ADOPTED adopted, $COLLAPSED duplicate(s) collapsed, $UNADOPTED unrecognized"
+[ ${#SWEEP_ERRORS[@]} -gt 0 ] && SUMMARY="$SUMMARY; FAILED TO SWEEP: ${SWEEP_ERRORS[*]}"
 echo "$SUMMARY"
 ```
 
-On success:
+Success requires that every detected repo was actually enumerated. A partial
+sweep is a failure, however few failures it found:
+
 ```bash
-gt plugin record-run --plugin github-sheriff --result success \
-  --title "github-sheriff: $SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
+if [ ${#SWEEP_ERRORS[@]} -eq 0 ] && [ "$SWEPT" -gt 0 ]; then
+  gt plugin record-run --plugin github-sheriff --result success \
+    --title "github-sheriff: $SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
+else
+  gt plugin record-run --plugin github-sheriff --result failure \
+    --title "github-sheriff: PARTIAL SWEEP" --description "$SUMMARY" >/dev/null 2>&1 || true
+  gt escalate "Plugin FAILED: github-sheriff partial sweep" \
+    --severity low \
+    --reason "$SUMMARY"
+fi
 ```
 
-On failure:
+On an unhandled error:
 ```bash
 gt plugin record-run --plugin github-sheriff --result failure \
   --title "github-sheriff: FAILED" \


### PR DESCRIPTION
## Root cause

github-sheriff resolved its target repo with:

```bash
REPO=$(git -C "$GT_RIG_ROOT" remote get-url origin 2>/dev/null | sed ...)
if [ -z "$REPO" ]; then echo "SKIP: ..."; exit 0; fi
```

`GT_RIG_ROOT` is set **nowhere in this codebase** — `grep -rn GT_RIG_ROOT` returns exactly one hit, that line. And `git -C ""` does not error; it silently operates on the current directory. So the plugin resolved whatever repo the dog happened to be standing in, which is the workspace root:

```
git -C "" remote get-url origin   ->  BV-Tech-Solutions/gas-town-workspace.git
```

That is non-empty, so it passes the emptiness guard. The workspace root has no PRs and never will, so the plugin reported **"success — 0 open PRs" having swept nothing**. A wrong-but-non-empty answer defeats an emptiness check.

Even with the variable set it would still miss the repos that matter. Worktree rigs keep their remote in `<rig>/.repo.git`, so a plain `git -C <rig>` finds no repository at all. Measured across all 14 rigs:

| rig | `git -C <rig>` | `--git-dir=<rig>/.repo.git` |
|---|---|---|
| laser, teleport, payment_portal, gleam, shuffle, fathom, … (12) | fatal: not a git repository | resolves |
| beads-src, gastown (2) | resolves | — |

Every rig with CI failures was structurally invisible.

## Why detection had to be fixed first

This is one broken procedure, not four independent prose bugs. The plugin has no `run.sh` — `plugin.md` *is* the implementation, executed by an LLM each run. As written it could never reach laser/teleport/Payment_Portal, yet beads for exactly those repos exist, so agents were ignoring step 1 and enumerating repos their own way. Once an agent improvises step 1 it improvises the rest, which is where seven title formats, zero labels and inconsistent CANCELLED handling came from. Pinning the title format alone would not have held.

## Changes

**1. Detection.** Enumerate rigs town-wide from `mayor/rigs.json`, resolving each remote via `--git-dir=<rig>/.repo.git`, falling back to `git -C <rig>` for plain clones and to `rigs.json` `git_url` last. Both shapes are required: 12 rigs resolve only via `.repo.git`, 2 only via `git -C`, and 3 rigs have no `git_url` at all so config alone is insufficient. All 14 resolve.

**2. Scope.** The sweep is explicitly town-wide. The plugin is dispatched town-level; single-repo detection never matched how it runs.

**3. Fail loudly.** The workspace root is rejected by name. Detecting zero repos escalates rather than reporting an all-clear. A partial sweep is a failure however few failures it found, and the summary always states `swept N/M repos` so "no failures found" and "nothing was swept" can never render the same.

**4. The prose defects.** One mandated title `ci-failure: <owner>/<repo>#<pr>`, **one bead per PR** rather than per check (per-check beads are what produced 34 beads for a single PR), and three mandatory labels including a structural key `ci:<owner>/<repo>/<pr>`. Dedupe matches on that key, never on prose. `CANCELLED` and `TIMED_OUT` are no longer failures — they are runner noise with zero failed steps, reported in the summary but not filed.

**5. Legacy migration** (self-retiring). Beads predating the key are invisible to the new dedupe, so the first run would have filed a duplicate beside every one of them. They are adopted once — the PR reference parsed out of the old title, the key attached, duplicates collapsed onto a single survivor — after which they take the normal path. This is the only place a title is ever parsed.

**6. Expiry without extra API calls.** Beads whose PR is no longer open are closed, decided from the sweep already in hand rather than a `gh pr view` per bead. At ~14 dispatches/day that per-bead call is what exhausts the GitHub quota, and a rate-limited expiry step would start closing beads on failed lookups. Repos that errored are skipped — unknown is never a reason to close.

`timeout` raised 2m → 10m for the town-wide sweep (measured 26s for 14 repos, so this is headroom, not need).

## Test plan

Validated by executing the plugin's own bash blocks — extracted from `plugin.md` so the tested code is literally the shipped code — against the live town, with all `bd`/`gt` writes directed at a throwaway beads DB. No live-town beads were created or closed.

- **Detection**: all 14 rigs resolve, 0 unresolved, workspace root rejected by name. Verified both rig shapes independently.
- **Full sweep**: 14/14 repos, 32 open PRs, 26s. Reaches laser, teleport and Payment_Portal — the rigs that were previously invisible.
- **Dedupe fires** (the defect): run 1 created 9 and updated 1; runs 2 and 3 created **0** and updated 10. No key is ever held by more than one open bead.
- **CANCELLED suppressed**: laser alone carries 10 cancelled checks against 11 genuine failures. Payment_Portal #1091 (both legs cancelled) and #1304 (js cancelled, python passed) produce **no** beads — the three false beads reported on this issue, confirmed suppressed.
- **Legacy migration**: seeded 6 legacy beads in 5 historical title formats → 2 adopted, 3 duplicates collapsed, 1 unrecognized (a non-PR outage bead, correctly left alone). 28 of the 29 real legacy beads parse; the 1 that does not is that same outage bead.
- **Expiry**: a bead for closed PR laser#7476 is closed; beads for open PRs are not.
- **Fail-loudly, unplanned**: a run mid-testing hit GitHub secondary rate limits and swept 7/14. It refused to report success, named all 7 unswept repos, and expired nothing. This is the guard working against a failure I did not stage.

## Note for review

Mayor's spec suggested a per-check title (`… - <check>`) and label key. I pinned **per-PR** instead: check names contain spaces, parens and em-dashes (`Analyze (javascript-typescript)`, `Vulnerability scan — Trivy`), which makes them unusable as a structural label without slugification — and slugification is improvisation surface, which is the failure mode this PR exists to close. Per-check granularity is also what produced 34 beads for one PR. Failing check names are recorded in the description and updated in place. Happy to switch back if per-check beads are wanted.

Refs hq-bommfh

🤖 Generated with [Claude Code](https://claude.com/claude-code)