### PR TITLE
fix(daemon): compare like with like in JSONL backup spike detection (gt-e1u)

### DIFF
--- a/internal/daemon/jsonl_git_backup.go
+++ b/internal/daemon/jsonl_git_backup.go
@@ -137,14 +137,19 @@ func (d *Daemon) syncJsonlGitBackup() {
 
 	exported := 0
 	var failed []string
+	// counts holds the per-database total (all tables) used for the commit message.
+	// tableCounts holds the per-table breakdown used for spike detection, which
+	// must compare like with like against the per-table files in HEAD.
 	counts := make(map[string]int)
+	tableCounts := make(map[string]map[string]int)
 	for _, db := range databases {
-		n, err := d.exportDatabaseToJsonl(db, gitRepo, dataDir, scrub)
+		perTable, err := d.exportDatabaseToJsonl(db, gitRepo, dataDir, scrub)
 		if err != nil {
 			d.logger.Printf("jsonl_git_backup: %s: export failed: %v", db, err)
 			failed = append(failed, db)
 		} else {
-			counts[db] = n
+			tableCounts[db] = perTable
+			counts[db] = sumTableCounts(perTable)
 			exported++
 		}
 	}
@@ -162,7 +167,7 @@ func (d *Daemon) syncJsonlGitBackup() {
 	if removed > 0 {
 		d.logger.Printf("jsonl_git_backup: filtered %d total test-pollution record(s)", removed)
 		// Recount after filtering so spike detection uses accurate numbers.
-		recountAfterFilter(gitRepo, databases, counts)
+		recountAfterFilter(gitRepo, databases, tableCounts, counts)
 	}
 
 	// Post-scrub verification: re-scan output for any remaining pollution.
@@ -175,7 +180,7 @@ func (d *Daemon) syncJsonlGitBackup() {
 
 	// Phase D: Spike detection — compare current counts to previous commit.
 	threshold := spikeThreshold(config)
-	spikes := d.verifyExportCounts(gitRepo, databases, counts, threshold)
+	spikes := d.verifyExportCounts(gitRepo, databases, tableCounts, threshold)
 	if len(spikes) > 0 {
 		report := formatSpikeReport(spikes)
 		d.logger.Printf("jsonl_git_backup: HALTING — spike detected:\n%s", report)
@@ -207,6 +212,9 @@ func (d *Daemon) syncJsonlGitBackup() {
 	mol.closeStep("report")
 }
 
+// issuesTable is the primary (scrubbed) table exported for every database.
+const issuesTable = "issues"
+
 // supplementalTables lists non-issues tables to include in JSONL backup.
 // These contain structural data (dependencies, labels, config) that would be
 // lost if we only backed up the issues table. Wisp tables are excluded — they
@@ -220,25 +228,46 @@ var supplementalTables = []string{
 	"metadata",
 }
 
+// exportedTables returns every table exported per database in deterministic
+// order: issues first, then the supplemental tables.
+func exportedTables() []string {
+	tables := make([]string, 0, 1+len(supplementalTables))
+	tables = append(tables, issuesTable)
+	tables = append(tables, supplementalTables...)
+	return tables
+}
+
+// sumTableCounts totals a per-table count map.
+func sumTableCounts(perTable map[string]int) int {
+	total := 0
+	for _, n := range perTable {
+		total += n
+	}
+	return total
+}
+
 // exportDatabaseToJsonl exports the issues table (with optional scrub) and all
 // supplemental tables to JSONL files in {gitRepo}/{db}/ directory.
 //
 // Issues go to {db}/issues.jsonl (scrubbed). Other tables go to {db}/{table}.jsonl.
 // Also writes a legacy {db}.jsonl (symlink to {db}/issues.jsonl) for backward compat.
 //
-// Returns the total number of records exported across all tables.
-func (d *Daemon) exportDatabaseToJsonl(db, gitRepo, dataDir string, scrub bool) (int, error) {
+// Returns the number of records exported per table, keyed by table name.
+// Tables whose export failed (supplemental only — an issues failure is fatal)
+// are absent from the map rather than recorded as zero, so a transient query
+// failure is never mistaken for the table being emptied.
+func (d *Daemon) exportDatabaseToJsonl(db, gitRepo, dataDir string, scrub bool) (map[string]int, error) {
 	if !validDBName.MatchString(db) {
-		return 0, fmt.Errorf("invalid database name: %q", db)
+		return nil, fmt.Errorf("invalid database name: %q", db)
 	}
 
 	// Create per-database subdirectory.
 	dbDir := filepath.Join(gitRepo, db)
 	if err := os.MkdirAll(dbDir, 0755); err != nil {
-		return 0, fmt.Errorf("creating dir %s: %w", dbDir, err)
+		return nil, fmt.Errorf("creating dir %s: %w", dbDir, err)
 	}
 
-	total := 0
+	perTable := make(map[string]int, 1+len(supplementalTables))
 
 	// 1. Export issues table (with scrub filter).
 	var query string
@@ -247,11 +276,11 @@ func (d *Daemon) exportDatabaseToJsonl(db, gitRepo, dataDir string, scrub bool) 
 	} else {
 		query = "SELECT * FROM `" + db + "`.issues ORDER BY id"
 	}
-	n, err := d.exportTableToJsonl("issues", query, dbDir, dataDir)
+	n, err := d.exportTableToJsonl(issuesTable, query, dbDir, dataDir)
 	if err != nil {
-		return 0, fmt.Errorf("issues: %w", err)
+		return nil, fmt.Errorf("issues: %w", err)
 	}
-	total += n
+	perTable[issuesTable] = n
 
 	// 2. Export supplemental tables (no scrub, full export).
 	for _, table := range supplementalTables {
@@ -262,11 +291,11 @@ func (d *Daemon) exportDatabaseToJsonl(db, gitRepo, dataDir string, scrub bool) 
 			d.logger.Printf("jsonl_git_backup: %s/%s: export failed (non-fatal): %v", db, table, err)
 			continue
 		}
-		total += tn
+		perTable[table] = tn
 	}
 
-	d.logger.Printf("jsonl_git_backup: %s: exported %d records across %d tables", db, total, 1+len(supplementalTables))
-	return total, nil
+	d.logger.Printf("jsonl_git_backup: %s: exported %d records across %d tables", db, sumTableCounts(perTable), len(perTable))
+	return perTable, nil
 }
 
 // exportTableToJsonl runs a query and writes the result as JSONL to {dir}/{table}.jsonl.
@@ -604,9 +633,10 @@ func previousCommitLineCount(gitRepo, relPath string) (int, error) {
 	return lines, nil
 }
 
-// spikeInfo holds the result of a spike check for a single database file.
+// spikeInfo holds the result of a spike check for a single exported table file.
 type spikeInfo struct {
 	DB       string
+	Table    string
 	File     string
 	Previous int
 	Current  int
@@ -614,10 +644,18 @@ type spikeInfo struct {
 }
 
 // spikeBaseline records counts from a halted export so that subsequent runs
-// can detect when the count has stabilized at a new level.
+// can detect when the count has stabilized at a new level. Counts are keyed
+// per table via spikeKey ("db/table"); a baseline written by an older build
+// (keyed by database) simply won't match and is treated as absent, which is
+// safe — the file is git-ignored scratch state, rewritten on the next spike.
 type spikeBaseline struct {
 	Counts    map[string]int `json:"counts"`
 	Timestamp string         `json:"timestamp"`
+}
+
+// spikeKey is the per-table key used in the spike baseline file.
+func spikeKey(db, table string) string {
+	return db + "/" + table
 }
 
 const spikeBaselineFile = ".spike-counts.json"
@@ -680,102 +718,130 @@ func removeSpikeBaseline(gitRepo string) {
 }
 
 // verifyExportCounts compares current export line counts against the previous
-// commit for each database. Returns a list of anomalies that exceed the spike
-// threshold. On first export (no baseline), verification is skipped.
+// commit, one exported table at a time. Returns a list of anomalies that exceed
+// the spike threshold. On first export of a file (no baseline), verification is
+// skipped for that file.
+//
+// The comparison is per table — {db}/{table}.jsonl in HEAD against the count
+// this run exported for that same table — so both sides always measure the same
+// set of records. A blended per-database total cannot be compared against any
+// single committed file, and mixing the two guarantees a false spike (gt-e1u).
+// Per-table checks also keep pollution in a supplemental table visible instead
+// of hiding it inside a total dominated by the high-volume events table.
 //
 // Asymmetric thresholds: drops (possible data loss) use the configured threshold;
-// increases (new issues filed) use 2x the threshold since growth is normal.
+// increases (new records) use 2x the threshold since growth is normal.
 // Small absolute changes (<20 records) are always allowed to avoid false alarms
-// on small databases.
+// on small tables.
 //
 // Recovery mechanism: when spike detection fires, a baseline file is saved with
-// the current counts. On the next run, if the current count is stable relative
-// to the spike baseline (within threshold), the spike is cleared and the export
-// proceeds. This prevents permanent blocking after legitimate large changes
+// the current per-table counts. On the next run, if the current count is stable
+// relative to the spike baseline (within threshold), the spike is cleared and the
+// export proceeds. This prevents permanent blocking after legitimate large changes
 // (e.g., Reaper purges, filter updates).
-func (d *Daemon) verifyExportCounts(gitRepo string, databases []string, counts map[string]int, threshold float64) []spikeInfo {
+func (d *Daemon) verifyExportCounts(gitRepo string, databases []string, tableCounts map[string]map[string]int, threshold float64) []spikeInfo {
 	const minAbsoluteDelta = 20 // ignore changes smaller than this many records
 
 	var spikes []spikeInfo
 	spikeBase := loadSpikeBaseline(gitRepo)
 
 	for _, db := range databases {
-		currentCount, ok := counts[db]
+		perTable, ok := tableCounts[db]
 		if !ok {
 			continue // database failed export, skip
 		}
 
-		relPath := filepath.Join(db, "issues.jsonl")
-		prevCount, err := previousCommitLineCount(gitRepo, relPath)
-		if err != nil {
-			d.logger.Printf("jsonl_git_backup: verify: %s: error reading baseline: %v", db, err)
-			continue
-		}
-		if prevCount == 0 {
-			// First export — no baseline to compare against.
-			d.logger.Printf("jsonl_git_backup: verify: %s: first export (%d records), skipping spike check", db, currentCount)
-			continue
-		}
+		for _, table := range exportedTables() {
+			currentCount, ok := perTable[table]
+			if !ok {
+				continue // table export failed or was skipped, no current count to trust
+			}
 
-		absDelta := currentCount - prevCount
-		if absDelta < 0 {
-			absDelta = -absDelta
-		}
-		// Small absolute changes are always fine — avoids false alarms on
-		// small databases where a few issues cause large percentage swings.
-		if absDelta < minAbsoluteDelta {
-			continue
-		}
+			relPath := filepath.Join(db, table+".jsonl")
+			prevCount, err := previousCommitLineCount(gitRepo, relPath)
+			if err != nil {
+				d.logger.Printf("jsonl_git_backup: verify: %s/%s: error reading baseline: %v", db, table, err)
+				continue
+			}
+			if prevCount == 0 {
+				// First export of this file — no baseline to compare against.
+				d.logger.Printf("jsonl_git_backup: verify: %s/%s: first export (%d records), skipping spike check", db, table, currentCount)
+				continue
+			}
 
-		fractionalDelta := math.Abs(float64(currentCount-prevCount)) / float64(prevCount)
+			absDelta := currentCount - prevCount
+			if absDelta < 0 {
+				absDelta = -absDelta
+			}
+			// Small absolute changes are always fine — avoids false alarms on
+			// small tables where a few records cause large percentage swings.
+			if absDelta < minAbsoluteDelta {
+				continue
+			}
 
-		// Asymmetric: increases are less suspicious than drops.
-		// New issues being filed is normal growth; losing issues suggests data loss.
-		effectiveThreshold := threshold
-		if currentCount > prevCount {
-			effectiveThreshold = threshold * 2 // 2x tolerance for growth
-		}
+			fractionalDelta := math.Abs(float64(currentCount-prevCount)) / float64(prevCount)
 
-		if fractionalDelta > effectiveThreshold {
-			// Check spike baseline: if the current count is stable relative
-			// to a previously-halted count, this is a confirmed new level.
-			if spikeBase != nil {
-				if baseCount, ok := spikeBase.Counts[db]; ok && baseCount > 0 {
-					baseDelta := math.Abs(float64(currentCount-baseCount)) / float64(baseCount)
-					if baseDelta <= threshold {
-						d.logger.Printf("jsonl_git_backup: %s: count stable vs spike baseline (%d → %d, %.1f%% vs baseline %d), accepting new level",
-							db, prevCount, currentCount, fractionalDelta*100, baseCount)
-						continue // Stable relative to spike baseline — not a new spike.
+			// Asymmetric: increases are less suspicious than drops.
+			// New records being written is normal growth; losing them suggests data loss.
+			effectiveThreshold := threshold
+			if currentCount > prevCount {
+				effectiveThreshold = threshold * 2 // 2x tolerance for growth
+			}
+
+			if fractionalDelta > effectiveThreshold {
+				// Check spike baseline: if the current count is stable relative
+				// to a previously-halted count, this is a confirmed new level.
+				if spikeBase != nil {
+					if baseCount, ok := spikeBase.Counts[spikeKey(db, table)]; ok && baseCount > 0 {
+						baseDelta := math.Abs(float64(currentCount-baseCount)) / float64(baseCount)
+						if baseDelta <= threshold {
+							d.logger.Printf("jsonl_git_backup: %s/%s: count stable vs spike baseline (%d → %d, %.1f%% vs baseline %d), accepting new level",
+								db, table, prevCount, currentCount, fractionalDelta*100, baseCount)
+							continue // Stable relative to spike baseline — not a new spike.
+						}
 					}
 				}
-			}
 
-			spike := spikeInfo{
-				DB:       db,
-				File:     relPath,
-				Previous: prevCount,
-				Current:  currentCount,
-				Delta:    fractionalDelta,
-			}
-			spikes = append(spikes, spike)
+				spike := spikeInfo{
+					DB:       db,
+					Table:    table,
+					File:     filepath.ToSlash(relPath),
+					Previous: prevCount,
+					Current:  currentCount,
+					Delta:    fractionalDelta,
+				}
+				spikes = append(spikes, spike)
 
-			direction := "jump"
-			if currentCount < prevCount {
-				direction = "drop"
+				direction := "jump"
+				if currentCount < prevCount {
+					direction = "drop"
+				}
+				d.logger.Printf("jsonl_git_backup: SPIKE DETECTED: %s/%s: %s from %d to %d (%.1f%% %s, threshold %.1f%%)",
+					db, table, direction, prevCount, currentCount, fractionalDelta*100, direction, effectiveThreshold*100)
 			}
-			d.logger.Printf("jsonl_git_backup: SPIKE DETECTED: %s: %s from %d to %d (%.1f%% %s, threshold %.1f%%)",
-				db, direction, prevCount, currentCount, fractionalDelta*100, direction, effectiveThreshold*100)
 		}
 	}
 
 	// Save or clear spike baseline depending on results.
 	if len(spikes) > 0 {
-		if err := saveSpikeBaseline(gitRepo, counts); err != nil {
+		if err := saveSpikeBaseline(gitRepo, flattenTableCounts(tableCounts)); err != nil {
 			d.logger.Printf("jsonl_git_backup: failed to save spike baseline: %v", err)
 		}
 	}
 
 	return spikes
+}
+
+// flattenTableCounts converts db → table → count into the flat "db/table" → count
+// form stored in the spike baseline file.
+func flattenTableCounts(tableCounts map[string]map[string]int) map[string]int {
+	flat := make(map[string]int)
+	for db, perTable := range tableCounts {
+		for table, n := range perTable {
+			flat[spikeKey(db, table)] = n
+		}
+	}
+	return flat
 }
 
 // formatSpikeReport creates a human-readable summary of spike anomalies for escalation.
@@ -787,8 +853,14 @@ func formatSpikeReport(spikes []spikeInfo) string {
 		if s.Current < s.Previous {
 			direction = "DROP (possible data loss)"
 		}
+		// Name the exact file compared so the reader can reproduce the check
+		// with `git show HEAD:<file> | wc -l` rather than guessing the units.
+		label := s.File
+		if label == "" {
+			label = s.DB
+		}
 		fmt.Fprintf(&b, "  %s: %d → %d (%.1f%% change) — %s\n",
-			s.DB, s.Previous, s.Current, s.Delta*100, direction)
+			label, s.Previous, s.Current, s.Delta*100, direction)
 	}
 	b.WriteString("Export halted. Manual review required.")
 	return b.String()
@@ -815,18 +887,25 @@ func countFileLines(path string) (int, error) {
 
 // recountAfterFilter re-reads the issues.jsonl file for each database to get
 // accurate post-filter line counts. This is needed because counts from
-// exportDatabaseToJsonl reflect pre-filter totals.
-func recountAfterFilter(gitRepo string, databases []string, counts map[string]int) {
+// exportDatabaseToJsonl reflect pre-filter totals. Only the issues table is
+// filtered, so only that entry is recounted; the database total is then
+// recomputed so the commit message stays consistent with it.
+func recountAfterFilter(gitRepo string, databases []string, tableCounts map[string]map[string]int, counts map[string]int) {
 	for _, db := range databases {
-		if _, ok := counts[db]; !ok {
+		perTable, ok := tableCounts[db]
+		if !ok {
 			continue
 		}
-		issuesPath := filepath.Join(gitRepo, db, "issues.jsonl")
+		if _, ok := perTable[issuesTable]; !ok {
+			continue
+		}
+		issuesPath := filepath.Join(gitRepo, db, issuesTable+".jsonl")
 		n, err := countFileLines(issuesPath)
 		if err != nil {
 			continue
 		}
-		counts[db] = n
+		perTable[issuesTable] = n
+		counts[db] = sumTableCounts(perTable)
 	}
 }
 

--- a/internal/daemon/jsonl_git_backup_test.go
+++ b/internal/daemon/jsonl_git_backup_test.go
@@ -282,7 +282,7 @@ func TestVerifyExportCounts_FirstExport(t *testing.T) {
 
 	d := &Daemon{logger: log.New(io.Discard, "", 0)}
 
-	counts := map[string]int{"testdb": 100}
+	counts := tc("testdb", map[string]int{"issues": 100})
 	spikes := d.verifyExportCounts(gitRepo, []string{"testdb"}, counts, 0.20)
 	if len(spikes) != 0 {
 		t.Errorf("expected no spikes on first export, got %v", spikes)
@@ -303,7 +303,7 @@ func TestVerifyExportCounts_WithinThreshold(t *testing.T) {
 
 	// 130 records = 30% increase. With 0.20 threshold and 2x asymmetric
 	// multiplier for increases, effective threshold is 0.40, so 30% is fine.
-	counts := map[string]int{"testdb": 130}
+	counts := tc("testdb", map[string]int{"issues": 130})
 	spikes := d.verifyExportCounts(gitRepo, []string{"testdb"}, counts, 0.20)
 	if len(spikes) != 0 {
 		t.Errorf("expected no spikes for 30%% increase (effective threshold 40%%), got %v", spikes)
@@ -324,7 +324,7 @@ func TestVerifyExportCounts_ExceedsThreshold(t *testing.T) {
 
 	// 200 records = 100% jump. Even with 2x asymmetric multiplier (effective
 	// threshold 0.40), 100% exceeds it.
-	counts := map[string]int{"testdb": 200}
+	counts := tc("testdb", map[string]int{"issues": 200})
 	spikes := d.verifyExportCounts(gitRepo, []string{"testdb"}, counts, 0.20)
 	if len(spikes) != 1 {
 		t.Fatalf("expected 1 spike, got %d", len(spikes))
@@ -350,7 +350,7 @@ func TestVerifyExportCounts_Drop(t *testing.T) {
 
 	// 60 records = 40% drop. Drops use the base threshold (no 2x multiplier)
 	// because losing data is more suspicious than gaining it.
-	counts := map[string]int{"testdb": 60}
+	counts := tc("testdb", map[string]int{"issues": 60})
 	spikes := d.verifyExportCounts(gitRepo, []string{"testdb"}, counts, 0.20)
 	if len(spikes) != 1 {
 		t.Fatalf("expected 1 spike for drop, got %d", len(spikes))
@@ -374,7 +374,7 @@ func TestVerifyExportCounts_SmallAbsoluteChangeIgnored(t *testing.T) {
 
 	// 5 records = 50% drop, but only 5 records absolute change.
 	// Below minAbsoluteDelta (20), so should NOT spike.
-	counts := map[string]int{"testdb": 5}
+	counts := tc("testdb", map[string]int{"issues": 5})
 	spikes := d.verifyExportCounts(gitRepo, []string{"testdb"}, counts, 0.20)
 	if len(spikes) != 0 {
 		t.Errorf("expected no spikes for small absolute change (<20 records), got %v", spikes)
@@ -393,14 +393,14 @@ func TestVerifyExportCounts_AsymmetricThreshold(t *testing.T) {
 	d := &Daemon{logger: log.New(io.Discard, "", 0)}
 
 	// 70 records = 30% drop at 0.20 threshold → should spike (drops use base threshold)
-	counts := map[string]int{"testdb": 70}
+	counts := tc("testdb", map[string]int{"issues": 70})
 	spikes := d.verifyExportCounts(gitRepo, []string{"testdb"}, counts, 0.20)
 	if len(spikes) != 1 {
 		t.Fatalf("expected 1 spike for 30%% drop at 20%% threshold, got %d", len(spikes))
 	}
 
 	// 130 records = 30% increase at 0.20 threshold → should NOT spike (increases use 2x = 0.40)
-	counts = map[string]int{"testdb": 130}
+	counts = tc("testdb", map[string]int{"issues": 130})
 	spikes = d.verifyExportCounts(gitRepo, []string{"testdb"}, counts, 0.20)
 	if len(spikes) != 0 {
 		t.Errorf("expected no spike for 30%% increase at 40%% effective threshold, got %v", spikes)
@@ -420,7 +420,7 @@ func TestVerifyExportCounts_SpikeBaselineRecovery(t *testing.T) {
 	d := &Daemon{logger: log.New(io.Discard, "", 0)}
 
 	// First run: 400 records = 60% drop → should spike and save baseline.
-	counts := map[string]int{"testdb": 400}
+	counts := tc("testdb", map[string]int{"issues": 400})
 	spikes := d.verifyExportCounts(gitRepo, []string{"testdb"}, counts, 0.50)
 	if len(spikes) != 1 {
 		t.Fatalf("expected 1 spike on first detection, got %d", len(spikes))
@@ -431,12 +431,12 @@ func TestVerifyExportCounts_SpikeBaselineRecovery(t *testing.T) {
 	if sb == nil {
 		t.Fatal("expected spike baseline to be saved after spike detection")
 	}
-	if sb.Counts["testdb"] != 400 {
-		t.Errorf("expected baseline count 400, got %d", sb.Counts["testdb"])
+	if sb.Counts["testdb/issues"] != 400 {
+		t.Errorf("expected baseline count 400, got %d", sb.Counts["testdb/issues"])
 	}
 
 	// Second run: same count (400) → stable vs spike baseline → should NOT spike.
-	counts = map[string]int{"testdb": 400}
+	counts = tc("testdb", map[string]int{"issues": 400})
 	spikes = d.verifyExportCounts(gitRepo, []string{"testdb"}, counts, 0.50)
 	if len(spikes) != 0 {
 		t.Errorf("expected no spikes on second run (stable vs baseline), got %v", spikes)
@@ -455,7 +455,7 @@ func TestVerifyExportCounts_SpikeBaselineUnstable(t *testing.T) {
 	d := &Daemon{logger: log.New(io.Discard, "", 0)}
 
 	// First run: 400 records = 60% drop → spikes and saves baseline at 400.
-	counts := map[string]int{"testdb": 400}
+	counts := tc("testdb", map[string]int{"issues": 400})
 	spikes := d.verifyExportCounts(gitRepo, []string{"testdb"}, counts, 0.50)
 	if len(spikes) != 1 {
 		t.Fatalf("expected 1 spike, got %d", len(spikes))
@@ -463,10 +463,249 @@ func TestVerifyExportCounts_SpikeBaselineUnstable(t *testing.T) {
 
 	// Second run: 100 records = still a spike vs HEAD, AND unstable vs baseline
 	// (400 → 100 = 75% drop, exceeds threshold). Should still spike.
-	counts = map[string]int{"testdb": 100}
+	counts = tc("testdb", map[string]int{"issues": 100})
 	spikes = d.verifyExportCounts(gitRepo, []string{"testdb"}, counts, 0.50)
 	if len(spikes) != 1 {
 		t.Errorf("expected 1 spike for unstable count vs baseline, got %d", len(spikes))
+	}
+}
+
+// TestVerifyExportCounts_NoFalseSpikeAfterFullExport is the gt-e1u regression.
+// The baseline used to be read from issues.jsonl alone (71 lines) while the
+// current count was the total across all seven tables (2181), so every cycle
+// after the first full export looked like a ~2972% jump and halted the backup.
+// Compared per table, the honest delta is issues 71 → 73: not a spike.
+func TestVerifyExportCounts_NoFalseSpikeAfterFullExport(t *testing.T) {
+	gitRepo := t.TempDir()
+	initGitRepo(t, gitRepo)
+
+	// Run 1: full export of every table, committed. This is what arms the bug.
+	writeTableFiles(t, gitRepo, "hq", incidentCounts())
+	commitAll(t, gitRepo, "backup: full export of all 7 tables")
+
+	d := &Daemon{logger: log.New(io.Discard, "", 0)}
+
+	// Run 2: two new issues filed, every other table unchanged.
+	current := incidentCounts()
+	current["issues"] = 73
+
+	spikes := d.verifyExportCounts(gitRepo, []string{"hq"}, tc("hq", current), defaultSpikeThreshold)
+	if len(spikes) != 0 {
+		t.Fatalf("expected no spikes on the cycle after a full export, got %+v", spikes)
+	}
+
+	// And no spike baseline should have been written — nothing was halted.
+	if sb := loadSpikeBaseline(gitRepo); sb != nil {
+		t.Errorf("expected no spike baseline to be saved, got %+v", sb)
+	}
+
+	// Guard the guard: confirm this fixture still reproduces the original
+	// mismatch, so the test can't quietly stop covering the bug. Comparing the
+	// committed issues.jsonl against the blended all-tables total must exceed
+	// even the 2x growth tolerance.
+	prev, err := previousCommitLineCount(gitRepo, filepath.Join("hq", "issues.jsonl"))
+	if err != nil {
+		t.Fatalf("reading baseline: %v", err)
+	}
+	if prev != 71 {
+		t.Fatalf("expected committed issues.jsonl to have 71 lines, got %d", prev)
+	}
+	blendedDelta := float64(sumTableCounts(current)-prev) / float64(prev)
+	if blendedDelta <= defaultSpikeThreshold*2 {
+		t.Fatalf("fixture no longer reproduces the mismatch: blended delta %.2f is within tolerance", blendedDelta)
+	}
+}
+
+// TestVerifyExportCounts_SupplementalTableJumpCaught proves the per-table check
+// still catches a genuine pollution event — one that an issues-only baseline
+// would have been blind to.
+func TestVerifyExportCounts_SupplementalTableJumpCaught(t *testing.T) {
+	gitRepo := t.TempDir()
+	initGitRepo(t, gitRepo)
+
+	writeTableFiles(t, gitRepo, "hq", incidentCounts())
+	commitAll(t, gitRepo, "baseline")
+
+	d := &Daemon{logger: log.New(io.Discard, "", 0)}
+
+	// comments 86 → 900: a >900% jump, far past the 2x growth tolerance.
+	// The issues table is untouched, so the old issues-only check saw nothing.
+	current := incidentCounts()
+	current["comments"] = 900
+
+	spikes := d.verifyExportCounts(gitRepo, []string{"hq"}, tc("hq", current), defaultSpikeThreshold)
+	if len(spikes) != 1 {
+		t.Fatalf("expected 1 spike for the comments table, got %d: %+v", len(spikes), spikes)
+	}
+	if spikes[0].Table != "comments" {
+		t.Errorf("expected spike on comments, got %q", spikes[0].Table)
+	}
+	if spikes[0].File != "hq/comments.jsonl" {
+		t.Errorf("expected file hq/comments.jsonl, got %q", spikes[0].File)
+	}
+	if spikes[0].Previous != 86 || spikes[0].Current != 900 {
+		t.Errorf("expected 86→900, got %d→%d", spikes[0].Previous, spikes[0].Current)
+	}
+
+	// The report should name the file, not just the database, so a reader can
+	// reproduce the comparison.
+	if report := formatSpikeReport(spikes); !contains(report, "hq/comments.jsonl") {
+		t.Errorf("report should name the compared file: %s", report)
+	}
+}
+
+// TestVerifyExportCounts_SupplementalTableDropCaught covers data loss in a
+// supplemental table (drops use the base threshold, no 2x tolerance).
+func TestVerifyExportCounts_SupplementalTableDropCaught(t *testing.T) {
+	gitRepo := t.TempDir()
+	initGitRepo(t, gitRepo)
+
+	writeTableFiles(t, gitRepo, "hq", incidentCounts())
+	commitAll(t, gitRepo, "baseline")
+
+	d := &Daemon{logger: log.New(io.Discard, "", 0)}
+
+	// events 1796 → 100: catastrophic loss that a blended total would have
+	// dominated in the other direction.
+	current := incidentCounts()
+	current["events"] = 100
+
+	spikes := d.verifyExportCounts(gitRepo, []string{"hq"}, tc("hq", current), defaultSpikeThreshold)
+	if len(spikes) != 1 {
+		t.Fatalf("expected 1 spike for the events table, got %d: %+v", len(spikes), spikes)
+	}
+	if spikes[0].Table != "events" {
+		t.Errorf("expected spike on events, got %q", spikes[0].Table)
+	}
+	if spikes[0].Current >= spikes[0].Previous {
+		t.Errorf("expected a drop, got %d→%d", spikes[0].Previous, spikes[0].Current)
+	}
+}
+
+// TestVerifyExportCounts_FailedTableSkipped ensures a supplemental table whose
+// export failed (absent from the counts map) is not read as "dropped to zero".
+func TestVerifyExportCounts_FailedTableSkipped(t *testing.T) {
+	gitRepo := t.TempDir()
+	initGitRepo(t, gitRepo)
+
+	writeTableFiles(t, gitRepo, "hq", incidentCounts())
+	commitAll(t, gitRepo, "baseline")
+
+	d := &Daemon{logger: log.New(io.Discard, "", 0)}
+
+	current := incidentCounts()
+	delete(current, "events") // export failed this cycle
+
+	spikes := d.verifyExportCounts(gitRepo, []string{"hq"}, tc("hq", current), defaultSpikeThreshold)
+	if len(spikes) != 0 {
+		t.Errorf("expected no spikes when a table export failed, got %+v", spikes)
+	}
+}
+
+// TestVerifyExportCounts_PerTableBaselineRecovery checks that the halt/accept
+// recovery path keys off the same per-table units as the check itself.
+func TestVerifyExportCounts_PerTableBaselineRecovery(t *testing.T) {
+	gitRepo := t.TempDir()
+	initGitRepo(t, gitRepo)
+
+	writeTableFiles(t, gitRepo, "hq", incidentCounts())
+	commitAll(t, gitRepo, "baseline")
+
+	d := &Daemon{logger: log.New(io.Discard, "", 0)}
+
+	// A real bulk import triples the comments table — halts and records the level.
+	current := incidentCounts()
+	current["comments"] = 900
+
+	spikes := d.verifyExportCounts(gitRepo, []string{"hq"}, tc("hq", current), defaultSpikeThreshold)
+	if len(spikes) != 1 {
+		t.Fatalf("expected 1 spike on first detection, got %d", len(spikes))
+	}
+	sb := loadSpikeBaseline(gitRepo)
+	if sb == nil {
+		t.Fatal("expected a spike baseline after detection")
+	}
+	if sb.Counts["hq/comments"] != 900 {
+		t.Errorf("expected per-table baseline hq/comments=900, got %d", sb.Counts["hq/comments"])
+	}
+	if sb.Counts["hq/issues"] != 71 {
+		t.Errorf("expected per-table baseline hq/issues=71, got %d", sb.Counts["hq/issues"])
+	}
+
+	// Next cycle: count holds at the new level, so it is accepted.
+	spikes = d.verifyExportCounts(gitRepo, []string{"hq"}, tc("hq", current), defaultSpikeThreshold)
+	if len(spikes) != 0 {
+		t.Errorf("expected the stable new level to be accepted, got %+v", spikes)
+	}
+}
+
+// TestVerifyExportCounts_StaleDBKeyedBaselineIgnored covers upgrade from a build
+// that keyed the baseline by database. The stale key must not match a per-table
+// lookup and must not suppress a real spike.
+func TestVerifyExportCounts_StaleDBKeyedBaselineIgnored(t *testing.T) {
+	gitRepo := t.TempDir()
+	initGitRepo(t, gitRepo)
+
+	writeTableFiles(t, gitRepo, "hq", incidentCounts())
+	commitAll(t, gitRepo, "baseline")
+
+	// Old-format baseline: keyed by database, holding the blended total.
+	if err := saveSpikeBaseline(gitRepo, map[string]int{"hq": 2181}); err != nil {
+		t.Fatalf("save baseline: %v", err)
+	}
+
+	d := &Daemon{logger: log.New(io.Discard, "", 0)}
+
+	current := incidentCounts()
+	current["comments"] = 900
+
+	spikes := d.verifyExportCounts(gitRepo, []string{"hq"}, tc("hq", current), defaultSpikeThreshold)
+	if len(spikes) != 1 {
+		t.Fatalf("expected the stale db-keyed baseline to be ignored and the spike reported, got %d", len(spikes))
+	}
+	// The stale entry is replaced by per-table keys.
+	sb := loadSpikeBaseline(gitRepo)
+	if sb == nil {
+		t.Fatal("expected a rewritten spike baseline")
+	}
+	if _, stale := sb.Counts["hq"]; stale {
+		t.Errorf("expected the db-keyed entry to be gone, got %v", sb.Counts)
+	}
+}
+
+func TestRecountAfterFilter_UpdatesIssuesAndTotal(t *testing.T) {
+	gitRepo := t.TempDir()
+
+	// On-disk issues.jsonl reflects the post-filter state (3 records removed).
+	perTable := incidentCounts()
+	writeTableFiles(t, gitRepo, "hq", map[string]int{"issues": 68})
+
+	tableCounts := map[string]map[string]int{"hq": perTable}
+	counts := map[string]int{"hq": sumTableCounts(perTable)}
+
+	recountAfterFilter(gitRepo, []string{"hq"}, tableCounts, counts)
+
+	if got := tableCounts["hq"]["issues"]; got != 68 {
+		t.Errorf("expected issues recounted to 68, got %d", got)
+	}
+	// Supplemental tables are not filtered, so only the issues delta moves the total.
+	if want := sumTableCounts(incidentCounts()) - 3; counts["hq"] != want {
+		t.Errorf("expected total %d, got %d", want, counts["hq"])
+	}
+}
+
+func TestExportedTablesCoversEveryExportedFile(t *testing.T) {
+	tables := exportedTables()
+	if len(tables) != 1+len(supplementalTables) {
+		t.Fatalf("expected %d tables, got %d", 1+len(supplementalTables), len(tables))
+	}
+	if tables[0] != issuesTable {
+		t.Errorf("expected issues first, got %q", tables[0])
+	}
+	// Mutating the result must not corrupt supplementalTables.
+	tables[1] = "mutated"
+	if supplementalTables[0] == "mutated" {
+		t.Error("exportedTables aliases supplementalTables backing array")
 	}
 }
 
@@ -588,6 +827,38 @@ func containsHelper(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// tc wraps a single database's per-table counts in the map shape
+// verifyExportCounts expects.
+func tc(db string, perTable map[string]int) map[string]map[string]int {
+	return map[string]map[string]int{db: perTable}
+}
+
+// incidentCounts is the per-table shape captured from the gt-e1u incident on
+// the hq database. Returned fresh each call so callers can mutate it.
+func incidentCounts() map[string]int {
+	return map[string]int{
+		"issues":       71,
+		"comments":     86,
+		"config":       60,
+		"dependencies": 1,
+		"events":       1796,
+		"labels":       161,
+		"metadata":     4,
+	}
+}
+
+// writeTableFiles writes one JSONL file per table into {gitRepo}/{db}/.
+func writeTableFiles(t *testing.T, gitRepo, db string, perTable map[string]int) {
+	t.Helper()
+	dbDir := filepath.Join(gitRepo, db)
+	if err := os.MkdirAll(dbDir, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", dbDir, err)
+	}
+	for table, n := range perTable {
+		writeNLines(t, filepath.Join(dbDir, table+".jsonl"), n)
+	}
 }
 
 func initGitRepo(t *testing.T, dir string) {


### PR DESCRIPTION
## Problem

`jsonl_git_backup` spike detection compared mismatched units:

```go
relPath := filepath.Join(db, "issues.jsonl")
prevCount, err := previousCommitLineCount(gitRepo, relPath)  // issues.jsonl ALONE
...
currentCount := counts[db]  // total across ALL 7 exported tables
```

Baseline was one file; current count was seven. Once a full export landed, the
next cycle read `hq: 71 → 2181 (2971.8%)`, halted the export, and fired a HIGH
escalation (`hq-wisp-08y`). The data was correct — the comparison was not. The
honest like-for-like delta was issues 71 → 73: +2 records, under
`minAbsoluteDelta`.

The `.spike-counts.json` recovery path turned this into an oscillation rather
than a clean failure:

| run | outcome |
|-----|---------|
| N   | 71 vs 2181 → SPIKE → halt, escalate, save baseline 2181 |
| N+1 | stable vs baseline → accept new level → commit → clear baseline |
| N+2 | committed issues.jsonl (73) vs 2181 → SPIKE again → halt, escalate |

So every other cycle halted and escalated, indefinitely: alarm fatigue on the
one channel that actually reaches a human, plus 50% backup coverage.

## Fix

Spike-check **per table** (option (b) from the issue), so both sides of every
comparison always measure the same set of records.

- `exportDatabaseToJsonl` returns per-table counts instead of a blended total.
  A supplemental table whose export failed is **absent** from the map rather
  than recorded as zero, so a transient query failure is never mistaken for the
  table being emptied.
- `verifyExportCounts` walks db × table, comparing `{db}/{table}.jsonl` in HEAD
  against that same table's current count. The asymmetric growth tolerance and
  `minAbsoluteDelta` are applied per table, so the high-volume `events` table
  can no longer dominate a blended metric, and pollution in a supplemental
  table is no longer invisible behind an issues-only baseline.
- The spike baseline file is keyed `"db/table"`. A baseline written by an older
  build is keyed by database, will not match, and is treated as absent — safe,
  since the file is git-ignored scratch state rewritten on the next spike.
- Spike reports now name the exact file compared, so a reader can reproduce the
  check with `git show HEAD:<file> | wc -l`.

Per-database totals in the commit message are unchanged.

## Acceptance

- [x] baseline and current count are computed over the same set of files
- [x] a normal cycle after a full export does NOT trigger a spike —
      `TestVerifyExportCounts_NoFalseSpikeAfterFullExport`, built on the
      incident's real per-table shape (issues 71, comments 86, config 60,
      dependencies 1, events 1796, labels 161, metadata 4), run twice with
      issues 71 → 73
- [x] regression test asserts no spike **and** no baseline written on the
      second run — and additionally asserts the fixture still reproduces the
      original mismatch, so it cannot quietly stop covering the bug
- [x] a genuine pollution event in a supplemental table IS still caught —
      `TestVerifyExportCounts_SupplementalTableJumpCaught` (comments 86 → 900),
      plus `..._SupplementalTableDropCaught` (events 1796 → 100)

Also covered: failed table export is skipped rather than read as a drop to
zero, per-table halt/accept baseline recovery, and the stale-baseline upgrade
path.

## Verification

`go build ./...`, `go vet ./internal/daemon/`, and the full
`go test ./internal/daemon/` suite pass (217s). Both changed files are
`gofmt`-clean. All eight pre-existing `verifyExportCounts` tests were updated
to the new signature and still pass.

Closes gt-e1u.

🤖 Generated with [Claude Code](https://claude.com/claude-code)