### PR TITLE
Make test binaries inert for town-global side effects (gt-dog)

### DIFF
--- a/internal/channelevents/channelevents.go
+++ b/internal/channelevents/channelevents.go
@@ -8,6 +8,7 @@ package channelevents
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/testmode"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
 
@@ -25,6 +27,53 @@ var ValidChannelName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 // emitSeq is an atomic counter to ensure unique event filenames even when
 // time.Now().UnixNano() has low resolution.
 var emitSeq atomic.Uint64
+
+// ErrLiveTownInTest is returned when a test binary tries to emit into the
+// live town's event directories. Channels are town-global and agents block
+// on them, so a synthetic event from the test suite wakes every rig's
+// refinery/witness for work that does not exist (gt-dog).
+var ErrLiveTownInTest = errors.New("refusing to emit a channel event into the live town from a test binary")
+
+// liveTownRoot is the town root this process started in, resolved once at
+// package init — before any test can chdir into a temp directory. Tests that
+// build their own town under t.TempDir() are unaffected; only writes that
+// land inside the real workspace are refused.
+var liveTownRoot = resolveLiveTownRoot()
+
+func resolveLiveTownRoot() string {
+	root, err := workspace.FindFromCwd()
+	if err != nil || root == "" {
+		home, homeErr := os.UserHomeDir()
+		if homeErr != nil || home == "" {
+			return ""
+		}
+		root = filepath.Join(home, "gt")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return root
+	}
+	return abs
+}
+
+// guardLiveTown blocks test binaries from writing into the live town root.
+// This is a backstop: callers should already be skipping their side effects
+// under testmode.Active(). It exists because a missed guard is silent
+// production pollution that only shows up as token burn on other agents.
+func guardLiveTown(eventDir string) error {
+	if !testmode.Active() || liveTownRoot == "" {
+		return nil
+	}
+	abs, err := filepath.Abs(eventDir)
+	if err != nil {
+		// Cannot prove the destination is safe — refuse.
+		return fmt.Errorf("%w: %s", ErrLiveTownInTest, eventDir)
+	}
+	if abs == liveTownRoot || strings.HasPrefix(abs, liveTownRoot+string(filepath.Separator)) {
+		return fmt.Errorf("%w: %s (set %s to override)", ErrLiveTownInTest, abs, testmode.AllowEnv)
+	}
+	return nil
+}
 
 // Emit creates an event file in the channel directory, resolving the town
 // root from the current working directory.
@@ -38,12 +87,7 @@ func Emit(channel, eventType string, payloadPairs []string) (string, error) {
 		home, _ := os.UserHomeDir()
 		townRoot = filepath.Join(home, "gt")
 	}
-	eventDir := filepath.Join(townRoot, "events", channel)
-	if err := os.MkdirAll(eventDir, 0755); err != nil {
-		return "", fmt.Errorf("creating event directory: %w", err)
-	}
-
-	return emitToDir(eventDir, channel, eventType, payloadPairs)
+	return emitToDir(filepath.Join(townRoot, "events", channel), channel, eventType, payloadPairs)
 }
 
 // EmitToTown creates an event file using an explicit town root.
@@ -53,17 +97,23 @@ func EmitToTown(townRoot, channel, eventType string, payloadPairs []string) (str
 		return "", fmt.Errorf("invalid channel name %q: must match [a-zA-Z0-9_-]", channel)
 	}
 
-	eventDir := filepath.Join(townRoot, "events", channel)
-	if err := os.MkdirAll(eventDir, 0755); err != nil {
-		return "", fmt.Errorf("creating event directory: %w", err)
-	}
-	return emitToDir(eventDir, channel, eventType, payloadPairs)
+	return emitToDir(filepath.Join(townRoot, "events", channel), channel, eventType, payloadPairs)
 }
 
-// emitToDir writes an event file to the given directory.
+// emitToDir writes an event file to the given directory, creating it if
+// needed. It is the single funnel for every emission, so the live-town guard
+// lives here — before any directory is created.
 func emitToDir(eventDir, channel, eventType string, payloadPairs []string) (string, error) {
 	if !ValidChannelName.MatchString(channel) {
 		return "", fmt.Errorf("invalid channel name %q: must match [a-zA-Z0-9_-]", channel)
+	}
+
+	if err := guardLiveTown(eventDir); err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(eventDir, 0755); err != nil {
+		return "", fmt.Errorf("creating event directory: %w", err)
 	}
 
 	payload := make(map[string]string)

--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -20,6 +20,7 @@ import (
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/telemetry"
+	"github.com/steveyegge/gastown/internal/testmode"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
@@ -167,6 +168,12 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 			_, _ = f.WriteString(entry)
 			_ = f.Close()
 		}
+		return nil
+	}
+
+	// Inert in test binaries even when the log hook is unset (gt-dog).
+	// Clearing GT_TEST_NUDGE_LOG must never mean "deliver to live agents".
+	if testmode.Active() {
 		return nil
 	}
 

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/telemetry"
+	"github.com/steveyegge/gastown/internal/testmode"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
@@ -941,6 +942,13 @@ func nudgeWitness(rigName, message string) {
 		return // Don't actually nudge tmux in tests
 	}
 
+	// Test binaries are inert even without the log hook (gt-dog). The suite
+	// runs from inside a live workspace, so falling through here would emit a
+	// town-global event and send keys to a real agent pane.
+	if testmode.Active() {
+		return
+	}
+
 	// Emit a file event so the witness's await-event unblocks instantly.
 	townRoot, _ := workspace.FindFromCwd()
 	if townRoot != "" {
@@ -973,6 +981,14 @@ func nudgeRefinery(rigName, message string) {
 			_ = f.Close()
 		}
 		return // Don't actually nudge tmux in tests
+	}
+
+	// Test binaries are inert even without the log hook (gt-dog). Without
+	// this, `go test ./internal/cmd/...` wrote a real MQ_SUBMIT event into
+	// the town-global refinery channel on every run, waking every rig's
+	// refinery for a merge request that does not exist.
+	if testmode.Active() {
+		return
 	}
 
 	// Emit a file event so the refinery's await-event unblocks instantly.

--- a/internal/cmd/sling_helpers_test.go
+++ b/internal/cmd/sling_helpers_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,7 +10,9 @@ import (
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/channelevents"
 	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/workspace"
 )
 
 func setupSlingTestRegistry(t *testing.T) {
@@ -105,14 +108,116 @@ func TestWakeRigAgentsDoesNotNudgeRefinery(t *testing.T) {
 }
 
 // TestNudgeRefineryNoOpWithoutLog verifies that nudgeRefinery doesn't panic
-// or error when called without the test log env var and without a real tmux session.
-// The tmux NudgeSession call should fail silently.
+// or error when the test log env var is unset.
+//
+// This test used to clear GT_TEST_NUDGE_LOG "to exercise the real tmux path",
+// which made every `go test ./internal/cmd/...` run emit a live MQ_SUBMIT
+// event into the town-global refinery channel and send real tmux keys
+// (gt-dog). Two things now prevent that, and this test asserts both:
+//
+//  1. nudgeRefinery is inert under testmode.Active(), so the side effects
+//     never start; and
+//  2. the town root is isolated to a temp dir, so even an unguarded emit
+//     could not reach production.
+//
+// The no-panic behaviour the test was written to check is still covered.
 func TestNudgeRefineryNoOpWithoutLog(t *testing.T) {
-	// Ensure test log is NOT set so we exercise the real tmux path
+	setupSlingTestRegistry(t)
+	townRoot := newIsolatedTownRoot(t)
+
+	// Ensure the log hook is NOT set: the inert-by-default guard, not the
+	// hook, is what must keep this call from touching shared state.
 	t.Setenv("GT_TEST_NUDGE_LOG", "")
 
-	// Should not panic even though no tmux session exists
+	// Should not panic even though no tmux session exists.
 	nudgeRefinery("nonexistent-rig", "test message")
+
+	assertNoEventsEmitted(t, townRoot)
+}
+
+// TestNudgeHelpersEmitNoEventsInTests is the regression test for gt-dog: the
+// nudge helpers must not write into any town's event channels when running
+// under the test suite, even with a fully-formed workspace reachable from the
+// working directory and no GT_TEST_NUDGE_LOG hook set.
+func TestNudgeHelpersEmitNoEventsInTests(t *testing.T) {
+	setupSlingTestRegistry(t)
+	townRoot := newIsolatedTownRoot(t)
+	t.Setenv("GT_TEST_NUDGE_LOG", "")
+
+	// Sanity check: the isolated town really is discoverable, so a missing
+	// guard would produce events here rather than silently finding nothing.
+	found, err := workspace.FindFromCwd()
+	if err != nil || found != townRoot {
+		t.Fatalf("workspace.FindFromCwd() = %q, %v; want %q — test fixture is not a discoverable town", found, err, townRoot)
+	}
+
+	nudgeRefinery("nonexistent-rig", "test message")
+	nudgeWitness("nonexistent-rig", "test message")
+
+	assertNoEventsEmitted(t, townRoot)
+}
+
+// TestEmitToTownRefusesLiveTownInTests covers the backstop: even if a caller
+// forgets the testmode guard, channelevents refuses to write into the town
+// root this test binary was launched from.
+func TestEmitToTownRefusesLiveTownInTests(t *testing.T) {
+	liveRoot, err := workspace.FindFromCwd()
+	if err != nil || liveRoot == "" {
+		t.Skip("skipping: not running inside a Gas Town workspace")
+	}
+
+	if _, err := channelevents.EmitToTown(liveRoot, "refinery", "MQ_SUBMIT", []string{"source=sling"}); !errors.Is(err, channelevents.ErrLiveTownInTest) {
+		t.Fatalf("EmitToTown(live town root) error = %v; want ErrLiveTownInTest", err)
+	}
+}
+
+// newIsolatedTownRoot creates a throwaway Gas Town workspace, makes it the
+// working directory, and clears the env vars that would otherwise let
+// workspace resolution escape to the real town. Returns the town root.
+func newIsolatedTownRoot(t *testing.T) string {
+	t.Helper()
+
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("creating mayor dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, workspace.PrimaryMarker), []byte("{}"), 0644); err != nil {
+		t.Fatalf("writing town marker: %v", err)
+	}
+
+	t.Setenv("GT_TOWN_ROOT", townRoot)
+	t.Setenv("GT_ROOT", townRoot)
+	t.Chdir(townRoot)
+
+	// t.TempDir() can hand back a symlinked path (/tmp -> /private/tmp on
+	// macOS); workspace.Find deliberately does not resolve symlinks, so
+	// compare against what the process actually sees.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getting working directory: %v", err)
+	}
+	return cwd
+}
+
+// assertNoEventsEmitted fails if any channel event file exists under townRoot.
+func assertNoEventsEmitted(t *testing.T, townRoot string) {
+	t.Helper()
+
+	eventsDir := filepath.Join(townRoot, "events")
+	entries, err := os.ReadDir(eventsDir)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("reading %s: %v", eventsDir, err)
+	}
+	if len(entries) > 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("test emitted channel events into %s: %v", eventsDir, names)
+	}
 }
 
 func TestIsDeferredBead(t *testing.T) {

--- a/internal/testmode/testmode.go
+++ b/internal/testmode/testmode.go
@@ -1,0 +1,40 @@
+// Package testmode reports whether the current process is a Go test binary.
+//
+// Gas Town's commands perform real side effects on shared town state: they
+// write event files into the town-global ~/gt/events/<channel>/ directories
+// and send keystrokes into live agent tmux panes. The test suite runs from
+// inside a live workspace, so those side effects reach production unless
+// something stops them.
+//
+// gt-dog is the canonical failure: TestNudgeRefineryNoOpWithoutLog cleared
+// the GT_TEST_NUDGE_LOG hook "to exercise the real path", so every
+// `go test ./internal/cmd/...` emitted a real MQ_SUBMIT event into the town
+// refinery channel. Because the channel is town-global and events are rarely
+// consumed, all four rigs' refineries woke on synthetic "test message"
+// events forever.
+//
+// Production code that is about to touch shared town state should call
+// Active() and skip the side effect when it returns true. Guards belong on
+// the *side effect*, not on the test: a test binary should be inert by
+// default and opt in to real behaviour, never the reverse.
+package testmode
+
+import (
+	"os"
+	"testing"
+)
+
+// AllowEnv opts a test binary back into real side effects. Set it only for
+// tests that deliberately drive real event/tmux behaviour against a
+// throwaway town root that cannot reach production.
+const AllowEnv = "GT_ALLOW_TEST_SIDE_EFFECTS"
+
+// Active reports whether this process is a Go test binary that has not opted
+// into real side effects. It returns false in the shipped gt binary, so
+// production behaviour is unchanged.
+func Active() bool {
+	if !testing.Testing() {
+		return false
+	}
+	return os.Getenv(AllowEnv) == ""
+}


### PR DESCRIPTION
## Problem

`TestNudgeRefineryNoOpWithoutLog` cleared `GT_TEST_NUDGE_LOG` "to exercise the real tmux path". That is the hook that makes `nudgeRefinery` inert, so every `go test ./internal/cmd/...` run fell through to the real side effects:

```go
townRoot, _ := workspace.FindFromCwd()          // resolves the LIVE town root
channelevents.EmitToTown(townRoot, "refinery", "MQ_SUBMIT", ...)
t.NudgeSession(refinerySession, message)
```

Because the suite runs from inside a live workspace — which is exactly where polecats run it — each run wrote a real `MQ_SUBMIT` event into the **town-global** refinery channel and attempted a real tmux nudge. The channel is shared and events are rarely consumed, so all four rigs' refineries woke on synthetic `"test message"` events indefinitely: continuous token burn generated by the test suite, scaling with agent activity. Traced by the mayor from `coparent/refinery`'s report of ~80s-cadence events with `source=sling`.

The hook was backwards: real side effects were the default and tests had to opt out. This inverts it and guards the **side effect**, not the test.

## Changes

- **`internal/testmode`** (new): `Active()` reports "this is a Go test binary that has not opted into real side effects". `GT_ALLOW_TEST_SIDE_EFFECTS` is the deliberate opt-in escape hatch. Returns `false` in the shipped `gt` binary, so production behaviour is unchanged.
- **Invert the hook** in `nudgeRefinery`, `nudgeWitness` (`sling_helpers.go`) and `deliverNudge` (`nudge.go`): all three return early under `testmode.Active()`, so clearing `GT_TEST_NUDGE_LOG` can no longer mean "deliver to live agents". The log hook itself is unchanged and still works for observability.
- **Backstop in `internal/channelevents`**: the live town root is resolved once at package init — before any test can `chdir` into a temp dir — and emission into it from a test binary is refused with a new exported `ErrLiveTownInTest`. `MkdirAll` moved into `emitToDir` so the guard fires *before* any directory is created. Tests that build their own town under `t.TempDir()` are unaffected; only writes landing inside the real workspace are refused.
- **Isolate the offending test**: `TestNudgeRefineryNoOpWithoutLog` now runs against a throwaway town (`t.TempDir()` + `mayor/town.json` marker, `t.Chdir`, `GT_TOWN_ROOT`/`GT_ROOT` overridden) so it cannot reach production even with every guard removed. Its original no-panic assertion is retained.

This is options (a) + (c) from the issue as the fix, with (b) as the backstop.

## New regression tests

- `TestNudgeHelpersEmitNoEventsInTests` — with a fully discoverable workspace at cwd and `GT_TEST_NUDGE_LOG` empty, `nudgeRefinery` + `nudgeWitness` write zero event files. It first asserts `FindFromCwd()` actually resolves the fixture, so it cannot pass vacuously by finding no town at all.
- `TestEmitToTownRefusesLiveTownInTests` — asserts the `channelevents` backstop returns `ErrLiveTownInTest` for the real town root.

## Verification

Snapshotted `~/gt/events` before and after running the suite from inside a live worktree:

- `go test ./internal/cmd/...` (82s) — **zero** new event files
- `go test ./...` — **zero** new event files

No tmux keys: the guards return before `tmux.NudgeSession` is reached.

Gates: `go build ./...` OK, `go vet ./...` clean, `gofmt` clean on all touched files. Three failures in the full suite (`TestGetServerAddr_UsesConfigYAMLPort`, `TestWaitForCatalog_NoServer`, `TestFindBrokenWorkspaces_MultipleRigs`) are **pre-existing** — verified identical on a stashed clean tree, and unrelated to this change.

## Not covered

- The sibling defect that these events carry no rig field (so a refinery cannot filter them) is untouched.
- `internal/tmux` `SendKeys`/`NudgeSession` has no test-binary guard; any other code path that sends keys from a test remains unguarded. The three nudge helpers were the ones this issue identified.

Fixes gt-dog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)