### PR TITLE
fix(cmd): scope isDoneCommand to root 'gt done' only

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -190,8 +190,14 @@ func isRoleCommand(cmd *cobra.Command) bool {
 }
 
 func isDoneCommand(cmd *cobra.Command) bool {
+	// Only the root-level "gt done" command (polecat completion) triggers the
+	// polecat worktree ownership check in persistentPreRun and the telemetry
+	// skip. Subcommands named "done" owned by other parents (gt dog done,
+	// gt wl done, gt mol step done) are unrelated and must not be treated as
+	// polecat completion, otherwise their pre-run check fails with
+	// "gt done is for polecats only" before the real handler ever runs.
 	for c := cmd; c != nil; c = c.Parent() {
-		if c.Name() == "done" {
+		if c == doneCmd {
 			return true
 		}
 	}


### PR DESCRIPTION
## Problem
`gt dog done` (and `gt dog done <name>`) route to the polecat `done` handler and error out with:
```
Error: gt done is for polecats only (BD_ACTOR=dog)
```
This leaves dogs stuck in `working` state forever, blocking their `DOG_DONE` handoff contract. Workaround is `gt dog clear --force`.

## Root Cause
`isDoneCommand()` in `internal/cmd/root.go` matches any command whose name-chain contains a subcommand named `done`. `persistentPreRun` then calls `resolveDonePolecatWorktree()` for those subcommands to "prove ownership before shared pre-run writes" — but that polecat check rejects non-polecat actors. Because `dog doneTask`, `wl done`, and `mol step done` all own subcommands named `done`, they are all wrongly treated as polecat completion and fail the pre-run ownership check before the real handler ever executes.

## Fix
Scope `isDoneCommand` to the root-level polecat `doneCmd` only. Subcommands named `done` owned by other parents are no longer misrouted.

## Verification
- `gt dog done` now runs `runDogDone` (no longer the polecat check)
- `gt dog done alpha` and auto-detection from a dog worktree return correct idle/clear results
- Root `gt done` behavior is unchanged (still polecat-only)
- `go vet ./internal/cmd/` clean