### PR TITLE
fix(witness): stop flagging working polecats as stalled, gate blind key injection (gt-czb)

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2181,6 +2181,23 @@ func (t *Tmux) AcceptBypassPermissionsWarning(session string) error {
 	return nil
 }
 
+// DetectStartupDialog reports whether a session's pane is currently showing a
+// blocking startup dialog (workspace trust, bypass permissions, agent update),
+// returning a human-readable reason when one is found.
+//
+// This is the safety interlock for DismissStartupDialogsBlind: callers must
+// confirm a dialog is actually on screen before injecting keystrokes into a
+// live agent session. A stall verdict derived from timers alone is not
+// sufficient evidence (gt-czb).
+func (t *Tmux) DetectStartupDialog(session string) (string, bool, error) {
+	content, err := t.CapturePane(session, 30)
+	if err != nil {
+		return "", false, fmt.Errorf("capturing pane for %s: %w", session, err)
+	}
+	reason, found := containsBlockingStartupDialog(content)
+	return reason, found, nil
+}
+
 // DismissStartupDialogsBlind sends the key sequences needed to dismiss all
 // known Claude Code startup dialogs without screen-scraping pane content.
 // This avoids coupling to third-party TUI strings that can change with any update.
@@ -2189,13 +2206,15 @@ func (t *Tmux) AcceptBypassPermissionsWarning(session string) error {
 //  1. Workspace trust dialog — Enter (option 1 "Yes, I trust this folder" is pre-selected)
 //  2. Bypass permissions warning — Down+Enter (select "Yes, I accept" then confirm)
 //
-// Safe to call on sessions where no dialog is showing: Enter sends a blank input
-// to an idle Claude prompt (harmless for a stalled session), and Down+Enter either
-// does nothing or sends another blank input.
+// DANGER: this is raw keystroke injection into whatever the pane is showing. It
+// is only safe on a session that really is parked on a startup dialog. On a
+// working agent, Down+Enter blindly selects the second option of any focused
+// dialog — answering, for example, a permission prompt without reading it.
+// Callers MUST confirm a dialog is present via DetectStartupDialog first; do
+// not reach this from a timer-derived verdict alone (gt-czb).
 //
-// This is intended for remediation of stalled sessions detected via structured
-// signals (session age + activity). For startup-time dialog handling where
-// precision matters, use AcceptStartupDialogs instead.
+// For startup-time dialog handling where precision matters, use
+// AcceptStartupDialogs instead.
 func (t *Tmux) DismissStartupDialogsBlind(session string) error {
 	// Step 1: Send Enter to dismiss trust dialog (if present)
 	if _, err := t.run("send-keys", "-t", session, "Enter"); err != nil {
@@ -2355,19 +2374,39 @@ func (t *Tmux) GetPanePID(target string) (string, error) {
 	return result, nil
 }
 
-// GetSessionActivity returns the last activity time for a session.
-// This is updated whenever there's any activity in the session (input/output).
+// GetSessionActivity returns the most recent activity time across every window
+// in a session. tmux stamps #{window_activity} on pane output, so the maximum
+// over a session's windows is the "last output" signal callers want.
+//
+// This deliberately does NOT read #{session_activity} (gt-czb): in practice that
+// field is stamped when the session is created and never advances afterward, so
+// every long-lived agent session reports activity == creation time forever. Any
+// caller comparing it against a staleness threshold would classify a busy agent
+// as idle after the threshold elapsed, and never recover.
 func (t *Tmux) GetSessionActivity(session string) (time.Time, error) {
-	out, err := t.run("display-message", "-t", session, "-p", "#{session_activity}")
+	out, err := t.run("list-windows", "-t", session, "-F", "#{window_activity}")
 	if err != nil {
 		return time.Time{}, err
 	}
 
-	timestamp, err := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("parsing session activity: %w", err)
+	var latest int64
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		timestamp, err := strconv.ParseInt(line, 10, 64)
+		if err != nil {
+			continue // Skip unparseable rows rather than failing the whole query
+		}
+		if timestamp > latest {
+			latest = timestamp
+		}
 	}
-	return time.Unix(timestamp, 0), nil
+	if latest == 0 {
+		return time.Time{}, fmt.Errorf("no window activity for session %s", session)
+	}
+	return time.Unix(latest, 0), nil
 }
 
 // ZombieStatus describes the liveness state of a tmux agent session.
@@ -3538,7 +3577,9 @@ func (t *Tmux) IsIdle(session string) bool {
 
 // GetSessionInfo returns detailed information about a session.
 func (t *Tmux) GetSessionInfo(name string) (*SessionInfo, error) {
-	format := "#{session_name}|#{session_windows}|#{session_created}|#{session_attached}|#{session_activity}|#{session_last_attached}"
+	// window_activity, not session_activity: the latter never advances past
+	// session creation, so Activity would always equal Created (gt-czb).
+	format := "#{session_name}|#{session_windows}|#{session_created}|#{session_attached}|#{window_activity}|#{session_last_attached}"
 	out, err := t.run("list-sessions", "-F", format, "-f", fmt.Sprintf("#{==:#{session_name},%s}", name))
 	if err != nil {
 		return nil, err

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2887,3 +2887,81 @@ func TestValidateCommandBinary(t *testing.T) {
 		})
 	}
 }
+
+// TestGetSessionActivity_AdvancesWithOutput is the regression test for gt-czb.
+//
+// GetSessionActivity used to read tmux's #{session_activity}, which is stamped
+// when the session is created and never moves again. Every caller comparing it
+// against a staleness threshold therefore classified busy, long-lived agent
+// sessions as idle forever. Activity must track real pane output.
+func TestGetSessionActivity_AdvancesWithOutput(t *testing.T) {
+	tm := newTestTmux(t)
+	sessionName := "gt-test-activity-advances"
+
+	_ = tm.KillSession(sessionName)
+	if err := tm.NewSession(sessionName, ""); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tm.KillSession(sessionName) }()
+
+	createdUnix, err := tm.GetSessionCreatedUnix(sessionName)
+	if err != nil {
+		t.Fatalf("GetSessionCreatedUnix: %v", err)
+	}
+	created := time.Unix(createdUnix, 0)
+
+	// tmux timestamps have one-second resolution, so keep producing output until
+	// the clock has moved past the creation second.
+	deadline := time.Now().Add(15 * time.Second)
+	var activity time.Time
+	for time.Now().Before(deadline) {
+		if _, err := tm.run("send-keys", "-t", sessionName, "echo gt-czb-activity-probe", "Enter"); err != nil {
+			t.Fatalf("send-keys: %v", err)
+		}
+		time.Sleep(500 * time.Millisecond)
+		activity, err = tm.GetSessionActivity(sessionName)
+		if err != nil {
+			t.Fatalf("GetSessionActivity: %v", err)
+		}
+		if activity.After(created) {
+			return
+		}
+	}
+
+	t.Errorf("GetSessionActivity = %v, still not later than session creation %v after "+
+		"repeated output: a frozen activity clock makes every busy session look idle (gt-czb)",
+		activity, created)
+}
+
+// TestDetectStartupDialog_NoDialog verifies the interlock that guards blind
+// keystroke injection: a session sitting at an ordinary shell prompt must not
+// be reported as showing a startup dialog (gt-czb).
+func TestDetectStartupDialog_NoDialog(t *testing.T) {
+	tm := newTestTmux(t)
+	sessionName := "gt-test-dialog-probe"
+
+	_ = tm.KillSession(sessionName)
+	if err := tm.NewSession(sessionName, ""); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tm.KillSession(sessionName) }()
+
+	reason, found, err := tm.DetectStartupDialog(sessionName)
+	if err != nil {
+		t.Fatalf("DetectStartupDialog: %v", err)
+	}
+	if found {
+		t.Errorf("DetectStartupDialog found %q on a plain shell session, want no dialog", reason)
+	}
+}
+
+// TestDetectStartupDialog_NonexistentSession ensures the interlock reports an
+// error rather than silently returning "no dialog" when it cannot see the pane.
+// Callers must be able to distinguish "confirmed no dialog" from "could not look".
+func TestDetectStartupDialog_NonexistentSession(t *testing.T) {
+	tm := newTestTmux(t)
+
+	if _, _, err := tm.DetectStartupDialog("nonexistent-session-xyz-12345"); err == nil {
+		t.Error("DetectStartupDialog on nonexistent session should return an error")
+	}
+}

--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -552,8 +552,9 @@ func (f *LiveConvoyFetcher) getSessionActivityForAssignee(assignee string) *time
 	sessionName := session.PolecatSessionName(session.PrefixFor(rig), polecat)
 
 	// Query tmux for session activity
-	// Format: session_activity returns unix timestamp
-	stdout, err := f.runTmuxCmd("list-sessions", "-F", "#{session_name}|#{session_activity}",
+	// Format: window_activity returns a unix timestamp. Not session_activity —
+	// that field never advances past session creation (gt-czb).
+	stdout, err := f.runTmuxCmd("list-sessions", "-F", "#{session_name}|#{window_activity}",
 		"-f", fmt.Sprintf("#{==:#{session_name},%s}", sessionName))
 	if err != nil {
 		return nil
@@ -585,7 +586,7 @@ func (f *LiveConvoyFetcher) getSessionActivityForAssignee(assignee string) *time
 func (f *LiveConvoyFetcher) getAllPolecatActivity() *time.Time {
 	// List all tmux sessions matching gt-*-* pattern (polecat sessions)
 	// Format: gt-{rig}-{polecat}
-	stdout, err := f.runTmuxCmd("list-sessions", "-F", "#{session_name}|#{session_activity}")
+	stdout, err := f.runTmuxCmd("list-sessions", "-F", "#{session_name}|#{window_activity}")
 	if err != nil {
 		return nil
 	}
@@ -1468,7 +1469,7 @@ func (f *LiveConvoyFetcher) FetchQueues() ([]QueueRow, error) {
 // FetchSessions returns active tmux sessions with role detection.
 func (f *LiveConvoyFetcher) FetchSessions() ([]SessionRow, error) {
 	// List tmux sessions
-	stdout, err := f.runTmuxCmd("list-sessions", "-F", "#{session_name}:#{session_activity}")
+	stdout, err := f.runTmuxCmd("list-sessions", "-F", "#{session_name}:#{window_activity}")
 	if err != nil {
 		return nil, nil // tmux not running or no sessions
 	}
@@ -1586,7 +1587,7 @@ func (f *LiveConvoyFetcher) FetchMayor() (*MayorStatus, error) {
 	mayorSessionName := session.MayorSessionName()
 
 	// Check if mayor tmux session exists
-	stdout, err := f.runTmuxCmd("list-sessions", "-F", "#{session_name}:#{session_activity}")
+	stdout, err := f.runTmuxCmd("list-sessions", "-F", "#{session_name}:#{window_activity}")
 	if err != nil {
 		// tmux not running or no sessions
 		return status, nil

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -2217,11 +2217,42 @@ func handleZombieRestart(bd *BdCli, workDir, rigName, polecatName, hookBead, cle
 // nukes them before they finish starting up. See GH#2036.
 const SpawnGracePeriod = 5 * time.Minute
 
+// startupHeartbeatBootWindow is how long after session creation a heartbeat may
+// be written and still be attributable to the session manager's spawn-time
+// touch. A heartbeat newer than this proves the agent ran a gt command of its
+// own, which means it cleared any startup dialog. See gt-czb.
+const startupHeartbeatBootWindow = 30 * time.Second
+
+// heartbeatRulesOutStartupStall reports whether a polecat's heartbeat file is
+// enough on its own to clear it of being stalled at startup.
+//
+// Two independent reasons it can be:
+//
+//   - A fresh v2 heartbeat (gt-3vr5): the agent reported in recently, so it is
+//     alive and making progress.
+//   - Any heartbeat written well after session creation (gt-czb): gt only
+//     touches the heartbeat when the agent runs a gt command, so a stale
+//     heartbeat says nothing about whether the agent is busy — an agent
+//     heads-down editing files or running tests is stale almost all the time.
+//     What the file does prove is which side of startup the agent is on. A
+//     session parked on a trust dialog never runs a gt command, so its only
+//     heartbeat is the one the session manager wrote at spawn. A later one
+//     means startup was cleared, and a *startup* stall is no longer possible.
+func heartbeatRulesOutStartupStall(hb *polecat.SessionHeartbeat, sessionStart, now time.Time) bool {
+	if hb == nil {
+		return false
+	}
+	if hb.IsV2() && now.Sub(hb.Timestamp) < polecat.SessionHeartbeatStaleThreshold {
+		return true
+	}
+	return hb.Timestamp.After(sessionStart.Add(startupHeartbeatBootWindow))
+}
+
 // StalledResult represents a single stalled polecat detection.
 type StalledResult struct {
 	PolecatName   string // e.g., "alpha"
-	StallType     string // "startup-stall", "unknown-prompt"
-	Action        string // "auto-dismissed", "escalated"
+	StallType     string // "startup-stall[: reason]", "suspected-stall", "unknown-prompt"
+	Action        string // "auto-dismissed", "escalated", "reported"
 	AgentState    string // Agent state from beads (e.g., "idle", "working")
 	HasHookedWork bool   // Whether this polecat has hooked work assigned
 	Error         error
@@ -2239,15 +2270,19 @@ type DetectStalledPolecatsResult struct {
 // Unlike zombie detection which looks for dead sessions/agents, this targets
 // alive-but-stuck agents that will never make progress without intervention.
 //
-// Detection uses structured tmux signals (session creation time + last activity)
-// rather than screen-scraping pane content. A session is considered stalled when:
+// Screening uses structured tmux signals (session creation time + last window
+// activity). A session is a stall *suspect* when:
 //   - It is older than StartupStallThreshold (90s)
 //   - Its last tmux activity is older than StartupActivityGrace (60s)
+//   - It has no fresh heartbeat, and no heartbeat proving it cleared startup
 //
-// When a startup stall is detected, DismissStartupDialogsBlind is called to
-// send blind key sequences that dismiss known blocking dialogs (workspace trust,
-// bypass permissions) without screen-scraping pane content. This avoids coupling
-// to third-party TUI strings that can change with any Claude Code update.
+// Screening alone never triggers remediation. Every suspect's pane is checked
+// for an actual blocking dialog first; only a confirmed dialog reaches
+// DismissStartupDialogsBlind, because that call injects raw keystrokes into a
+// live agent TUI. Suspects with no dialog on screen are reported, not touched.
+// See gt-czb: both timer signals have failed open in the field, and the
+// "harmless keystrokes" argument for blind injection holds only while the
+// detector is correct.
 func DetectStalledPolecats(workDir, rigName string) *DetectStalledPolecatsResult {
 	result := &DetectStalledPolecatsResult{}
 
@@ -2296,26 +2331,23 @@ func DetectStalledPolecats(workDir, rigName string) *DetectStalledPolecatsResult
 			continue // Dead agent — zombie detection handles this
 		}
 
-		// Heartbeat v2 check (gt-3vr5): if the agent has a fresh heartbeat,
-		// it's alive and making progress — skip stall detection entirely.
-		// This replaces tmux activity scraping for v2 agents.
-		if hb := polecat.ReadSessionHeartbeat(townRoot, sessionName); hb != nil && hb.IsV2() {
-			if time.Since(hb.Timestamp) < polecat.SessionHeartbeatStaleThreshold {
-				continue // Fresh v2 heartbeat — agent is alive, not stalled
-			}
-		}
-
-		// Legacy: Use structured signals to detect startup stalls:
-		// session_created (age) + session_activity (last output).
+		// Use structured signals to detect startup stalls:
+		// session_created (age) + last window activity (last output).
 		createdUnix, err := t.GetSessionCreatedUnix(sessionName)
 		if err != nil {
 			result.Errors = append(result.Errors,
 				fmt.Errorf("getting session created time for %s: %w", sessionName, err))
 			continue
 		}
-		sessionAge := now.Sub(time.Unix(createdUnix, 0))
+		sessionStart := time.Unix(createdUnix, 0)
+		sessionAge := now.Sub(sessionStart)
 		if sessionAge < stallThreshold {
 			continue // Too young — still in normal startup
+		}
+
+		hb := polecat.ReadSessionHeartbeat(townRoot, sessionName)
+		if heartbeatRulesOutStartupStall(hb, sessionStart, now) {
+			continue
 		}
 
 		activity, err := t.GetSessionActivity(sessionName)
@@ -2329,18 +2361,34 @@ func DetectStalledPolecats(workDir, rigName string) *DetectStalledPolecatsResult
 			continue // Recent activity — agent is making progress
 		}
 
-		// Session is old enough and has no recent activity: startup stall.
-		// Send blind key sequences to dismiss any startup dialogs without
-		// screen-scraping pane content (avoids coupling to third-party TUI strings).
+		// Session is old enough and has no recent activity. That is a *suspicion*,
+		// not a verdict: remediation here injects raw keystrokes into a live agent
+		// TUI, so it requires positive evidence that the pane really is parked on a
+		// startup dialog before it fires (gt-czb). Without that evidence the stall
+		// is reported for a human or the witness to look at, and nothing is sent.
 		stalled := StalledResult{
 			PolecatName: polecatName,
 			StallType:   "startup-stall",
 		}
-		if err := t.DismissStartupDialogsBlind(sessionName); err != nil {
-			stalled.Action = "escalated"
-			stalled.Error = fmt.Errorf("blind dismiss failed: %w", err)
-		} else {
-			stalled.Action = "auto-dismissed"
+		reason, atDialog, err := t.DetectStartupDialog(sessionName)
+		switch {
+		case err != nil:
+			stalled.StallType = "suspected-stall"
+			stalled.Action = "reported"
+			stalled.Error = fmt.Errorf("confirming startup dialog: %w", err)
+		case !atDialog:
+			// No dialog on screen — the timers are stale but the agent is not
+			// stuck at startup. Never inject keys on this path.
+			stalled.StallType = "suspected-stall"
+			stalled.Action = "reported"
+		default:
+			stalled.StallType = "startup-stall: " + reason
+			if err := t.DismissStartupDialogsBlind(sessionName); err != nil {
+				stalled.Action = "escalated"
+				stalled.Error = fmt.Errorf("blind dismiss failed: %w", err)
+			} else {
+				stalled.Action = "auto-dismissed"
+			}
 		}
 		result.Stalled = append(result.Stalled, stalled)
 	}

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/polecat"
+	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
@@ -2816,5 +2817,184 @@ func TestHandleZombieRestart_RestartsWhenBranchNotMerged(t *testing.T) {
 	// Should NOT take the archive path.
 	if strings.Contains(z.Action, "work-already-merged") {
 		t.Errorf("action = %q, should not archive when work is not merged", z.Action)
+	}
+}
+
+// --- gt-czb: stall detection must not fire on working agents ---
+
+// writeStallTestConfig writes a town settings file with the witness stall
+// thresholds turned down so a few seconds of session age counts as "past
+// startup". This isolates the activity signal as the thing under test.
+func writeStallTestConfig(t *testing.T, townRoot, stallThreshold, activityGrace string) {
+	t.Helper()
+	settingsDir := filepath.Join(townRoot, "settings")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := map[string]any{
+		"type":    "town-settings",
+		"version": 1,
+		"operational": map[string]any{
+			"witness": map[string]any{
+				"startup_stall_threshold": stallThreshold,
+				"startup_activity_grace":  activityGrace,
+			},
+		},
+	}
+	data, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(settingsDir, "config.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// startStallTestPolecat creates the polecat directory and a live tmux session
+// running command, returning the session name. The session is killed on cleanup.
+func startStallTestPolecat(t *testing.T, townRoot, rigName, polecatName, command string) string {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, rigName, "polecats", polecatName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The session name depends on the prefix registry, which DetectStalledPolecats
+	// initializes from the town root. Prime it so the name computed here is the
+	// same one the detector will look for.
+	DetectStalledPolecats(townRoot, rigName)
+	sessionName := session.PolecatSessionName(session.PrefixFor(rigName), polecatName)
+
+	tm := tmux.NewTmux()
+	_ = tm.KillSession(sessionName)
+	env := map[string]string{"GT_PROCESS_NAMES": "bash,sleep"}
+	if err := tm.NewSessionWithCommandAndEnv(sessionName, townRoot, command, env); err != nil {
+		t.Fatalf("creating test session %s: %v", sessionName, err)
+	}
+	t.Cleanup(func() { _ = tm.KillSession(sessionName) })
+
+	if !tm.IsAgentAlive(sessionName) {
+		t.Skipf("test harness: session %s not recognized as a live agent", sessionName)
+	}
+	return sessionName
+}
+
+// TestDetectStalledPolecats_ActiveSessionNotStalled is the regression test for
+// gt-czb: a polecat that is producing output must never be classified as
+// stalled, no matter how long it has been running.
+//
+// Before the fix, activity came from tmux's #{session_activity}, which is frozen
+// at session creation. Every polecat older than the grace period was therefore a
+// permanent "startup-stall", and each patrol scan injected Enter/Down/Enter into
+// its live TUI.
+func TestDetectStalledPolecats_ActiveSessionNotStalled(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "czbrig"
+	polecatName := "czbactive"
+
+	writeStallTestConfig(t, tmpDir, "1s", "3s")
+	// A pane printing once a second — what a working agent looks like to tmux.
+	startStallTestPolecat(t, tmpDir, rigName, polecatName,
+		"while true; do echo working; sleep 1; done")
+
+	// Age the session well past the stall threshold while it keeps working.
+	time.Sleep(4 * time.Second)
+
+	result := DetectStalledPolecats(tmpDir, rigName)
+
+	if result.Checked != 1 {
+		t.Fatalf("Checked = %d, want 1 (errors: %v)", result.Checked, result.Errors)
+	}
+	if len(result.Stalled) != 0 {
+		t.Errorf("Stalled = %+v, want none: an actively working session must not be "+
+			"classified as a startup stall (gt-czb)", result.Stalled)
+	}
+}
+
+// TestDetectStalledPolecats_QuietSessionReportedNotDismissed covers the second
+// half of gt-czb: when the timers do say "stalled" but the pane is not showing a
+// startup dialog, the witness reports the suspicion and injects nothing.
+func TestDetectStalledPolecats_QuietSessionReportedNotDismissed(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "czbrig"
+	polecatName := "czbquiet"
+
+	writeStallTestConfig(t, tmpDir, "1s", "1s")
+	// A pane that produces no output at all: stale by both timers, but plainly
+	// not parked on a trust dialog.
+	startStallTestPolecat(t, tmpDir, rigName, polecatName, "sleep 600")
+
+	time.Sleep(3 * time.Second)
+
+	result := DetectStalledPolecats(tmpDir, rigName)
+
+	if len(result.Stalled) != 1 {
+		t.Fatalf("Stalled = %+v, want 1 suspected stall (errors: %v)", result.Stalled, result.Errors)
+	}
+	s := result.Stalled[0]
+	if s.StallType != "suspected-stall" {
+		t.Errorf("StallType = %q, want %q: no dialog on screen means the stall is "+
+			"unconfirmed (gt-czb)", s.StallType, "suspected-stall")
+	}
+	if s.Action != "reported" {
+		t.Errorf("Action = %q, want %q: keystrokes must not be injected without "+
+			"evidence of a startup dialog (gt-czb)", s.Action, "reported")
+	}
+}
+
+// TestHeartbeatRulesOutStartupStall covers the heartbeat half of gt-czb: a
+// heartbeat that is stale but clearly postdates session creation proves the
+// agent got past startup, so the 3-minute staleness threshold must not be the
+// only thing keeping a busy agent out of startup-stall detection.
+func TestHeartbeatRulesOutStartupStall(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	sessionStart := now.Add(-2 * time.Hour)
+
+	tests := []struct {
+		name string
+		hb   *polecat.SessionHeartbeat
+		want bool
+	}{
+		{
+			name: "no heartbeat file",
+			hb:   nil,
+			want: false,
+		},
+		{
+			name: "fresh v2 heartbeat",
+			hb:   &polecat.SessionHeartbeat{Timestamp: now.Add(-10 * time.Second), State: polecat.HeartbeatWorking},
+			want: true,
+		},
+		{
+			// The gt-czb case: heads-down agent, hours into its session, last gt
+			// command 20 minutes ago. Stale, but plainly past startup.
+			name: "stale heartbeat written long after session start",
+			hb:   &polecat.SessionHeartbeat{Timestamp: now.Add(-20 * time.Minute), State: polecat.HeartbeatWorking},
+			want: true,
+		},
+		{
+			// A session parked on a trust dialog: its only heartbeat is the one
+			// the session manager wrote at spawn. Still eligible for detection.
+			name: "spawn-time heartbeat only",
+			hb:   &polecat.SessionHeartbeat{Timestamp: sessionStart.Add(2 * time.Second), State: polecat.HeartbeatWorking},
+			want: false,
+		},
+		{
+			name: "v1 heartbeat written long after session start",
+			hb:   &polecat.SessionHeartbeat{Timestamp: now.Add(-20 * time.Minute)},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := heartbeatRulesOutStartupStall(tt.hb, sessionStart, now); got != tt.want {
+				t.Errorf("heartbeatRulesOutStartupStall() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes gt-czb (P0). Patrol scans are halted town-wide pending this landing.

## The bug

Every actively-working polecat was classified as a permanent `startup-stall`, and each `gt patrol scan` then injected `Enter` / `Down` / `Enter` into its live agent TUI. Two independent signals feed the verdict, they are each other's fallback, and both were dead:

1. **`#{session_activity}` never advances.** Its docstring claimed it is "updated whenever there's any activity in the session (input/output)". On tmux 3.4 it is stamped at session creation and never moves again. Re-verified while writing this fix — a detached session created at `1786372880` still reported `session_activity=1786372880` after producing output, while `window_activity` had advanced to `1786372884`. Every agent session on the host shows `session_activity == session_created`, some by 8.7 hours.
2. **The heartbeat is always stale.** `gt` touches the heartbeat file only in `persistentPreRun`, so it advances only when the agent runs a `gt` command. An agent heads-down editing files or running tests blows past `SessionHeartbeatStaleThreshold` (3m) and stays past it for the rest of its life.

So: heartbeat stale → fall through to tmux → tmux clock frozen at creation → `activityAge` grows without bound → every polecat older than the grace period is a stall, forever.

The harm was not a log line. `DismissStartupDialogsBlind` sends `Down`+`Enter`, which blindly selects the second option of whatever dialog is focused. On a real permission prompt that answers it unread. The call's own comment justified the blind send as safe because "Enter sends a blank input to an idle Claude prompt" — sound only while the detector is correct. With the detector firing on every healthy agent, the premise was false and the safety argument went with it.

## The fix — three layers, each independently sufficient

**1. Read a clock that moves.** `GetSessionActivity` now takes the max `#{window_activity}` across the session's windows — what its docstring always claimed the value was. Same swap in `GetSessionInfo` (whose `Activity` field always equalled `Created`) and in the four `web/fetcher.go` idle calculations; `web/api.go` and `fetcher.go:848` already used `window_activity`, so this makes the codebase consistent with the places someone had already thought it through. Docstring now records why `session_activity` is not used.

Side benefit: `gt deacon` used `GetSessionActivity` as the secondary HEALTH_CHECK response signal for agents that answer in prose rather than via a bead update. That signal could never fire, so those agents were recorded as failures. It works now.

**2. Stop reading heartbeat staleness as evidence of a stall.** Extracted `heartbeatRulesOutStartupStall(hb, sessionStart, now)`. A fresh v2 heartbeat still clears (unchanged, gt-3vr5). New: *any* heartbeat written more than 30s after session creation also clears. Staleness says nothing about whether an agent is busy — but a session parked on a trust dialog never runs a `gt` command, so its only heartbeat is the session manager's spawn-time touch. A later one proves startup was cleared, and a *startup* stall is no longer possible. Genuine startup stalls are still detected.

**3. Require evidence before typing into a live pane.** New `DetectStartupDialog(session) (reason, found, error)` wraps the existing `containsBlockingStartupDialog`. The witness must confirm a dialog is on screen before `DismissStartupDialogsBlind` runs:

- confirmed dialog → `startup-stall: <reason>`, dismissed as before
- no dialog, or the pane capture fails → `suspected-stall` / `reported`, **zero keystrokes sent**

"Could not look" is deliberately not collapsed into "no dialog" — it is an error, and it reports rather than acts. `DetectStalledPolecats` is the only caller of the blind dismiss, so this closes the path.

## Tests

Both regression tests were run against the pre-fix code and fail there:

- `TestGetSessionActivity_AdvancesWithOutput` — fails on the old implementation with *"still not later than session creation ... after repeated output"*.
- `TestDetectStalledPolecats_ActiveSessionNotStalled` — a polecat pane printing once a second, aged past lowered test thresholds. Fails on the old implementation with `Stalled=[{czbactive suspected-stall reported}]`. Worth noting it reports rather than dismisses even against the old clock — that is layer 3 holding on its own.
- `TestDetectStalledPolecats_QuietSessionReportedNotDismissed` — genuinely quiet session, no dialog: must be reported, not typed into.
- `TestHeartbeatRulesOutStartupStall` — table test including the spawn-time-heartbeat-only case that must remain eligible for detection.
- `TestDetectStartupDialog_NoDialog` / `_NonexistentSession`.

Green: `internal/{tmux,witness,web,polecat,config,cmd}`. `go vet ./...` clean.

## Not in this PR

The bead also suggests polecats refresh their heartbeat *during* work. That needs an agent-side mechanism (periodic hook or background toucher) — there is no in-process timer to hang it on today, since heartbeats are written only by `persistentPreRun`, `gt done`, and the spawn-time touch. This PR fixes the interpretation of the stale file instead, which removes the false positive without introducing a new background process. Worth filing separately if periodic heartbeats are wanted for other consumers.

Also unchanged: the asymmetry the report flagged, where `CLAUDE.md` tells agents "never use raw tmux send-keys" while `gt` does exactly that. It is now gated on evidence rather than on a false verdict, but `gt` still types into agent panes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
