### PR TITLE
fix: resolve rig identity beads against the town DB, stop failing closed (gt-gf6)

### DIFF
--- a/internal/beads/beads_rig.go
+++ b/internal/beads/beads_rig.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -93,6 +95,122 @@ func ParseRigFields(description string) *RigFields {
 	return fields
 }
 
+// NewRigBeadStore returns a Beads wrapper for rig identity bead operations in
+// the given town.
+//
+// Rig identity beads (<prefix>-rig-<name>) carry the rig's own ID prefix but,
+// like agent beads, they live in the TOWN (hq) database. Prefix routing maps
+// "sv-" to the svalscripts rig database, so a routed lookup for
+// "sv-rig-svalscripts" is sent to a database that has never held the bead and
+// comes back "issue not found" (gt-gf6). Re-rooting at the town .beads dir and
+// disabling routing is what makes these lookups resolve at all.
+//
+// Callers that already know the town root should prefer this over ForRigBead,
+// which has to walk the filesystem to find it.
+func NewRigBeadStore(townRoot string) *Beads {
+	if townRoot == "" {
+		return &Beads{}
+	}
+	return &Beads{
+		workDir:  townRoot,
+		beadsDir: filepath.Join(townRoot, ".beads"),
+		townRoot: townRoot,
+		noRoute:  true,
+	}
+}
+
+// ForRigBead returns a Beads wrapper suitable for operating on rig identity
+// beads, preserving this wrapper's isolation and server-port settings.
+// See NewRigBeadStore for why rig identity beads need a town-rooted wrapper.
+//
+// If the town root cannot be determined, returns the original wrapper so
+// isolated/test setups keep working.
+func (b *Beads) ForRigBead() *Beads {
+	return b.ForAgentBead()
+}
+
+// rigBeadTarget returns the wrapper rig identity bead operations should run
+// against. Mirrors agentBeadTarget: already-unrouted wrappers (including those
+// from NewRigBeadStore) are used as-is.
+func (b *Beads) rigBeadTarget() *Beads {
+	if b.noRoute {
+		return b
+	}
+	return b.ForRigBead()
+}
+
+// legacyRigBeadDirs returns the rig-scoped beads directories that may hold a
+// rig identity bead created before the town database became canonical,
+// deduplicated and in lookup order.
+func legacyRigBeadDirs(rigPath string) []string {
+	var dirs []string
+	seen := make(map[string]bool)
+	add := func(dir string) {
+		if dir == "" || seen[dir] {
+			return
+		}
+		seen[dir] = true
+		dirs = append(dirs, dir)
+	}
+
+	mayorRig := filepath.Join(rigPath, "mayor", "rig")
+	if _, err := os.Stat(filepath.Join(mayorRig, ".beads")); err == nil {
+		add(ResolveBeadsDir(mayorRig))
+	}
+	add(ResolveBeadsDir(rigPath))
+	return dirs
+}
+
+// ShowRigBead resolves a rig identity bead for the given rig.
+//
+// The town database is canonical (see NewRigBeadStore), but towns predating
+// that rule have rig identity beads sitting in the rig's own database —
+// anything docked by an older 'gt rig dock' wrote its status:docked label
+// there. Reading only the town database would make those states invisible and
+// silently un-dock the rig, so the rig-scoped database is consulted as a
+// fallback.
+//
+// Returns ErrNotFound only when the bead is absent from both. If either lookup
+// failed for a reason other than not-found — an unreachable backend — that
+// error is returned so callers can tell "no docked state recorded" apart from
+// "could not read the docked state".
+func ShowRigBead(townRoot, rigName, prefix string) (*Issue, error) {
+	id := RigBeadIDWithPrefix(prefix, rigName)
+
+	var hardErr error
+	note := func(err error) {
+		if hardErr == nil && !errors.Is(err, ErrNotFound) {
+			hardErr = err
+		}
+	}
+
+	issue, err := NewRigBeadStore(townRoot).Show(id)
+	if err == nil {
+		return issue, nil
+	}
+	note(err)
+
+	// Legacy locations, in the order the pre-fix readers used: the mayor/rig
+	// checkout when it has its own .beads, then the rig root (following any
+	// redirect). Routing is disabled because the ID's prefix would send the
+	// lookup right back to the database we are already pointing at.
+	rigPath := filepath.Join(townRoot, rigName)
+	for _, dir := range legacyRigBeadDirs(rigPath) {
+		legacy := NewWithBeadsDir(rigPath, dir)
+		legacy.noRoute = true
+		issue, err = legacy.Show(id)
+		if err == nil {
+			return issue, nil
+		}
+		note(err)
+	}
+
+	if hardErr != nil {
+		return nil, hardErr
+	}
+	return nil, ErrNotFound
+}
+
 // EnsureRigBead returns the rig identity bead, creating it if it doesn't exist.
 // This is idempotent: if the bead already exists, it is returned as-is.
 // Handles races and Dolt query hiccups where Show may fail even when the bead
@@ -103,20 +221,21 @@ func (b *Beads) EnsureRigBead(name string, fields *RigFields) (*Issue, error) {
 		prefix = fields.Prefix
 	}
 	id := RigBeadIDWithPrefix(prefix, name)
+	target := b.rigBeadTarget()
 
 	// Try to find existing bead first
-	if existing, err := b.Show(id); err == nil {
+	if existing, err := target.Show(id); err == nil {
 		return existing, nil
 	}
 
 	// Not found — try to create
-	created, createErr := b.CreateRigBead(name, fields)
+	created, createErr := target.CreateRigBead(name, fields)
 	if createErr == nil {
 		return created, nil
 	}
 
 	// Create failed (likely duplicate key from race or Dolt hiccup) — retry Show
-	if existing, err := b.Show(id); err == nil {
+	if existing, err := target.Show(id); err == nil {
 		return existing, nil
 	}
 
@@ -143,11 +262,12 @@ func (b *Beads) CreateRigBead(name string, fields *RigFields) (*Issue, error) {
 	}
 	id := RigBeadIDWithPrefix(prefix, name)
 	description := FormatRigDescription(name, fields)
+	target := b.rigBeadTarget()
 
 	// Ensure target database keeps rig as a durable custom type, not an
 	// infra/wisp type. Failing closed avoids silently creating ephemeral rig
 	// identity beads when type config cannot be persisted.
-	if err := EnsureCustomTypes(b.getResolvedBeadsDir()); err != nil {
+	if err := EnsureCustomTypes(target.getResolvedBeadsDir()); err != nil {
 		return nil, fmt.Errorf("ensuring rig bead types: %w", err)
 	}
 
@@ -164,11 +284,11 @@ func (b *Beads) CreateRigBead(name string, fields *RigFields) (*Issue, error) {
 
 	// Default actor from BD_ACTOR env var for provenance tracking
 	// Uses getActor() to respect isolated mode (tests)
-	if actor := b.getActor(); actor != "" {
+	if actor := target.getActor(); actor != "" {
 		args = append(args, "--actor="+actor)
 	}
 
-	out, err := b.run(args...)
+	out, err := target.run(args...)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +305,7 @@ func (b *Beads) CreateRigBead(name string, fields *RigFields) (*Issue, error) {
 // Returns ErrNotFound if the rig does not exist.
 func (b *Beads) GetRigBead(name string) (*Issue, *RigFields, error) {
 	id := RigBeadID(name)
-	issue, err := b.Show(id)
+	issue, err := b.rigBeadTarget().Show(id)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return nil, nil, ErrNotFound
@@ -204,7 +324,7 @@ func (b *Beads) GetRigBead(name string) (*Issue, *RigFields, error) {
 // GetRigByID retrieves a rig bead by its full ID.
 // Returns ErrNotFound if the rig does not exist.
 func (b *Beads) GetRigByID(id string) (*Issue, *RigFields, error) {
-	issue, err := b.Show(id)
+	issue, err := b.rigBeadTarget().Show(id)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return nil, nil, ErrNotFound
@@ -231,12 +351,13 @@ func (b *Beads) UpdateRigBead(name string, fields *RigFields) (*Issue, error) {
 	}
 
 	description := FormatRigDescription(name, fields)
+	target := b.rigBeadTarget()
 
-	if err := b.Update(issue.ID, UpdateOptions{Description: &description}); err != nil {
+	if err := target.Update(issue.ID, UpdateOptions{Description: &description}); err != nil {
 		return nil, err
 	}
 
-	updated, err := b.Show(issue.ID)
+	updated, err := target.Show(issue.ID)
 	if err != nil {
 		return nil, fmt.Errorf("fetching updated rig: %w", err)
 	}
@@ -246,12 +367,12 @@ func (b *Beads) UpdateRigBead(name string, fields *RigFields) (*Issue, error) {
 // DeleteRigBead permanently deletes a rig bead.
 func (b *Beads) DeleteRigBead(name string) error {
 	id := RigBeadID(name)
-	return b.deleteBead(id)
+	return b.rigBeadTarget().deleteBead(id)
 }
 
 // ListRigBeads returns all rig beads.
 func (b *Beads) ListRigBeads() (map[string]*RigFields, error) {
-	out, err := b.run("list", "--label=gt:rig", "--json")
+	out, err := b.rigBeadTarget().run("list", "--label=gt:rig", "--json")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -2357,14 +2357,9 @@ func getRigOperationalState(townRoot, rigName string) (state string, source stri
 	}
 
 	// Check rig bead labels (global/synced)
-	// Rig identity bead ID: <prefix>-rig-<name>
-	// Look for status:docked or status:parked labels
+	// Look for status:docked or status:parked labels on the rig identity bead.
 	rigPath := filepath.Join(townRoot, rigName)
-	rigBeadsDir := beads.ResolveBeadsDir(rigPath)
-	bd := beads.NewWithBeadsDir(rigPath, rigBeadsDir)
 
-	// Try to find the rig identity bead
-	// Convention: <prefix>-rig-<rigName>
 	// Try to get prefix from rig config.json, fall back to rigs.json registry
 	var prefix string
 	if rigCfg, err := rig.LoadRigConfig(rigPath); err == nil && rigCfg.Beads != nil {
@@ -2375,8 +2370,7 @@ func getRigOperationalState(townRoot, rigName string) (state string, source stri
 	}
 
 	if prefix != "" {
-		rigBeadID := fmt.Sprintf("%s-rig-%s", prefix, rigName)
-		if issue, err := bd.Show(rigBeadID); err == nil {
+		if issue, err := beads.ShowRigBead(townRoot, rigName, prefix); err == nil {
 			for _, label := range issue.Labels {
 				if strings.HasPrefix(label, "status:") {
 					statusValue := strings.TrimPrefix(label, "status:")

--- a/internal/cmd/rig_dock.go
+++ b/internal/cmd/rig_dock.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -16,7 +14,6 @@ import (
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/witness"
-	"github.com/steveyegge/gastown/internal/workspace"
 )
 
 // RigDockedLabel is the label set on rig identity beads when docked.
@@ -86,7 +83,7 @@ func runRigDock(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get rig
-	_, r, err := getRig(rigName)
+	townRoot, r, err := getRig(rigName)
 	if err != nil {
 		return err
 	}
@@ -98,8 +95,9 @@ func runRigDock(cmd *cobra.Command, args []string) error {
 	}
 
 	// Find or create the rig identity bead (idempotent; handles duplicates
-	// and Dolt query hiccups gracefully — gt-d8681).
-	bd := beads.New(r.BeadsPath())
+	// and Dolt query hiccups gracefully — gt-d8681). Rig identity beads live in
+	// the town database despite their rig prefix — see beads.NewRigBeadStore.
+	bd := beads.NewRigBeadStore(townRoot)
 	rigBead, err := bd.EnsureRigBead(rigName, &beads.RigFields{
 		Repo:   r.GitURL,
 		Prefix: prefix,
@@ -170,11 +168,8 @@ func runRigDock(cmd *cobra.Command, args []string) error {
 
 	// Remove rig from daemon.json patrol config so daemon stops spawning
 	// witness/refinery sessions for this rig on every heartbeat cycle.
-	townRoot, twErr := workspace.FindFromCwdOrError()
-	if twErr == nil {
-		if err := config.RemoveRigFromDaemonPatrols(townRoot, rigName); err != nil {
-			fmt.Printf("  %s Could not update daemon.json patrols: %v\n", style.Warning.Render("!"), err)
-		}
+	if err := config.RemoveRigFromDaemonPatrols(townRoot, rigName); err != nil {
+		fmt.Printf("  %s Could not update daemon.json patrols: %v\n", style.Warning.Render("!"), err)
 	}
 
 	// Output
@@ -203,7 +198,7 @@ func runRigUndock(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get rig and town root
-	_, r, err := getRig(rigName)
+	townRoot, r, err := getRig(rigName)
 	if err != nil {
 		return err
 	}
@@ -214,9 +209,9 @@ func runRigUndock(cmd *cobra.Command, args []string) error {
 		prefix = r.Config.Prefix
 	}
 
-	// Find the rig identity bead
+	// Find the rig identity bead (town database — see beads.NewRigBeadStore)
 	rigBeadID := beads.RigBeadIDWithPrefix(prefix, rigName)
-	bd := beads.New(r.BeadsPath())
+	bd := beads.NewRigBeadStore(townRoot)
 
 	// Check if rig bead exists, create if not
 	rigBead, err := bd.Show(rigBeadID)
@@ -248,11 +243,8 @@ func runRigUndock(cmd *cobra.Command, args []string) error {
 
 	// Re-add rig to daemon.json patrol config so daemon resumes spawning
 	// witness/refinery sessions for this rig.
-	townRoot, twErr := workspace.FindFromCwdOrError()
-	if twErr == nil {
-		if err := config.AddRigToDaemonPatrols(townRoot, rigName); err != nil {
-			fmt.Printf("  %s Could not update daemon.json patrols: %v\n", style.Warning.Render("!"), err)
-		}
+	if err := config.AddRigToDaemonPatrols(townRoot, rigName); err != nil {
+		fmt.Printf("  %s Could not update daemon.json patrols: %v\n", style.Warning.Render("!"), err)
 	}
 
 	fmt.Printf("%s Rig %s undocked\n", style.Success.Render("✓"), rigName)
@@ -266,17 +258,7 @@ func runRigUndock(cmd *cobra.Command, args []string) error {
 // IsRigDocked checks if a rig is docked by checking for the status:docked label
 // on the rig identity bead. This function is exported for use by the daemon.
 func IsRigDocked(townRoot, rigName, prefix string) bool {
-	// Construct the rig beads path
-	rigPath := filepath.Join(townRoot, rigName)
-	beadsPath := filepath.Join(rigPath, "mayor", "rig")
-	if _, err := os.Stat(beadsPath); err != nil {
-		beadsPath = rigPath
-	}
-
-	bd := beads.New(beadsPath)
-	rigBeadID := beads.RigBeadIDWithPrefix(prefix, rigName)
-
-	rigBead, err := bd.Show(rigBeadID)
+	rigBead, err := beads.ShowRigBead(townRoot, rigName, prefix)
 	if err != nil {
 		return false
 	}

--- a/internal/cmd/rig_helpers.go
+++ b/internal/cmd/rig_helpers.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -74,15 +73,7 @@ func hasRigBeadLabel(townRoot, rigName, label string) bool {
 		return false
 	}
 
-	beadsPath := filepath.Join(rigPath, "mayor", "rig")
-	if _, err := os.Stat(beadsPath); err != nil {
-		beadsPath = rigPath
-	}
-
-	bd := beads.New(beadsPath)
-	rigBeadID := beads.RigBeadIDWithPrefix(prefix, rigName)
-
-	rigBead, err := bd.Show(rigBeadID)
+	rigBead, err := beads.ShowRigBead(townRoot, rigName, prefix)
 	if err != nil {
 		return false
 	}
@@ -121,14 +112,7 @@ func IsRigParkedOrDocked(townRoot, rigName string) (bool, string) {
 		return false, ""
 	}
 
-	beadsPath := filepath.Join(rigPath, "mayor", "rig")
-	if _, err := os.Stat(beadsPath); err != nil {
-		beadsPath = rigPath
-	}
-
-	bd := beads.New(beadsPath)
-	rigBeadID := beads.RigBeadIDWithPrefix(prefix, rigName)
-	rigBead, err := bd.Show(rigBeadID)
+	rigBead, err := beads.ShowRigBead(townRoot, rigName, prefix)
 	if err != nil {
 		return false, ""
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2181,6 +2181,13 @@ func (d *Daemon) getPatrolRigs(patrol string) []string {
 	return operational
 }
 
+// showRigBead resolves a rig identity bead for a rig. It is a package-level
+// seam so tests can exercise the found / not-found / backend-unreachable
+// branches of isRigOperational deterministically.
+var showRigBead = func(townRoot, rigName, prefix string) (*beads.Issue, error) {
+	return beads.ShowRigBead(townRoot, rigName, prefix)
+}
+
 // isRigOperational checks if a rig is in an operational state.
 // Returns true if the rig can have agents auto-started.
 // Returns false (with reason) if the rig is parked, docked, or has auto_restart blocked/disabled.
@@ -2220,25 +2227,37 @@ func (d *Daemon) isRigOperational(rigName string) (bool, string) {
 		prefix = agentconfig.GetRigPrefix(d.config.TownRoot, rigName)
 	}
 
-	rigBeadID := fmt.Sprintf("%s-rig-%s", prefix, rigName)
-	rigBeadsDir := beads.ResolveBeadsDir(rigPath)
-	bd := beads.NewWithBeadsDir(rigPath, rigBeadsDir)
-	if issue, err := bd.Show(rigBeadID); err == nil {
-		for _, label := range issue.Labels {
-			if label == "status:docked" {
-				return false, "rig is docked (global)"
-			}
-			if label == "status:parked" {
-				return false, "rig is parked (global)"
-			}
-		}
+	if prefix == "" {
+		// No prefix means we cannot even name the identity bead. That is a
+		// registry gap, not a docked rig — keep supervising and say so.
+		d.logger.Printf("Warning: no beads prefix for rig %s; skipping docked/parked bead check (assuming operational)", rigName)
 	} else {
-		// Log when rig bead lookup fails - this helps debug transient Dolt issues
-		// FAIL-SAFE: When we can't verify docked status (Dolt down, network issue, etc.),
-		// assume the rig is NOT operational. This prevents wasting API credits starting
-		// witnesses that might be docked. Better to delay work than burn credits unnecessarily.
-		d.logger.Printf("Warning: failed to check rig bead %s for docked/parked status: %v (assuming not operational)", rigBeadID, err)
-		return false, "cannot verify rig status (Dolt unavailable)"
+		rigBeadID := beads.RigBeadIDWithPrefix(prefix, rigName)
+		issue, err := showRigBead(d.config.TownRoot, rigName, prefix)
+		switch {
+		case err == nil:
+			for _, label := range issue.Labels {
+				if label == "status:docked" {
+					return false, "rig is docked (global)"
+				}
+				if label == "status:parked" {
+					return false, "rig is parked (global)"
+				}
+			}
+		case errors.Is(err, beads.ErrNotFound):
+			// No identity bead means no recorded docked/parked state. Treating
+			// that as "not operational" would disable witness/refinery restarts
+			// for a perfectly healthy rig, silently, for as long as the bead is
+			// missing (gt-gf6). A rig we cannot read is not a rig that is docked.
+			d.logger.Printf("Warning: rig identity bead %s not found; assuming operational (no docked/parked state recorded)", rigBeadID)
+		default:
+			// The beads backend itself is unreachable (Dolt down, network
+			// issue). Unlike a lookup miss this really is transient, so keep
+			// the fail-safe that avoids starting agents for a possibly-docked
+			// rig — but report the actual error instead of asserting a cause.
+			d.logger.Printf("Warning: could not read rig identity bead %s for docked/parked status: %v (assuming not operational)", rigBeadID, err)
+			return false, fmt.Sprintf("cannot verify rig status: %v", err)
+		}
 	}
 
 	// Check auto_restart config

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -15,6 +17,7 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
@@ -882,107 +885,117 @@ func TestHasPendingEvents_IgnoresNonEventFiles(t *testing.T) {
 	}
 }
 
-// TestIsRigOperational_FailSafeOnDoltUnavailable verifies that when Dolt is
-// unavailable and we can't check the rig bead for docked status, we fail-safe
-// by assuming the rig is NOT operational. This prevents wasting API credits
-// starting witnesses for potentially docked rigs. (Regression test for
-// bug where witnesses started for docked rigs during Dolt outage)
-func TestIsRigOperational_FailSafeOnDoltUnavailable(t *testing.T) {
+// withStubbedRigBeadLookup replaces the rig identity bead lookup seam for the
+// duration of a test.
+func withStubbedRigBeadLookup(t *testing.T, fn func(townRoot, rigName, prefix string) (*beads.Issue, error)) {
+	t.Helper()
+	prev := showRigBead
+	showRigBead = fn
+	t.Cleanup(func() { showRigBead = prev })
+}
+
+// newRigOperationalTestDaemon builds a town containing one rig with the given
+// beads prefix, plus the town-level .beads dir the rig bead store targets.
+func newRigOperationalTestDaemon(t *testing.T, rigName, prefix string) *Daemon {
+	t.Helper()
 	tmpDir := t.TempDir()
 
-	// Create a minimal rig structure without a beads database
-	rigName := "testrig"
 	rigPath := filepath.Join(tmpDir, rigName)
 	if err := os.MkdirAll(rigPath, 0755); err != nil {
 		t.Fatal(err)
 	}
-
-	// Create config.json with a prefix
-	configPath := filepath.Join(rigPath, "config.json")
-	configJSON := `{"beads": {"prefix": "tr"}}`
-	if err := os.WriteFile(configPath, []byte(configJSON), 0644); err != nil {
+	configJSON := fmt.Sprintf(`{"beads": {"prefix": %q}}`, prefix)
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
 		t.Fatal(err)
 	}
 
-	// Create mayor/rig/.beads directory but NO Dolt database
-	// This simulates Dolt being down or database not accessible
-	mayorBeads := filepath.Join(rigPath, "mayor", "rig", ".beads")
-	if err := os.MkdirAll(mayorBeads, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create town-level .beads with routes.jsonl
-	townBeads := filepath.Join(tmpDir, ".beads")
-	if err := os.MkdirAll(townBeads, 0755); err != nil {
-		t.Fatal(err)
-	}
-	routesContent := `{"prefix":"tr-","path":"testrig/mayor/rig"}`
-	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create daemon with no Dolt server running
-	d := &Daemon{
-		config: &Config{
-			TownRoot: tmpDir,
-		},
-		logger: log.New(io.Discard, "", 0), // Suppress log output
-	}
-
-	// When Dolt is unavailable, isRigOperational should return false
-	// (fail-safe: assume not operational rather than risk starting docked rig)
-	operational, reason := d.isRigOperational(rigName)
-	if operational {
-		t.Error("isRigOperational should return false when Dolt is unavailable (fail-safe)")
-	}
-	if reason == "" {
-		t.Error("isRigOperational should provide a reason when returning false")
-	}
-	if !strings.Contains(reason, "Dolt unavailable") && !strings.Contains(reason, "cannot verify") {
-		t.Errorf("reason should mention Dolt unavailable, got: %q", reason)
+	return &Daemon{
+		config: &Config{TownRoot: tmpDir},
+		logger: log.New(io.Discard, "", 0),
 	}
 }
 
-// TestIsRigOperational_DockedRig verifies that docked rigs are correctly
-// identified as not operational.
-func TestIsRigOperational_DockedRig(t *testing.T) {
-	tmpDir := t.TempDir()
+// TestIsRigOperational_FailSafeOnDoltUnavailable verifies that when the beads
+// backend is unreachable we fail-safe by assuming the rig is NOT operational.
+// This prevents wasting API credits starting witnesses for potentially docked
+// rigs, and the reason must report the real error rather than assert a cause.
+func TestIsRigOperational_FailSafeOnDoltUnavailable(t *testing.T) {
+	d := newRigOperationalTestDaemon(t, "testrig", "tr")
 
-	// Create rig with docked label on rig bead
-	rigName := "dockedrig"
-	rigPath := filepath.Join(tmpDir, rigName)
-	if err := os.MkdirAll(filepath.Join(rigPath, "mayor", "rig", ".beads"), 0755); err != nil {
-		t.Fatal(err)
-	}
+	withStubbedRigBeadLookup(t, func(townRoot, rigName, prefix string) (*beads.Issue, error) {
+		return nil, errors.New("dial tcp 127.0.0.1:3307: connect: connection refused")
+	})
 
-	// Create config.json
-	configPath := filepath.Join(rigPath, "config.json")
-	configJSON := `{"beads": {"prefix": "dr"}}`
-	if err := os.WriteFile(configPath, []byte(configJSON), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create town-level .beads with routes.jsonl
-	townBeads := filepath.Join(tmpDir, ".beads")
-	if err := os.MkdirAll(townBeads, 0755); err != nil {
-		t.Fatal(err)
-	}
-	routesContent := `{"prefix":"dr-","path":"dockedrig/mayor/rig"}`
-	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	d := &Daemon{
-		config: &Config{
-			TownRoot: tmpDir,
-		},
-		logger: log.New(io.Discard, "", 0),
-	}
-
-	// Without a rig bead, should fail-safe to not operational
-	operational, reason := d.isRigOperational(rigName)
+	operational, reason := d.isRigOperational("testrig")
 	if operational {
-		t.Error("isRigOperational should return false when rig bead is missing")
+		t.Error("isRigOperational should return false when the beads backend is unreachable (fail-safe)")
 	}
-	t.Logf("Docked rig check returned: operational=%v, reason=%q", operational, reason)
+	if !strings.Contains(reason, "cannot verify rig status") {
+		t.Errorf("reason should say the status could not be verified, got: %q", reason)
+	}
+	if !strings.Contains(reason, "connection refused") {
+		t.Errorf("reason should carry the underlying error, got: %q", reason)
+	}
+}
+
+// TestIsRigOperational_MissingRigBeadStaysOperational is the regression test
+// for gt-gf6: rig identity beads carry a rig prefix but live in the town
+// database, so prefix-routed lookups came back "not found". Treating that miss
+// as "not operational" excluded every rig from witness and refinery patrol,
+// silently disabling daemon supervision town-wide.
+func TestIsRigOperational_MissingRigBeadStaysOperational(t *testing.T) {
+	d := newRigOperationalTestDaemon(t, "testrig", "tr")
+
+	var lookedUp string
+	withStubbedRigBeadLookup(t, func(townRoot, rigName, prefix string) (*beads.Issue, error) {
+		lookedUp = beads.RigBeadIDWithPrefix(prefix, rigName)
+		return nil, beads.ErrNotFound
+	})
+
+	operational, reason := d.isRigOperational("testrig")
+	if !operational {
+		t.Errorf("a rig with no identity bead must stay operational, got false (%q)", reason)
+	}
+	if lookedUp != "tr-rig-testrig" {
+		t.Errorf("looked up %q, want tr-rig-testrig", lookedUp)
+	}
+}
+
+// TestIsRigOperational_DockedRig verifies that a rig whose identity bead
+// actually carries status:docked is reported as not operational.
+func TestIsRigOperational_DockedRig(t *testing.T) {
+	d := newRigOperationalTestDaemon(t, "dockedrig", "dr")
+
+	withStubbedRigBeadLookup(t, func(townRoot, rigName, prefix string) (*beads.Issue, error) {
+		return &beads.Issue{ID: beads.RigBeadIDWithPrefix(prefix, rigName), Labels: []string{"gt:rig", "status:docked"}}, nil
+	})
+
+	operational, reason := d.isRigOperational("dockedrig")
+	if operational {
+		t.Error("isRigOperational should return false for a rig labelled status:docked")
+	}
+	if !strings.Contains(reason, "docked") {
+		t.Errorf("reason should mention docked, got: %q", reason)
+	}
+}
+
+// TestIsRigOperational_ParkedRigBead verifies the status:parked label is
+// honoured the same way as status:docked.
+func TestIsRigOperational_ParkedRigBead(t *testing.T) {
+	d := newRigOperationalTestDaemon(t, "parkedrig", "pr")
+
+	withStubbedRigBeadLookup(t, func(townRoot, rigName, prefix string) (*beads.Issue, error) {
+		return &beads.Issue{ID: beads.RigBeadIDWithPrefix(prefix, rigName), Labels: []string{"gt:rig", "status:parked"}}, nil
+	})
+
+	operational, reason := d.isRigOperational("parkedrig")
+	if operational {
+		t.Error("isRigOperational should return false for a rig labelled status:parked")
+	}
+	if !strings.Contains(reason, "parked") {
+		t.Errorf("reason should mention parked, got: %q", reason)
+	}
 }

--- a/internal/daemon/patrol_rigs_filter_test.go
+++ b/internal/daemon/patrol_rigs_filter_test.go
@@ -7,15 +7,16 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/wisp"
 )
 
-// Regression test for gt-arz:
-// getPatrolRigs should filter parked/docked rigs at list-building time.
-func TestGetPatrolRigs_FiltersNonOperationalRigs(t *testing.T) {
+// newPatrolFilterTown seeds a town with rigs alpha/beta/gamma, marks beta
+// parked and gamma docked via the wisp layer, and returns a daemon for it.
+func newPatrolFilterTown(t *testing.T) *Daemon {
+	t.Helper()
 	townRoot := t.TempDir()
 
-	// Seed known rigs.
 	mayorDir := filepath.Join(townRoot, "mayor")
 	if err := os.MkdirAll(mayorDir, 0o755); err != nil {
 		t.Fatalf("mkdir mayor dir: %v", err)
@@ -33,18 +34,45 @@ func TestGetPatrolRigs_FiltersNonOperationalRigs(t *testing.T) {
 		t.Fatalf("set gamma docked: %v", err)
 	}
 
-	d := &Daemon{
+	return &Daemon{
 		config: &Config{TownRoot: townRoot},
 		logger: log.New(os.Stderr, "[test] ", 0),
 	}
+}
+
+// Regression test for gt-arz:
+// getPatrolRigs should filter parked/docked rigs at list-building time.
+func TestGetPatrolRigs_FiltersNonOperationalRigs(t *testing.T) {
+	d := newPatrolFilterTown(t)
+
+	withStubbedRigBeadLookup(t, func(townRoot, rigName, prefix string) (*beads.Issue, error) {
+		return &beads.Issue{ID: beads.RigBeadIDWithPrefix(prefix, rigName), Labels: []string{"gt:rig"}}, nil
+	})
 
 	got := d.getPatrolRigs("witness")
 	slices.Sort(got)
-	// When Dolt is unavailable, isRigOperational() fails safe and returns false
-	// for all rigs (can't verify docked status). This prevents witnesses from
-	// starting for potentially docked rigs during Dolt outages.
-	want := []string{}
+	want := []string{"alpha"}
 	if !slices.Equal(got, want) {
-		t.Fatalf("getPatrolRigs() = %v, want %v (all rigs excluded when Dolt unavailable - fail-safe)", got, want)
+		t.Fatalf("getPatrolRigs() = %v, want %v", got, want)
+	}
+}
+
+// Regression test for gt-gf6: a rig identity bead that cannot be found must not
+// remove the rig from patrol. The prefix-routing miss made every lookup return
+// "not found", which excluded all four rigs from both the witness and refinery
+// patrols for hours — the daemon stopped supervising the entire town while
+// reporting healthy.
+func TestGetPatrolRigs_MissingRigBeadsDoNotEmptyPatrol(t *testing.T) {
+	d := newPatrolFilterTown(t)
+
+	withStubbedRigBeadLookup(t, func(townRoot, rigName, prefix string) (*beads.Issue, error) {
+		return nil, beads.ErrNotFound
+	})
+
+	got := d.getPatrolRigs("witness")
+	slices.Sort(got)
+	want := []string{"alpha"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("getPatrolRigs() = %v, want %v (missing rig beads must not disable supervision)", got, want)
 	}
 }

--- a/internal/doctor/rig_config_sync_check.go
+++ b/internal/doctor/rig_config_sync_check.go
@@ -251,10 +251,11 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 			}
 		}
 
-		// Check if rig identity bead exists
+		// Check if rig identity bead exists. Rig identity beads live in the town
+		// database despite carrying the rig prefix — see beads.NewRigBeadStore.
 		if configPrefix != "" {
-			rigBeadID := fmt.Sprintf("%s-rig-%s", configPrefix, rigName)
-			if !c.rigBeadExists(rigBeadID, rigPath, beadsDir) {
+			rigBeadID := beads.RigBeadIDWithPrefix(configPrefix, rigName)
+			if !c.rigBeadExists(ctx.TownRoot, rigBeadID) {
 				c.missingRigBeads = append(c.missingRigBeads, rigBeadInfo{
 					rigName: rigName,
 					prefix:  configPrefix,
@@ -523,11 +524,8 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 	}
 
 	// Fix missing rig identity beads
+	bd := beads.NewRigBeadStore(ctx.TownRoot)
 	for _, info := range c.missingRigBeads {
-		rigPath := filepath.Join(ctx.TownRoot, info.rigName)
-		beadsDir := doltserver.FindRigBeadsDir(ctx.TownRoot, info.rigName)
-
-		bd := beads.NewWithBeadsDir(rigPath, beadsDir)
 		fields := &beads.RigFields{
 			Repo:   info.gitURL,
 			Prefix: info.prefix,
@@ -537,13 +535,9 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 		if _, err := bd.CreateRigBead(info.rigName, fields); err != nil {
 			return fmt.Errorf("could not create rig bead for %s: %w", info.rigName, err)
 		}
-
-		// Add status:docked label if the rig should be docked
-		rigBeadID := fmt.Sprintf("%s-rig-%s", info.prefix, info.rigName)
-		cmd := exec.Command("bd", "label", rigBeadID, "--add", "status:docked")
-		cmd.Dir = rigPath
-		cmd.Env = append(stripEnvPrefixes(os.Environ(), "BEADS_DIR="), "BEADS_DIR="+beadsDir)
-		_ = cmd.Run() // Best effort - ignore errors
+		// No status label is applied here: a rig whose identity bead went
+		// missing is not thereby docked, and stamping status:docked on repair
+		// would stop the daemon supervising it (gt-gf6). Use 'gt rig dock'.
 	}
 
 	return nil
@@ -567,16 +561,7 @@ func (c *RigConfigSyncCheck) doltDatabaseExists(ctx *CheckContext, dbName string
 }
 
 // rigBeadExists checks if a rig identity bead exists.
-func (c *RigConfigSyncCheck) rigBeadExists(rigBeadID, rigPath, beadsDir string) bool {
-	// Try to show the bead using bd
-	cmd := exec.Command("bd", "show", rigBeadID, "--json")
-	cmd.Dir = rigPath
-	cmd.Env = append(stripEnvPrefixes(os.Environ(), "BEADS_DIR="), "BEADS_DIR="+beadsDir)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return false
-	}
-
-	// Check if the output contains the bead ID
-	return strings.Contains(string(output), rigBeadID)
+func (c *RigConfigSyncCheck) rigBeadExists(townRoot, rigBeadID string) bool {
+	_, err := beads.NewRigBeadStore(townRoot).Show(rigBeadID)
+	return err == nil
 }


### PR DESCRIPTION
## Impact

The daemon excluded **every rig from both witness and refinery patrol for 2h35m**, logging `cannot verify rig status (Dolt unavailable)` while Dolt was up at 0s latency. 408 `Excluding` lines, 817 `failed to check rig bead` lines, all 4 rigs, both patrols, every tick.

Nothing had visibly broken — that was the danger. The daemon is the safety net that restarts dead witness/refinery sessions. It had switched itself off and was reporting normal operation.

## Two defects, one outage

**1. The lookup can never succeed.** Rig identity beads (`<prefix>-rig-<name>`) carry the rig's own ID prefix but live in the **town (hq)** database. Prefix routing sends `sv-rig-svalscripts` to the svalscripts database, which has never held it. Confirmed in both directions:

```
bd show gt-rig-gastown   from /home/morga/gt          -> resolves
bd show gt-rig-gastown   from gastown/                -> no issue found
bd show gt-rig-gastown   from gastown/mayor/rig/      -> no issue found   (where routes.jsonl sends gt-)
```

This is the same problem `ForAgentBead` already solves for agent beads — agent beads also carry rig prefixes while living in the town DB. Rig identity beads never got the equivalent.

**2. The fallback failed closed, silently.** A lookup miss was treated as "not operational", which disables supervision for that rig. A rig whose status *cannot be read* is not a rig that *is docked*. Every rig missed, so every rig was excluded.

The error message also asserted a cause it never checked. "Dolt unavailable" at 0s latency sent responders hunting a Dolt outage that did not exist; the reporter nearly opened a Dolt incident on it.

## Changes

**`internal/beads`** — `NewRigBeadStore`/`ForRigBead` give rig identity beads a town-rooted, unrouted wrapper, and the rig-bead methods self-route to it so **writers agree with readers** going forward. `ShowRigBead` reads the town DB first, then falls back to the rig-scoped DB.

That fallback is not optional: the pre-fix `gt rig dock` wrote its `status:docked` label into the rig database. A town-only read would have silently **un-docked every rig docked by an older gt**. The pre-existing `TestIsRigParked_WhenOnlyBeadLabelPresent` seeds a rig bead in exactly that location — it failed against a town-only read, which is real evidence the legacy layout exists.

**`internal/daemon`** — not-found now keeps the rig operational. Only a genuinely unreachable backend still fails safe, preserving the original credit-protection intent, and it reports the actual error rather than naming a cause.

**`internal/cmd`** — `hasRigBeadLabel`, `IsRigParkedOrDocked`, `IsRigDocked`, dock/undock and `getRigOperationalState` share the resolver. These had the identical defect and failed *open*, so persistent docked state was invisible to every dispatch path.

**`internal/doctor`** — `rigBeadExists` uses the resolver. Also **removed an unconditional `bd label <rig> --add status:docked`** in the repair path: there is no "should be docked" signal in `rigBeadInfo`, so it stamped every repaired rig as docked. It was inert only because the routing bug made it fail — fixing the routing would have armed it, letting `gt doctor --fix` recreate this very outage.

## Verification

Against live town data (temporary test, since removed) — the bead's own verify criterion, both directions:

| bead | old path | new path |
|---|---|---|
| `gt-rig-gastown` | issue not found | resolves |
| `sv-rig-svalscripts` | issue not found | resolves |
| `co-rig-coparent` | issue not found | resolves |
| `hw-rig-hello_world` | issue not found | resolves |

`TestGetPatrolRigs_MissingRigBeadsDoNotEmptyPatrol` is the regression guard. The old test asserted `want=[]` with the comment *"all rigs excluded when Dolt unavailable - fail-safe"* — it had encoded the bug as the contract.

`go test` passes for `internal/{beads,daemon,cmd,doctor}` apart from failures that reproduce identically on a clean tree: `doctor TestGetServerAddr_UsesConfigYAMLPort`, `doltserver TestWaitForCatalog_NoServer`, `doltserver TestFindBrokenWorkspaces_MultipleRigs`.

## On hq-vjd — they do **not** share a root cause

The issue asked to confirm this and re-rate `hq-vjd` accordingly. They are unrelated. `no wisp config for <rig> - parked state may have been lost` comes from an `os.Stat()` on the wisp config file at the top of `isRigOperational` — a filesystem existence check, no bead lookup, no Dolt. It fires for any rig that has never been parked, which is the normal state.

So `hq-vjd` remains a genuine false alarm and its P2 rating is correct on impact. But its framing as *cosmetic* is wrong for a different reason: at ~11,600 lines/day it is the noise that buried this outage for 2h35m. Worth fixing as log hygiene, not because it is secretly critical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
