### PR TITLE
fix(dashboard): stop running 'mayor attach' as a buffered subprocess

### DIFF
--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -90,6 +90,14 @@ func TestValidateCommand(t *testing.T) {
 			errSubstr: "blocked pattern",
 		},
 
+		// Terminal-only commands cannot run as a buffered subprocess
+		{
+			name:      "mayor attach is terminal-only",
+			command:   "mayor attach",
+			wantErr:   true,
+			errSubstr: "interactive terminal",
+		},
+
 		// Not in whitelist
 		{
 			name:      "unknown command",

--- a/internal/web/commands.go
+++ b/internal/web/commands.go
@@ -20,6 +20,10 @@ type CommandMeta struct {
 	Args string
 	// ArgType specifies what kind of options to show (rigs, polecats, convoys, agents, hooks)
 	ArgType string
+	// TerminalOnly marks commands that hand off the TTY (e.g. tmux attach via
+	// syscall.Exec) and can therefore never succeed as a buffered dashboard
+	// subprocess. The UI copies these to the clipboard instead of running them.
+	TerminalOnly bool
 }
 
 // AllowedCommands defines which gt commands can be executed from the dashboard.
@@ -77,7 +81,7 @@ var AllowedCommands = map[string]CommandMeta{
 	// Agent lifecycle (careful)
 	"witness start":  {Confirm: true, Desc: "Start witness", Category: "Agents", Args: "<rig-name>", ArgType: "rigs"},
 	"refinery start": {Confirm: true, Desc: "Start refinery", Category: "Agents", Args: "<rig-name>", ArgType: "rigs"},
-	"mayor attach":   {Confirm: true, Desc: "Attach mayor", Category: "Agents"},
+	"mayor attach":   {TerminalOnly: true, Desc: "Attach mayor", Category: "Agents"},
 	"deacon start":   {Confirm: true, Desc: "Start deacon", Category: "Agents"},
 
 	// Polecat actions
@@ -130,6 +134,10 @@ func ValidateCommand(rawCommand string) (*CommandMeta, error) {
 	meta, ok := AllowedCommands[baseCmd]
 	if !ok {
 		return nil, fmt.Errorf("command not in whitelist: %s", baseCmd)
+	}
+
+	if meta.TerminalOnly {
+		return nil, fmt.Errorf("%s requires an interactive terminal and cannot run from the dashboard; copy it and run it in a real terminal", baseCmd)
 	}
 
 	return &meta, nil
@@ -191,13 +199,14 @@ func GetCommandList() []CommandInfo {
 	commands := make([]CommandInfo, 0, len(AllowedCommands))
 	for name, meta := range AllowedCommands {
 		commands = append(commands, CommandInfo{
-			Name:     name,
-			Desc:     meta.Desc,
-			Category: meta.Category,
-			Safe:     meta.Safe,
-			Confirm:  meta.Confirm,
-			Args:     meta.Args,
-			ArgType:  meta.ArgType,
+			Name:         name,
+			Desc:         meta.Desc,
+			Category:     meta.Category,
+			Safe:         meta.Safe,
+			Confirm:      meta.Confirm,
+			Args:         meta.Args,
+			ArgType:      meta.ArgType,
+			TerminalOnly: meta.TerminalOnly,
 		})
 	}
 	return commands
@@ -205,11 +214,12 @@ func GetCommandList() []CommandInfo {
 
 // CommandInfo is the JSON-serializable form of a command for the UI.
 type CommandInfo struct {
-	Name     string `json:"name"`
-	Desc     string `json:"desc"`
-	Category string `json:"category"`
-	Safe     bool   `json:"safe"`
-	Confirm  bool   `json:"confirm"`
-	Args     string `json:"args,omitempty"`
-	ArgType  string `json:"argType,omitempty"`
+	Name         string `json:"name"`
+	Desc         string `json:"desc"`
+	Category     string `json:"category"`
+	Safe         bool   `json:"safe"`
+	Confirm      bool   `json:"confirm"`
+	Args         string `json:"args,omitempty"`
+	ArgType      string `json:"argType,omitempty"`
+	TerminalOnly bool   `json:"terminalOnly,omitempty"`
 }

--- a/internal/web/static/dashboard.js
+++ b/internal/web/static/dashboard.js
@@ -682,6 +682,18 @@
         var matchedCmd = allCommands.find(function(c) { return cmdName.indexOf(c.name) === 0; });
         saveRecentCommand(matchedCmd ? matchedCmd.name : baseName);
 
+        // Terminal-only commands (e.g. tmux attach) can never succeed as a
+        // buffered dashboard subprocess - copy them to the clipboard instead.
+        if (matchedCmd && matchedCmd.terminalOnly) {
+            var terminalCmd = 'gt ' + cmdName;
+            navigator.clipboard.writeText(terminalCmd).then(function() {
+                showToast('success', 'Copied', terminalCmd + ' — run in a terminal');
+            }).catch(function() {
+                showToast('info', 'Run in terminal', terminalCmd);
+            });
+            return;
+        }
+
         executionLock = true;
         console.log('Running command:', cmdName);
 


### PR DESCRIPTION
## Problem

Clicking "mayor attach" in the `gt dashboard` command palette always fails with:

```
open terminal failed: not a terminal
```

Root cause: `gt mayor attach` hands the controlling TTY off to tmux via `syscall.Exec` (see the existing comment in `internal/cmd/session.go`):

```go
// Hand the terminal off to tmux via syscall.Exec so tmux inherits our
// controlling TTY directly. Running tmux as a subprocess with buffered
// stdio triggers "open terminal failed: not a terminal".
```

But the dashboard's `/api/run` endpoint runs whitelisted commands as a *buffered* `exec.CommandContext` subprocess (`internal/web/api.go`). Since the dashboard server has no controlling TTY of its own, `mayor attach` can **never** succeed through this path — it's not a flaky bug, it's structurally impossible.

## Fix

- Add a `TerminalOnly` flag to `CommandMeta` in `internal/web/commands.go` and set it on `mayor attach`.
- `ValidateCommand` now rejects `TerminalOnly` commands server-side with a clear error, as defense in depth.
- The dashboard palette (`dashboard.js`) now copies `gt mayor attach` to the clipboard instead of POSTing it to `/api/run`, matching the already-working behavior of the per-crew-member attach buttons in the crew table.

## Related

- #3710 shares the same error string but a different root cause (`gt session at` failing from a *real* TTY) — not a duplicate, left untouched by this PR.

## Testing

- `go build ./...`
- `go test ./...` (full suite passes)
- Added a `TestValidateCommand` case covering the new `TerminalOnly` rejection