### PR TITLE
daemon: don't kill an idle Deacon; apply the idle guard to both tiers

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1607,27 +1607,49 @@ func (d *Daemon) checkDeaconHeartbeat() {
 	// Two-tier response: nudge for stale (5-20 min), kill and restart
 	// only for very stale (>= 20 min). Kill threshold must be > backoff-max
 	// to avoid false positive kills during legitimate await-signal sleep.
+
+	// Idle guard, applied to BOTH tiers.
+	//
+	// This guard used to sit only on the nudge branch below, which inverted the
+	// escalation: an idle Deacon was protected from the harmless action (a
+	// nudge) and left exposed to the destructive one (kill and restart). The
+	// observed sequence on a real town, all with no work in flight:
+	//
+	//   09:40  stale  6m -> "nudge skipped: no active work in flight"
+	//   09:43  stale  9m -> skipped
+	//   09:47  stale 13m -> skipped
+	//   09:50  stale 16m -> skipped
+	//   09:53  stale 19m -> skipped
+	//   09:56  stale 22m -> STUCK DEACON: killing session
+	//
+	// Five deliberate deferrals, then a kill of a perfectly healthy session.
+	// The heartbeat file is only refreshed by an explicit call during an active
+	// turn, so a Deacon idle at a prompt goes stale by construction and crosses
+	// the 20 minute line by simply having nothing to do.
+	//
+	// If nothing is in flight there is no work being blocked, so there is
+	// nothing to rescue by restarting — and a restart destroys session context.
+	// Waiting costs nothing. hasActiveWork is conservative (returns true on
+	// store errors), so a genuinely stuck Deacon holding work is still killed.
+	if !d.hasActiveWork() {
+		d.logger.Printf("Deacon heartbeat stale (%s) but no work in flight - idle, not stuck; taking no action", age.Round(time.Minute))
+		return
+	}
+
 	if hb.IsVeryStale() {
 		// Stuck-agent-dog: kill and restart
 		d.logger.Printf("STUCK DEACON: heartbeat stale for %s, session %s needs restart", age.Round(time.Minute), sessionName)
 		d.restartStuckDeacon(sessionName, fmt.Sprintf("heartbeat stale for %s", age.Round(time.Minute)))
 	} else {
-		// Stale but not very stale (5-20 min) - nudge to wake up (unless idle).
+		// Stale but not very stale (5-20 min) - nudge to wake up.
 		//
-		// Idle guard: skip nudge if no beads are actively in flight.
-		// This mirrors the Boot idle guard (ensureBootRunning). When the Deacon's
-		// heartbeat has gone stale during an await-signal backoff sleep, sending a
-		// nudge interrupts the exponential backoff for no reason — the Deacon will
-		// wake naturally at its next timeout. Only nudge if work is actually in
-		// flight (in_progress or hooked) that the Deacon may need to act on.
-		// Conservative: on store errors hasActiveWork returns true, so nudge fires.
-		// See also: runtime/runtime.go:99-101 — session-started nudge was removed
-		// for the same reason (it interrupted the deacon's await-signal backoff).
-		if !d.hasActiveWork() {
-			d.logger.Println("Deacon nudge skipped: no active work in flight, await-signal will fire naturally")
-			return
-		}
-
+		// The idle guard that used to live here now runs above, before the
+		// tier split, so it covers the kill path too. Rationale unchanged:
+		// when the Deacon's heartbeat goes stale during an await-signal backoff
+		// sleep, nudging interrupts the exponential backoff for no reason — it
+		// will wake naturally at its next timeout. See also
+		// runtime/runtime.go:99-101, where the session-started nudge was
+		// removed for the same reason.
 		d.logger.Printf("Deacon stuck for %s - nudging session", age.Round(time.Minute))
 		if err := d.tmux.NudgeSession(sessionName, "HEALTH_CHECK: heartbeat stale, respond to confirm responsiveness"); err != nil {
 			d.logger.Printf("Error nudging stuck Deacon: %v", err)

--- a/internal/daemon/deacon_idle_guard_test.go
+++ b/internal/daemon/deacon_idle_guard_test.go
@@ -74,6 +74,7 @@ func TestCheckDeaconHeartbeat_IdleGuard(t *testing.T) {
 		stores           map[string]beadsdk.Storage
 		wantNudgeLog     bool
 		wantIdleGuardLog bool
+		wantRestartLog   bool
 		desc             string
 	}{
 		{
@@ -121,14 +122,28 @@ func TestCheckDeaconHeartbeat_IdleGuard(t *testing.T) {
 			desc:             "Nudge must fire conservatively when work state is unknown",
 		},
 		{
-			name:         "very stale: heartbeat >= 20 min — escalation path, no nudge",
+			name:         "very stale + idle: heartbeat >= 20 min, no work — must NOT be killed",
 			heartbeatAge: 21 * time.Minute,
 			stores: map[string]beadsdk.Storage{
 				"hq": &searchStorage{results: map[string][]*beadsdk.Issue{}},
 			},
 			wantNudgeLog:     false,
+			wantIdleGuardLog: true,
+			wantRestartLog:   false,
+			desc:             "Idle guard must cover the kill tier too: an idle Deacon crosses 20min by having nothing to do, and restarting it destroys a healthy session for no gain",
+		},
+		{
+			name:         "very stale + active work: heartbeat >= 20 min, in_progress — genuinely stuck, restart",
+			heartbeatAge: 21 * time.Minute,
+			stores: map[string]beadsdk.Storage{
+				"hq": &searchStorage{results: map[string][]*beadsdk.Issue{
+					"in_progress": {{ID: "sc-stuck"}},
+				}},
+			},
+			wantNudgeLog:     false,
 			wantIdleGuardLog: false,
-			desc:             "Very stale heartbeat takes escalation path, not nudge path; idle guard not reached",
+			wantRestartLog:   true,
+			desc:             "A Deacon holding in-flight work past the kill threshold is genuinely stuck and must still be restarted",
 		},
 	}
 
@@ -156,7 +171,7 @@ func TestCheckDeaconHeartbeat_IdleGuard(t *testing.T) {
 
 			logOutput := logBuf.String()
 
-			hasIdleGuardLog := strings.Contains(logOutput, "nudge skipped")
+			hasIdleGuardLog := strings.Contains(logOutput, "idle, not stuck")
 			if hasIdleGuardLog != tc.wantIdleGuardLog {
 				t.Errorf("%s\nidle guard log present=%v, want=%v\nlog:\n%s",
 					tc.desc, hasIdleGuardLog, tc.wantIdleGuardLog, logOutput)
@@ -166,6 +181,12 @@ func TestCheckDeaconHeartbeat_IdleGuard(t *testing.T) {
 			if hasNudgeLog != tc.wantNudgeLog {
 				t.Errorf("%s\nnudge log present=%v, want=%v\nlog:\n%s",
 					tc.desc, hasNudgeLog, tc.wantNudgeLog, logOutput)
+			}
+
+			hasRestartLog := strings.Contains(logOutput, "STUCK DEACON: heartbeat stale")
+			if hasRestartLog != tc.wantRestartLog {
+				t.Errorf("%s\nrestart log present=%v, want=%v\nlog:\n%s",
+					tc.desc, hasRestartLog, tc.wantRestartLog, logOutput)
 			}
 		})
 	}


### PR DESCRIPTION
`checkDeaconHeartbeat` has a two-tier response to a stale heartbeat: nudge at 5–20 min, kill and restart past 20. The idle guard — *skip if no work is in flight* — sat **only on the nudge branch**.

That inverts the escalation: an idle Deacon was protected from the harmless action and left exposed to the destructive one.

## Observed on a live town

Every line below has no work in flight:

```
09:40  stale  6m -> Deacon nudge skipped: no active work in flight
09:43  stale  9m -> skipped
09:47  stale 13m -> skipped
09:50  stale 16m -> skipped
09:53  stale 19m -> skipped
09:56  stale 22m -> STUCK DEACON: heartbeat stale for 22m, killing session
```

Five deliberate deferrals, then a kill of a perfectly healthy session.

The heartbeat file is only refreshed by an explicit call during an active turn, so a Deacon idle at a prompt goes stale **by construction** and crosses the kill threshold simply by having nothing to do. The quieter the town, the more certain the kill — and the failure is invisible afterwards, since the restart looks like recovery from a hang that never happened.

The existing comment shows the intent was already right — *"Kill threshold must be > backoff-max to avoid false positive kills during legitimate await-signal sleep"* — the guard just wasn't applied to that branch.

## Fix

Moved the guard above the tier split. If nothing is in flight there is no work being blocked, so a restart rescues nothing while destroying session context; waiting costs nothing.

`hasActiveWork` remains conservative (returns `true` on store errors), so a Deacon genuinely stuck **while holding work** is still killed. That path is now covered by a test.

## The existing test encoded the bug

`TestCheckDeaconHeartbeat_IdleGuard`'s "very stale" case asserted the idle guard is deliberately *not* reached at 21 min with no work — i.e. it pinned the kill-an-idle-Deacon behaviour as correct:

```go
name:             "very stale: heartbeat >= 20 min — escalation path, no nudge",
heartbeatAge:     21 * time.Minute,
stores:           /* no work */
wantIdleGuardLog: false,
desc:             "...idle guard not reached",
```

Rewritten to assert an idle Deacon is **not** restarted, plus a new companion case asserting a Deacon holding `in_progress` work past the threshold still is. Added a `wantRestartLog` field so the kill path is asserted directly rather than inferred from the absence of a nudge — the old assertions could not distinguish "guarded" from "killed", since neither logs a nudge.

`go test ./internal/daemon/` passes.

## Related

Same class of defect as #4673 (health reporting green over absent subsystems): a condition that is invisible precisely when it matters. Here the town cannot tell a killed-healthy Deacon from a recovered-stuck one, because both produce the same restart line.